### PR TITLE
Push Git tags before building images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,6 +237,12 @@ jobs:
           name: Show version
           command: echo ${VERSION}
       - run:
+          name: Tag git
+          command: git tag ${VERSION}
+      - run:
+          name: Push git tags
+          command: git push --tags
+      - run:
           name: Docker login
           command: eval $(aws ecr get-login --region $AWS_REGION --no-include-email --profile digideps-ci)
       - run:
@@ -251,9 +257,3 @@ jobs:
       - run:
           name: Push client image
           command: docker push ${AWS_REGISTRY}/digideps/client:${VERSION}
-      - run:
-          name: Tag git
-          command: git tag ${VERSION}
-      - run:
-          name: Push git tags
-          command: git push --tags


### PR DESCRIPTION
## Purpose
This effectively "reserves" the tag so that any concurrent builds don't try to use the same tag.

## Approach
A second build could both try and use the same tag by starting between "set version" and "push tags". By reordering the steps, this window is now much smaller.

## Learning
We would further reduce the likelihood of a collision by tagging with the branch name or commit ID. This would also give more predictable build numbers. The current sequential method is a bit misleading since branches aren't merged into master first.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
  - N/A
- [x] I have successfully built my branch to a feature environment
  - N/A
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [x] The product team have tested these changes
  - N/A