### PR TITLE
Add Slack notifications when approvals needed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,12 @@ workflows:
           filters: { branches: { only: [ master ] } }
           tf_workspace: preprod
 
+      - slack/approval-notification:
+          name: approve release to production notification
+          message: "Production is ready for release and pending approval"
+          requires: [ stabilize preproduction ]
+          filters: { branches: { only: [ master ] } }
+
       - approve:
           name: approve release to production
           type: approval
@@ -92,6 +98,7 @@ workflows:
 
 orbs:
   aws-cli: circleci/aws-cli@0.1.13
+  slack: circleci/slack@3.3.0
 
 jobs:
   plan:


### PR DESCRIPTION
## Purpose
Deployment to production needs manual approval, but this can be awkward to track now that  everything is automated. By using Slack notifications we can immediately inform the team when work is ready to go.

## Approach
Added the Slack orb and a notification when approval is required.

NB: Slack notification is currently going to me personally. When we've verified the master pipeline has succeeded, I'll repoint to #opg-digideps-team
