### PR TITLE
DDPB-2839: Fix typo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,12 +88,6 @@ workflows:
           filters: { branches: { only: [ master ] } }
           tf_workspace: master
 
-      - api_unit_test:
-          name: api unit test
-          requires: [ stabilize master ]
-          filters: { branches: { only: [ master ] } }
-          tf_workspace: master
-
       - apply:
           name: apply training
           requires: [ api unit test, client integration test ]


### PR DESCRIPTION
## Purpose
Master pipeline should only be run on the master branch. Without this fix, it gets stuck at `stabilize master`

Fixes [DDPB-2839](https://opgtransform.atlassian.net/browse/DDPB-2839)

## Approach
Used `only:master` rather than `ignore:master`

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have successfully built my branch to a feature environment
 - N/A, since only master deployment pipeline has changed