### PR TITLE
DDPB-2840: Correct name of service in terms of use

### DIFF
--- a/client/src/AppBundle/Resources/views/Index/terms.html.twig
+++ b/client/src/AppBundle/Resources/views/Index/terms.html.twig
@@ -7,102 +7,95 @@
 
 {% block linkBack %}
     {% if backlink %}
-        <a href="{{ backlink }}" class="link-back behat-link-step-back">{{ 'back' | trans({}, 'common' ) }}</a>
+        <a href="{{ backlink }}" class="govuk-back-link behat-link-step-back">{{ 'back' | trans({}, 'common' ) }}</a>
     {% endif %}
 {% endblock %}
 
 {% block pageContent %}
 
-<div class="text">
-  <p class="lede">The Complete the deputy report service lets you create your deputy report online and submit it to the Office of the Public Guardian (OPG).</p>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <p class="govuk-body-l">The Complete the deputy report service lets you create your deputy report online and submit it to the Office of the Public Guardian (OPG).</p>
 
-  <p>The service is intended for use by either:</p>
+        <p>The service is intended for use by either:</p>
 
-  <ul class="list list-bullet">
-    <li>a court-appointed deputy</li>
-    <li>someone working on behalf of and with the consent of a professional or public authority court-appointed deputy</li>
-  </ul>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>a court-appointed deputy</li>
+            <li>someone working on behalf of and with the consent of a professional or public authority court-appointed deputy</li>
+        </ul>
 
-  <p>By using this service you agree to keep to:</p>
+        <p>By using this service you agree to keep to:</p>
 
-  <ul class="list list-bullet">
-    <li>these terms of use</li>
-    <li>the <a href="https://www.gov.uk/help/terms-conditions" target="_blank">GOV.UK terms and conditions</a></li>
-    <li>the standards set out in OPG’s <a href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/personal-information-charter" target="_blank">personal information charter</a></li>
-  </ul>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>these terms of use</li>
+            <li>the <a href="https://www.gov.uk/help/terms-conditions" target="_blank">GOV.UK terms and conditions</a></li>
+            <li>the standards set out in OPG’s <a href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/personal-information-charter" target="_blank">personal information charter</a></li>
+        </ul>
 
-  <p>Any information you provide will be stored securely and used in line with our <a href="{{path('privacy')}}">privacy notice</a> and <a href="https://www.gov.uk/help/cookies" target="_blank">cookie policy</a>.</p>
+        <p>Any information you provide will be stored securely and used in line with our <a href="{{path('privacy')}}">privacy notice</a> and <a href="https://www.gov.uk/help/cookies" target="_blank">cookie policy</a>.</p>
 
-</div>
+        <h2 class="govuk-heading-m">Completing your report</h2>
 
-<h2 class="heading-medium">Completing your report</h2>
+        <p>You’re responsible for completing your report as accurately and as fully as possible.</p>
 
-<div class="text">
-  <p>You’re responsible for completing your report as accurately and as fully as possible.</p>
+        <p>If you are appointed as a joint or joint and several deputy, you should consult the other deputies when completing the report.</p>
 
-  <p>If you are appointed as a joint or joint and several deputy, you should consult the other deputies when completing the report.</p>
+        <h3 class="govuk-heading-s">Changing your report</h3>
 
-  <h3 class="heading-small">Changing your report</h3>
+        <p>Before you submit your report to OPG, you can make changes to the information you’ve provided.</p>
 
-  <p>Before you submit your report to OPG, you can make changes to the information you’ve provided.</p>
+        <p>Once you’ve submitted your report to OPG, you cannot make any further changes to it online. If you need to make changes after you’ve submitted your report, please contact us.</p>
 
-  <p>Once you’ve submitted your report to OPG, you cannot make any further changes to it online. If you need to make changes after you’ve submitted your report, please contact us.</p>
+        <h3 class="govuk-heading-s">What happens when you submit your report</h3>
 
-  <h3 class="heading-small">What happens when you submit your report</h3>
+        <p>When you click submit within the service, your report can be accessed by relevant members of OPG staff.</p>
 
-  <p>When you click submit within the service, your report can be accessed by relevant members of OPG staff.</p>
+        <p>Your report will be kept and processed in accordance with our <a href="{{path('privacy')}}">privacy notice</a> and OPG’s <a href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/personal-information-charter" target="_blank">personal information charter</a>.</p>
 
-  <p>Your report will be kept and processed in accordance with our <a href="{{path('privacy')}}">privacy notice</a> and OPG’s <a href="https://www.gov.uk/government/organisations/office-of-the-public-guardian/about/personal-information-charter" target="_blank">personal information charter</a>.</p>
-
-  <p>OPG will send you an acknowledgement letter or email when we’ve reviewed your report. We may contact you to ask for more information.</p>
-</div>
+        <p>OPG will send you an acknowledgement letter or email when we’ve reviewed your report. We may contact you to ask for more information.</p>
 
 
-<h2 class="heading-medium">Your account security</h2>
+        <h2 class="govuk-heading-m">Your account security</h2>
 
-<div class="text">
-  <p>When you create a deputy report service account, use a valid email address and choose a strong password that someone else will not be able to guess easily.</p>
+        <p>When you create a deputy report service account, use a valid email address and choose a strong password that someone else will not be able to guess easily.</p>
 
-  <p>It’s your responsibility to keep your sign-in details safe. Do not share your password with anyone or write it down.</p>
+        <p>It’s your responsibility to keep your sign-in details safe. Do not share your password with anyone or write it down.</p>
 
-  <p>You are responsible for all activity on your Complete the deputy report service account.</p>
+        <p>You are responsible for all activity on your Complete the deputy report service account.</p>
 
-  <p>We recommend that you sign out of your account when you’re not using the service. We’ll automatically sign you out if you have not used the service for 20 minutes.</p>
+        <p>We recommend that you sign out of your account when you’re not using the service. We’ll automatically sign you out if you have not used the service for 20 minutes.</p>
 
-  <h3 class="heading-small">Accessing the service securely</h3>
+        <h3 class="govuk-heading-s">Accessing the service securely</h3>
 
-  <p>You’re responsible for accessing the service securely. You should not access it using a computer or network that may leave personal information accessible to others. For example,you should not:</p>
+        <p>You’re responsible for accessing the service securely. You should not access it using a computer or network that may leave personal information accessible to others. For example,you should not:</p>
 
-  <ul class="list list-bullet">
-    <li>leave a computer unprotected while you’re signed in to the service</li>
-    <li>access the service using a shared or public computer</li>
-    <li>access the service using an open WiFi network</li>
-  </ul>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>leave a computer unprotected while you’re signed in to the service</li>
+            <li>access the service using a shared or public computer</li>
+            <li>access the service using an open WiFi network</li>
+        </ul>
 
-  <p>We make every effort to check and test this service whenever we amend or update it. However, you must take your own precautions to ensure that the way you access this service does not expose you to the risk of viruses, malicious computer code or other forms of interference which may damage your computer.</p>
-</div>
+        <p>We make every effort to check and test this service whenever we amend or update it. However, you must take your own precautions to ensure that the way you access this service does not expose you to the risk of viruses, malicious computer code or other forms of interference which may damage your computer.</p>
 
-<h2 class="heading-medium">Governing law</h2>
+        <h2 class="govuk-heading-m">Governing law</h2>
 
-<div class="text">
-  <p>These terms of use are governed by and construed in accordance with the laws of England and Wales, including:</p>
+        <p>These terms of use are governed by and construed in accordance with the laws of England and Wales, including:</p>
 
-  <ul class="list list-bullet">
-    <li>Computer Misuse Act 1990</li>
-    <li>General Data Protection Regulation 2018</li>
-    <li>Data Protection Act 2018</li>
-    <li>Mental Capacity Act 2005</li>
-  </ul>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>Computer Misuse Act 1990</li>
+            <li>General Data Protection Regulation 2018</li>
+            <li>Data Protection Act 2018</li>
+            <li>Mental Capacity Act 2005</li>
+        </ul>
 
-  <p>Any dispute you have which relates to these terms of use, or your use of GOV.UK (whether it be contractual or non-contractual), will be subject to the exclusive jurisdiction of the courts of England and Wales.</p>
-</div>
+        <p>Any dispute you have which relates to these terms of use, or your use of GOV.UK (whether it be contractual or non-contractual), will be subject to the exclusive jurisdiction of the courts of England and Wales.</p>
 
-<h2 class="heading-medium">About these terms of use</h2>
+        <h2 class="govuk-heading-m">About these terms of use</h2>
 
-<div class="text">
-  <p>These terms of use affect your rights and liabilities under the law. They govern your use of, and relationship with, the Complete the deputy report service. They do not apply to other OPG services, or to any other department or service that links to this service.</p>
+        <p>These terms of use affect your rights and liabilities under the law. They govern your use of, and relationship with, the Complete the deputy report service. They do not apply to other OPG services, or to any other department or service that links to this service.</p>
 
-  <p>Please check these terms of use regularly. We may update them at any time without notice. This might happen if there’s a change in the law or a change to the way the service works. You’ll agree to any changes if you continue to use the service after the terms of use have been updated.</p>
+        <p>Please check these terms of use regularly. We may update them at any time without notice. This might happen if there’s a change in the law or a change to the way the service works. You’ll agree to any changes if you continue to use the service after the terms of use have been updated.</p>
+    </div>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
## Purpose
Error in current terms of use accessed at foot of service - final section refers to 'LPA' service rather than digideps.

Fixes [DDPB-2840](https://opgtransform.atlassian.net/browse/DDPB-2840)

## Approach
Updated to "Complete the deputy report"

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
  - N/A
- [ ] I have successfully built my branch to a feature environment
- [ ] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [ ] The product team have tested these changes

### Frontend
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [x] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [x] There are no deprecated CSS classes noted in the profiler
- [x] Translations are used and the profiler doesn't identify any missing
