### PR TITLE
DDPB-2822: Don't show account balance question for 103-5 reports

### DIFF
--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/partials/_money-in-and-out.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/partials/_money-in-and-out.html.twig
@@ -138,7 +138,8 @@
 
 <hr />
 
-{% if report.type not in ['103-5'] %}
+{# Don't show question for professional reports with short money sections #}
+{% if report.type not in ['103-5', '103-4-5'] %}
     {{ form_checkbox_group(form.accountsBalance, (page ~ '.form.accountsBalance' ~ nonLayAppend), {
         'fieldSetClass' : 'inline',
         'formGroupClass': 'push-half--bottom'


### PR DESCRIPTION
## Purpose
The checklist question "Do the accounts balance and match bank statements, where provided?" is not appropriate for professional 103 (103-5) reports.

Fixes [DDPB-2822](https://opgtransform.atlassian.net/browse/DDPB-2822)

## Approach
I removed that section if the report type is 103-5.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [ ] The product team have tested these changes

### Frontend
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
