### PR TITLE
DDPB-2858: Fixes money in money out section not showing on checklist …

### DIFF
--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
@@ -165,7 +165,7 @@
             </div>
         {% endif %}
 
-        {% if report.hasSection('moneyInShort') or report.hasSection('moneyOutShort') or report.hasSection('deputyExpenses') or report.hasSection('paDeputyExpenses') %}
+        {% if report.hasSection('moneyInShort') or report.hasSection('moneyOutShort') or report.hasSection('gifts') or report.hasSection('deputyExpenses') or report.hasSection('paDeputyExpenses') %}
             <div class="section">
                 <h2 class="section-heading">{{ (page ~ '.heading.money') | trans({}, 'admin-checklist') }}</h2>
 

--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/checklist.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/checklist.html.twig
@@ -128,7 +128,7 @@
             {% endif %}
 
             {# Money transfers, Money in and money out #}
-            {% if report.hasSection('moneyInShort') or report.hasSection('moneyOutShort') or report.hasSection('gifts') or report.hasSection('deputyExpenses') %}
+            {% if report.hasSection('moneyInShort') or report.hasSection('moneyOutShort') or report.hasSection('gifts') or report.hasSection('deputyExpenses') or report.hasSection('paDeputyExpenses') %}
                 {% include 'AppBundle:Admin/Client/Report/partials:_money-in-and-out.html.twig' %}
             {% endif %}
 


### PR DESCRIPTION
…PDF for Profs

## Purpose
Fixes money in money out section not showing on the checklist PDF for Profs

Fixes [DDPB-2858](https://opgtransform.atlassian.net/browse/DDPB-2858)

## Approach
The section was correctly showing on the checklist page (non PDF) because the twig contains a check for the *gifts* section. This check was not being made in the checklist-pdf twig file. I have added the check. 

The checklist-pdf twig was also doing a check for a section that the checklist twig was not. I have added that check to the checklist twig, so now both are in sync and doing the same checks.

## Learning


## Checklist
- [x] I have performed a self-review of my own code
- [N/A] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [N/A] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] I have successfully built my branch to a feature environment
- [ ] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [ ] The product team have tested these changes

### API
- [x] There are no Composer security issues (`docker-compose run api php app/console security:check`)

### Frontend
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [N/A] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [N/A] There are no deprecated CSS classes noted in the profiler
- [N/A] Translations are used and the profiler doesn't identify any missing
