### PR TITLE
DDPB-2850: Remove 'gifting review' from lodging checklist

### DIFF
--- a/client/src/AppBundle/Resources/translations/admin-checklist.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin-checklist.en.yml
@@ -153,7 +153,7 @@ checklistPage:
     finalDecision:
       label: Final decision?
       options:
-        forReview: I am referring the case for a staff review or gifting review
+        forReview: I am referring the case for a staff review
         incomplete: The report is incomplete
         furtherCaseworkRequired: |
           I have lodged and acknowledged the report but issues require further case work
@@ -162,4 +162,3 @@ checklistPage:
           sent an acknowledgment to the deputy(s)
     furtherInformationReceived:
       label: Further information received
-    


### PR DESCRIPTION
## Purpose
Gifting review is no longer used by case managers - please remove the wording on the checklist

Fixes [DDPB-2850](https://opgtransform.atlassian.net/browse/DDPB-2850)

## Approach
Removed "or gifting review" from option description

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
  - N/A
- [ ] The product team have tested these changes
