### PR TITLE
DDPB-2738 - Adds Strict-Transport-Security header to nginx config

### DIFF
--- a/client/composer.json
+++ b/client/composer.json
@@ -26,6 +26,7 @@
         "behat/mink-browserkit-driver": "^1.3.3",
         "behat/mink-selenium2-driver": "^1.3.1",
         "behat/symfony2-extension": "^2.1.2",
+        "behatch/contexts": "^3.2",
         "mockery/mockery": "^0.9.11",
         "phpunit/phpunit": "^4.8.36",
         "snc/redis-bundle": "^2.1.9",

--- a/client/composer.lock
+++ b/client/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "80af60bc96d55ab60329954feacc7167",
+    "content-hash": "27a753838abb902aadf636da5f0af57d",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -6088,7 +6088,131 @@
             "time": "2019-08-24T08:43:50+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "behatch/contexts",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Behatch/contexts.git",
+                "reference": "cbda31e1f83423f267ebb56d0d45e849ecac6dc2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Behatch/contexts/zipball/cbda31e1f83423f267ebb56d0d45e849ecac6dc2",
+                "reference": "cbda31e1f83423f267ebb56d0d45e849ecac6dc2",
+                "shasum": ""
+            },
+            "require": {
+                "behat/behat": "^3.0.13",
+                "behat/mink-extension": "^2.3.1",
+                "justinrainbow/json-schema": "^5.0",
+                "php": ">=5.5",
+                "symfony/dom-crawler": "^2.4|^3.0|^4.0",
+                "symfony/http-foundation": "^2.3|^3.0|^4.0",
+                "symfony/property-access": "^2.3|^3.0|^4.0"
+            },
+            "replace": {
+                "sanpi/behatch-contexts": "self.version"
+            },
+            "require-dev": {
+                "atoum/atoum": "^2.8|^3.0",
+                "behat/mink-goutte-driver": "^1.1",
+                "behat/mink-selenium2-driver": "^1.3",
+                "fabpot/goutte": "^3.2",
+                "guzzlehttp/guzzle": "^6.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Behatch\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "beerware"
+            ],
+            "description": "Behatch contexts",
+            "keywords": [
+                "BDD",
+                "Behat",
+                "Context",
+                "Symfony2"
+            ],
+            "time": "2018-08-13T16:31:50+00:00"
+        },
+        {
+            "name": "justinrainbow/json-schema",
+            "version": "5.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/justinrainbow/json-schema.git",
+                "reference": "dcb6e1006bb5fd1e392b4daa68932880f37550d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/dcb6e1006bb5fd1e392b4daa68932880f37550d4",
+                "reference": "dcb6e1006bb5fd1e392b4daa68932880f37550d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.2.20",
+                "json-schema/json-schema-test-suite": "1.2.0",
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JsonSchema\\": "src/JsonSchema/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
+                {
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
+                }
+            ],
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/justinrainbow/json-schema",
+            "keywords": [
+                "json",
+                "schema"
+            ],
+            "time": "2019-01-14T23:55:14+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],

--- a/client/docker/confd/templates/app.conf.tmpl
+++ b/client/docker/confd/templates/app.conf.tmpl
@@ -8,6 +8,9 @@ server {
     server_name  {{ getv "/opg/nginx/server/names" }};
     root /var/www/web;
 
+    ## Headers
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
+
     {{ if exists "/opg/nginx/clientmaxbodysize" }}
     client_max_body_size {{ getv "/opg/nginx/clientmaxbodysize" }};
     {{ end }}

--- a/client/docker/confd/templates/behat.yml.tmpl
+++ b/client/docker/confd/templates/behat.yml.tmpl
@@ -72,6 +72,15 @@ default:
                 - DigidepsBehat\FeatureContext: [{ dbName: api, sessionName: 'digideps' }]
             {{ end }}
 
+        security:
+            description: Tests to assert on the apps security features
+            paths: [ %paths.base%/features/security ]
+            filters:
+                tags: "@security"
+            contexts:
+                - behatch:context:rest
+                - DigidepsBehat\FeatureContext: [{ dbName: "api" }]
+
     extensions:
         Behat\Symfony2Extension: ~
         Behat\MinkExtension\ServiceContainer\MinkExtension:
@@ -84,6 +93,7 @@ default:
           {{ else }}
               base_url: "https://digideps-client.local/"
           {{ end }}
+        Behatch\Extension: ~
 
 chrome:
     extensions:

--- a/client/tests/behat/features/security/headers.feature
+++ b/client/tests/behat/features/security/headers.feature
@@ -1,0 +1,7 @@
+Feature: headers
+
+    @security
+    Scenario: ensure Strict-Transport-Security header exists
+        Given I send a GET request to "/login"
+        Then the response status code should be 200
+        And the header "Strict-Transport-Security" should be equal to "max-age=31536000; includeSubdomains;"


### PR DESCRIPTION
## Purpose
As per ITHC recommendations, this change adds a `Strict-Transport-Security` header to help enforce HTTPS connections. Behatch behat context helpers has been added to aid assertions on responses.

Fixes [DDPB-2738](https://opgtransform.atlassian.net/browse/DDPB-2738)

## Approach
Adding the header in the nginx config ensures the header will always be added.

## Learning
Interesting to see that the behat config is generated using a confd template. This wasn't very obvious when working out how to persist changes to `behat.yml` and it may be possible to keep the functionality of the confd approach using env vars instead. I'll add a ticket to the backlog to look into this.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] The product team have tested these changes

### Frontend
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [x] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
