### PR TITLE
DDPB-2926 - Adds apply shared-preproduction job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,8 +58,15 @@ workflows:
           tf_workspace: development
 
       - apply:
+          name: apply shared-preproduction
+          requires: [ build master ]
+          filters: { branches: { only: [ master ] } }
+          tf_tier: shared
+          tf_workspace: preproduction
+
+      - apply:
           name: apply master
-          requires: [ apply shared-development ]
+          requires: [ apply shared-development, apply shared-preproduction ]
           filters: { branches: { only: [ master ] } }
           tf_workspace: master
 


### PR DESCRIPTION
## Purpose
Adding this step in order to ensure preproduction account has the relevant changes from master and are verified before being applied to production.

Fixes [DDPB-2926](https://opgtransform.atlassian.net/browse/DDPB-2926)

## Learning
Got a good overview of digideps infra and circleci jobs and workflows.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] The product team have tested these changes
