### PR TITLE
DDPB-2924 - Apply training after approve release to production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ workflows:
 
       - apply:
           name: apply training
-          requires: [ api unit test, client integration test ]
+          requires: [ approve release to production ]
           filters: { branches: { only: [ master ] } }
           tf_workspace: training
 


### PR DESCRIPTION
## Purpose
Ensures that training has the same stability as production.

Fixes [DDPB-2924](https://opgtransform.atlassian.net/browse/DDPB-2924)

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] The product team have tested these changes