### PR TITLE
DDPB-2929: Push admin load balancer timeout to 300s

### DIFF
--- a/environment/admin_lb.tf
+++ b/environment/admin_lb.tf
@@ -35,6 +35,7 @@ resource "aws_lb" "admin" {
   internal           = false
   load_balancer_type = "application"
   subnets            = data.aws_subnet.public.*.id
+  idle_timeout       = 300
 
   security_groups = [
     aws_security_group.admin_elb.id,


### PR DESCRIPTION
## Purpose
In #75 we pushed the admin Nginx service to have a timeout of 300s, so it can handle long requests (specifically, provisioning large zip files for downloads). However, this was not reflected in the load balancers, so they now timeout instead of Nginx 🙄 

Fixes [DDPB-2929](https://opgtransform.atlassian.net/browse/DDPB-2929)

## Approach
Pushed the admin load balancer maximum timeout to 300s, matching the configuration of Nginx.

## Learning
I'd actually dealt with this exact issue in our local development environment with the proxy, but I didn't realise load balancers _also_ enforced timeouts.

This further pushes the point that timeouts shouldn't really be messed with. Hopefully we'll be able to deal with this more thoroughly in the future, either by improving how we store/access S3 items or by pushing directly to Sirius and removing the need for a download option.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
  - N/A
- [x] The product team have tested these changes
  - N/A