### PR TITLE
Enables VPC DNS hostname and resolution support

### DIFF
--- a/shared/vpc.tf
+++ b/shared/vpc.tf
@@ -7,7 +7,7 @@ resource "aws_vpc" "main" {
     { Name = "private" },
   )
   enable_dns_hostnames = true
-  enable_dns_support = true
+  enable_dns_support   = true
 }
 
 resource "aws_internet_gateway" "igw" {


### PR DESCRIPTION
## Purpose
Client tasks were unable to reach API due to DNS hostnames being disabled. Resolution support was manually enabled so this change persists the setting in code.

Fixes [DDPB-2927](https://opgtransform.atlassian.net/browse/DDPB-2927)

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] The product team have tested these changes