### PR TITLE
DDPB-2989: Handle API max body size in PHP

### DIFF
--- a/api/docker/confd/templates/app.conf.tmpl
+++ b/api/docker/confd/templates/app.conf.tmpl
@@ -39,6 +39,8 @@ server {
         # for more information).
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         fastcgi_param DOCUMENT_ROOT $realpath_root;
+        
+        fastcgi_request_buffering off;
 
         # Prevents URIs that include the front controller. This will 404:
         # http://domain.tld/app.php/some-path


### PR DESCRIPTION
## Purpose
In #101, we removed the environment variable which sets API's Nginx's `client_max_body_size` to 10M. This makes Nginx drop to the default 1M, which appears to have caused some problems with lay CSV upload.

Problems or not though, we don't want two gatekeepers. Much as we did recently with the client, we should just handle max upload sizes with PHP. It gives us control in one place and allows us to more gracefully handle errors.

## Approach
As with the Client, PHP limits are already in place (in `pool.conf.tmpl`) so I just disabled the Nginx's limit.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
  - N/A
- [x] The product team have tested these changes
  - N/A
