### PR TITLE
DDPB-2957: Allows deputies to run case number searches that contain 'T'

### DIFF
--- a/api/src/AppBundle/Entity/Repository/ReportRepository.php
+++ b/api/src/AppBundle/Entity/Repository/ReportRepository.php
@@ -152,9 +152,9 @@ class ReportRepository extends EntityRepository
             ->andWhere('r.submitted = false OR r.submitted is null');
 
         if ($q = $query->get('q')) {
-            $qb->andWhere('lower(c.firstname) LIKE :qLike OR lower(c.lastname) LIKE :qLike OR c.caseNumber = :q');
+            $qb->andWhere('lower(c.firstname) LIKE :qLike OR lower(c.lastname) LIKE :qLike OR lower(c.caseNumber) = :q');
             $qb->setParameter('qLike', '%' . strtolower($q) . '%');
-            $qb->setParameter('q', $q);
+            $qb->setParameter('q', strtolower($q));
         }
 
         $endOfToday = new \DateTime('today midnight');


### PR DESCRIPTION
## Purpose
Allows deputies to run case number searches that contain 'T'.

This works fine for admin searches as that lower cases the search query, but the frontend query for deputies neglects to do so.

This forms part of a larger search improvement ticket (2957), but I think each issue can be released in solo where possible.

Fixes [DDPB-3001](https://opgtransform.atlassian.net/browse/DDPB-3001)

## Approach
Normalise the db column and the search query both to lowercase. 

## Learning

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] The product team have tested these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
