### PR TITLE
DDPB-2956: Use endpoint for ECR, S3 and Cloudwatch

### DIFF
--- a/shared/endpoint_ecr.tf
+++ b/shared/endpoint_ecr.tf
@@ -1,0 +1,28 @@
+resource "aws_vpc_endpoint" "ecr" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.eu-west-1.ecr.dkr"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  security_group_ids  = aws_security_group.ecr_endpoint[*].id
+  subnet_ids          = aws_subnet.private[*].id
+  tags                = merge(local.default_tags, { Name = "ecr" })
+}
+
+resource "aws_security_group" "ecr_endpoint" {
+  name_prefix = "ecr_endpoint"
+  vpc_id      = aws_vpc.main.id
+  tags        = merge(local.default_tags, { Name = "ecr_endpoint" })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "ecr_endpoint_https_in" {
+  from_port         = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.ecr_endpoint.id
+  to_port           = 443
+  type              = "ingress"
+  cidr_blocks       = [aws_vpc.main.cidr_block]
+}

--- a/shared/endpoint_logs.tf
+++ b/shared/endpoint_logs.tf
@@ -1,0 +1,28 @@
+resource "aws_vpc_endpoint" "logs" {
+  vpc_id              = aws_vpc.main.id
+  service_name        = "com.amazonaws.eu-west-1.logs"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+  security_group_ids  = aws_security_group.logs_endpoint[*].id
+  subnet_ids          = aws_subnet.private[*].id
+  tags                = merge(local.default_tags, { Name = "logs" })
+}
+
+resource "aws_security_group" "logs_endpoint" {
+  name_prefix = "logs_endpoint"
+  vpc_id      = aws_vpc.main.id
+  tags        = merge(local.default_tags, { Name = "logs_endpoint" })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "logs_endpoint_https_in" {
+  from_port         = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.logs_endpoint.id
+  to_port           = 443
+  type              = "ingress"
+  cidr_blocks       = [aws_vpc.main.cidr_block]
+}

--- a/shared/endpoint_s3.tf
+++ b/shared/endpoint_s3.tf
@@ -1,0 +1,7 @@
+resource "aws_vpc_endpoint" "s3" {
+  service_name      = "com.amazonaws.eu-west-1.s3"
+  vpc_id            = aws_vpc.main.id
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = aws_route_table.private[*].id
+  tags              = merge(local.default_tags, { Name = "s3" })
+}


### PR DESCRIPTION
## Purpose
Adding endpoints to access ECR, S3 and Cloudwatch in order to limit outbound traffic for Tasks and Services. Part of #117. 

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] The product team have tested these changes
