### PR TITLE
DDPB-2991: Show APK packages in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,7 +327,6 @@ jobs:
           name: Push images
           command: docker-compose -f docker-compose.ci.yml push
 
-
   run-task:
     executor: terraform/terraform
     parameters:


### PR DESCRIPTION
## Purpose
It is difficult to know if a vulnerability will affect us, since it is not always clear what version of software we are running. We already lock and check NPM and composer dependencies, but need to be able to identify what version of each APK package is installed.

Fixes [DDPB-2991](https://opgtransform.atlassian.net/browse/DDPB-2991)

## Approach
Added new steps to CI process which use `apk list` to identify which packages are installed, and the version of each.

[You can see this in the CircleCI logs](https://app.circleci.com/jobs/github/ministryofjustice/opg-digideps/5362)

## Learning
I set up [Trivy](https://github.com/aquasecurity/trivy) in the CircleCI pipeline but found it to be time intensive and unreliable. Specifically, it always reported a libsass error (even on API where libsass isn't installed) and didn't complain at a version of PHP vulnerable to CVE-2019-11043.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
  - N/A
- [x] The product team have tested these change
  - N/A