### PR TITLE
DDPB-3013: Move backup and restore jobs after test suites

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,13 +33,13 @@ workflows:
 
       - run-task:
           name: client unit test
-          requires: [ restore environment  ]
+          requires: [ apply environment  ]
           filters: { branches: { ignore: [ master ] } }
           task_name: client_unit_test
 
       - run-task:
           name: api unit test
-          requires: [ restore environment ]
+          requires: [ apply environment ]
           filters: { branches: { ignore: [ master ] } }
           task_name: api_unit_test
           timeout: 600


### PR DESCRIPTION
## Purpose
A quick change to move the backup and restore tasks during feature branch pipelines to be after tests so we can get to test feedback approx 2.5 mins quicker.

Fixes [DDPB-3013](https://opgtransform.atlassian.net/browse/DDPB-3013)

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] The product team have tested these changes
