### PR TITLE
Update cloud9 instructions with mbstring package and github 2fa SSO info

### DIFF
--- a/docs/AWS-DB-ACCESS.md
+++ b/docs/AWS-DB-ACCESS.md
@@ -21,7 +21,7 @@ Production account:
 ### Upgrade to PHP 7.3 and install required libs
 ```bash
 sudo yum remove php*
-sudo yum install php73 php73-pdo php73-pgsql postgresql -y
+sudo yum install php73 php73-pdo php73-pgsql postgresql php73-mbstring.x86_64 -y
 ```
 
 ### Install composer
@@ -36,6 +36,7 @@ cd /tmp && curl -sS https://getcomposer.org/installer | php && sudo mv composer.
 git clone https://github.com/ministryofjustice/opg-digideps.git
 ```
 
+If you're getting invalid password or username here despite providing valid creds then its likely down to 2FA and SSO enforced on MOJ org. You can provide your personal access token instead of password - unfortunately unless you have this saved somewhere it will mean [generating a new token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line#creating-a-token) in github. Follow any feedback provided in the response regarding SSO.
 
 ### Run composer
 
@@ -43,8 +44,7 @@ git clone https://github.com/ministryofjustice/opg-digideps.git
 cd opg-digideps\api
 composer install
 ```
-It will ask you to set parameters. Set database host to postgres.environment-name.internal, and add database credentials for database. Leave the others as default (just press enter)
-
+It will ask you to set parameters. Set database host to postgres.<environment-name>.internal, and add database credentials for database (these are available in secrets manager and the ECS task definition for API). Leave the others as default (just press enter).
 
 ### Connect to database
 
@@ -52,7 +52,7 @@ It will ask you to set parameters. Set database host to postgres.environment-nam
 psql -h postgres.<environment name>.internal -U digidepsmaster api
 ```
 
-### Run migrations 
+### Run migrations
 #### WARNING: Migrations will execute against whichever database is set in parameters.yml
 ```bash
 cd opg-digideps\api


### PR DESCRIPTION
## Purpose
Updating Cloud9 steps to include a step to install `mbstring` extension which is a dependency of the latest version of `phpunit`.

I also encountered some issues when trying to clone the repo as I have 2FA and SSO enabled on my account. I've added some additional info to the repo cloning section in case anyone else has this.