### PR TITLE
DDPB-3081 - Bump Symfony version to fix cve-2019-18888

### DIFF
--- a/client/composer.json
+++ b/client/composer.json
@@ -9,7 +9,7 @@
     },
     "require": {
         "php": ">=7.3.5",
-        "symfony/symfony": "^3.4.28",
+        "symfony/symfony": "^3.4.35",
         "twig/extensions": "^1.5.4",
         "symfony/swiftmailer-bundle": "^3.0.0",
         "symfony/monolog-bundle": "^3.0.0",


### PR DESCRIPTION
## Purpose
Symfony version bump to fix [cve-2019-18888](https://symfony.com/cve-2019-18888)

Fixes [DDPB-3081](https://opgtransform.atlassian.net/browse/DDPB-3081)