### PR TITLE
Turn on autowiring and autoconfiguring

### DIFF
--- a/client/app/config/services.yml
+++ b/client/app/config/services.yml
@@ -22,9 +22,12 @@ services:
         resource: "@AppBundle/Controller/"
         tags: [controller.service_arguments]
 
-    redirector_service:
+    AppBundle\Service\Redirector:
         class: AppBundle\Service\Redirector
         arguments: [ "@security.token_storage", "@security.authorization_checker", "@router", "@session", "%env%" ]
+
+    redirector_service:
+        alias: AppBundle\Service\Redirector
 
     wkhtmltopdf:
         class: AppBundle\Service\WkHtmlToPdfGenerator

--- a/client/app/config/services_login.yml
+++ b/client/app/config/services_login.yml
@@ -9,6 +9,9 @@ services:
         class: AppBundle\Service\Client\TokenStorage\RedisStorage
         arguments: ["@snc_redis.default", "redis_token_storage_dd"]
 
-    deputy_provider:
-        class:  AppBundle\Service\DeputyProvider
+    AppBundle\Service\DeputyProvider:
+        class: AppBundle\Service\DeputyProvider
         arguments: [ "@rest_client", "@logger" ]
+
+    deputy_provider:
+        alias: AppBundle\Service\DeputyProvider

--- a/client/src/AppBundle/Controller/IndexController.php
+++ b/client/src/AppBundle/Controller/IndexController.php
@@ -3,24 +3,52 @@
 namespace AppBundle\Controller;
 
 use AppBundle\Form as FormDir;
+use AppBundle\Service\DeputyProvider;
+use AppBundle\Service\Redirector;
 use AppBundle\Service\StringUtils;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class IndexController extends AbstractController
 {
     /**
+     * @var DeputyProvider
+     */
+    private $deputyProvider;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    public function __construct(DeputyProvider $deputyProvider, EventDispatcherInterface $eventDispatcher, TokenStorageInterface $tokenStorage)
+    {
+        $this->deputyProvider = $deputyProvider;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    /**
      * @Route("/", name="homepage")
      */
-    public function indexAction()
+    public function indexAction(Redirector $redirector)
     {
-        if ($url = $this->get('redirector_service')->getHomepageRedirect()) {
+        if ($url = $redirector->getHomepageRedirect()) {
             return $this->redirect($url);
         }
 
@@ -32,7 +60,7 @@ class IndexController extends AbstractController
      * @Route("login", name="login")
      * @Template("AppBundle:Index:login.html.twig")
      */
-    public function loginAction(Request $request)
+    public function loginAction(Request $request, TranslatorInterface $translator)
     {
         $form = $this->createForm(FormDir\LoginType::class, null, [
             'action' => $this->generateUrl('login'),
@@ -53,9 +81,9 @@ class IndexController extends AbstractController
             } catch (\Throwable $e) {
                 $error = $e->getMessage();
 
-                if ($e->getCode() == 423) {
+                if ($e->getCode() == 423 && method_exists($e, 'getData')) {
                     $lockedFor = ceil(($e->getData()['data'] - time()) / 60);
-                    $error = $this->get('translator')->trans('bruteForceLocked', ['%minutes%' => $lockedFor], 'signin');
+                    $error = $translator->trans('bruteForceLocked', ['%minutes%' => $lockedFor], 'signin');
                 }
 
                 if ($e->getCode() == 499) {
@@ -71,6 +99,7 @@ class IndexController extends AbstractController
         }
 
         // different page version for timeout and manual logout
+        /** @var SessionInterface */
         $session = $request->getSession();
 
         if ($session->get('loggedOutFrom') === 'logoutPage') {
@@ -80,7 +109,7 @@ class IndexController extends AbstractController
                 ] + $vars);
         } elseif ($session->get('loggedOutFrom') === 'timeout' || $request->query->get('from') === 'api') {
             $session->set('loggedOutFrom', null); //avoid display the message at next page reload
-            $vars['error'] = $this->get('translator')->trans('sessionTimeoutOutWarning', [
+            $vars['error'] = $translator->trans('sessionTimeoutOutWarning', [
                 '%time%' => StringUtils::secondsToHoursMinutes($this->container->getParameter('session_expire_seconds')),
             ], 'signin');
         }
@@ -125,11 +154,12 @@ class IndexController extends AbstractController
      */
     private function logUserIn($credentials, Request $request, array $sessionVars)
     {
-        $user = $this->get('deputy_provider')->login($credentials);
+        $user = $this->deputyProvider->login($credentials);
         // manually set session token into security context (manual login)
         $token = new UsernamePasswordToken($user, null, 'secured_area', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
+        $this->tokenStorage->setToken($token);
 
+        /** @var SessionInterface */
         $session = $request->getSession();
         $session->set('_security_secured_area', serialize($token));
         foreach ($sessionVars as $k=>$v) {
@@ -140,7 +170,7 @@ class IndexController extends AbstractController
         $session->migrate();
 
         $event = new InteractiveLoginEvent($request, $token);
-        $this->get('event_dispatcher')->dispatch('security.interactive_login', $event);
+        $this->eventDispatcher->dispatch('security.interactive_login', $event);
 
         $session->set('lastLoggedIn', $user->getLastLoggedIn());
     }
@@ -170,7 +200,9 @@ class IndexController extends AbstractController
      */
     public function sessionKeepAliveAction(Request $request)
     {
-        $request->getSession()->set('refreshedAt', time());
+        /** @var SessionInterface */
+        $session = $request->getSession();
+        $session->set('refreshedAt', time());
 
         return new Response('session refreshed successfully');
     }
@@ -208,8 +240,12 @@ class IndexController extends AbstractController
      */
     public function logoutAction(Request $request)
     {
-        $this->get('security.token_storage')->setToken(null);
-        $request->getSession()->invalidate();
+        $this->tokenStorage->setToken(null);
+
+        /** @var SessionInterface */
+        $session = $request->getSession();
+        $session->invalidate();
+
         return $this->redirect(
             $this->generateUrl('homepage')
         );
@@ -238,7 +274,7 @@ class IndexController extends AbstractController
             ];
             setcookie(
                 'cookie_policy',
-                json_encode($settings),
+                strval(json_encode($settings)),
                 time() + (60 * 60 * 24 * 365),
                 '',
                 '',


### PR DESCRIPTION
## Purpose
We've manually disabled autowiring and autoconfiguring. These are core features of Symfony which reduce the amount of service definition we need to do in YAML files.

This branch re-enables those settings and demonstrates their use on `IndexController`.

## Approach
You can use autowiring in a class constructor without needing to make any YAML file changes:

```php
class IndexController {
  /** @var TranslatorInterface */
  private $translator;

  public function __construct(TranslatorInterface $translator)
  {
    $this->translator = $translator;
  }
}
```

You can also pull in services for a single route/action by putting them in the action arguments (again with no additional YAML configuration):

```php
public function deleteAction(int $documentId, DocumentService $documentService)
```