### PR TITLE
DDPB-3046: Remove ES6 syntax

### DIFF
--- a/client/src/AppBundle/Resources/assets/javascripts/modules/uploadProgressPA.js
+++ b/client/src/AppBundle/Resources/assets/javascripts/modules/uploadProgressPA.js
@@ -6,7 +6,7 @@ var uploadProgressPA = function (element) {
   var $uploadExplanation = $form.find('[data-js="upload-explanation"]')
   var $uploadError = $form.find('[data-js="upload-error"]')
 
-  $button.on('click', (event) => {
+  $button.on('click', function (event) {
     event.preventDefault()
 
     var redirectUrl = window.location.href
@@ -25,11 +25,11 @@ var uploadProgressPA = function (element) {
       contentType: false,
       xhrFields: {
         onprogress: function (e) {
-          const lines = e.currentTarget.response.split('\n')
+          var lines = e.currentTarget.response.split('\n')
 
-          lines.forEach(line => {
-            const log = line.split(' ')
-            const command = log.shift()
+          lines.forEach(function (line) {
+            var log = line.split(' ')
+            var command = log.shift()
 
             if (command === 'PROG') {
               $progress.val(parseInt(log[0]) / parseInt(log[1]))


### PR DESCRIPTION
## Purpose
The JavaScript introduced in DDPB-2997 used some ES6 syntax. This cannot be processed by older versions Internet Explorer, meaning all the JavaScript fails to load.

Fixes [DDPB-3046](https://opgtransform.atlassian.net/browse/DDPB-3046)

## Approach
I replaced the ES6 elements with ES5.

## Learning
I'm going to look at installing Babel to ensure back-compat.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
  - N/A
- [ ] The product team have tested these changes
