### PR TITLE
DDPB-3070: Throw more suitable exception

### DIFF
--- a/client/src/AppBundle/Controller/Admin/Client/ReportController.php
+++ b/client/src/AppBundle/Controller/Admin/Client/ReportController.php
@@ -6,7 +6,6 @@ use AppBundle\Controller\AbstractController;
 use AppBundle\Entity\Report\Checklist;
 use AppBundle\Entity\Report\Report;
 use AppBundle\Entity\ReportInterface;
-use AppBundle\Exception\DisplayableException;
 use AppBundle\Exception\ReportNotSubmittedException;
 use AppBundle\Form\Admin\ReviewChecklistType;
 use AppBundle\Form\Admin\ReportChecklistType;
@@ -22,7 +21,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
  * @Route("/admin/report/{id}/", requirements={"id":"\d+"})
@@ -101,7 +99,7 @@ class ReportController extends AbstractController
         $reportDueDate = $report->getDueDate();
 
         if (!$report->getSubmitted()) {
-            throw new DisplayableException('Only submitted report can be managed');
+            throw new ReportNotSubmittedException('Only submitted report can be managed');
         }
 
         $form = $this->createForm(UnsubmitReportType::class, $report);


### PR DESCRIPTION
## Purpose
The ReportController throws a `DisplayableException` when it should just show a 404 error.

This triggers the critical error alarm.

Fixes [DDPB-3070](https://opgtransform.atlassian.net/browse/DDPB-3070)

## Approach
I used our existing `ReportNotSubmittedException` exception which resolves to 404 errors, not 500s.

## Learning
This was identified through the more-aware alarm introduced in DDPB-3025

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
  - N/A
- [x] The product team have tested these changes
  - N/A
