### PR TITLE
DDPB-3081: Fixes deputy type search filter when used with full name s…

### DIFF
--- a/api/src/AppBundle/Entity/Repository/UserRepository.php
+++ b/api/src/AppBundle/Entity/Repository/UserRepository.php
@@ -160,10 +160,8 @@ class UserRepository extends AbstractEntityRepository
             $nameBasedQuery .= ' OR (lower(c.firstname) = :firstname AND lower(c.lastname) = :lastname)';
         }
 
-        $this->qb->setParameters([
-            'firstname' => strtolower($firstName),
-            'lastname' => strtolower($lastname),
-        ]);
+        $this->qb->setParameter('firstname', strtolower($firstName));
+        $this->qb->setParameter('lastname', strtolower($lastname));
 
         $this->qb->andWhere($nameBasedQuery);
     }

--- a/api/src/AppBundle/Service/Search/ClientSearchFilter.php
+++ b/api/src/AppBundle/Service/Search/ClientSearchFilter.php
@@ -48,6 +48,7 @@ class ClientSearchFilter
     private function addFullNameExactMatchFilter(string $firstName, string $lastname, QueryBuilder $qb, string $alias): void
     {
         $qb->andWhere('(lower('.$alias.'.firstname) = :firstname AND lower('.$alias.'.lastname) = :lastname)');
-        $qb->setParameters(['firstname' => strtolower($firstName), 'lastname' => strtolower($lastname),]);
+        $qb->setParameter('firstname', strtolower($firstName));
+        $qb->setParameter('lastname', strtolower($lastname));
     }
 }

--- a/behat/tests/features/admin/08-deputy-search.feature
+++ b/behat/tests/features/admin/08-deputy-search.feature
@@ -48,3 +48,12 @@ Feature: Deputy search
     When I search in admin for a deputy with the term "john 104-client" and include clients
     Then I should see "Found 1 users"
     And I should see "Lay Deputy 104 User"
+
+  @admin @admin-search @deputy-search
+  Scenario: Search exact name match across a specific deputy role
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    When I search in admin for a deputy with the term "Admin User" and filter role by "ROLE_PA_NAMED"
+    Then I should see "Found 0 users"
+    When I search in admin for a deputy with the term "Admin User" and filter role by "ROLE_ADMIN"
+    Then I should see "Found 1 users"
+    And I should see "Admin User"


### PR DESCRIPTION
## Purpose

Fixes [DDPB-3081](https://opgtransform.atlassian.net/browse/DDPB-3081)

## Approach


## Learning
Use individual calls to `setParameter` instead of `setParameters` when building a query dynamically.

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] The product team have tested these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
