### PR TITLE
DDPB-3095: Deleting a submitted document throws critical error

### DIFF
--- a/client/src/AppBundle/Controller/Report/DocumentController.php
+++ b/client/src/AppBundle/Controller/Report/DocumentController.php
@@ -249,7 +249,7 @@ class DocumentController extends AbstractController
         $document = $this->getDocument($documentId);
 
         if ($document->getReportSubmission() instanceof EntityDir\Report\ReportSubmission) {
-            return $this->renderError('Document already submitted and cannot be removed.', Response::HTTP_METHOD_NOT_ALLOWED);
+            return $this->renderError('Document already submitted and cannot be removed.', Response::HTTP_FORBIDDEN);
         }
 
         $this->denyAccessUnlessGranted(DocumentVoter::DELETE_DOCUMENT, $document, 'Access denied');


### PR DESCRIPTION
## Purpose
If you try and delete a submitted document it throws a critical error (RuntimeException). Instead, it should just tell the user that they can't delete a submitted document.

Fixes [DDPB-3095](https://opgtransform.atlassian.net/browse/DDPB-3095)

## Approach
Now shows a custom error to the user rather than throwing a critical exception and unnecessarily notifying us.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
  - N/A
- [x] The product team have tested these changes
  - N/A
