### PR TITLE
DDPB-3092: Migrate new team members to organisations

### DIFF
--- a/api/app/DoctrineMigrations/Version226.php
+++ b/api/app/DoctrineMigrations/Version226.php
@@ -39,7 +39,10 @@ final class Version226 extends AbstractMigration implements ContainerAwareInterf
                 continue;
             }
 
-            $organisation->addUser($user);
+            if (count($user->getOrganisations()) === 0) {
+                $organisation->addUser($user);
+            }
+
             $this->attachUsersTeamMembersToOrganisation($organisation, $user->getTeams());
 
             $em->flush();


### PR DESCRIPTION
## Purpose
We previously ran Migration217 (DDPB-2794) to move people from teams to organisations. However, since that migration (9th September 2019), new users have been added to teams. If we were to activate the corresponding organisations, our membership information would be three months out of date.

Out of date information would also affect our report of organisations with problems, meaning we can’t automatically activate as many orgs.

We need to rerun the migration to ensure that the organisation membership is up-to-date.

Fixes [DDPB-3092](https://opgtransform.atlassian.net/browse/DDPB-3092)

## Approach
I duplicated migration `Version217`, but with a couple of changes:

- I removed the code for creating organisations: if the organisation was created by the CSV then there's no reason to set up one with no clients in it.
- I stopped setting the organisation if a user is already in an active organisation: otherwise we could change active permissions for users who've already switched to organisation logic. Users can still be switched into an active organisation if they're not currently in one (e.g. users added since 9th Sep)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
  - N/A
- [ ] The product team have tested these changes