### PR TITLE
DDPB-3087: Remove duplicate Money transfers summary in lodging checklist

### DIFF
--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/partials/_money-in-and-out.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/partials/_money-in-and-out.html.twig
@@ -171,27 +171,6 @@
 
 {{ checklist_radios(form.moneyMovementsAcceptable) }}
 
-{# Don't show money transfers for short finance reports #}
-{% if report.hasSection('moneyTransfers') %}
-    {% if report.enoughBankAccountForTransfers %}
-        {% set contents %}
-            {% include 'AppBundle:Report/MoneyTransfer:_list.html.twig' with {
-                hideEditLink: true
-            } %}
-        {% endset %}
-
-        {{ macros.details({
-            summaryText: (page ~ '.revealTitle.moneyTransfersSummary') | trans,
-            text: contents,
-            classes: 'govuk-!-margin-bottom-0',
-        }) }}
-    {% else %}
-        <p class="govuk-body">
-            {{ (page ~ '.noTransferToShow') | trans }}
-        </p>
-    {% endif %}
-{% endif %}
-
 {{ include('AppBundle:Admin/Client/Report/partials:_money-summaries.html.twig', { collapseMargin: true }) }}
 
 {% if report.hasSection('gifts') %}


### PR DESCRIPTION
## Purpose
Money transfers answers are displaying twice in the lodging checklist.

Fixes [DDPB-3087](https://opgtransform.atlassian.net/browse/DDPB-3087)

## Approach
I removed the summary from `_money-in-and-out.html.twig`. It's now in `_money-summaries.html.twig` which is also used by the full review checklist.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
  - N/A
- [x] The product team have tested these changes

### Frontend
- [x] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [x] There are no deprecated CSS classes noted in the profiler
- [x] Translations are used and the profiler doesn't identify any missing
