### PR TITLE
DDPB-3106: checks data types in OrgService before invoking methods to…

### DIFF
--- a/api/src/AppBundle/Service/OrgService.php
+++ b/api/src/AppBundle/Service/OrgService.php
@@ -265,12 +265,15 @@ class OrgService
 
         if ($client && $this->clientHasSwitchedOrganisation($client)) {
             $csvDeputyNo = EntityDir\User::padDeputyNumber($row['Deputy No']);
-            if ($client->getNamedDeputy() instanceof EntityDir\NamedDeputy && $client->getNamedDeputy()->getDeputyNo() !== $csvDeputyNo) {
+
+            if (is_null($client->getNamedDeputy())) {
+                throw new \RuntimeException('Can\'t determine if deputy has moved with client to new org');
+            } else if ($client->getNamedDeputy()->getDeputyNo() === $csvDeputyNo) {
+                $client->setOrganisation(null);
+            } else {
                 // discharge client and recreate new one
                 $this->dischargeClient($client);
                 unset($client);
-            } else {
-                $client->setOrganisation(null);
             }
         }
 


### PR DESCRIPTION
… prevent fatal errors which prevent furhter processing of the row

## Purpose
For clients that have moved to new orgs since they were put into their previous orgs, we are reading their `$client->getNamedDeputy()`. However, since DDPB-3020, that will be null because we haven't reach the area of code that reassigns it. Therefore, all clients that have moved orgs will remain in the old org, and without a named deputy.

We also have instances of clients not having an org at all yet, and so when we attempt to verify if they have switched orgs, we call `$organisation->getId()` on null. Again causing an error that results in the client not making it to the org.

It is still unknown how clients exist in the db without an org. One feasible scenario is for clients that were previously lay, but are now prof/pa - they will exist but without an org. Stacey is verifying if that is the case for the reported clients.

This PR will ensure that clients are assigned a named deputy. For discharged clients, we will need to re-upload to CSV a second time to process the discharge

Fixes [DDPB-####](https://opgtransform.atlassian.net/browse/DDPB-####)

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] The product team have tested these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
