### PR TITLE
DDPB-3110: Money transfer delete confirmation page throws 500

### DIFF
--- a/client/src/AppBundle/Controller/Report/MoneyTransferController.php
+++ b/client/src/AppBundle/Controller/Report/MoneyTransferController.php
@@ -111,6 +111,11 @@ class MoneyTransferController extends AbstractController
         // create (add mode) or load transaction (edit mode)
         if ($transferId) {
             $transfer = $report->getMoneyTransferWithId($transferId);
+
+            if (is_null($transfer)) {
+                throw $this->createNotFoundException('Transfer not found');
+            }
+
             $transfer->setAccountFromId($transfer->getAccountFrom()->getId());
             $transfer->setAccountToId($transfer->getAccountTo()->getId());
         } else {

--- a/client/src/AppBundle/Entity/Report/Traits/ReportTransfersTrait.php
+++ b/client/src/AppBundle/Entity/Report/Traits/ReportTransfersTrait.php
@@ -33,7 +33,7 @@ trait ReportTransfersTrait
     }
 
     /**
-     * @return MoneyTransfer
+     * @return MoneyTransfer|null
      */
     public function getMoneyTransferWithId($id)
     {
@@ -43,7 +43,7 @@ trait ReportTransfersTrait
             }
         }
 
-        return;
+        return null;
     }
 
 


### PR DESCRIPTION
## Purpose
If you access the delete confirmation page for a non-existent money transfer (for example, pressing "back" after deleting one), the page throws a 500 "Application Error" and alerts the service team.

It should instead just return 404 and alert no-one.

Fixes [DDPB-3110](https://opgtransform.atlassian.net/browse/DDPB-3110)

## Approach
Updated `getMoneyTransferWithId` to return null when not found, updated `MoneyTransferController` to handle null values from that function.

The [actual change](https://github.com/ministryofjustice/opg-digideps/pull/182/files#diff-a7a2aead94adf3c6290c3e45f11765d6R255-R257) is quite small, the rest is just PHPStan.

## Learning
Once the PHPDoc for `getMoneyTransferWithId` had been updated the rest was basically just fixing PHPStan errors, which was a ringing endorsement for PHPStan.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
  - I have not, but adding a new test for just checking a HTTP status code seems overkill. In a perfect world we'd already have PHPUnit tests for the controller, and I could add a quick "deleteActionReturns404IfDeleted" test.
- [x] The product team have tested these changes
  - N/A
