### PR TITLE
DDPB-3111: Throw 404 error when document cannot be retrieved from S3

### DIFF
--- a/client/src/AppBundle/Service/File/Storage/S3Storage.php
+++ b/client/src/AppBundle/Service/File/Storage/S3Storage.php
@@ -58,15 +58,13 @@ class S3Storage implements StorageInterface
      * header('Content-Disposition: attachment; filename="' . $_GET['filename'] .'"');
      * readfile(<this method>);
      *
-     *
-     * @param $bucketName
      * @param $key
      *
      * @throws FileNotFoundException is the file is not found
      *
      * @return string file content
      */
-    public function retrieve($key)
+    public function retrieve(string $key)
     {
         // If a file is deleted in S3 it will return an AccessDenied error until its permanently deleted
         $missingFileAWSErrorCodes = ['NoSuchKey', 'AccessDenied'];

--- a/client/src/AppBundle/Service/File/Storage/StorageInterface.php
+++ b/client/src/AppBundle/Service/File/Storage/StorageInterface.php
@@ -4,7 +4,7 @@ namespace AppBundle\Service\File\Storage;
 
 interface StorageInterface
 {
-    public function retrieve($key);
+    public function retrieve(string $key);
 
     public function delete($key);
 


### PR DESCRIPTION
## Purpose
We are currently throwing a 500 error when trying to retrieve a document that either does not exist or has expired resulting in critical alarms being triggered. This change throws a 404 and friendly error message instead.

Fixes [DDPB-3111](https://opgtransform.atlassian.net/browse/DDPB-3111)

## Approach
As with #182, it would have been nice to have a regression test for this but its a big chunk of work mocking out the RestClient.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] The product team have tested these changes
