### PR TITLE
DDPB-3126: Don't crash clamav when reloading definitions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,8 +151,8 @@ services:
     file-scanner-server:
         image: mkodockx/docker-clamav
         environment:
-            CLAMD_CONF_SelfCheck: 1800
-            FRESHCLAM_CONF_NotifyClamd: 'no'
+            CLAMD_CONF_SelfCheck: 0
+            FRESHCLAM_CONF_NotifyClamd: /etc/clamav/clamd.conf
 
     file-scanner-rest:
         image: lokori/clamav-rest

--- a/environment/scan.tf
+++ b/environment/scan.tf
@@ -107,8 +107,8 @@ EOF
         }
       },
       "environment": [
-        { "name": "CLAMD_CONF_SelfCheck", "value": "1800" },
-        { "name": "FRESHCLAM_CONF_NotifyClamd", "value": "no" }
+        { "name": "CLAMD_CONF_SelfCheck", "value": "0" },
+        { "name": "FRESHCLAM_CONF_NotifyClamd", "value": "/etc/clamav/clamd.conf" }
       ]
   }
 


### PR DESCRIPTION
**This is currently just a test to see if it resolves the existing problem.**

## Purpose
ClamAV sometimes crashes when reloading definitions.

We suspect this may be related to the configuration, which causes freshclam to notify ClamAV of updates but also asks ClamAV to check itself. These two procedures happen at very similar times, due to being based on the initial deployment time of the container. We suspect they're conflicting.

Fixes [DDPB-3126](https://opgtransform.atlassian.net/browse/DDPB-3126)

## Approach
I disabled freshclam's notification features, [as suggested in the docs](https://linux.die.net/man/5/freshclam.conf) and reduced ClamAV's self-check time to the default 1800 seconds.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] The product team have tested these changes
