### PR TITLE
DDPB-3143: temp removal or report download btn in admin

### DIFF
--- a/behat/tests/features/deputy/03-report/04-post-submit/00-report-download-admin.feature
+++ b/behat/tests/features/deputy/03-report/04-post-submit/00-report-download-admin.feature
@@ -4,10 +4,11 @@ Feature: As an admin user, in order to ensure correct report PDFs can always be 
   Scenario: Case manager user downloads a report that has been submitted
     Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
     When I click on "client-detail-102"
-    And I follow "Download"
-    Then the response status code should be 200
-    And the response should have the "Content-Type" header containing "application/pdf"
-    And the response should have the "Content-Disposition" header containing ".pdf"
+    Then I should not see "Download"
+#    And I follow "Download"
+#    Then the response status code should be 200
+#    And the response should have the "Content-Type" header containing "application/pdf"
+#    And the response should have the "Content-Disposition" header containing ".pdf"
 
   @deputy @download-reports
   Scenario: Case manager cannot download a non submitted report

--- a/client/src/AppBundle/Resources/views/Admin/Client/Client/details.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Client/details.html.twig
@@ -186,8 +186,8 @@
                             <br />
                         {% endif %}
                         {% if enableDownloadLink %}
-                            <a href="{{ path('report_pdf', {'reportId': report.id}) }}"
-                               class="behat-link-download">{{ 'download' | trans({}, 'common') }}</a>
+{#                            <a href="{{ path('report_pdf', {'reportId': report.id}) }}"#}
+{#                               class="behat-link-download">{{ 'download' | trans({}, 'common') }}</a>#}
                         {% endif %}
                     </td>
                 </tr>


### PR DESCRIPTION
## Purpose
As an admin user, in order to prevent misuse of the report generation feature, I want the feature disabled until I fully understand when it should be used.

Fixes [DDPB-3143](https://opgtransform.atlassian.net/browse/DDPB-3143)

## Approach
Given that we intend to re-add the functionality, I have simply commented out. If a decision is made to remove, we can remove the commented code.

## Learning


## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] The product team have tested these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
