### PR TITLE
Only look for moderate and above vulnerabilities

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -12,7 +12,7 @@ RUN npm install
 
 # Check linting
 RUN npm run lint
-RUN npm audit
+RUN npm audit --audit-level=moderate
 
 # Build assets
 RUN NODE_ENV=production npm run build


### PR DESCRIPTION
There's currently a [low-level vulnerability](https://www.npmjs.com/advisories/961) that's blocking all builds. This will allow us to unblock the pipeline whilst still stopping at moderate, high and severe vulnerabilities.

NB: The node-sass vulnerability is a potential Denial of Service which can only occur with specially crafted input. This would require an attacker to change our or a dependency's CSS, and would crash our build pipeline not the application. Also, this vulnerability [has not been disclosed to the node-sass team](https://github.com/sass/node-sass/issues/2816#issuecomment-574097368) and there is no CVE, so there is very little understanding of the actual issue.

I'll add a note to the risk board to discuss long-term plans for this situation next week.