### PR TITLE
DDPB-3148: Fix triggers

### DIFF
--- a/environment/scheduler.tf
+++ b/environment/scheduler.tf
@@ -9,7 +9,6 @@ resource "aws_cloudwatch_event_rule" "redeploy_file_scanner" {
   tags                = local.default_tags
 }
 
-
 resource "aws_cloudwatch_event_target" "redeploy_file_scanner" {
   rule  = aws_cloudwatch_event_rule.redeploy_file_scanner.name
   arn   = data.aws_lambda_function.redeployer_lambda.arn
@@ -19,4 +18,12 @@ resource "aws_cloudwatch_event_target" "redeploy_file_scanner" {
       "service": "${aws_ecs_service.scan.name}"
     }
   EOF
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_call_lambda" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = data.aws_lambda_function.redeployer_lambda.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.redeploy_file_scanner.arn
 }


### PR DESCRIPTION
## Purpose
The Lambda needs a permission set up to allow CloudWatch to call it: it isn't sufficent to just tell CloudWatch to do so.

Fixes [DDPB-3148](https://opgtransform.atlassian.net/browse/DDPB-3148)

## Approach
I added a `aws_lambda_permission` record to specifically allow my CloudWatch event rule to trigger the redeployer Lambda.

## Learning
I missed that this resource was necessary, though it does say so [in the Terraform documentation](https://www.terraform.io/docs/providers/aws/r/cloudwatch_event_target.html#argument-reference). It was unexpected but makes sense in retrospect: you don't want your Lambdas to just be callable by anybody.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
  - N/A
- [x] The product team have tested these changes
  - N/A