### PR TITLE
DDPB-3126: Use unique statement ID in Lambda permission

### DIFF
--- a/environment/scheduler.tf
+++ b/environment/scheduler.tf
@@ -21,7 +21,7 @@ resource "aws_cloudwatch_event_target" "redeploy_file_scanner" {
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_call_lambda" {
-  statement_id  = "AllowExecutionFromCloudWatch"
+  statement_id  = "AllowExecutionFrom-${aws_cloudwatch_event_rule.redeploy_file_scanner.name}"
   action        = "lambda:InvokeFunction"
   function_name = data.aws_lambda_function.redeployer_lambda.function_name
   principal     = "events.amazonaws.com"


### PR DESCRIPTION
## Purpose
Lambda permission statement IDs need to be unique within an account.

Fixes [DDPB-3126](https://opgtransform.atlassian.net/browse/DDPB-3126)

## Approach
Since we have oone permission per-environment, I made the statement ID vary by the environment name.

## Learning
Again, with closer inspection of the docs I could have spotted this sooner.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
  - N/A
- [x] The product team have tested these changes
  - N/A