### PR TITLE
Add initial ADR

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/architecture/decisions

--- a/docs/architecture/decisions/0001-record-architecture-decisions.md
+++ b/docs/architecture/decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2020-01-22
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).


### PR DESCRIPTION
## Purpose
Per [decision from retrospective](https://opgtransform.atlassian.net/wiki/spaces/DigiDeps/pages/1289027585/2020-01-21+Retrospective), adding an ADR to acknowledge our intent to record ADRs.

## Approach
Used [adr-tools](https://github.com/npryce/adr-tools) to initiliaze our ADR repository.

## Learning
Future architectural decisions will be recorded in ADRs, often as the output of spikes.