### PR TITLE
DDPB-3062: Adds users and client totals to org view page in admin

### DIFF
--- a/client/src/AppBundle/Resources/views/Admin/Organisation/view.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Organisation/view.html.twig
@@ -27,7 +27,7 @@
 
     <table class="govuk-table">
         <caption class="govuk-table__caption">
-            {{ (page ~ '.users.caption') | trans }}
+            {{ (page ~ '.users.caption') | trans }} ({{ organisation.users | length }} in total)
         </caption>
 
         <thead class="govuk-table__head">
@@ -77,7 +77,7 @@
 
     <table class="govuk-table">
         <caption class="govuk-table__caption">
-            {{ (page ~ '.clients.caption') | trans }}
+            {{ (page ~ '.clients.caption') | trans }} ({{ organisation.clients | length }} in total)
         </caption>
 
         <thead class="govuk-table__head">


### PR DESCRIPTION
## Purpose
As a PA/Professional user
I want to see the number of clients in each organisation 
So I know how many clients each organisation has

Fixes [DDPB-3602](https://opgtransform.atlassian.net/browse/DDPB-3602)

## Approach
This is the 1st phase which is to simply display the counts to the user.
A 2nd phase will focus on a better design, but this provides useful information in the meantime.

## Learning


## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] The product team have tested these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
