### PR TITLE
DDPB-3057: Revert "Remove unused healthcheck config"

### DIFF
--- a/environment/api_service.tf
+++ b/environment/api_service.tf
@@ -15,6 +15,10 @@ resource "aws_service_discovery_service" "api" {
 
     routing_policy = "MULTIVALUE"
   }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
 }
 
 resource "aws_ecs_task_definition" "api" {

--- a/environment/scan.tf
+++ b/environment/scan.tf
@@ -15,6 +15,10 @@ resource "aws_service_discovery_service" "scan" {
 
     routing_policy = "MULTIVALUE"
   }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
 }
 
 resource "aws_iam_role" "scan" {

--- a/environment/wkhtmltopdf.tf
+++ b/environment/wkhtmltopdf.tf
@@ -15,6 +15,10 @@ resource "aws_service_discovery_service" "wkhtmltopdf" {
 
     routing_policy = "MULTIVALUE"
   }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
 }
 
 resource "aws_iam_role" "wkhtmltopdf" {


### PR DESCRIPTION
In DDPB-3057, I casually removed some unnecessary healthcheck config. It wasn't causing a problem, just untidy.

However, whilst this looks like a trivial change in Terraform, it actually requires _manually_ stopping every service-discoverable task (API, wkhtmltopdf, virus scanner), deregistering them and deleting the service. This necessarily causes downtime.

Given the original task was just to tidy up some code, I suggest we revert the tidying and accept the mess for now. The risk and cost of manually shutting off our production service isn't worth the original tidying.

With regard to the original task, I'll exclude the Trusted Advisor check which warned us about this.