### PR TITLE
DDPB-3089 - Add UpdateOrgName command

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -30,7 +30,8 @@
     "snc/redis-bundle": "^2.1.9",
     "predis/predis": "^1.1.1",
     "stof/doctrine-extensions-bundle": "^1.3.0",
-    "monolog/monolog": "^1.25.1"
+    "monolog/monolog": "^1.25.1",
+    "league/csv": "^9.5"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0.0",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca08767ca6fb8d20153970869266a678",
+    "content-hash": "8f53201edc6a99dd8724645200b28c2e",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -1758,6 +1758,75 @@
                 "xml"
             ],
             "time": "2019-03-30T10:26:09+00:00"
+        },
+        {
+            "name": "league/csv",
+            "version": "9.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/csv.git",
+                "reference": "b348d09d0d258a4f068efb50a2510dc63101c213"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/csv/zipball/b348d09d0d258a4f068efb50a2510dc63101c213",
+                "reference": "b348d09d0d258a4f068efb50a2510dc63101c213",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=7.0.10"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "friendsofphp/php-cs-fixer": "^2.12",
+                "phpstan/phpstan": "^0.9.2",
+                "phpstan/phpstan-phpunit": "^0.9.4",
+                "phpstan/phpstan-strict-rules": "^0.9.0",
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-iconv": "Needed to ease transcoding CSV using iconv stream filters"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Csv\\": "src"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://github.com/nyamsprod/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Csv data manipulation made easy in PHP",
+            "homepage": "http://csv.thephpleague.com",
+            "keywords": [
+                "csv",
+                "export",
+                "filter",
+                "import",
+                "read",
+                "write"
+            ],
+            "time": "2019-12-15T19:51:41+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -3781,6 +3850,7 @@
                 "code",
                 "zf"
             ],
+            "abandoned": "laminas/laminas-code",
             "time": "2019-10-05T23:18:22+00:00"
         },
         {
@@ -3835,6 +3905,7 @@
                 "events",
                 "zf2"
             ],
+            "abandoned": "laminas/laminas-eventmanager",
             "time": "2018-04-25T15:33:34+00:00"
         }
     ],
@@ -5492,8 +5563,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "role": "lead",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
             "description": "Simple template engine.",

--- a/api/src/AppBundle/Command/UpdateOrgNames.php
+++ b/api/src/AppBundle/Command/UpdateOrgNames.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types=1);
+
+
+namespace AppBundle\Command;
+
+
+use AppBundle\Entity\Repository\OrganisationRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\NonUniqueResultException;
+use League\Csv\Reader;
+use League\Csv\Statement;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Finder\Finder;
+
+class UpdateOrgNames extends Command
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    private $em;
+    /**
+     * @var OrganisationRepository
+     */
+    private $repository;
+
+    /**
+     * CsvImportCommand constructor.
+     *
+     * @param EntityManagerInterface $em
+     * @param OrganisationRepository $repository
+     */
+    public function __construct(EntityManagerInterface $em, OrganisationRepository $repository)
+    {
+        parent::__construct();
+
+        $this->em = $em;
+        $this->repository = $repository;
+    }
+
+    /**
+     * Configure
+     * @throws InvalidArgumentException
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('orgs:update:names')
+            ->setDescription('Updates the name of an org based on a CSV with email identifier and org name')
+            ->addArgument('CSVName', InputArgument::REQUIRED, 'The name of the CSV')
+        ;
+    }
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @return void
+     * @throws NonUniqueResultException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): void
+    {
+        $io = new SymfonyStyle($input, $output);
+        $fileName = $input->getArgument('CSVName');
+        $fileLocation = $this->getFileLocation($fileName);
+
+        if (empty($fileLocation)) {
+            $io->error("Could not find file with name $fileName");
+            return;
+        }
+
+        $csv = Reader::createFromPath($fileLocation);
+        $csv->setHeaderOffset(0);
+
+        $records = (new Statement())->process($csv);
+
+        $success = 0;
+        $failure = 0;
+
+        foreach ($records as $row) {
+            $org = $this->repository->findByEmailIdentifier($row['email_identifier']);
+
+            if ($org !== null) {
+                $org->setName($row['organisation_name']);
+                $this->em->persist($org);
+                ++$success;
+            } else {
+                ++$failure;
+            }
+        }
+
+        $this->em->flush();
+
+        $io->success("Successfully updated $success, failed to update $failure");
+    }
+
+    /**
+     * @param string $fileName
+     * @return false|string
+     */
+    private function getFileLocation(string $fileName)
+    {
+        $finder = new Finder();
+        $finder->files()->in('*')->name($fileName);
+        $absoluteFilePath = '';
+
+        foreach ($finder as $file) {
+            $absoluteFilePath = $file->getRealPath();
+        }
+
+        return $absoluteFilePath;
+    }
+
+}

--- a/api/tests/AppBundle/Command/UpdateOrgNamesTest.php
+++ b/api/tests/AppBundle/Command/UpdateOrgNamesTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Tests\AppBundle\Command;
+
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class UpdateOrgNamesTest extends KernelTestCase
+{
+    /** @dataProvider fileNameProvider */
+    public function testExecute($fileName, $expectedOutput)
+    {
+        $kernel = static::createKernel();
+        $application = new Application($kernel);
+
+        $command = $application->find('orgs:update:names');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['CSVName' => $fileName]);
+
+        $output = $commandTester->getDisplay();
+        self::assertStringContainsString($expectedOutput, $output);
+    }
+
+    public function fileNameProvider()
+    {
+        return [
+            'File name exists' => ['orgNameUpdate.csv', 'Successfully updated 0, failed to update 2'],
+            'File name does not exist' => ['nonExistentFile.csv', 'Could not find file with name nonExistentFile.csv'],
+        ];
+    }
+}

--- a/api/tests/AppBundle/TestData/orgNameUpdate.csv
+++ b/api/tests/AppBundle/TestData/orgNameUpdate.csv
@@ -1,0 +1,3 @@
+email_identifier,organisation_name,
+fakeOrg.co.uk,,
+anotherFakeOrg.com,FAKE ORG LLP,


### PR DESCRIPTION
## Purpose
Adds a Symfony console command we can run to update Org names based on email identifier.

Fixes [DDPB-3089](https://opgtransform.atlassian.net/browse/DDPB-3089)

## Approach
I was a little wary of trying to put together the raw SQL so I've handed off the responsibility to Doctrine instead and wrapped it up in a command. I'm planning to run this in cloud9 and manually add the CSV file with the Orgs in where required as I didn't really want to have to commit the file and then drop it in a later commit.

## Learning
I've used an out the box CSV parser for this which was pretty nice to work with (https://csv.thephpleague.com/). Could be something to look into if we need to change how we're uploading CSVs from Sirius rather than trying to roll our own.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] The product team have tested these changes
