### PR TITLE
DDPB 3179: Silence unnecessary scanner alerts

### DIFF
--- a/client/src/AppBundle/Service/File/Scanner/ClamFileScanner.php
+++ b/client/src/AppBundle/Service/File/Scanner/ClamFileScanner.php
@@ -61,6 +61,7 @@ class ClamFileScanner
         }
 
         if (!$response instanceof Response) {
+            $this->logger->error(sprintf('Scanner service down: %s', $e->getMessage()));
             throw new \RuntimeException('Scanner service not available');
         }
 

--- a/client/src/AppBundle/Service/File/Scanner/ClamFileScanner.php
+++ b/client/src/AppBundle/Service/File/Scanner/ClamFileScanner.php
@@ -61,7 +61,6 @@ class ClamFileScanner
         }
 
         if (!$response instanceof Response) {
-            $this->logger->critical(sprintf('Scanner service down: %s', $e->getMessage()));
             throw new \RuntimeException('Scanner service not available');
         }
 

--- a/client/tests/phpunit/Service/File/Scanner/ClamFileScannerTest.php
+++ b/client/tests/phpunit/Service/File/Scanner/ClamFileScannerTest.php
@@ -93,7 +93,7 @@ class ClamFileScannerTest extends TestCase
 
         $this
             ->ensureServiceIsForeverUnavailable()
-            ->ensureCriticalWillBeLogged()
+            ->ensureErrorWillBeLogged()
             ->invokeTest('file.pdf');
     }
 
@@ -186,12 +186,12 @@ class ClamFileScannerTest extends TestCase
     /**
      * @return ClamFileScannerTest
      */
-    private function ensureCriticalWillBeLogged(): ClamFileScannerTest
+    private function ensureErrorWillBeLogged(): ClamFileScannerTest
     {
         $this
             ->logger
             ->expects($this->once())
-            ->method('critical')
+            ->method('error')
             ->with('Scanner service down: unavailable');
 
         return $this;


### PR DESCRIPTION
## Purpose
Ensure the UX is adequate in the case of a failed scan, and prevent the unnecessary critical alert.

Fixes [DDPB-3179](https://opgtransform.atlassian.net/browse/DDPB-3179)

## Approach
The UX is handled reasonably gracefully as the error is caught and a message to retry is displayed to the user, which usually resolves the issue first time.

The log that we write to manually has been downgraded to an `error` status to prevent firing off a critical alert. There is no sign that previous occurrences have not been more or less instantly recoverable by a retry, so it feels reasonable to downgrade the error level. If we ever have a persistent outage, we can look at setting up a separate alert that monitors the success rate of scanner requests within an hour, to help capture it earlier.

## Learning


## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] The product team have tested these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
