### PR TITLE
DDPB-3032: Don't autowire Swift_SmtpTransport

### DIFF
--- a/client/app/config/services_mail.yml
+++ b/client/app/config/services_mail.yml
@@ -4,6 +4,7 @@ services:
         autoconfigure: true
 
     mailer.transport.smtp.default:
+        autowire: false
         class: Swift_SmtpTransport
         arguments: [ "%smtp_default_hostname%", "%smtp_default_port%" ]
         calls:


### PR DESCRIPTION
It can't autowire its calls properly
