### PR TITLE
Use email_domain for from_address in both prod and non-prod envs

### DIFF
--- a/client/docker/confd/templates/parameters.yml.tmpl
+++ b/client/docker/confd/templates/parameters.yml.tmpl
@@ -30,7 +30,7 @@ parameters:
         feedback_send_to_address: digideps+feedback@digital.justice.gov.uk
         update_send_to_address: laydeputysupport@publicguardian.gov.uk
         {{ else }}
-        from_email: noreply-opgdeputyservice@digital.justice.gov.uk
+        from_email: noreply-opgdeputyservice@{{ getv "/email/domain" }}
         report_submit_to_address: digideps+noop@digital.justice.gov.uk
         feedback_send_to_address: digideps+noop@digital.justice.gov.uk
         update_send_to_address: digideps+noop@digital.justice.gov.uk


### PR DESCRIPTION
## Purpose
We have some kind fo domain checking as part of our custom email service that was failing when the from_address on emails didn't match `complete-deputy-report.service.gov.uk`. This change ensures the domain will be set as required in all envs.
