### PR TITLE
Ddpb 3181: CSV upload from Sirius

### DIFF
--- a/api/app/DoctrineMigrations/Version228.php
+++ b/api/app/DoctrineMigrations/Version228.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version228 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE casrec ADD source VARCHAR(255) NOT NULL DEFAULT \'casrec\'');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE casrec DROP source');
+    }
+}

--- a/api/app/DoctrineMigrations/Version228.php
+++ b/api/app/DoctrineMigrations/Version228.php
@@ -22,7 +22,7 @@ final class Version228 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
 
-        $this->addSql('ALTER TABLE casrec ADD source VARCHAR(255) NOT NULL DEFAULT \'casrec\'');
+        $this->addSql('ALTER TABLE casrec ADD source VARCHAR(255) DEFAULT \'casrec\'');
     }
 
     public function down(Schema $schema) : void

--- a/api/app/config/services/assemblers.yml
+++ b/api/app/config/services/assemblers.yml
@@ -20,3 +20,7 @@ services:
 
   PlainOrganisationAssembler:
     class: AppBundle\v2\Assembler\OrganisationAssembler
+
+  AppBundle\v2\Registration\Assembler\CasRecToLayDeputyshipDtoAssembler: ~
+  AppBundle\v2\Registration\Assembler\LayDeputyshipDtoAssemblerInterface: '@AppBundle\v2\Registration\Assembler\CasRecToLayDeputyshipDtoAssembler'
+

--- a/api/app/config/services/repositories.yml
+++ b/api/app/config/services/repositories.yml
@@ -39,3 +39,9 @@ services:
     factory: ["@doctrine.orm.entity_manager", getRepository]
     arguments:
       - AppBundle\Entity\NamedDeputy
+
+  AppBundle\Entity\Repository\CasRecRepository:
+    class: AppBundle\Entity\CasRec
+    factory: ["@doctrine.orm.entity_manager", getRepository]
+    arguments:
+      - AppBundle\Entity\CasRec

--- a/api/src/AppBundle/Controller/CasRecController.php
+++ b/api/src/AppBundle/Controller/CasRecController.php
@@ -29,7 +29,7 @@ class CasRecController extends RestController
     public function deleteBySource(CasRecRepository $casRecRepository, $source)
     {
         if (!in_array($source, CasRec::validSources())) {
-            return new JsonResponse(['Invalid source'], 400);
+            throw new \InvalidArgumentException(sprintf('Invalid source: %s', $source));
         }
 
         $result = $casRecRepository->deleteAllBySource($source);

--- a/api/src/AppBundle/Controller/CasRecController.php
+++ b/api/src/AppBundle/Controller/CasRecController.php
@@ -40,7 +40,7 @@ class CasRecController extends RestController
     public function deleteBySource($source)
     {
         if (!in_array($source, CasRec::validSources())) {
-            return new JsonResponse('Invalid source', 400);
+            return new JsonResponse(['Invalid source'], 400);
         }
 
         /** @var QueryBuilder $qb */

--- a/api/src/AppBundle/Entity/CasRec.php
+++ b/api/src/AppBundle/Entity/CasRec.php
@@ -200,7 +200,9 @@ class CasRec
         $this->deputyPostCode = self::normaliseSurname($row['Dep Postcode']);
         $this->typeOfReport = self::normaliseCorrefAndTypeOfRep($row['Typeofrep']);
         $this->corref = self::normaliseCorrefAndTypeOfRep($row['Corref']);
-        $this->source = isset($row['source']) ? strtolower($row['source']) : self::CASREC_SOURCE;
+
+        $source = isset($row['Source']) ? $row['Source'] : self::CASREC_SOURCE;
+        $this->setSource($source);
 
         $this->otherColumns = serialize($row);
         $this->createdAt = new \DateTime();
@@ -392,6 +394,11 @@ class CasRec
      */
     public function setSource($source)
     {
+        $source = strtolower($source);
+        if (!in_array($source, self::validSources())) {
+            throw new \InvalidArgumentException(sprintf('Attempting to set invalid source: %s given', $source));
+        }
+
         $this->source = $source;
         return $this;
     }

--- a/api/src/AppBundle/Entity/CasRec.php
+++ b/api/src/AppBundle/Entity/CasRec.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Table(name="casrec", indexes={@ORM\Index(name="updated_at_idx", columns={"updated_at"})})
- * @ORM\Entity()
+ * @ORM\Entity(repositoryClass="AppBundle\Entity\Repository\CasRecRepository")
  */
 class CasRec
 {
@@ -200,7 +200,7 @@ class CasRec
         $this->deputyPostCode = self::normaliseSurname($row['Dep Postcode']);
         $this->typeOfReport = self::normaliseCorrefAndTypeOfRep($row['Typeofrep']);
         $this->corref = self::normaliseCorrefAndTypeOfRep($row['Corref']);
-        $this->source = self::CASREC_SOURCE;
+        $this->source = isset($row['source']) ? strtolower($row['source']) : self::CASREC_SOURCE;
 
         $this->otherColumns = serialize($row);
         $this->createdAt = new \DateTime();

--- a/api/src/AppBundle/Entity/CasRec.php
+++ b/api/src/AppBundle/Entity/CasRec.php
@@ -17,6 +17,9 @@ class CasRec
     const REALM_PROF = 'REALM_PROF';
     const REALM_LAY = 'REALM_LAY';
 
+    const CASREC_SOURCE = 'casrec';
+    const SIRIUS_SOURCE = 'sirius';
+
     /**
      * Holds the mapping rules to define the report type based on the CSV file (CASREC)
      * Used by both PA and Lay
@@ -167,7 +170,7 @@ class CasRec
     /**
      * @var string
      *
-     * @ORM\Column(name="source", type="string", nullable=false)
+     * @ORM\Column(name="source", type="string", nullable=true, options={"default" : "casrec"})
      */
     private $source;
 
@@ -197,6 +200,7 @@ class CasRec
         $this->deputyPostCode = self::normaliseSurname($row['Dep Postcode']);
         $this->typeOfReport = self::normaliseCorrefAndTypeOfRep($row['Typeofrep']);
         $this->corref = self::normaliseCorrefAndTypeOfRep($row['Corref']);
+        $this->source = self::CASREC_SOURCE;
 
         $this->otherColumns = serialize($row);
         $this->createdAt = new \DateTime();
@@ -390,5 +394,16 @@ class CasRec
     {
         $this->source = $source;
         return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public static function validSources()
+    {
+        return [
+            self::CASREC_SOURCE,
+            self::SIRIUS_SOURCE
+        ];
     }
 }

--- a/api/src/AppBundle/Entity/CasRec.php
+++ b/api/src/AppBundle/Entity/CasRec.php
@@ -165,6 +165,13 @@ class CasRec
     private $updatedAt;
 
     /**
+     * @var string
+     *
+     * @ORM\Column(name="source", type="string", nullable=false)
+     */
+    private $source;
+
+    /**
      * Filled from cron
      *
      * @var array
@@ -365,5 +372,23 @@ class CasRec
     public function getUpdatedAt()
     {
         return $this->updatedAt;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getSource()
+    {
+        return $this->source;
+    }
+
+    /**
+     * @param mixed $source
+     * @return CasRec
+     */
+    public function setSource($source)
+    {
+        $this->source = $source;
+        return $this;
     }
 }

--- a/api/src/AppBundle/Entity/Repository/CasRecRepository.php
+++ b/api/src/AppBundle/Entity/Repository/CasRecRepository.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace AppBundle\Entity\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
+
+class CasRecRepository extends EntityRepository
+{
+    /**
+     * @param string $source
+     * @return mixed
+     * @throws \Doctrine\ORM\NonUniqueResultException
+     */
+    public function deleteAllBySource(string $source)
+    {
+        /** @var QueryBuilder $qb */
+        $qb = $this->getEntityManager()->createQueryBuilder();
+
+        $qb
+            ->delete('AppBundle\Entity\CasRec', 'cr')
+            ->where('cr.source = :source')
+            ->setParameter('source', $source);
+
+        return $qb->getQuery()->getOneOrNullResult();
+    }
+}

--- a/api/src/AppBundle/v2/Registration/Assembler/LayDeputyshipDtoCollectionAssembler.php
+++ b/api/src/AppBundle/v2/Registration/Assembler/LayDeputyshipDtoCollectionAssembler.php
@@ -6,7 +6,7 @@ use AppBundle\v2\Registration\DTO\LayDeputyshipDtoCollection;
 
 class LayDeputyshipDtoCollectionAssembler
 {
-    /** @var CasRecToLayDeputyshipDtoAssembler */
+    /** @var LayDeputyshipDtoAssemblerInterface */
     private $layDeputyshipDtoAssembler;
 
     /**
@@ -21,7 +21,7 @@ class LayDeputyshipDtoCollectionAssembler
      * @param array $data
      * @return LayDeputyshipDtoCollection
      */
-    public function assembleFromArray(array $data)
+    public function assembleFromArray(array $data): LayDeputyshipDtoCollection
     {
         $collection = new LayDeputyshipDtoCollection();
 
@@ -31,5 +31,10 @@ class LayDeputyshipDtoCollectionAssembler
         }
 
         return $collection;
+    }
+
+    public function getLayDeputyshipDtoAssembler(): LayDeputyshipDtoAssemblerInterface
+    {
+        return $this->layDeputyshipDtoAssembler;
     }
 }

--- a/api/src/AppBundle/v2/Registration/Assembler/SiriusToLayDeputyshipDtoAssembler.php
+++ b/api/src/AppBundle/v2/Registration/Assembler/SiriusToLayDeputyshipDtoAssembler.php
@@ -2,11 +2,10 @@
 
 namespace AppBundle\v2\Registration\Assembler;
 
-use AppBundle\Entity\CasRec;
-use AppBundle\Service\DataNormaliser;
+    use AppBundle\Service\DataNormaliser;
 use AppBundle\v2\Registration\DTO\LayDeputyshipDto;
 
-class CasRecToLayDeputyshipDtoAssembler implements LayDeputyshipDtoAssemblerInterface
+class SiriusToLayDeputyshipDtoAssembler implements LayDeputyshipDtoAssemblerInterface
 {
     /** @var DataNormaliser */
     private $normaliser;
@@ -31,15 +30,15 @@ class CasRecToLayDeputyshipDtoAssembler implements LayDeputyshipDtoAssemblerInte
 
         return
             (new LayDeputyshipDto())
-            ->setCaseNumber($this->normaliser->normaliseCaseNumber($data['Case']))
-            ->setClientSurname($this->normaliser->normaliseSurname($data['Surname']))
-            ->setDeputyNumber($this->normaliser->normaliseDeputyNo($data['Deputy No']))
-            ->setDeputySurname($this->normaliser->normaliseSurname($data['Dep Surname']))
-            ->setDeputyPostcode($this->normaliser->normalisePostCode($data['Dep Postcode']))
-            ->setTypeOfReport($data['Typeofrep'])
-            ->setCorref($data['Corref'])
-            ->setIsNdrEnabled($this->determineNdrStatus($data['NDR']))
-            ->setSource(CasRec::CASREC_SOURCE);
+                ->setCaseNumber($this->normaliser->normaliseCaseNumber($data['Case']))
+                ->setClientSurname($this->normaliser->normaliseSurname($data['Surname']))
+                ->setDeputyNumber($this->normaliser->normaliseDeputyNo($data['Deputy No']))
+                ->setDeputySurname($this->normaliser->normaliseSurname($data['Dep Surname']))
+                ->setDeputyPostcode($this->normaliser->normalisePostCode($data['Dep Postcode']))
+                ->setTypeOfReport($data['Typeofrep'])
+                ->setCorref($data['Corref'])
+                ->setIsNdrEnabled($this->determineNdrStatus($data['NDR']))
+                ->setSource($data['source']);
     }
 
     /**
@@ -56,7 +55,8 @@ class CasRecToLayDeputyshipDtoAssembler implements LayDeputyshipDtoAssemblerInte
             array_key_exists('Dep Postcode', $data) &&
             array_key_exists('Typeofrep', $data) &&
             array_key_exists('Corref', $data) &&
-            array_key_exists('NDR', $data);
+            array_key_exists('NDR', $data) &&
+            array_key_exists('source', $data);
     }
 
     /**

--- a/api/src/AppBundle/v2/Registration/Assembler/SiriusToLayDeputyshipDtoAssembler.php
+++ b/api/src/AppBundle/v2/Registration/Assembler/SiriusToLayDeputyshipDtoAssembler.php
@@ -57,13 +57,4 @@ class SiriusToLayDeputyshipDtoAssembler implements LayDeputyshipDtoAssemblerInte
             array_key_exists('Typeofrep', $data) &&
             array_key_exists('Corref', $data);
     }
-
-    /**
-     * @param $value
-     * @return bool
-     */
-    private function determineNdrStatus($value): bool
-    {
-        return ($value === 1 || $value === 'Y') ? true : false;
-    }
 }

--- a/api/src/AppBundle/v2/Registration/Assembler/SiriusToLayDeputyshipDtoAssembler.php
+++ b/api/src/AppBundle/v2/Registration/Assembler/SiriusToLayDeputyshipDtoAssembler.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\v2\Registration\Assembler;
 
+    use AppBundle\Entity\CasRec;
     use AppBundle\Service\DataNormaliser;
 use AppBundle\v2\Registration\DTO\LayDeputyshipDto;
 
@@ -37,8 +38,8 @@ class SiriusToLayDeputyshipDtoAssembler implements LayDeputyshipDtoAssemblerInte
                 ->setDeputyPostcode($this->normaliser->normalisePostCode($data['Dep Postcode']))
                 ->setTypeOfReport($data['Typeofrep'])
                 ->setCorref($data['Corref'])
-                ->setIsNdrEnabled($this->determineNdrStatus($data['NDR']))
-                ->setSource($data['source']);
+                ->setIsNdrEnabled(false)
+                ->setSource(CasRec::SIRIUS_SOURCE);
     }
 
     /**
@@ -54,9 +55,7 @@ class SiriusToLayDeputyshipDtoAssembler implements LayDeputyshipDtoAssemblerInte
             array_key_exists('Dep Surname', $data) &&
             array_key_exists('Dep Postcode', $data) &&
             array_key_exists('Typeofrep', $data) &&
-            array_key_exists('Corref', $data) &&
-            array_key_exists('NDR', $data) &&
-            array_key_exists('source', $data);
+            array_key_exists('Corref', $data);
     }
 
     /**

--- a/api/src/AppBundle/v2/Registration/Controller/LayDeputyshipUploadController.php
+++ b/api/src/AppBundle/v2/Registration/Controller/LayDeputyshipUploadController.php
@@ -2,8 +2,8 @@
 
 namespace AppBundle\v2\Registration\Controller;
 
-use AppBundle\v2\Registration\Assembler\LayDeputyshipDtoCollectionAssembler;
 use AppBundle\Service\DataCompression;
+use AppBundle\v2\Registration\SelfRegistration\Factory\LayDeputyshipDtoCollectionAssemblerFactory;
 use AppBundle\v2\Registration\Uploader\LayDeputyshipUploader;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
@@ -17,24 +17,24 @@ class LayDeputyshipUploadController
     /** @var DataCompression */
     private $dataCompression;
 
-    /** @var LayDeputyshipDtoCollectionAssembler */
-    private $assembler;
+    /** @var LayDeputyshipDtoCollectionAssemblerFactory */
+    private $factory;
 
     /** @var LayDeputyshipUploader */
     private $uploader;
 
     /**
      * @param DataCompression $dataCompression
-     * @param LayDeputyshipDtoCollectionAssembler $assembler
+     * @param LayDeputyshipDtoCollectionAssemblerFactory $factory
      * @param LayDeputyshipUploader $uploader
      */
     public function __construct(
         DataCompression $dataCompression,
-        LayDeputyshipDtoCollectionAssembler $assembler,
+        LayDeputyshipDtoCollectionAssemblerFactory $factory,
         LayDeputyshipUploader $uploader
     ) {
         $this->dataCompression = $dataCompression;
-        $this->assembler = $assembler;
+        $this->factory = $factory;
         $this->uploader = $uploader;
     }
 
@@ -50,7 +50,8 @@ class LayDeputyshipUploadController
         ini_set('memory_limit', '1024M');
 
         $postedData = $this->dataCompression->decompress($request->getContent());
-        $uploadCollection = $this->assembler->assembleFromArray($postedData);
+        $assembler = $this->factory->create($postedData);
+        $uploadCollection = $assembler->assembleFromArray($postedData);
 
         return $this->uploader->upload($uploadCollection);
     }

--- a/api/src/AppBundle/v2/Registration/DTO/LayDeputyshipDto.php
+++ b/api/src/AppBundle/v2/Registration/DTO/LayDeputyshipDto.php
@@ -28,6 +28,9 @@ class LayDeputyshipDto
     /** @var bool */
     private $isNdrEnabled;
 
+    /** @var string */
+    private $source;
+
     /** @return string */
     public function getCaseNumber(): string
     {
@@ -153,6 +156,24 @@ class LayDeputyshipDto
     public function setIsNdrEnabled(bool $isNdrEnabled): LayDeputyshipDto
     {
         $this->isNdrEnabled = $isNdrEnabled;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSource(): string
+    {
+        return $this->source;
+    }
+
+    /**
+     * @param string $source
+     * @return LayDeputyshipDto
+     */
+    public function setSource(string $source): LayDeputyshipDto
+    {
+        $this->source = $source;
         return $this;
     }
 }

--- a/api/src/AppBundle/v2/Registration/SelfRegistration/Factory/CasRecFactory.php
+++ b/api/src/AppBundle/v2/Registration/SelfRegistration/Factory/CasRecFactory.php
@@ -53,7 +53,8 @@ class CasRecFactory
             'Dep Postcode' => $dto->getDeputyPostcode(),
             'Typeofrep' => $dto->getTypeOfReport(),
             'Corref' => $dto->getCorref(),
-            'NDR' => $dto->isNdrEnabled()
+            'NDR' => $dto->isNdrEnabled(),
+            'source' => $dto->getSource()
         ];
     }
 

--- a/api/src/AppBundle/v2/Registration/SelfRegistration/Factory/CasRecFactory.php
+++ b/api/src/AppBundle/v2/Registration/SelfRegistration/Factory/CasRecFactory.php
@@ -54,7 +54,7 @@ class CasRecFactory
             'Typeofrep' => $dto->getTypeOfReport(),
             'Corref' => $dto->getCorref(),
             'NDR' => $dto->isNdrEnabled(),
-            'source' => $dto->getSource()
+            'Source' => $dto->getSource()
         ];
     }
 

--- a/api/src/AppBundle/v2/Registration/SelfRegistration/Factory/LayDeputyshipDtoCollectionAssemblerFactory.php
+++ b/api/src/AppBundle/v2/Registration/SelfRegistration/Factory/LayDeputyshipDtoCollectionAssemblerFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace AppBundle\v2\Registration\SelfRegistration\Factory;
+
+use AppBundle\Entity\CasRec;
+use AppBundle\Service\DataNormaliser;
+use AppBundle\v2\Registration\Assembler\CasRecToLayDeputyshipDtoAssembler;
+use AppBundle\v2\Registration\Assembler\LayDeputyshipDtoAssemblerInterface;
+use AppBundle\v2\Registration\Assembler\LayDeputyshipDtoCollectionAssembler;
+use AppBundle\v2\Registration\Assembler\SiriusToLayDeputyshipDtoAssembler;
+
+class LayDeputyshipDtoCollectionAssemblerFactory
+{
+    /**
+     * @param array $uploadedData
+     * @return LayDeputyshipDtoCollectionAssembler
+     */
+    public function create(array $uploadedData): LayDeputyshipDtoCollectionAssembler
+    {
+        $source = $this->determineSource($uploadedData);
+        $assembler = $this->buildAssemblerBySourceType($source);
+
+        return new LayDeputyshipDtoCollectionAssembler($assembler);
+    }
+
+    private function determineSource(array $postedData)
+    {
+        // Absence of a source implies it is from CasRec.
+        if (!isset($postedData[0]['source'])) {
+            return CasRec::CASREC_SOURCE;
+        }
+
+        // Not expected, but if invalid source, fallback to casrec, for now at least.
+        if (!in_array($postedData[0]['source'], CasRec::validSources())) {
+            return CasRec::CASREC_SOURCE;
+        }
+
+        return $postedData[0]['source'];
+    }
+
+    private function buildAssemblerBySourceType(string $source): LayDeputyshipDtoAssemblerInterface
+    {
+        switch ($source) {
+            case CasRec::CASREC_SOURCE:
+                return new CasRecToLayDeputyshipDtoAssembler(new DataNormaliser());
+            case CasRec::SIRIUS_SOURCE:
+                return new SiriusToLayDeputyshipDtoAssembler(new DataNormaliser());
+            default:
+                throw new \InvalidArgumentException(sprintf('Unable to build assembler from unknown source: %s', $source));
+        }
+    }
+}

--- a/api/tests/AppBundle/Controller/CasRecControllerTest.php
+++ b/api/tests/AppBundle/Controller/CasRecControllerTest.php
@@ -126,10 +126,10 @@ class CasRecControllerTest extends AbstractTestController
             'Dep Surname' => 'Dep Surname',
             'Dep Postcode' => 'SW1',
             'Typeofrep' => 'OPG102',
-            'Corref' => 'L2'
+            'Corref' => 'L2',
+            'Source' => $source
         ]);
 
-        $casRec->setSource($source);
         $this->fixtures()->persist($casRec);
 
         return $casRec;

--- a/api/tests/AppBundle/Controller/CasRecControllerTest.php
+++ b/api/tests/AppBundle/Controller/CasRecControllerTest.php
@@ -54,24 +54,6 @@ class CasRecControllerTest extends AbstractTestController
         ]);
     }
 
-    public function testTruncate()
-    {
-        // just to check it gets truncated
-        $casRec = $this->buildAndPersistCasRecEntity('CaseNumber');
-        $this->fixtures()->flush($casRec);
-        $this->fixtures()->clear();
-
-        $url = '/casrec/truncate';
-        $this->assertEndpointNeedsAuth('DELETE', $url);
-        $this->assertEndpointNotAllowedFor('DELETE', $url, self::$tokenDeputy);
-
-        $this->assertJsonRequest('DELETE', $url, [
-            'mustSucceed' => true,
-            'AuthToken' => self::$tokenAdmin,
-        ]);
-        $this->assertCount(0, $this->fixtures()->clear()->getRepo('CasRec')->findAll());
-    }
-
     public function testDeleteBySourceVerifiesSourceInput()
     {
         $this->buildAndPersistCasRecEntity('12345678', CasRec::CASREC_SOURCE);

--- a/api/tests/AppBundle/v2/Registration/Assembler/CasRecToLayDeputyshipDtoAssemblerTest.php
+++ b/api/tests/AppBundle/v2/Registration/Assembler/CasRecToLayDeputyshipDtoAssemblerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\AppBundle\v2\Registration\Assembler;
+
+use AppBundle\Entity\CasRec;
+use AppBundle\Service\DataNormaliser;
+use AppBundle\v2\Registration\Assembler\CasRecToLayDeputyshipDtoAssembler;
+use AppBundle\v2\Registration\DTO\LayDeputyshipDto;
+use PHPUnit\Framework\TestCase;
+
+class CasRecToLayDeputyshipDtoAssemblerTest extends TestCase
+{
+    /** @var CasRecToLayDeputyshipDtoAssembler */
+    private $sut;
+
+    /** {@inheritDoc} */
+    protected function setUp(): void
+    {
+        $this->sut = new CasRecToLayDeputyshipDtoAssembler(new DataNormaliser());
+    }
+
+    /**
+     * @test
+     * @dataProvider getMissingDataVariations
+     * @param $itemToRemove
+     */
+    public function assembleFromArrayThrowsExceptionIfGivenIncompleteData($itemToRemove): void
+    {
+        $input = $this->getInput();
+        unset($input[$itemToRemove]);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->sut->assembleFromArray($input);
+    }
+
+    /** @return array */
+    public function getMissingDataVariations(): array
+    {
+        return [
+            ['Case'],
+            ['Surname'],
+            ['Deputy No'],
+            ['Dep Surname'],
+            ['Dep Postcode'],
+            ['Typeofrep'],
+            ['Corref'],
+            ['NDR']
+        ];
+    }
+
+    /** @test */
+    public function assembleFromArrayAssemblesAndReturnsALayDeputyshipDto(): void
+    {
+        $result = $this->sut->assembleFromArray($this->getInput());
+
+        $this->assertInstanceOf(LayDeputyshipDto::class, $result);
+        $this->assertEquals('caset', $result->getCaseNumber());
+        $this->assertEquals('surname', $result->getClientSurname());
+        $this->assertEquals('deputy_no', $result->getDeputyNumber());
+        $this->assertEquals('deputysurname', $result->getDeputySurname());
+        $this->assertEquals('deputypostcode', $result->getDeputyPostcode());
+        $this->assertEquals('type_of_rep', $result->getTypeOfReport());
+        $this->assertEquals('corref', $result->getCorref());
+        $this->assertEquals(true, $result->isNdrEnabled());
+        $this->assertEquals(CasRec::CASREC_SOURCE, $result->getSource());
+    }
+
+    /**
+     * @test
+     * @dataProvider getNdrVariations
+     * @param $ndrValue
+     * @param $expected
+     */
+    public function assembleFromArrayDeterminesIfNdrEnabled($ndrValue, $expected): void
+    {
+        $input = $this->getInput();
+        $input['NDR'] = $ndrValue;
+
+        $result = $this->sut->assembleFromArray($input);
+        $this->assertEquals($expected, $result->isNdrEnabled());
+    }
+
+    /** @return array */
+    public function getNdrVariations(): array
+    {
+        return [
+            ['ndrValue' => 'Y', 'expected' => true],
+            ['ndrValue' => 1, 'expected' => true],
+            ['ndrValue' => 'N', 'expected' => false],
+            ['ndrValue' => 0, 'expected' => false],
+            ['ndrValue' => null, 'expected' => false],
+            ['ndrValue' => '', 'expected' => false],
+        ];
+    }
+
+    /** @return array */
+    private function getInput(): array
+    {
+        return [
+            'Case' => 'caseT',
+            'Surname' => 'surname',
+            'Deputy No' => 'deputy_no',
+            'Dep Surname' => 'deputysurname',
+            'Dep Postcode' => 'deputy_postcode',
+            'Typeofrep' => 'type_of_rep',
+            'Corref' => 'corref',
+            'NDR' => 'Y',
+            'Not used' => 'not_used',
+        ];
+    }
+}

--- a/api/tests/AppBundle/v2/Registration/Assembler/SiriusToLayDeputyshipDtoAssemblerTest.php
+++ b/api/tests/AppBundle/v2/Registration/Assembler/SiriusToLayDeputyshipDtoAssemblerTest.php
@@ -2,20 +2,21 @@
 
 namespace Tests\AppBundle\v2\Registration\Assembler;
 
+use AppBundle\Entity\CasRec;
 use AppBundle\Service\DataNormaliser;
-use AppBundle\v2\Registration\Assembler\CasRecToLayDeputyshipDtoAssembler;
+use AppBundle\v2\Registration\Assembler\SiriusToLayDeputyshipDtoAssembler;
 use AppBundle\v2\Registration\DTO\LayDeputyshipDto;
 use PHPUnit\Framework\TestCase;
 
-class LayDeputyshipDtoAssemblerTest extends TestCase
+class SiriusToLayDeputyshipDtoAssemblerTest extends TestCase
 {
-    /** @var CasRecToLayDeputyshipDtoAssembler */
+    /** @var SiriusToLayDeputyshipDtoAssembler */
     private $sut;
 
     /** {@inheritDoc} */
     protected function setUp(): void
     {
-        $this->sut = new CasRecToLayDeputyshipDtoAssembler(new DataNormaliser());
+        $this->sut = new SiriusToLayDeputyshipDtoAssembler(new DataNormaliser());
     }
 
     /**
@@ -43,8 +44,7 @@ class LayDeputyshipDtoAssemblerTest extends TestCase
             ['Dep Surname'],
             ['Dep Postcode'],
             ['Typeofrep'],
-            ['Corref'],
-            ['NDR']
+            ['Corref']
         ];
     }
 
@@ -61,35 +61,8 @@ class LayDeputyshipDtoAssemblerTest extends TestCase
         $this->assertEquals('deputypostcode', $result->getDeputyPostcode());
         $this->assertEquals('type_of_rep', $result->getTypeOfReport());
         $this->assertEquals('corref', $result->getCorref());
-        $this->assertEquals(true, $result->isNdrEnabled());
-    }
-
-    /**
-     * @test
-     * @dataProvider getNdrVariations
-     * @param $ndrValue
-     * @param $expected
-     */
-    public function assembleFromArrayDeterminesIfNdrEnabled($ndrValue, $expected): void
-    {
-        $input = $this->getInput();
-        $input['NDR'] = $ndrValue;
-
-        $result = $this->sut->assembleFromArray($input);
-        $this->assertEquals($expected, $result->isNdrEnabled());
-    }
-
-    /** @return array */
-    public function getNdrVariations(): array
-    {
-        return [
-            ['ndrValue' => 'Y', 'expected' => true],
-            ['ndrValue' => 1, 'expected' => true],
-            ['ndrValue' => 'N', 'expected' => false],
-            ['ndrValue' => 0, 'expected' => false],
-            ['ndrValue' => null, 'expected' => false],
-            ['ndrValue' => '', 'expected' => false],
-        ];
+        $this->assertEquals(false, $result->isNdrEnabled());
+        $this->assertEquals(CasRec::SIRIUS_SOURCE, $result->getSource());
     }
 
     /** @return array */
@@ -103,7 +76,7 @@ class LayDeputyshipDtoAssemblerTest extends TestCase
             'Dep Postcode' => 'deputy_postcode',
             'Typeofrep' => 'type_of_rep',
             'Corref' => 'corref',
-            'NDR' => 'Y',
+            'Source' => 'will-use-constant-instead',
             'Not used' => 'not_used',
         ];
     }

--- a/api/tests/AppBundle/v2/Registration/SelfRegistration/CasRecFactoryTest.php
+++ b/api/tests/AppBundle/v2/Registration/SelfRegistration/CasRecFactoryTest.php
@@ -66,6 +66,7 @@ class CasRecFactoryTest extends TestCase
             ->method('getDateTime')
             ->willReturn(new \DateTime('2010-01-03 12:03:23'));
 
+        /** @var CasRec $result */
         $result = $this->factory->createFromDto($this->buildLayDeputyshipDto());
 
         $this->assertInstanceOf(CasRec::class, $result);
@@ -78,6 +79,7 @@ class CasRecFactoryTest extends TestCase
         $this->assertEquals('corref', $result->getCorref());
         $this->assertEquals(true, $result->getColumn('NDR'));
         $this->assertEquals('2010-01-03 12:03:23', $result->getUpdatedAt()->format('Y-m-d H:i:s'));
+        $this->assertEquals('some-source', $result->getSource());
     }
 
     /**
@@ -93,6 +95,7 @@ class CasRecFactoryTest extends TestCase
             ->setDeputyPostcode('postcode')
             ->setTypeOfReport('type')
             ->setIsNdrEnabled(true)
-            ->setCorref('corref');
+            ->setCorref('corref')
+            ->setSource('some-source');
     }
 }

--- a/api/tests/AppBundle/v2/Registration/SelfRegistration/Factory/CasRecFactoryTest.php
+++ b/api/tests/AppBundle/v2/Registration/SelfRegistration/Factory/CasRecFactoryTest.php
@@ -79,7 +79,7 @@ class CasRecFactoryTest extends TestCase
         $this->assertEquals('corref', $result->getCorref());
         $this->assertEquals(true, $result->getColumn('NDR'));
         $this->assertEquals('2010-01-03 12:03:23', $result->getUpdatedAt()->format('Y-m-d H:i:s'));
-        $this->assertEquals('some-source', $result->getSource());
+        $this->assertEquals(CasRec::SIRIUS_SOURCE, $result->getSource());
     }
 
     /**
@@ -96,6 +96,6 @@ class CasRecFactoryTest extends TestCase
             ->setTypeOfReport('type')
             ->setIsNdrEnabled(true)
             ->setCorref('corref')
-            ->setSource('some-source');
+            ->setSource(CasRec::SIRIUS_SOURCE);
     }
 }

--- a/api/tests/AppBundle/v2/Registration/SelfRegistration/Factory/CasRecFactoryTest.php
+++ b/api/tests/AppBundle/v2/Registration/SelfRegistration/Factory/CasRecFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\AppBundle\v2\Registration\SelfRegistration;
+namespace Tests\AppBundle\v2\Registration\SelfRegistration\Factory;
 
 use AppBundle\Entity\CasRec;
 use AppBundle\Service\DateTimeProvider;

--- a/api/tests/AppBundle/v2/Registration/SelfRegistration/Factory/LayDeputyshipDtoCollectionAssemblerFactoryTest.php
+++ b/api/tests/AppBundle/v2/Registration/SelfRegistration/Factory/LayDeputyshipDtoCollectionAssemblerFactoryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\AppBundle\v2\Registration\SelfRegistration\Factory;
+
+use AppBundle\v2\Registration\Assembler\CasRecToLayDeputyshipDtoAssembler;
+use AppBundle\v2\Registration\Assembler\SiriusToLayDeputyshipDtoAssembler;
+use AppBundle\v2\Registration\SelfRegistration\Factory\LayDeputyshipDtoCollectionAssemblerFactory;
+use PHPUnit\Framework\TestCase;
+
+class LayDeputyshipDtoCollectionAssemblerFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function createsCasRecAssemblerWhenSourceIsNotSet()
+    {
+        $assembler = (new LayDeputyshipDtoCollectionAssemblerFactory())->create([['not-source' => 'foo']]);
+        $this->assertInstanceOf(CasRecToLayDeputyshipDtoAssembler::class, $assembler->getLayDeputyshipDtoAssembler());
+    }
+
+    /**
+     * @test
+     */
+    public function createsCasRecAssemblerWhenSourceIsNotValid()
+    {
+        $assembler = (new LayDeputyshipDtoCollectionAssemblerFactory())->create([['source' => 'invalid']]);
+        $this->assertInstanceOf(CasRecToLayDeputyshipDtoAssembler::class, $assembler->getLayDeputyshipDtoAssembler());
+    }
+
+    /**
+     * @test
+     */
+    public function createsCasRecAssemblerWhenSourceIsCasRec()
+    {
+        $assembler = (new LayDeputyshipDtoCollectionAssemblerFactory())->create([['source' => 'casrec']]);
+        $this->assertInstanceOf(CasRecToLayDeputyshipDtoAssembler::class, $assembler->getLayDeputyshipDtoAssembler());
+    }
+
+    /**
+     * @test
+     */
+    public function createsSiriusAssemblerWhenSourceIsSirius()
+    {
+        $assembler = (new LayDeputyshipDtoCollectionAssemblerFactory())->create([['source' => 'sirius']]);
+        $this->assertInstanceOf(SiriusToLayDeputyshipDtoAssembler::class, $assembler->getLayDeputyshipDtoAssembler());
+    }
+}

--- a/behat/tests/behat.yml
+++ b/behat/tests/behat.yml
@@ -67,6 +67,12 @@ default:
             contexts:
                 - DigidepsBehat\ACL\ACLfeatureContext
 
+        registration:
+            description: Coverage of the self and auto registration processes
+            paths: [ "%paths.base%/features/registration" ]
+            contexts:
+                - DigidepsBehat\Registration\RegistrationFeatureContext
+
     extensions:
         Behat\MinkExtension\ServiceContainer\MinkExtension:
               goutte:

--- a/behat/tests/bootstrap/Common/AuthenticationTrait.php
+++ b/behat/tests/bootstrap/Common/AuthenticationTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DigidepsBehat;
+namespace DigidepsBehat\Common;
 
 use Behat\Gherkin\Node\TableNode;
 

--- a/behat/tests/bootstrap/Common/BaseFeatureContext.php
+++ b/behat/tests/bootstrap/Common/BaseFeatureContext.php
@@ -3,9 +3,6 @@
 namespace DigidepsBehat\Common;
 
 use Behat\MinkExtension\Context\MinkContext;
-use DigidepsBehat\AuthenticationTrait;
-use DigidepsBehat\FormTrait;
-use DigidepsBehat\SiteNavigationTrait;
 
 class BaseFeatureContext extends MinkContext
 {

--- a/behat/tests/bootstrap/Common/EmailTrait.php
+++ b/behat/tests/bootstrap/Common/EmailTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DigidepsBehat;
+namespace DigidepsBehat\Common;
 
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 

--- a/behat/tests/bootstrap/Common/FormTrait.php
+++ b/behat/tests/bootstrap/Common/FormTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DigidepsBehat;
+namespace DigidepsBehat\Common;
 
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Element\NodeElement;

--- a/behat/tests/bootstrap/Common/LinksTrait.php
+++ b/behat/tests/bootstrap/Common/LinksTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DigidepsBehat;
+namespace DigidepsBehat\Common;
 
 trait LinksTrait
 {

--- a/behat/tests/bootstrap/Common/RegionTrait.php
+++ b/behat/tests/bootstrap/Common/RegionTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DigidepsBehat;
+namespace DigidepsBehat\Common;
 
 use Behat\Gherkin\Node\TableNode;
 

--- a/behat/tests/bootstrap/Common/ReportTrait.php
+++ b/behat/tests/bootstrap/Common/ReportTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DigidepsBehat;
+namespace DigidepsBehat\Common;
 
 use Behat\Gherkin\Node\TableNode;
 

--- a/behat/tests/bootstrap/Common/SiteNavigationTrait.php
+++ b/behat/tests/bootstrap/Common/SiteNavigationTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DigidepsBehat;
+namespace DigidepsBehat\Common;
 
 trait SiteNavigationTrait
 {

--- a/behat/tests/bootstrap/FeatureContext.php
+++ b/behat/tests/bootstrap/FeatureContext.php
@@ -5,6 +5,7 @@ namespace DigidepsBehat;
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\MinkExtension\Context\MinkContext;
 use DigidepsBehat\Common\AuthenticationTrait;
+use DigidepsBehat\Common\EmailTrait;
 use DigidepsBehat\Common\FormTrait;
 use DigidepsBehat\Common\LinksTrait;
 use DigidepsBehat\Common\RegionTrait;

--- a/behat/tests/bootstrap/FeatureContext.php
+++ b/behat/tests/bootstrap/FeatureContext.php
@@ -4,6 +4,12 @@ namespace DigidepsBehat;
 
 use Behat\Behat\Context\SnippetAcceptingContext;
 use Behat\MinkExtension\Context\MinkContext;
+use DigidepsBehat\Common\AuthenticationTrait;
+use DigidepsBehat\Common\FormTrait;
+use DigidepsBehat\Common\LinksTrait;
+use DigidepsBehat\Common\RegionTrait;
+use DigidepsBehat\Common\ReportTrait;
+use DigidepsBehat\Common\SiteNavigationTrait;
 
 /**
  * Behat context class.

--- a/behat/tests/bootstrap/Registration/RegistrationFeatureContext.php
+++ b/behat/tests/bootstrap/Registration/RegistrationFeatureContext.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DigidepsBehat\Registration;
+
+use DigidepsBehat\Common\BaseFeatureContext;
+
+class RegistrationFeatureContext extends BaseFeatureContext
+{
+    
+}

--- a/behat/tests/bootstrap/Registration/RegistrationFeatureContext.php
+++ b/behat/tests/bootstrap/Registration/RegistrationFeatureContext.php
@@ -2,9 +2,85 @@
 
 namespace DigidepsBehat\Registration;
 
+use Behat\Gherkin\Node\TableNode;
 use DigidepsBehat\Common\BaseFeatureContext;
+use DigidepsBehat\Common\EmailTrait;
+use DigidepsBehat\Common\LinksTrait;
 
 class RegistrationFeatureContext extends BaseFeatureContext
 {
-    
+    use EmailTrait;
+    use LinksTrait;
+
+    /**
+     * @Given the self registration lookup table is empty
+     */
+    public function theSelfRegistrationLookupTableIsEmpty()
+    {
+        $query = "DELETE FROM casrec";
+        $command = sprintf('psql %s -c "%s"', self::$dbName, $query);
+        exec($command);
+    }
+
+    /**
+     * @Given an admin user uploads the :file file into the Lay CSV uploader
+     */
+    public function anAdminUserUploadsTheFileIntoTheLayCsvUploader($file)
+    {
+        $this->iAmLoggedInToAdminAsWithPassword('admin@publicguardian.gov.uk', 'Abcd1234');
+        $this->visitAdminPath("/admin/casrec-upload");
+        $this->attachFileToField("admin_upload_file", $file);
+        $this->pressButton("admin_upload_upload");
+    }
+
+    /**
+     * @When these deputies register to deputise the following court orders:
+     */
+    public function theseDeputiesRegisterToDeputiseTheFollowingCourtOrders(TableNode $table)
+    {
+        foreach ($table as $courtOrder) {
+            $this->visit('/register');
+            $this->fillField('self_registration_firstname', 'Brian');
+            $this->fillField('self_registration_lastname', $courtOrder['deputySurname']);
+            $this->fillField('self_registration_email_first', $courtOrder['deputyEmail']);
+            $this->fillField('self_registration_email_second', $courtOrder['deputyEmail']);
+            $this->fillField('self_registration_postcode', $courtOrder['deputyPostCode']);
+            $this->fillField('self_registration_clientFirstname', 'Billy');
+            $this->fillField('self_registration_clientLastname', $courtOrder['clientSurname']);
+            $this->fillField('self_registration_caseNumber', $courtOrder['caseNumber']);
+            $this->pressButton('self_registration_save');
+
+            $this->iOpenTheSpecificLinkOnTheEmail('/user/activate/');
+            $this->fillField('set_password_password_first', 'Abcd1234');
+            $this->fillField('set_password_password_second', 'Abcd1234');
+            $this->checkOption('set_password_showTermsAndConditions');
+            $this->pressButton('set_password_save');
+
+            $this->fillField('user_details_address1', '102 Petty France');
+            $this->fillField('user_details_address2', 'MOJ');
+            $this->fillField('user_details_address3', 'London');
+            $this->fillField('user_details_addressCountry', 'GB');
+            $this->fillField('user_details_phoneMain', '01789 321234');
+            $this->pressButton('user_details_save');
+
+            $this->fillField('client_address', '1 South Parade');
+            $this->fillField('client_address2', 'First Floor');
+            $this->fillField('client_county', 'Notts');
+            $this->fillField('client_postcode', 'NG1 2HT');
+            $this->fillField('client_country', 'GB');
+            $this->fillField('client_phone', '01789432876');
+            $this->fillField('client_courtDate_day', '01');
+            $this->fillField('client_courtDate_month', '01');
+            $this->fillField('client_courtDate_year', '2016');
+            $this->pressButton('client_save');
+
+            $this->fillField('report_startDate_day', '02');
+            $this->fillField('report_startDate_month', '03');
+            $this->fillField('report_startDate_year', '2016');
+            $this->fillField('report_endDate_day', '01');
+            $this->fillField('report_endDate_month', '03');
+            $this->fillField('report_endDate_year', '2017');
+            $this->pressButton('report_save');
+        }
+    }
 }

--- a/behat/tests/bootstrap/ReportManagement/ReportManagementFeatureContext.php
+++ b/behat/tests/bootstrap/ReportManagement/ReportManagementFeatureContext.php
@@ -2,14 +2,11 @@
 
 namespace DigidepsBehat\ReportManagement;
 
-use DigidepsBehat\AuthenticationTrait;
 use DigidepsBehat\Common\BaseFeatureContext;
 use DigidepsBehat\Common\CourtOrderTrait;
-use DigidepsBehat\FormTrait;
-use DigidepsBehat\LinksTrait;
-use DigidepsBehat\RegionTrait;
-use DigidepsBehat\ReportTrait;
-use DigidepsBehat\SiteNavigationTrait;
+use DigidepsBehat\Common\LinksTrait;
+use DigidepsBehat\Common\RegionTrait;
+use DigidepsBehat\Common\ReportTrait;
 
 class ReportManagementFeatureContext extends BaseFeatureContext
 {

--- a/behat/tests/features/registration/lay-deputy-upload.feature
+++ b/behat/tests/features/registration/lay-deputy-upload.feature
@@ -1,0 +1,19 @@
+Feature: Lay deputy upload into registration lookup table
+  In order to ensure that I can use the service
+  As a lay deputy
+  I need the details of my court order loading into the application to enable me to register
+
+  Scenario: CSV upload populates registration lookup table and deletes entries corresponding to the CSV source
+    Given the self registration lookup table is empty
+    # Upload 25 users from a casrec source
+    When an admin user uploads the "behat-lay-casrec.csv" file into the Lay CSV uploader
+    Then I should see "25 users in the database"
+    # Upload 15 users from a sirius source
+    When an admin user uploads the "behat-lay-sirius.csv" file into the Lay CSV uploader
+    Then I should see "40 users in the database"
+    # Upload 10 users from a casrec source
+    When an admin user uploads the "behat-lay-casrec-follow-up.csv" file into the Lay CSV uploader
+    Then I should see "25 users in the database"
+    # Upload 5 users from a sirius source
+    When an admin user uploads the "behat-lay-sirius-follow-up.csv" file into the Lay CSV uploader
+    Then I should see "15 users in the database"

--- a/behat/tests/features/registration/self-registration.feature
+++ b/behat/tests/features/registration/self-registration.feature
@@ -1,0 +1,27 @@
+Feature: Self registration
+  In order to ensure that I can use the service
+  As a lay deputy
+  I need to self register my details to create an account
+
+  Background:
+    Given the self registration lookup table is empty
+    And emails are sent from "deputy" area
+
+  Scenario: Register a deputy from a casrec source
+    Given an admin user uploads the "behat-lay-casrec.csv" file into the Lay CSV uploader
+    When these deputies register to deputise the following court orders:
+      | deputySurname | deputyEmail      | deputyPostCode | clientSurname | caseNumber |
+      | Parker        | peter@parker.com | SW10 1AA       | Davies        | T5001034   |
+    And I am logged in as "peter@parker.com" with password "Abcd1234"
+    Then I should be on "/lay"
+    And I should see "Davies"
+
+  Scenario: Register a deputy from a sirius source
+    Given an admin user uploads the "behat-lay-sirius.csv" file into the Lay CSV uploader
+    When these deputies register to deputise the following court orders:
+      | deputySurname | deputyEmail    | deputyPostCode | clientSurname | caseNumber |
+      | Wayne        | bruce@wayne.com | SW1 2SA        | Hendry        | T5001041   |
+    And I am logged in as "bruce@wayne.com" with password "Abcd1234"
+    Then I should be on "/lay"
+    And I should see "Hendry"
+

--- a/behat/tests/fixtures/behat-lay-casrec-follow-up.csv
+++ b/behat/tests/fixtures/behat-lay-casrec-follow-up.csv
@@ -1,0 +1,11 @@
+Case,Surname,Dep Type,Email,Email2,Email3,Deputy No,Dep Forename,Dep Surname,Dep Adrs1,Dep Adrs2,Dep Adrs3,Dep Adrs4,Dep Adrs5,Dep Postcode,Tele1,Tele2,Tele3,Mobile1,Mobile2,AddrTele,Made Date,Dig,Digdate,Foreign,Corref,Due Date,Typeofrep,Typeofrep2,Team,Fee Payer,Corres,Sett Comp,NDR
+T1001020,S1020,,,,,test0001,NAME,SURNAME,,,,,,SW1,,,,,,,14-Jun-11,,,,L2,19-May-17,OPG102,,Team 1,Y,Y,,Yes
+T2001020,S1020,,,,,test0002,NAME,SURNAME,,,,,,SW1,,,,,,,15-Jun-11,,,,L2,03-Jul-17,OPG102,,Team 1,Y,Y,,Yes
+T3001020,S1020,,,,,test0003,NAME,SURNAME,,,,,,SW1,,,,,,,16-Jun-11,,,,L2,17-Aug-17,OPG102,,Team 1,Y,Y,,Y
+T4001020,S1020,,,,,test0004,NAME,SURNAME,,,,,,SW1,,,,,,,17-Jun-11,,,,L2,01-Oct-17,OPG102,,Team 1,Y,Y,,
+T5001020,S1020,,,,,test0005,NAME,SURNAME,,,,,,SW1,,,,,,,18-Jun-11,,,,L2,15-Nov-17,OPG102,,Team 1,Y,Y,,
+T1001030,S1030,,,,,test0006,NAME,SURNAME,,,,,,SW1,,,,,,,02-Aug-11,,,,L3,02-Jun-23,OPG103,,Team 1,Y,Y,,
+T2001030,S1030,,,,,test0007,NAME,SURNAME,,,,,,SW1,,,,,,,03-Aug-11,,,,L3,17-Jul-23,OPG103,,Team 1,Y,Y,,
+T3001030,S1030,,,,,test0008,NAME,SURNAME,,,,,,SW1,,,,,,,04-Aug-11,,,,L3,31-Aug-23,OPG103,,Team 1,Y,Y,,
+T4001030,S1030,,,,,test0009,NAME,SURNAME,,,,,,SW1,,,,,,,05-Aug-11,,,,L3,15-Oct-23,OPG103,,Team 1,Y,Y,,
+T5001030,S1030,,,,,test0010,NAME,SURNAME,,,,,,SW1,,,,,,,06-Aug-11,,,,L3,29-Nov-23,OPG103,,Team 1,Y,Y,,

--- a/behat/tests/fixtures/behat-lay-casrec.csv
+++ b/behat/tests/fixtures/behat-lay-casrec.csv
@@ -23,4 +23,4 @@ T1001034,S1034,,,,,test0016,NAME,SURNAME,,,,,,SW1,,,,,,,06-Aug-11,,,,hw,29-Nov-2
 T2001034,S1034,,,,,test0017,NAME,SURNAME,,,,,,SW1,,,,,,,06-Aug-11,,,,hw,29-Nov-23,OPG103,,Team 1,Y,Y,,
 T3001034,S1034,,,,,test0018,NAME,SURNAME,,,,,,SW1,,,,,,,06-Aug-11,,,,hw,29-Nov-23,OPG103,,Team 1,Y,Y,,
 T4001034,S1034,,,,,test0019,NAME,SURNAME,,,,,,SW1,,,,,,,06-Aug-11,,,,hw,29-Nov-23,OPG103,,Team 1,Y,Y,,
-T5001034,S1034,,,,,test0020,NAME,SURNAME,,,,,,SW1,,,,,,,06-Aug-11,,,,hw,29-Nov-23,OPG103,,Team 1,Y,Y,,
+T5001034,Davies,,,,,test0020,Peter,Parker,,,,,,SW10 1AA,,,,,,,06-Aug-11,,,,hw,29-Nov-23,OPG103,,Team 1,Y,Y,,

--- a/behat/tests/fixtures/behat-lay-sirius-follow-up.csv
+++ b/behat/tests/fixtures/behat-lay-sirius-follow-up.csv
@@ -1,6 +1,6 @@
-Case,Surname,Dep Type,Email,Email2,Email3,Deputy No,Dep Forename,Dep Surname,Dep Adrs1,Dep Adrs2,Dep Adrs3,Dep Adrs4,Dep Adrs5,Dep Postcode,Tele1,Tele2,Tele3,Mobile1,Mobile2,AddrTele,Made Date,Dig,Digdate,Foreign,Corref,Due Date,Typeofrep,Typeofrep2,Team,Fee Payer,Corres,Sett Comp,NDR,source
-T1001021,S1020,,,,,test0001,NAME,SURNAME,,,,,,SW1,,,,,,,14-Jun-11,,,,L2,19-May-17,OPG102,,Team 1,Y,Y,,Yes,sirius
-T2001021,S1020,,,,,test0002,NAME,SURNAME,,,,,,SW1,,,,,,,15-Jun-11,,,,L2,03-Jul-17,OPG102,,Team 1,Y,Y,,Yes,sirius
-T3001021,S1020,,,,,test0003,NAME,SURNAME,,,,,,SW1,,,,,,,16-Jun-11,,,,L2,17-Aug-17,OPG102,,Team 1,Y,Y,,Y,sirius
-T4001021,S1020,,,,,test0004,NAME,SURNAME,,,,,,SW1,,,,,,,17-Jun-11,,,,L2,01-Oct-17,OPG102,,Team 1,Y,Y,,,sirius
-T5001021,S1020,,,,,test0005,NAME,SURNAME,,,,,,SW1,,,,,,,18-Jun-11,,,,L2,15-Nov-17,OPG102,,Team 1,Y,Y,,,sirius
+Case,Surname,Deputy No,Dep Surname,Dep Postcode,Made Date,Corref,Typeofrep,source
+T1001021,S1020,test0001,SURNAME,SW1,14-Jun-11,L2,OPG102,sirius
+T2001021,S1020,test0002,SURNAME,SW1,15-Jun-11,L2,OPG102,sirius
+T3001021,S1020,test0003,SURNAME,SW1,16-Jun-11,L2,OPG102,sirius
+T4001021,S1020,test0004,SURNAME,SW1,17-Jun-11,L2,OPG102,sirius
+T5001021,S1020,test0005,SURNAME,SW1,18-Jun-11,L2,OPG102,sirius

--- a/behat/tests/fixtures/behat-lay-sirius-follow-up.csv
+++ b/behat/tests/fixtures/behat-lay-sirius-follow-up.csv
@@ -1,0 +1,6 @@
+Case,Surname,Dep Type,Email,Email2,Email3,Deputy No,Dep Forename,Dep Surname,Dep Adrs1,Dep Adrs2,Dep Adrs3,Dep Adrs4,Dep Adrs5,Dep Postcode,Tele1,Tele2,Tele3,Mobile1,Mobile2,AddrTele,Made Date,Dig,Digdate,Foreign,Corref,Due Date,Typeofrep,Typeofrep2,Team,Fee Payer,Corres,Sett Comp,NDR,source
+T1001021,S1020,,,,,test0001,NAME,SURNAME,,,,,,SW1,,,,,,,14-Jun-11,,,,L2,19-May-17,OPG102,,Team 1,Y,Y,,Yes,sirius
+T2001021,S1020,,,,,test0002,NAME,SURNAME,,,,,,SW1,,,,,,,15-Jun-11,,,,L2,03-Jul-17,OPG102,,Team 1,Y,Y,,Yes,sirius
+T3001021,S1020,,,,,test0003,NAME,SURNAME,,,,,,SW1,,,,,,,16-Jun-11,,,,L2,17-Aug-17,OPG102,,Team 1,Y,Y,,Y,sirius
+T4001021,S1020,,,,,test0004,NAME,SURNAME,,,,,,SW1,,,,,,,17-Jun-11,,,,L2,01-Oct-17,OPG102,,Team 1,Y,Y,,,sirius
+T5001021,S1020,,,,,test0005,NAME,SURNAME,,,,,,SW1,,,,,,,18-Jun-11,,,,L2,15-Nov-17,OPG102,,Team 1,Y,Y,,,sirius

--- a/behat/tests/fixtures/behat-lay-sirius.csv
+++ b/behat/tests/fixtures/behat-lay-sirius.csv
@@ -1,16 +1,16 @@
-Case,Surname,Dep Type,Email,Email2,Email3,Deputy No,Dep Forename,Dep Surname,Dep Adrs1,Dep Adrs2,Dep Adrs3,Dep Adrs4,Dep Adrs5,Dep Postcode,Tele1,Tele2,Tele3,Mobile1,Mobile2,AddrTele,Made Date,Dig,Digdate,Foreign,Corref,Due Date,Typeofrep,Typeofrep2,Team,Fee Payer,Corres,Sett Comp,NDR,source
-T1001021,S1020,,,,,test0001,NAME,SURNAME,,,,,,SW1,,,,,,,14-Jun-11,,,,L2,19-May-17,OPG102,,Team 1,Y,Y,,Yes,sirius
-T2001021,S1020,,,,,test0002,NAME,SURNAME,,,,,,SW1,,,,,,,15-Jun-11,,,,L2,03-Jul-17,OPG102,,Team 1,Y,Y,,Yes,sirius
-T3001021,S1020,,,,,test0003,NAME,SURNAME,,,,,,SW1,,,,,,,16-Jun-11,,,,L2,17-Aug-17,OPG102,,Team 1,Y,Y,,Y,sirius
-T4001021,S1020,,,,,test0004,NAME,SURNAME,,,,,,SW1,,,,,,,17-Jun-11,,,,L2,01-Oct-17,OPG102,,Team 1,Y,Y,,,sirius
-T5001021,S1020,,,,,test0005,NAME,SURNAME,,,,,,SW1,,,,,,,18-Jun-11,,,,L2,15-Nov-17,OPG102,,Team 1,Y,Y,,,sirius
-T1001031,S1030,,,,,test0006,NAME,SURNAME,,,,,,SW1,,,,,,,02-Aug-11,,,,L3,02-Jun-23,OPG103,,Team 1,Y,Y,,,sirius
-T2001031,S1030,,,,,test0007,NAME,SURNAME,,,,,,SW1,,,,,,,03-Aug-11,,,,L3,17-Jul-23,OPG103,,Team 1,Y,Y,,,sirius
-T3001031,S1030,,,,,test0008,NAME,SURNAME,,,,,,SW1,,,,,,,04-Aug-11,,,,L3,31-Aug-23,OPG103,,Team 1,Y,Y,,,sirius
-T4001031,S1030,,,,,test0009,NAME,SURNAME,,,,,,SW1,,,,,,,05-Aug-11,,,,L3,15-Oct-23,OPG103,,Team 1,Y,Y,,,sirius
-T5001031,S1030,,,,,test0010,NAME,SURNAME,,,,,,SW1,,,,,,,06-Aug-11,,,,L3,29-Nov-23,OPG103,,Team 1,Y,Y,,,sirius
-T1001041,S1040,,,,,test0011,NAME,SURNAME,,,,,,SW1,,,,,,,02-Aug-11,,,,hw,02-Jun-23,,,Team 1,Y,Y,,,sirius
-T2001041,S1040,,,,,test0012,NAME,SURNAME,,,,,,SW1,,,,,,,03-Aug-11,,,,hw,17-Jul-23,,,Team 1,Y,Y,,,sirius
-T3001041,S1040,,,,,test0013,NAME,SURNAME,,,,,,SW1,,,,,,,04-Aug-11,,,,hw,31-Aug-23,,,Team 1,Y,Y,,,sirius
-T4001041,S1040,,,,,test0014,NAME,SURNAME,,,,,,SW1,,,,,,,05-Aug-11,,,,hw,15-Oct-23,,,Team 1,Y,Y,,,sirius
-T5001041,Hendry,,,,,test0015,Bruce,Wayne,,,,,,SW1 2SA,,,,,,,06-Aug-11,,,,hw,29-Nov-23,,,Team 1,Y,Y,,,sirius
+Case,Surname,Deputy No,Dep Surname,Dep Postcode,Made Date,Corref,Typeofrep,source
+T1001021,S1020,test0001,SURNAME,SW1,14-Jun-11,L2,OPG102,sirius
+T2001021,S1020,test0002,SURNAME,SW1,15-Jun-11,L2,OPG102,sirius
+T3001021,S1020,test0003,SURNAME,SW1,16-Jun-11,L2,OPG102,sirius
+T4001021,S1020,test0004,SURNAME,SW1,17-Jun-11,L2,OPG102,sirius
+T5001021,S1020,test0005,SURNAME,SW1,18-Jun-11,L2,OPG102,sirius
+T1001031,S1030,test0006,SURNAME,SW1,02-Aug-11,L3,OPG103,sirius
+T2001031,S1030,test0007,SURNAME,SW1,03-Aug-11,L3,OPG103,sirius
+T3001031,S1030,test0008,SURNAME,SW1,04-Aug-11,L3,OPG103,sirius
+T4001031,S1030,test0009,SURNAME,SW1,05-Aug-11,L3,OPG103,sirius
+T5001031,S1030,test0010,SURNAME,SW1,06-Aug-11,L3,OPG103,sirius
+T1001041,S1040,test0011,SURNAME,SW1,02-Aug-11,hw,,sirius
+T2001041,S1040,test0012,SURNAME,SW1,03-Aug-11,hw,,sirius
+T3001041,S1040,test0013,SURNAME,SW1,04-Aug-11,hw,,sirius
+T4001041,S1040,test0014,SURNAME,SW1,05-Aug-11,hw,,sirius
+T5001041,Hendry,test0015,Wayne,SW1 2SA,06-Aug-11,hw,,sirius

--- a/behat/tests/fixtures/behat-lay-sirius.csv
+++ b/behat/tests/fixtures/behat-lay-sirius.csv
@@ -1,0 +1,16 @@
+Case,Surname,Dep Type,Email,Email2,Email3,Deputy No,Dep Forename,Dep Surname,Dep Adrs1,Dep Adrs2,Dep Adrs3,Dep Adrs4,Dep Adrs5,Dep Postcode,Tele1,Tele2,Tele3,Mobile1,Mobile2,AddrTele,Made Date,Dig,Digdate,Foreign,Corref,Due Date,Typeofrep,Typeofrep2,Team,Fee Payer,Corres,Sett Comp,NDR,source
+T1001021,S1020,,,,,test0001,NAME,SURNAME,,,,,,SW1,,,,,,,14-Jun-11,,,,L2,19-May-17,OPG102,,Team 1,Y,Y,,Yes,sirius
+T2001021,S1020,,,,,test0002,NAME,SURNAME,,,,,,SW1,,,,,,,15-Jun-11,,,,L2,03-Jul-17,OPG102,,Team 1,Y,Y,,Yes,sirius
+T3001021,S1020,,,,,test0003,NAME,SURNAME,,,,,,SW1,,,,,,,16-Jun-11,,,,L2,17-Aug-17,OPG102,,Team 1,Y,Y,,Y,sirius
+T4001021,S1020,,,,,test0004,NAME,SURNAME,,,,,,SW1,,,,,,,17-Jun-11,,,,L2,01-Oct-17,OPG102,,Team 1,Y,Y,,,sirius
+T5001021,S1020,,,,,test0005,NAME,SURNAME,,,,,,SW1,,,,,,,18-Jun-11,,,,L2,15-Nov-17,OPG102,,Team 1,Y,Y,,,sirius
+T1001031,S1030,,,,,test0006,NAME,SURNAME,,,,,,SW1,,,,,,,02-Aug-11,,,,L3,02-Jun-23,OPG103,,Team 1,Y,Y,,,sirius
+T2001031,S1030,,,,,test0007,NAME,SURNAME,,,,,,SW1,,,,,,,03-Aug-11,,,,L3,17-Jul-23,OPG103,,Team 1,Y,Y,,,sirius
+T3001031,S1030,,,,,test0008,NAME,SURNAME,,,,,,SW1,,,,,,,04-Aug-11,,,,L3,31-Aug-23,OPG103,,Team 1,Y,Y,,,sirius
+T4001031,S1030,,,,,test0009,NAME,SURNAME,,,,,,SW1,,,,,,,05-Aug-11,,,,L3,15-Oct-23,OPG103,,Team 1,Y,Y,,,sirius
+T5001031,S1030,,,,,test0010,NAME,SURNAME,,,,,,SW1,,,,,,,06-Aug-11,,,,L3,29-Nov-23,OPG103,,Team 1,Y,Y,,,sirius
+T1001041,S1040,,,,,test0011,NAME,SURNAME,,,,,,SW1,,,,,,,02-Aug-11,,,,hw,02-Jun-23,,,Team 1,Y,Y,,,sirius
+T2001041,S1040,,,,,test0012,NAME,SURNAME,,,,,,SW1,,,,,,,03-Aug-11,,,,hw,17-Jul-23,,,Team 1,Y,Y,,,sirius
+T3001041,S1040,,,,,test0013,NAME,SURNAME,,,,,,SW1,,,,,,,04-Aug-11,,,,hw,31-Aug-23,,,Team 1,Y,Y,,,sirius
+T4001041,S1040,,,,,test0014,NAME,SURNAME,,,,,,SW1,,,,,,,05-Aug-11,,,,hw,15-Oct-23,,,Team 1,Y,Y,,,sirius
+T5001041,Hendry,,,,,test0015,Bruce,Wayne,,,,,,SW1 2SA,,,,,,,06-Aug-11,,,,hw,29-Nov-23,,,Team 1,Y,Y,,,sirius

--- a/client/app/config/services_mail.yml
+++ b/client/app/config/services_mail.yml
@@ -4,6 +4,7 @@ services:
         autoconfigure: true
 
     mailer.transport.smtp.default:
+        autowire: false
         class: Swift_SmtpTransport
         arguments: [ "%smtp_default_hostname%", "%smtp_default_port%" ]
         calls:

--- a/client/src/AppBundle/Controller/Admin/AjaxController.php
+++ b/client/src/AppBundle/Controller/Admin/AjaxController.php
@@ -15,14 +15,14 @@ use Symfony\Component\HttpFoundation\Request;
 class AjaxController extends AbstractController
 {
     /**
-     * @Route("/casrec-truncate", name="casrec_truncate_ajax")
+     * @Route("/casrec-delete-by-source/{source}", name="casrec_delete_by_source_ajax")
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
      */
-    public function truncateUsersAjaxAction(Request $request)
+    public function deleteUsersBySourceAjaxAction(Request $request, $source)
     {
         try {
             $before = $this->getRestClient()->get('casrec/count', 'array');
-            $this->getRestClient()->delete('casrec/truncate');
+            $this->getRestClient()->delete('casrec/delete-by-source/'.$source);
             $after = $this->getRestClient()->get('casrec/count', 'array');
 
             return new JsonResponse(['before'=>$before, 'after'=>$after]);

--- a/client/src/AppBundle/Controller/Admin/IndexController.php
+++ b/client/src/AppBundle/Controller/Admin/IndexController.php
@@ -295,7 +295,7 @@ class IndexController extends AbstractController
                     ->setUnexpectedColumns(['Last Report Day'])
                     ->getData();
 
-                $source = isset($data[0]['source']) ? $data[0]['source'] : 'casrec';
+                $source = isset($data[0]['source']) ? strtolower($data[0]['source']) : 'casrec';
 
                 // small amount of data -> immediate posting and redirect (needed for behat)
                 if (count($data) < $chunkSize) {

--- a/client/src/AppBundle/Controller/Admin/IndexController.php
+++ b/client/src/AppBundle/Controller/Admin/IndexController.php
@@ -290,32 +290,18 @@ class IndexController extends AbstractController
             try {
                 $csvToArray = new CsvToArray($fileName, false, true);
 
-                $data = $csvToArray->setExpectedColumns([
-                        'Case',
-                        'Surname',
-                        'Deputy No',
-                        'Dep Surname',
-                        'Dep Postcode',
-                        'Typeofrep',
-                        'Corref',
-                        'NDR', // if not present, would indicate a prof/PA CSV is being used incorrectly here
-                        'Dep Type',
-                        'Dep Adrs1',
-                        'Dep Adrs2',
-                        'Dep Adrs3'
-                    ])
+                $data = $csvToArray
                     ->setOptionalColumns($csvToArray->getFirstRow())
-                    ->setUnexpectedColumns([
-                        //'Pat Create', 'Dship Create', //should hold reg date / Cour order date, but no specs given yet
-                        'Last Report Day'
-                    ])
+                    ->setUnexpectedColumns(['Last Report Day'])
                     ->getData();
+
+                $source = isset($data[0]['source']) ? $data[0]['source'] : 'casrec';
 
                 // small amount of data -> immediate posting and redirect (needed for behat)
                 if (count($data) < $chunkSize) {
                     $compressedData = CsvUploader::compressData($data);
 
-                    $this->getRestClient()->delete('casrec/truncate');
+                    $this->getRestClient()->delete('casrec/delete-by-source/'.$source);
                     $ret = $this->getRestClient()->setTimeout(600)->post('v2/lay-deputyship/upload', $compressedData);
                     $this->addFlash(
                         'notice',
@@ -323,10 +309,7 @@ class IndexController extends AbstractController
                     );
 
                     foreach ($ret['errors'] as $err) {
-                        $this->addFlash(
-                            'error',
-                            $err
-                        );
+                        $this->addFlash('error', $err);
                     }
 
                     return $this->redirect($this->generateUrl('casrec_upload'));
@@ -343,7 +326,7 @@ class IndexController extends AbstractController
                 }
 
 
-                return $this->redirect($this->generateUrl('casrec_upload', ['nOfChunks' => count($chunks)]));
+                return $this->redirect($this->generateUrl('casrec_upload', ['nOfChunks' => count($chunks), 'source' => $source]));
             } catch (\Throwable $e) {
                 $message = $e->getMessage();
                 if ($e instanceof RestClientException && isset($e->getData()['message'])) {
@@ -355,6 +338,7 @@ class IndexController extends AbstractController
 
         return [
             'nOfChunks'      => $request->get('nOfChunks'),
+            'source'         => $request->get('source'),
             'currentRecords' => $this->getRestClient()->get('casrec/count', 'array'),
             'form'           => $form->createView(),
             'maxUploadSize'  => min([ini_get('upload_max_filesize'), ini_get('post_max_size')]),

--- a/client/src/AppBundle/Resources/assets/javascripts/modules/uploadProgress.js
+++ b/client/src/AppBundle/Resources/assets/javascripts/modules/uploadProgress.js
@@ -3,10 +3,10 @@ var uploadProgress = function (element) {
   // check if exists
   if ($(element).length === 1) {
     var nOfChunks = $(element).attr('max') - 1
-    var casrecTruncateAjaxUrl = $(element).data('path-casrec-truncate-ajax')
+    var casrecDeleteBySourceUrl = $(element).data('path-casrec-delete-by-source-ajax')
 
     $.ajax({
-      url: casrecTruncateAjaxUrl,
+      url: casrecDeleteBySourceUrl,
       dataType: 'json'
     }).done(function (data) {
       $(element).val(1)

--- a/client/src/AppBundle/Resources/views/Admin/Index/uploadUsers.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Index/uploadUsers.html.twig
@@ -19,7 +19,7 @@
 
 <p class="text">{{ (page ~ '.uploading') | trans | raw }}</p>
 
-<progress id="uploadProgress" value="0" max="{{ nOfChunks + 1 }}" data-path-casrec-truncate-ajax="{{ path('casrec_truncate_ajax') }}" data-path-casrec-add-ajax="{{ path('casrec_add_ajax') }}" data-path-casrec-upload="{{ path('casrec_upload') }}" class="js-upload-progress">
+<progress id="uploadProgress" value="0" max="{{ nOfChunks + 1 }}" data-path-casrec-delete-by-source-ajax="{{ path('casrec_delete_by_source_ajax', {'source': source}) }}" data-path-casrec-add-ajax="{{ path('casrec_add_ajax') }}" data-path-casrec-upload="{{ path('casrec_upload') }}" class="js-upload-progress">
 
     {% else %}
 


### PR DESCRIPTION
## Purpose
Support Lay CSV upload from multiple sources

```
As a deputy
I want lay CSVs to be imported from CasRec and Sirius
So that I can register for the digital reporting service
```
Fixes [DDPB-3181](https://opgtransform.atlassian.net/browse/DDPB-3181)

## Approach
There are two things we need to take care of: deleting the relevant items in the `casrec` table according to the source of the CSV, and uploading new entries into the `casrec` table with a new `source` field, also according to the source of the CSV.

Identifying the source is straightforward: if there isn't one in the CSV, or there is an invalid one (i.e not "casrec" or "sirius"), assume "casrec", otherwise use the source value from the CSV. 

Use the determined source to hit a new endpoint `casrec/delete-by-source/{source}` which will remove all casrec entries by the given source. Now we are ready to upload new entries into casrec.

Uploading casrec rows from a new Sirius source is a case of creating a new Assembler that has knowledge of the Sirius CSV headers, and assembles a `LayDeputyshipDto` from the data. The DTO is a normalised domain object that the `LayDeputyshipUploader` takes in. So long as the Assembler creates a valid DTO and passes it to the uploader, then the upload will work as usual.

## Learning
As it stands, each upload begins with an API call to a /truncate endpoint. At first, instead of creating a /delete-by-source endpoint, I did it directly from within the API inside the upload process. This would reduce the extra API call across the network, and also allow us to add the deletion into the database transaction that the upload uses, so any failure would not execute the delete. However, the separate API call is required as it’s a one time event for the entire upload, whereas the upload code within the API runs once for every batch that is sent, effectively meaning we would be deleting by source many times per upload of the entire file (once for each batch). At least this clarifies why we have the separate call out.

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] The product team have tested these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
