### PR TITLE
DDPB-3031 - Add account level cloud9 instance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,8 +204,8 @@ orbs:
         docker:
           - image: circleci/golang:1.12
         environment:
-          TF_VERSION: 0.12.17
-          TF_SHA256SUM: 8124c7dfe5036377de0637378ad32cf530477403c29ab1ccefbaa50a05d059c2
+          TF_VERSION: 0.12.20
+          TF_SHA256SUM: 46bd906f8cb9bbb871905ecb23ae7344af8017d214d735fbb6d6c8e0feb20ff3
           TF_CLI_ARGS_plan: -input=false -lock=false
           TF_CLI_ARGS_apply: -input=false -auto-approve
           TF_CLI_ARGS_destroy: -input=false -auto-approve

--- a/docs/AWS-DB-ACCESS.md
+++ b/docs/AWS-DB-ACCESS.md
@@ -36,8 +36,6 @@ cd /tmp && curl -sS https://getcomposer.org/installer | php && sudo mv composer.
 git clone https://github.com/ministryofjustice/opg-digideps.git
 ```
 
-If you're getting invalid password or username here despite providing valid creds then its likely down to 2FA and SSO enforced on MOJ org. You can provide your personal access token instead of password - unfortunately unless you have this saved somewhere it will mean [generating a new token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line#creating-a-token) in github. Follow any feedback provided in the response regarding SSO.
-
 ### Run composer
 
 ```bash

--- a/environment/api_sg.tf
+++ b/environment/api_sg.tf
@@ -83,8 +83,8 @@ locals {
       port        = 5432
       protocol    = "tcp"
       type        = "ingress"
-      target_type = "cidr_block"
-      target      = data.aws_vpc.vpc.cidr_block
+      target_type = "security_group_id"
+      target      = data.aws_security_group.cloud9.id
     }
     backup = {
       port        = 5432
@@ -130,4 +130,11 @@ module "api_rds_security_group" {
   name   = "api-rds"
   tags   = local.default_tags
   vpc_id = data.aws_vpc.vpc.id
+}
+
+data "aws_security_group" "cloud9" {
+  filter {
+    name   = "tag:aws:cloud9:environment"
+    values = data.terraform_remote_state.shared.outputs.cloud9_env_id
+  }
 }

--- a/environment/api_sg.tf
+++ b/environment/api_sg.tf
@@ -135,6 +135,6 @@ module "api_rds_security_group" {
 data "aws_security_group" "cloud9" {
   filter {
     name   = "tag:aws:cloud9:environment"
-    values = data.terraform_remote_state.shared.outputs.cloud9_env_id
+    values = [data.terraform_remote_state.shared.outputs.cloud9_env_id]
   }
 }

--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -16,7 +16,8 @@
       "mock_emails": false,
       "symfony_env": "prod",
       "db_subnet_group": "rds-private-subnets-prod-vpc",
-      "ec_subnet_group": "ec-pvt-subnets-prod-vpc"
+      "ec_subnet_group": "ec-pvt-subnets-prod-vpc",
+      "state_source": "production"
     },
     "preproduction": {
       "account_id": "454262938596",
@@ -32,7 +33,8 @@
       "mock_emails": false,
       "symfony_env": "prod",
       "db_subnet_group": "private",
-      "ec_subnet_group": "private"
+      "ec_subnet_group": "private",
+      "state_source": "preproduction"
     },
     "training": {
       "account_id": "515688267891",
@@ -48,7 +50,8 @@
       "mock_emails": false,
       "symfony_env": "prod",
       "db_subnet_group": "rds-private-subnets-prod-vpc",
-      "ec_subnet_group": "ec-pvt-subnets-prod-vpc"
+      "ec_subnet_group": "ec-pvt-subnets-prod-vpc",
+      "state_source": "production"
     },
     "master": {
       "account_id": "454262938596",
@@ -64,7 +67,8 @@
       "mock_emails": true,
       "symfony_env": "test",
       "db_subnet_group": "private",
-      "ec_subnet_group": "private"
+      "ec_subnet_group": "private",
+      "state_source": "development"
     },
     "default": {
       "account_id": "248804316466",
@@ -81,7 +85,8 @@
       "mock_emails": true,
       "symfony_env": "test",
       "db_subnet_group": "private",
-      "ec_subnet_group": "private"
+      "ec_subnet_group": "private",
+      "state_source": "development"
     }
   }
 }

--- a/environment/variables.tf
+++ b/environment/variables.tf
@@ -31,6 +31,15 @@ data "aws_ip_ranges" "route53_healthchecks_ips" {
   services = ["route53_healthchecks"]
 }
 
+data "terraform_remote_state" "shared" {
+  backend = "s3"
+  config = {
+    bucket = "opg.terraform.state"
+    key    = "digideps-infrastructure-shared/terraform.tfstate"
+    region = "eu-west-1"
+  }
+}
+
 locals {
   default_whitelist = concat([
     "157.203.176.138/32",

--- a/environment/variables.tf
+++ b/environment/variables.tf
@@ -23,21 +23,13 @@ variable "accounts" {
       symfony_env          = string
       db_subnet_group      = string
       ec_subnet_group      = string
+      state_source         = string
     })
   )
 }
 
 data "aws_ip_ranges" "route53_healthchecks_ips" {
   services = ["route53_healthchecks"]
-}
-
-data "terraform_remote_state" "shared" {
-  backend = "s3"
-  config = {
-    bucket = "opg.terraform.state"
-    key    = "digideps-infrastructure-shared/terraform.tfstate"
-    region = "eu-west-1"
-  }
 }
 
 locals {
@@ -73,4 +65,15 @@ locals {
   subdomain       = local.account["subdomain_enabled"] ? local.environment : ""
   front_whitelist = length(local.account["front_whitelist"]) > 0 ? local.account["front_whitelist"] : local.default_whitelist
   admin_whitelist = length(local.account["admin_whitelist"]) > 0 ? local.account["admin_whitelist"] : local.default_whitelist
+}
+
+data "terraform_remote_state" "shared" {
+  backend   = "s3"
+  workspace = local.account.state_source
+  config = {
+    bucket   = "opg.terraform.state"
+    key      = "digideps-infrastructure-shared/terraform.tfstate"
+    region   = "eu-west-1"
+    role_arn = "arn:aws:iam::311462405659:role/${var.DEFAULT_ROLE}"
+  }
 }

--- a/shared/cloud9.tf
+++ b/shared/cloud9.tf
@@ -3,13 +3,6 @@ resource "aws_cloud9_environment_ec2" "shared" {
   name                        = "shared-env"
   automatic_stop_time_minutes = 20
   description                 = "Shared Cloud9 instance to be used by all devs"
-  subnet_id                   = aws_subnet.private[0].id
+  subnet_id                   = aws_subnet.public[0].id
+  owner_arn                   = "arn:aws:iam::${var.accounts[terraform.workspace].account_id}:assumed-role/operator/alex.saunders"
 }
-
-
-//name - (Required) The name of the environment.
-//instance_type - (Required) The type of instance to connect to the environment, e.g. t2.micro.
-//automatic_stop_time_minutes - (Optional) The number of minutes until the running instance is shut down after the environment has last been used.
-//description - (Optional) The description of the environment.
-//owner_arn - (Optional) The ARN of the environment owner. This can be ARN of any AWS IAM principal. Defaults to the environment's creator.
-//subnet_id - (Optional) The ID of the subnet in Amazon VPC that AWS Cloud9 will use to communicate with the Amazon EC2 instance.

--- a/shared/cloud9.tf
+++ b/shared/cloud9.tf
@@ -1,6 +1,6 @@
 resource "aws_cloud9_environment_ec2" "shared" {
   instance_type               = "t2.micro"
-  name                        = "shared-env"
+  name                        = "team-cloud9-env"
   automatic_stop_time_minutes = 20
   description                 = "Shared Cloud9 instance to be used by all devs"
   subnet_id                   = aws_subnet.public[0].id

--- a/shared/cloud9.tf
+++ b/shared/cloud9.tf
@@ -1,0 +1,15 @@
+resource "aws_cloud9_environment_ec2" "shared" {
+  instance_type               = "t2.micro"
+  name                        = "shared-env"
+  automatic_stop_time_minutes = 20
+  description                 = "Shared Cloud9 instance to be used by all devs"
+  subnet_id                   = aws_subnet.private[0].id
+}
+
+
+//name - (Required) The name of the environment.
+//instance_type - (Required) The type of instance to connect to the environment, e.g. t2.micro.
+//automatic_stop_time_minutes - (Optional) The number of minutes until the running instance is shut down after the environment has last been used.
+//description - (Optional) The description of the environment.
+//owner_arn - (Optional) The ARN of the environment owner. This can be ARN of any AWS IAM principal. Defaults to the environment's creator.
+//subnet_id - (Optional) The ID of the subnet in Amazon VPC that AWS Cloud9 will use to communicate with the Amazon EC2 instance.

--- a/shared/outputs.tf
+++ b/shared/outputs.tf
@@ -1,0 +1,3 @@
+output "cloud9_env_id" {
+  value = aws_cloud9_environment_ec2.shared.id
+}


### PR DESCRIPTION
## Purpose
Adding a single shared account level cloud9 means we can reduce the number of resources on our account (and associated costs) while locking down the security for RDS <--> cloud9.

Fixes DDPB-3031

## Approach
This was a bit of a pain to get set up as we need to apply the security group automatically generated when creating a cloud9 environment to each environments RDS instance. We didn't have a mechanism to get the id of the account level cloud9 instance from `shared` to `environment` and terraform doesn't provide a data source for cloud9 instances. Instead, I've output the id of the cloud9 instance created during the `shared` which is then available in the tfstate file. We then access this state file remotely in S3 using a `terraform_remote_state` data source to access and assign the security group (phew).

One point to note, I had to assign myself as the owner of the cloud9 env in order to make it visible int he console. I'll manually share this with the rest of the team as there is (currently) no way to automate this in code via Terraform.

## Learning
I wasn't even aware accessing tfstate remotely was possible until Andrew filled me in in web ops community. Its something to keep in mind for any other occasion we need to pass data around. 

Also, I came up against a few issues when trying to initially create the cloud9 instance using Terraform by not applying an owner or an owner other than myself. This led to multiples of the same environment being created which were then unable to be destroyed as they had a dependency chain on SGs and network interfaces. In the end, I resorted to destroying my entire PR environment and rebuilding - don't make the same mistake I did and try and go down the rabbit hole of deleting the dependencies int he correct order 🙃 

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
