### PR TITLE
DDPB-3205: wkhtmltopdf not clearing memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Complete the deputy report
 
 This app is the [Complete the deputy report][service] service. It provides an online reporting service used by deputies to submit their reports, and the private area for case managers to review submitted reports.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Complete the deputy report
 
 This app is the [Complete the deputy report][service] service. It provides an online reporting service used by deputies to submit their reports, and the private area for case managers to review submitted reports.

--- a/wkhtmltopdf/Dockerfile
+++ b/wkhtmltopdf/Dockerfile
@@ -11,11 +11,11 @@ RUN pip install werkzeug executor gunicorn
 
 ADD docker-entrypoint.sh /docker-entrypoint.sh
 ADD app.py /app.py
-# ADD clean-tmp /etc/cron.hourly/clean-tmp
+ADD clean-tmp /etc/cron.hourly/clean-tmp
 EXPOSE 80
 
 # Make commands executable
-# RUN ["chmod", "+x", "/etc/cron.hourly/clean-tmp"]
+RUN ["chmod", "+x", "/etc/cron.hourly/clean-tmp"]
 RUN ["chmod", "+x", "/docker-entrypoint.sh"]
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/wkhtmltopdf/Dockerfile
+++ b/wkhtmltopdf/Dockerfile
@@ -11,11 +11,11 @@ RUN pip install werkzeug executor gunicorn
 
 ADD docker-entrypoint.sh /docker-entrypoint.sh
 ADD app.py /app.py
-ADD clean-tmp /etc/cron.hourly/clean-tmp
+# ADD clean-tmp /etc/cron.hourly/clean-tmp
 EXPOSE 80
 
 # Make commands executable
-RUN ["chmod", "+x", "/etc/cron.hourly/clean-tmp"]
+# RUN ["chmod", "+x", "/etc/cron.hourly/clean-tmp"]
 RUN ["chmod", "+x", "/docker-entrypoint.sh"]
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/wkhtmltopdf/app.py
+++ b/wkhtmltopdf/app.py
@@ -40,9 +40,6 @@ def application(request):
             # Load any options that may have been provided in options
             options = json.loads(request.form.get('options', '{}'))
 
-        # Cleanup old files
-        execute(' '.join(['find', '/tmp', '-mmin', '+5', '-type', 'f', '-delete']))
-
         source_file.flush()
 
         # Evaluate argument to run with subprocess

--- a/wkhtmltopdf/app.py
+++ b/wkhtmltopdf/app.py
@@ -40,6 +40,9 @@ def application(request):
             # Load any options that may have been provided in options
             options = json.loads(request.form.get('options', '{}'))
 
+        # Cleanup old files
+        execute(' '.join(['find', '/tmp', '-mmin', '+5', '-type', 'f', '-delete']))
+
         source_file.flush()
 
         # Evaluate argument to run with subprocess

--- a/wkhtmltopdf/app.py
+++ b/wkhtmltopdf/app.py
@@ -42,6 +42,9 @@ def application(request):
 
         source_file.flush()
 
+        # Cleanup old files
+        execute(' '.join(['find', '/tmp', '-mmin', '+5', '-type', 'f', '-delete']))
+
         # Evaluate argument to run with subprocess
         args = ['wkhtmltopdf']
 

--- a/wkhtmltopdf/docker-entrypoint.sh
+++ b/wkhtmltopdf/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 service cron restart
 
-usr/local/bin/gunicorn --max-requests 1000 $@
+usr/local/bin/gunicorn --max-requests 100 $@

--- a/wkhtmltopdf/docker-entrypoint.sh
+++ b/wkhtmltopdf/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 service cron restart
 
-usr/local/bin/gunicorn $@
+usr/local/bin/gunicorn --max-requests 1000 $@

--- a/wkhtmltopdf/docker-entrypoint.sh
+++ b/wkhtmltopdf/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 service cron restart
 
-usr/local/bin/gunicorn --max-requests 100 $@
+usr/local/bin/gunicorn --max-requests 10000 $@


### PR DESCRIPTION
## Purpose
The wkhtmltopdf container gets through memory quickly and regularly finds itself near 100% memory usage. This is, if nothing else, a  waste of electricity.

![image](https://user-images.githubusercontent.com/100852/74243324-769e8000-4cd7-11ea-9b0a-7edac64c40b9.png)

Part of the reason for this is the load the container is put under: whilst it's used fairly infrequently by users, the healthcheck page actually generates a PDF to verify the service works (one that just contains the word "test"). This results in 32 PDFs being generated every minute, without any user load, which clearly eats into the memory somehow.

Fixes DDPB-3205

## Approach
I've applied a fairly blunt solution: using [an out-of-the-box config option](https://docs.gunicorn.org/en/0.16.0/configure.html#max-requests) I've made the gunicorn process restart every 10,000 requests. So after generating 10,000 PDFs it starts a new process, kills the old one (with no downtime) and completely cleans up its memory.

This may seem a bit iffy, but compare it to a Lambda (which the service basically acts like) which is _effectively_ set to `--max-requests=1`.

## Learning
I considered adding a dedicated healthcheck endpoint so that it didn't have to constantly generate PDFs, but that would have lowered the confidence of our healthcheck. It would've also been a lot more work.

I also considered digging deeper into the actual cause of the memory leak, but it would have meant a lot digging through Python/werkzeug/wkhtmltopdf in a bit of a time-wasting exercise. The load on the server is so unnaturally high that I think we can forgive the memory leak itself.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work
  - N/A
- [x] The product team have approved these changes
  - N/A