### PR TITLE
ddpb-3192 add redis read replicas

### DIFF
--- a/environment/admin_elasticache.tf
+++ b/environment/admin_elasticache.tf
@@ -1,4 +1,23 @@
+resource "aws_elasticache_replication_group" "admin" {
+  count                         = local.account.is_production == 0 ? 1 : 0
+  automatic_failover_enabled    = true
+  engine                        = "redis"
+  engine_version                = "5.0.0"
+  availability_zones            = ["eu-west-1a", "eu-west-1b"]
+  replication_group_id          = "admin-rep-group-${local.environment}"
+  replication_group_description = "Replication Group for Admin"
+  node_type                     = "cache.t2.small"
+  number_cache_clusters         = 2
+  parameter_group_name          = "default.redis5.0"
+  port                          = 6379
+  subnet_group_name             = local.account.ec_subnet_group
+  security_group_ids            = [module.admin_cache_security_group.id]
+  tags                          = local.default_tags
+  apply_immediately             = true
+}
+
 resource "aws_elasticache_cluster" "admin" {
+  count                = local.account.is_production == 0 ? 0 : 1
   cluster_id           = "admin-${local.environment}"
   engine               = "redis"
   node_type            = "cache.t2.small"

--- a/environment/api_elasticache.tf
+++ b/environment/api_elasticache.tf
@@ -1,4 +1,26 @@
+resource "aws_elasticache_replication_group" "api" {
+  count                         = local.account.is_production == 0 ? 1 : 0
+  automatic_failover_enabled    = true
+  engine                        = "redis"
+  engine_version                = "5.0.0"
+  availability_zones            = ["eu-west-1a", "eu-west-1b"]
+  replication_group_id          = "api-rep-group-${local.environment}"
+  replication_group_description = "Replication Group for API"
+  node_type                     = "cache.t2.small"
+  number_cache_clusters         = 2
+  parameter_group_name          = "default.redis5.0"
+  port                          = 6379
+  subnet_group_name             = local.account.ec_subnet_group
+  security_group_ids            = [module.api_cache_security_group.id]
+  apply_immediately             = true
+  tags = {
+    InstanceName = "api-${local.environment}"
+    Stack        = local.environment
+  }
+}
+
 resource "aws_elasticache_cluster" "api" {
+  count                = local.account.is_production == 0 ? 0 : 1
   cluster_id           = "api-${local.environment}"
   engine               = "redis"
   node_type            = "cache.t2.small"
@@ -14,12 +36,4 @@ resource "aws_elasticache_cluster" "api" {
     InstanceName = "api-${local.environment}"
     Stack        = local.environment
   }
-}
-
-resource "aws_route53_record" "api_redis" {
-  name    = "api-redis"
-  type    = "CNAME"
-  zone_id = aws_route53_zone.internal.id
-  records = [aws_elasticache_cluster.api.cache_nodes[0].address]
-  ttl     = 300
 }

--- a/environment/dns_private.tf
+++ b/environment/dns_private.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "front_redis" {
   name    = "front-redis"
   type    = "CNAME"
   zone_id = aws_route53_zone.internal.id
-  records = [aws_elasticache_replication_group.front.primary_endpoint_address]
+  records = local.account.is_production == 0 ? [aws_elasticache_replication_group.front[0].primary_endpoint_address] : [aws_elasticache_cluster.front[0].cache_nodes[0].address]
   ttl     = 300
 }
 
@@ -19,6 +19,14 @@ resource "aws_route53_record" "admin_redis" {
   name    = "admin-redis"
   type    = "CNAME"
   zone_id = aws_route53_zone.internal.id
-  records = [aws_elasticache_cluster.admin.cache_nodes[0].address]
+  records = local.account.is_production == 0 ? [aws_elasticache_replication_group.admin[0].primary_endpoint_address] : [aws_elasticache_cluster.admin[0].cache_nodes[0].address]
+  ttl     = 300
+}
+
+resource "aws_route53_record" "api_redis" {
+  name    = "api-redis"
+  type    = "CNAME"
+  zone_id = aws_route53_zone.internal.id
+  records = local.account.is_production == 0 ? [aws_elasticache_replication_group.api[0].primary_endpoint_address] : [aws_elasticache_cluster.api[0].cache_nodes[0].address]
   ttl     = 300
 }

--- a/environment/dns_private.tf
+++ b/environment/dns_private.tf
@@ -11,7 +11,7 @@ resource "aws_route53_record" "front_redis" {
   name    = "front-redis"
   type    = "CNAME"
   zone_id = aws_route53_zone.internal.id
-  records = [aws_elasticache_cluster.front.cache_nodes[0].address]
+  records = [aws_elasticache_replication_group.front.primary_endpoint_address]
   ttl     = 300
 }
 

--- a/environment/front_elasticache.tf
+++ b/environment/front_elasticache.tf
@@ -1,23 +1,11 @@
-//resource "aws_elasticache_cluster" "front" {
-//  cluster_id           = "front-${local.environment}"
-//  engine               = "redis"
-//  node_type            = "cache.t2.small"
-//  num_cache_nodes      = 1
-//  parameter_group_name = "default.redis5.0"
-//  engine_version       = "5.0.0"
-//  port                 = 6379
-//  subnet_group_name    = local.account.ec_subnet_group
-//  security_group_ids   = [module.front_cache_security_group.id]
-//  tags                 = local.default_tags
-//}
-
 resource "aws_elasticache_replication_group" "front" {
+  count                         = local.account.is_production == 0 ? 1 : 0
   automatic_failover_enabled    = true
   engine                        = "redis"
   engine_version                = "5.0.0"
   availability_zones            = ["eu-west-1a", "eu-west-1b"]
-  replication_group_id          = "front-rep-group-1"
-  replication_group_description = "test description"
+  replication_group_id          = "front-rep-group-${local.environment}"
+  replication_group_description = "Replication Group for Front"
   node_type                     = "cache.t2.small"
   number_cache_clusters         = 2
   parameter_group_name          = "default.redis5.0"
@@ -26,19 +14,18 @@ resource "aws_elasticache_replication_group" "front" {
   security_group_ids            = [module.front_cache_security_group.id]
   tags                          = local.default_tags
   apply_immediately             = true
-  lifecycle {
-    ignore_changes = [number_cache_clusters]
-  }
 }
 
-resource "aws_elasticache_cluster" "node1" {
-  cluster_id           = "test-redis-001"
-  replication_group_id = aws_elasticache_replication_group.front.id
-  apply_immediately    = true
-}
-
-resource "aws_elasticache_cluster" "node2" {
-  cluster_id           = "test-redis-002"
-  replication_group_id = aws_elasticache_replication_group.front.id
-  apply_immediately    = true
+resource "aws_elasticache_cluster" "front" {
+  count                = local.account.is_production == 0 ? 0 : 1
+  cluster_id           = "front-${local.environment}"
+  engine               = "redis"
+  node_type            = "cache.t2.small"
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis5.0"
+  engine_version       = "5.0.0"
+  port                 = 6379
+  subnet_group_name    = local.account.ec_subnet_group
+  security_group_ids   = [module.front_cache_security_group.id]
+  tags                 = local.default_tags
 }

--- a/environment/front_elasticache.tf
+++ b/environment/front_elasticache.tf
@@ -13,32 +13,32 @@
 
 resource "aws_elasticache_replication_group" "front" {
   automatic_failover_enabled    = true
-  engine               = "redis"
-  engine_version       = "5.0.0"
+  engine                        = "redis"
+  engine_version                = "5.0.0"
   availability_zones            = ["eu-west-1a", "eu-west-1b"]
   replication_group_id          = "front-rep-group-1"
   replication_group_description = "test description"
-  node_type            = "cache.t2.small"
+  node_type                     = "cache.t2.small"
   number_cache_clusters         = 2
   parameter_group_name          = "default.redis5.0"
   port                          = 6379
-  subnet_group_name = local.account.ec_subnet_group
-  security_group_ids = [module.front_cache_security_group.id]
-  tags                 = local.default_tags
-  apply_immediately = true
+  subnet_group_name             = local.account.ec_subnet_group
+  security_group_ids            = [module.front_cache_security_group.id]
+  tags                          = local.default_tags
+  apply_immediately             = true
   lifecycle {
     ignore_changes = [number_cache_clusters]
   }
 }
 
 resource "aws_elasticache_cluster" "node1" {
-  cluster_id = "test-redis-001"
+  cluster_id           = "test-redis-001"
   replication_group_id = aws_elasticache_replication_group.front.id
-  apply_immediately = true
+  apply_immediately    = true
 }
 
 resource "aws_elasticache_cluster" "node2" {
   cluster_id           = "test-redis-002"
   replication_group_id = aws_elasticache_replication_group.front.id
-  apply_immediately = true
+  apply_immediately    = true
 }

--- a/environment/front_elasticache.tf
+++ b/environment/front_elasticache.tf
@@ -1,12 +1,44 @@
-resource "aws_elasticache_cluster" "front" {
-  cluster_id           = "front-${local.environment}"
+//resource "aws_elasticache_cluster" "front" {
+//  cluster_id           = "front-${local.environment}"
+//  engine               = "redis"
+//  node_type            = "cache.t2.small"
+//  num_cache_nodes      = 1
+//  parameter_group_name = "default.redis5.0"
+//  engine_version       = "5.0.0"
+//  port                 = 6379
+//  subnet_group_name    = local.account.ec_subnet_group
+//  security_group_ids   = [module.front_cache_security_group.id]
+//  tags                 = local.default_tags
+//}
+
+resource "aws_elasticache_replication_group" "front" {
+  automatic_failover_enabled    = true
   engine               = "redis"
-  node_type            = "cache.t2.small"
-  num_cache_nodes      = 1
-  parameter_group_name = "default.redis5.0"
   engine_version       = "5.0.0"
-  port                 = 6379
-  subnet_group_name    = local.account.ec_subnet_group
-  security_group_ids   = [module.front_cache_security_group.id]
+  availability_zones            = ["eu-west-1a", "eu-west-1b"]
+  replication_group_id          = "front-rep-group-1"
+  replication_group_description = "test description"
+  node_type            = "cache.t2.small"
+  number_cache_clusters         = 2
+  parameter_group_name          = "default.redis5.0"
+  port                          = 6379
+  subnet_group_name = local.account.ec_subnet_group
+  security_group_ids = [module.front_cache_security_group.id]
   tags                 = local.default_tags
+  apply_immediately = true
+  lifecycle {
+    ignore_changes = [number_cache_clusters]
+  }
+}
+
+resource "aws_elasticache_cluster" "node1" {
+  cluster_id = "test-redis-001"
+  replication_group_id = aws_elasticache_replication_group.front.id
+  apply_immediately = true
+}
+
+resource "aws_elasticache_cluster" "node2" {
+  cluster_id           = "test-redis-002"
+  replication_group_id = aws_elasticache_replication_group.front.id
+  apply_immediately = true
 }


### PR DESCRIPTION
== Don't merge. Testing. ==

## Purpose
Create only 1 additional read node per ECS cluster for Front, Admin and API in production only (due to cost) in a different availability zone. 

Fixes DDPB-3192

## Approach
My initial approach was to try and add non clustered read replicas managed by terraform through this resource: aws_elasticache_replication_group and adding the replicas as stated here https://www.terraform.io/docs/providers/aws/r/elasticache_replication_group.html. However after trying every combination and a lot of google searching, I wasn't able to get just two nodes with terraform managing the redis nodes so I had to let the aws_elasticache_replication_group manage it directly. For testing I used cloud9 with it's security group added to the redis sg allow list to use the redis-cli to set some values on redis, then fail over the (checking events that it failed over correctly) then doing a get and checking the values still appeared on the new primary. This worked fine. The other tests are based on the standard behat tests running through correctly in clustered mode.

## Learning
What looks like it ought to work in the documentation that is supposed to give fine grained access for managing individual replicas in terraform doesn't work as advertised. It is possible to add 2 number_cache_clusters and 2 managed replicas for example but the documentation suggests that when they are named the same, it would create the 2 number_cache_clusters as the replicas. This isn't the case and it complains about them having the same name (also impossible to set number_cache_clusters to less than 2) so have had to go for non managed. Have learned that you can test redis manually by allowing the cloud 9 security group access on the redis security group temporarily. 

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
