### PR TITLE
Prefer github source for slack module to fix path bug

### DIFF
--- a/environment/cleanup.tf
+++ b/environment/cleanup.tf
@@ -2,8 +2,15 @@ data "aws_iam_role" "events_task_runner" {
   name = "events_task_runner"
 }
 
+resource "aws_cloudwatch_event_rule" "nightly" {
+  name                = "nightly-${local.environment}"
+  description         = "Nightly scheduled tasks"
+  schedule_expression = "cron(0 3 * * ? *)"
+  tags                = local.default_tags
+}
+
 resource "aws_cloudwatch_event_target" "cleanup" {
-  rule     = "nightly" # There's no aws_cloudwatch_event_rule data source, so hard-code name
+  rule     = aws_cloudwatch_event_rule.nightly
   arn      = aws_ecs_cluster.main.arn
   role_arn = data.aws_iam_role.events_task_runner.arn
 

--- a/environment/cleanup.tf
+++ b/environment/cleanup.tf
@@ -10,7 +10,7 @@ resource "aws_cloudwatch_event_rule" "nightly" {
 }
 
 resource "aws_cloudwatch_event_target" "cleanup" {
-  rule     = aws_cloudwatch_event_rule.nightly
+  rule     = aws_cloudwatch_event_rule.nightly.name
   arn      = aws_ecs_cluster.main.arn
   role_arn = data.aws_iam_role.events_task_runner.arn
 

--- a/shared/events.tf
+++ b/shared/events.tf
@@ -40,10 +40,3 @@ resource "aws_iam_role_policy" "events_task_runner" {
 }
 DOC
 }
-
-resource "aws_cloudwatch_event_rule" "nightly" {
-  name                = "nightly"
-  description         = "Nightly scheduled tasks"
-  schedule_expression = "cron(0 3 * * ? *)"
-  tags                = local.default_tags
-}

--- a/shared/sns.tf
+++ b/shared/sns.tf
@@ -3,8 +3,7 @@ resource "aws_sns_topic" "alerts" {
 }
 
 module "notify_slack" {
-  source  = "terraform-aws-modules/notify-slack/aws"
-  version = "~> 2.0"
+  source = "github.com/terraform-aws-modules/terraform-aws-notify-slack.git?ref=v2.4.0"
 
   sns_topic_name   = aws_sns_topic.alerts.name
   create_sns_topic = false
@@ -26,8 +25,7 @@ resource "aws_sns_topic" "availability-alert" {
 }
 
 module "notify_slack_us-east-1" {
-  source  = "terraform-aws-modules/notify-slack/aws"
-  version = "~> 2.0"
+  source = "github.com/terraform-aws-modules/terraform-aws-notify-slack.git?ref=v2.4.0"
 
   providers = {
     aws = aws.us-east-1


### PR DESCRIPTION
## Purpose
Using GitHub as source for Slack terraform module to fix the path bug referenced [here](https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/21#issuecomment-565092931).