### PR TITLE
ddpb-3031 add missing sg rule for restore from prod

### DIFF
--- a/environment/api_sg.tf
+++ b/environment/api_sg.tf
@@ -100,6 +100,13 @@ locals {
       target_type = "security_group_id"
       target      = module.restore.security_group_id
     }
+    restore_from_production = {
+      port        = 5432
+      type        = "ingress"
+      protocol    = "tcp"
+      target_type = "security_group_id"
+      target      = module.restore_from_production.security_group_id
+    }
     api_unit_test = {
       port        = 5432
       type        = "ingress"


### PR DESCRIPTION
## Purpose
As some fallout from 3031, a security group rule that was used by cloud9 was actually allowing the restore of the database from prod into preprod. Since the rules were tightened up this failed to work as there was a rule missing.

Fixes DDPB-3031

## Approach
Looked in console for the correct ingress rule and saw it was missing.

## Learning
Learned that this doesn't work cross account. Prod backups to s3 then a separate process restores from that s3 bucket into the preprod env.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
