### PR TITLE
ddpb-3192 remove old elasticache cluster

### DIFF
--- a/environment/admin_elasticache.tf
+++ b/environment/admin_elasticache.tf
@@ -2,7 +2,6 @@ resource "aws_elasticache_replication_group" "admin" {
   automatic_failover_enabled    = local.account.elasticache_count == 1 ? false : true
   engine                        = "redis"
   engine_version                = "5.0.0"
-  availability_zones            = null_resource.elasticache_az_list.*.triggers.az
   replication_group_id          = "admin-rep-group-${local.environment}"
   replication_group_description = "Replication Group for Admin"
   node_type                     = "cache.t2.small"

--- a/environment/admin_elasticache.tf
+++ b/environment/admin_elasticache.tf
@@ -1,33 +1,16 @@
 resource "aws_elasticache_replication_group" "admin" {
-  // Include this once first two subtasks of DDBP-3192 are done
-  //  count                         = local.account.is_production == 1 ? 1 : 0
-  automatic_failover_enabled    = true
+  automatic_failover_enabled    = local.account.elasticache_count == 1 ? false : true
   engine                        = "redis"
   engine_version                = "5.0.0"
-  availability_zones            = ["eu-west-1a", "eu-west-1b"]
+  availability_zones            = null_resource.elasticache_az_list.*.triggers.az
   replication_group_id          = "admin-rep-group-${local.environment}"
   replication_group_description = "Replication Group for Admin"
   node_type                     = "cache.t2.small"
-  number_cache_clusters         = 2
+  number_cache_clusters         = local.account.elasticache_count
   parameter_group_name          = "default.redis5.0"
   port                          = 6379
   subnet_group_name             = local.account.ec_subnet_group
   security_group_ids            = [module.admin_cache_security_group.id]
   tags                          = local.default_tags
   apply_immediately             = true
-}
-
-resource "aws_elasticache_cluster" "admin" {
-  // Include this once first two subtasks of DDBP-3192 are done
-  //  count                = local.account.is_production == 1 ? 0 : 1
-  cluster_id           = "admin-${local.environment}"
-  engine               = "redis"
-  node_type            = "cache.t2.small"
-  num_cache_nodes      = 1
-  parameter_group_name = "default.redis5.0"
-  engine_version       = "5.0.0"
-  port                 = 6379
-  subnet_group_name    = local.account.ec_subnet_group
-  security_group_ids   = [module.admin_cache_security_group.id]
-  tags                 = local.default_tags
 }

--- a/environment/api_elasticache.tf
+++ b/environment/api_elasticache.tf
@@ -1,39 +1,17 @@
 resource "aws_elasticache_replication_group" "api" {
-  // Include this once first two subtasks of DDBP-3192 are done
-  //  count                         = local.account.is_production == 1 ? 1 : 0
-  automatic_failover_enabled    = true
+  automatic_failover_enabled    = local.account.elasticache_count == 1 ? false : true
   engine                        = "redis"
   engine_version                = "5.0.0"
-  availability_zones            = ["eu-west-1a", "eu-west-1b"]
+  availability_zones            = null_resource.elasticache_az_list.*.triggers.az
   replication_group_id          = "api-rep-group-${local.environment}"
   replication_group_description = "Replication Group for API"
   node_type                     = "cache.t2.small"
-  number_cache_clusters         = 2
+  number_cache_clusters         = local.account.elasticache_count
   parameter_group_name          = "default.redis5.0"
   port                          = 6379
   subnet_group_name             = local.account.ec_subnet_group
   security_group_ids            = [module.api_cache_security_group.id]
   apply_immediately             = true
-  tags = {
-    InstanceName = "api-${local.environment}"
-    Stack        = local.environment
-  }
-}
-
-resource "aws_elasticache_cluster" "api" {
-  // Include this once first two subtasks of DDBP-3192 are done
-  //  count                = local.account.is_production == 1 ? 0 : 1
-  cluster_id           = "api-${local.environment}"
-  engine               = "redis"
-  node_type            = "cache.t2.small"
-  num_cache_nodes      = 1
-  parameter_group_name = "default.redis5.0"
-  engine_version       = "5.0.0"
-  port                 = 6379
-  subnet_group_name    = local.account.ec_subnet_group
-
-  security_group_ids = [module.api_cache_security_group.id]
-
   tags = {
     InstanceName = "api-${local.environment}"
     Stack        = local.environment

--- a/environment/api_elasticache.tf
+++ b/environment/api_elasticache.tf
@@ -2,7 +2,6 @@ resource "aws_elasticache_replication_group" "api" {
   automatic_failover_enabled    = local.account.elasticache_count == 1 ? false : true
   engine                        = "redis"
   engine_version                = "5.0.0"
-  availability_zones            = null_resource.elasticache_az_list.*.triggers.az
   replication_group_id          = "api-rep-group-${local.environment}"
   replication_group_description = "Replication Group for API"
   node_type                     = "cache.t2.small"

--- a/environment/dns_private.tf
+++ b/environment/dns_private.tf
@@ -12,9 +12,7 @@ resource "aws_route53_record" "front_redis" {
   type    = "CNAME"
   zone_id = aws_route53_zone.internal.id
   records = [aws_elasticache_replication_group.front.primary_endpoint_address]
-  // Include this once first two subtasks of DDBP-3192 are done
-  //  records = local.account.is_production == 1 ? [aws_elasticache_replication_group.front[0].primary_endpoint_address] : [aws_elasticache_cluster.front[0].cache_nodes[0].address]
-  ttl = 300
+  ttl     = 300
 }
 
 resource "aws_route53_record" "admin_redis" {
@@ -22,9 +20,7 @@ resource "aws_route53_record" "admin_redis" {
   type    = "CNAME"
   zone_id = aws_route53_zone.internal.id
   records = [aws_elasticache_replication_group.admin.primary_endpoint_address]
-  // Include this once first two subtasks of DDBP-3192 are done
-  //  records = local.account.is_production == 1 ? [aws_elasticache_replication_group.admin[0].primary_endpoint_address] : [aws_elasticache_cluster.admin[0].cache_nodes[0].address]
-  ttl = 300
+  ttl     = 300
 }
 
 resource "aws_route53_record" "api_redis" {
@@ -32,7 +28,5 @@ resource "aws_route53_record" "api_redis" {
   type    = "CNAME"
   zone_id = aws_route53_zone.internal.id
   records = [aws_elasticache_replication_group.api.primary_endpoint_address]
-  // Include this once first two subtasks of DDBP-3192 are done
-  //  records = local.account.is_production == 1 ? [aws_elasticache_replication_group.api[0].primary_endpoint_address] : [aws_elasticache_cluster.api[0].cache_nodes[0].address]
-  ttl = 300
+  ttl     = 300
 }

--- a/environment/front_elasticache.tf
+++ b/environment/front_elasticache.tf
@@ -1,33 +1,16 @@
 resource "aws_elasticache_replication_group" "front" {
-  // Include this once first two subtasks of DDBP-3192 are done
-  //  count                         = local.account.is_production == 1 ? 1 : 0
-  automatic_failover_enabled    = true
+  automatic_failover_enabled    = local.account.elasticache_count == 1 ? false : true
   engine                        = "redis"
   engine_version                = "5.0.0"
-  availability_zones            = ["eu-west-1a", "eu-west-1b"]
+  availability_zones            = null_resource.elasticache_az_list.*.triggers.az
   replication_group_id          = "front-rep-group-${local.environment}"
   replication_group_description = "Replication Group for Front"
   node_type                     = "cache.t2.small"
-  number_cache_clusters         = 2
+  number_cache_clusters         = local.account.elasticache_count
   parameter_group_name          = "default.redis5.0"
   port                          = 6379
   subnet_group_name             = local.account.ec_subnet_group
   security_group_ids            = [module.front_cache_security_group.id]
   tags                          = local.default_tags
   apply_immediately             = true
-}
-
-resource "aws_elasticache_cluster" "front" {
-  // Include this once first two subtasks of DDBP-3192 are done
-  //  count                = local.account.is_production == 1 ? 0 : 1
-  cluster_id           = "front-${local.environment}"
-  engine               = "redis"
-  node_type            = "cache.t2.small"
-  num_cache_nodes      = 1
-  parameter_group_name = "default.redis5.0"
-  engine_version       = "5.0.0"
-  port                 = 6379
-  subnet_group_name    = local.account.ec_subnet_group
-  security_group_ids   = [module.front_cache_security_group.id]
-  tags                 = local.default_tags
 }

--- a/environment/front_elasticache.tf
+++ b/environment/front_elasticache.tf
@@ -2,7 +2,6 @@ resource "aws_elasticache_replication_group" "front" {
   automatic_failover_enabled    = local.account.elasticache_count == 1 ? false : true
   engine                        = "redis"
   engine_version                = "5.0.0"
-  availability_zones            = null_resource.elasticache_az_list.*.triggers.az
   replication_group_id          = "front-rep-group-${local.environment}"
   replication_group_description = "Replication Group for Front"
   node_type                     = "cache.t2.small"

--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -36,7 +36,7 @@
       "db_subnet_group": "private",
       "ec_subnet_group": "private",
       "state_source": "preproduction",
-      "elasticache_count": 1
+      "elasticache_count": 2
     },
     "training": {
       "account_id": "515688267891",

--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -17,7 +17,8 @@
       "symfony_env": "prod",
       "db_subnet_group": "rds-private-subnets-prod-vpc",
       "ec_subnet_group": "ec-pvt-subnets-prod-vpc",
-      "state_source": "production"
+      "state_source": "production",
+      "elasticache_count": 2
     },
     "preproduction": {
       "account_id": "454262938596",
@@ -34,7 +35,8 @@
       "symfony_env": "prod",
       "db_subnet_group": "private",
       "ec_subnet_group": "private",
-      "state_source": "preproduction"
+      "state_source": "preproduction",
+      "elasticache_count": 1
     },
     "training": {
       "account_id": "515688267891",
@@ -51,7 +53,8 @@
       "symfony_env": "prod",
       "db_subnet_group": "rds-private-subnets-prod-vpc",
       "ec_subnet_group": "ec-pvt-subnets-prod-vpc",
-      "state_source": "production"
+      "state_source": "production",
+      "elasticache_count": 1
     },
     "master": {
       "account_id": "454262938596",
@@ -68,7 +71,8 @@
       "symfony_env": "test",
       "db_subnet_group": "private",
       "ec_subnet_group": "private",
-      "state_source": "preproduction"
+      "state_source": "preproduction",
+      "elasticache_count": 1
     },
     "default": {
       "account_id": "248804316466",
@@ -86,7 +90,8 @@
       "symfony_env": "test",
       "db_subnet_group": "private",
       "ec_subnet_group": "private",
-      "state_source": "development"
+      "state_source": "development",
+      "elasticache_count": 1
     }
   }
 }

--- a/environment/variables.tf
+++ b/environment/variables.tf
@@ -24,6 +24,7 @@ variable "accounts" {
       db_subnet_group      = string
       ec_subnet_group      = string
       state_source         = string
+      elasticache_count    = number
     })
   )
 }
@@ -46,6 +47,20 @@ locals {
   subdomain       = local.account["subdomain_enabled"] ? local.environment : ""
   front_whitelist = length(local.account["front_whitelist"]) > 0 ? local.account["front_whitelist"] : local.default_whitelist
   admin_whitelist = length(local.account["admin_whitelist"]) > 0 ? local.account["admin_whitelist"] : local.default_whitelist
+
+  elasticache_az = [
+    "eu-west-1a",
+    "eu-west-1b",
+    "eu-west-1c"
+  ]
+}
+
+resource "null_resource" "elasticache_az_list" {
+  count = local.account.elasticache_count
+
+  triggers = {
+    az = element(local.elasticache_az, count.index)
+  }
 }
 
 data "terraform_remote_state" "shared" {

--- a/environment/variables.tf
+++ b/environment/variables.tf
@@ -47,20 +47,6 @@ locals {
   subdomain       = local.account["subdomain_enabled"] ? local.environment : ""
   front_whitelist = length(local.account["front_whitelist"]) > 0 ? local.account["front_whitelist"] : local.default_whitelist
   admin_whitelist = length(local.account["admin_whitelist"]) > 0 ? local.account["admin_whitelist"] : local.default_whitelist
-
-  elasticache_az = [
-    "eu-west-1a",
-    "eu-west-1b",
-    "eu-west-1c"
-  ]
-}
-
-resource "null_resource" "elasticache_az_list" {
-  count = local.account.elasticache_count
-
-  triggers = {
-    az = element(local.elasticache_az, count.index)
-  }
 }
 
 data "terraform_remote_state" "shared" {


### PR DESCRIPTION
## Purpose
Create only 1 additional read node per ECS cluster for Front, Admin and API in production only (due to cost) in a different availability zone.
Fixes DDPB-3192

## Approach
My initial approach was to try and add non clustered read replicas managed by terraform through this resource: aws_elasticache_replication_group and adding the replicas as stated here https://www.terraform.io/docs/providers/aws/r/elasticache_replication_group.html. However after trying every combination and a lot of google searching, I wasn't able to get just two nodes with terraform managing the redis nodes so I had to let the aws_elasticache_replication_group manage it directly. For testing I used cloud9 with it's security group added to the redis sg allow list to use the redis-cli to set some values on redis, then fail over the (checking events that it failed over correctly) then doing a get and checking the values still appeared on the new primary. This worked fine. The other tests are based on the standard behat tests running through correctly in clustered mode.

For the release I had to split this into 3 stages. This is the final stage that will remove the superfluous code and the old elasticache cluster as it has been replaced by a distribution zone.

## Learning
What looks like it ought to work in the documentation that is supposed to give fine grained access for managing individual replicas in terraform doesn't work as advertised. It is possible to add 2 number_cache_clusters and 2 managed replicas for example but the documentation suggests that when they are named the same, it would create the 2 number_cache_clusters as the replicas. This isn't the case and it complains about them having the same name (also impossible to set number_cache_clusters to less than 2) so have had to go for non managed. Have learned that you can test redis manually by allowing the cloud 9 security group access on the redis security group temporarily.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
