### PR TITLE
Move enhanced monitoring role into shared

### DIFF
--- a/environment/api_rds.tf
+++ b/environment/api_rds.tf
@@ -92,26 +92,8 @@ resource "aws_rds_cluster" "api" {
 #   }
 # }
 
-resource "aws_iam_role" "enhanced_monitoring" {
-  name               = "rds-enhanced-monitoring"
-  assume_role_policy = data.aws_iam_policy_document.enhanced_monitoring.json
-}
-
-resource "aws_iam_role_policy_attachment" "enhanced_monitoring" {
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
-  role       = aws_iam_role.enhanced_monitoring.name
-}
-
-data "aws_iam_policy_document" "enhanced_monitoring" {
-  statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      identifiers = ["monitoring.rds.amazonaws.com"]
-      type        = "Service"
-    }
-  }
+data "aws_iam_role" "enhanced_monitoring" {
+  name = "rds-enhanced-monitoring"
 }
 
 locals {

--- a/shared/rds.tf
+++ b/shared/rds.tf
@@ -1,0 +1,21 @@
+resource "aws_iam_role" "enhanced_monitoring" {
+  name               = "rds-enhanced-monitoring"
+  assume_role_policy = data.aws_iam_policy_document.enhanced_monitoring.json
+}
+
+resource "aws_iam_role_policy_attachment" "enhanced_monitoring" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+  role       = aws_iam_role.enhanced_monitoring.name
+}
+
+data "aws_iam_policy_document" "enhanced_monitoring" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      identifiers = ["monitoring.rds.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}


### PR DESCRIPTION
We were previously creating a role per environment, but getting a resource conflict because they have the same name. We only need one role per account, so I've moved it to shared.