### PR TITLE
DDPB-3195: Remove L7.2 questions from 103 report checklists

### DIFF
--- a/client/src/AppBundle/Form/Admin/ReportChecklistType.php
+++ b/client/src/AppBundle/Form/Admin/ReportChecklistType.php
@@ -60,8 +60,8 @@ class ReportChecklistType extends AbstractType
                 ->add('debtsManaged', FormTypes\ChoiceType::class, $yesNoNaOptions)
                 ->add('openClosingBalancesMatch', FormTypes\ChoiceType::class, $yesNoNaOptions);
 
-            // Don't show balancing question for professional reports with short money sections
-            if (!in_array($this->report->getType(), ['103-5', '103-4-5'])) {
+            // Only show balancing question for reports which can be balanced
+            if ($this->report->hasSection('balance')) {
                 $builder->add('accountsBalance', FormTypes\ChoiceType::class, $yesNoNaOptions);
             }
 


### PR DESCRIPTION
## Purpose
Question L7.2 is not relevant to 103 reports as accounts cannot be balanced. It should be removed for the 103 checklists of lay and PA clients (already done for professionals) 

Fixes DDPB-3195

## Approach
I made the question dependent on the report having a balacing section, rather than muddling with report types again.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work
  - N/A, there's no real abstraction here
- [ ] The product team have approved these changes
