### PR TITLE
DDPB-3237: Add "synchronised" status and time to document model

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,9 +327,9 @@ jobs:
       - run:
           name: Check updated PHP files for errors
           command: |
-            MERGE_BASE_COMMIT=$(git merge-base master HEAD)
-            API_CHANGED_FILES=$(git diff --relative=api --name-only --diff-filter=d $MERGE_BASE_COMMIT | grep .php) || [[ $? == 1 ]]
-            CLIENT_CHANGED_FILES=$(git diff --relative=client --name-only --diff-filter=d $MERGE_BASE_COMMIT | grep .php) || [[ $? == 1 ]]
+            MERGE_BASE_COMMIT=( $(git merge-base master HEAD) )
+            API_CHANGED_FILES=( $(git diff --relative=api --name-only --diff-filter=d $MERGE_BASE_COMMIT | grep .php) ) || [[ $? == 1 ]]
+            CLIENT_CHANGED_FILES=( $(git diff --relative=client --name-only --diff-filter=d $MERGE_BASE_COMMIT | grep .php) ) || [[ $? == 1 ]]
 
             if [ -n "$API_CHANGED_FILES" ]; then
                 docker-compose -f docker-compose.ci.yml run --rm api php bin/phpstan analyse $API_CHANGED_FILES --memory-limit=0 --level=max

--- a/api/app/DoctrineMigrations/Version231.php
+++ b/api/app/DoctrineMigrations/Version231.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version231 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE document ADD synchronised_by INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE document ADD synchronisation_status VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE document ADD synchronisation_time TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+        $this->addSql('ALTER TABLE document ADD synchronisation_error VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE document ADD CONSTRAINT FK_D8698A761EFE0E05 FOREIGN KEY (synchronised_by) REFERENCES dd_user (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_D8698A761EFE0E05 ON document (synchronised_by)');
+        $this->addSql('ALTER TABLE report_submission ADD opg_uuid VARCHAR(36) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE document DROP CONSTRAINT FK_D8698A761EFE0E05');
+        $this->addSql('DROP INDEX IDX_D8698A761EFE0E05');
+        $this->addSql('ALTER TABLE document DROP synchronised_by');
+        $this->addSql('ALTER TABLE document DROP synchronisation_status');
+        $this->addSql('ALTER TABLE document DROP synchronisation_time');
+        $this->addSql('ALTER TABLE document DROP synchronisation_error');
+        $this->addSql('ALTER TABLE report_submission DROP opg_uuid');
+    }
+}

--- a/api/composer.json
+++ b/api/composer.json
@@ -37,9 +37,9 @@
     "phpunit/phpunit": "^8.0.0",
     "mockery/mockery": "^1.0.0",
     "doctrine/doctrine-fixtures-bundle": "^3.2.2",
-    "phpstan/phpstan": "^0.11.19",
-    "phpstan/phpstan-mockery": "^0.11.3",
-    "phpstan/phpstan-phpunit": "^0.11.2"
+    "phpstan/phpstan": "^0.12.0",
+    "phpstan/phpstan-mockery": "^0.12.0",
+    "phpstan/phpstan-phpunit": "^0.12.0"
   },
   "scripts": {
     "post-install-cmd": [

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f53201edc6a99dd8724645200b28c2e",
+    "content-hash": "84727c45d8ac24f4bdfc93b8e0bf8c9f",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -5236,114 +5236,78 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.11.19",
+            "version": "0.12.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "63cc502f6957b7f74efbac444b4cf219dcadffd7"
+                "reference": "ca5f2b7cf81c6d8fba74f9576970399c5817e03b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/63cc502f6957b7f74efbac444b4cf219dcadffd7",
-                "reference": "63cc502f6957b7f74efbac444b4cf219dcadffd7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ca5f2b7cf81c6d8fba74f9576970399c5817e03b",
+                "reference": "ca5f2b7cf81c6d8fba74f9576970399c5817e03b",
                 "shasum": ""
             },
             "require": {
-                "composer/xdebug-handler": "^1.3.0",
-                "jean85/pretty-package-versions": "^1.0.3",
-                "nette/bootstrap": "^2.4 || ^3.0",
-                "nette/di": "^2.4.7 || ^3.0",
-                "nette/neon": "^2.4.3 || ^3.0",
-                "nette/robot-loader": "^3.0.1",
-                "nette/schema": "^1.0",
-                "nette/utils": "^2.4.5 || ^3.0",
-                "nikic/php-parser": "^4.2.3",
-                "php": "~7.1",
-                "phpstan/phpdoc-parser": "^0.3.5",
-                "symfony/console": "~3.2 || ~4.0",
-                "symfony/finder": "~3.2 || ~4.0"
-            },
-            "conflict": {
-                "symfony/console": "3.4.16 || 4.1.5"
-            },
-            "require-dev": {
-                "brianium/paratest": "^2.0 || ^3.0",
-                "consistence/coding-standard": "^3.5",
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-                "ext-intl": "*",
-                "ext-mysqli": "*",
-                "ext-simplexml": "*",
-                "ext-soap": "*",
-                "ext-zip": "*",
-                "jakub-onderka/php-parallel-lint": "^1.0",
-                "localheinz/composer-normalize": "^1.1.0",
-                "phing/phing": "^2.16.0",
-                "phpstan/phpstan-deprecation-rules": "^0.11",
-                "phpstan/phpstan-php-parser": "^0.11",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-strict-rules": "^0.11",
-                "phpunit/phpunit": "^7.5.14 || ^8.0",
-                "slevomat/coding-standard": "^4.7.2",
-                "squizlabs/php_codesniffer": "^3.3.2"
+                "php": "^7.1"
             },
             "bin": [
-                "bin/phpstan"
+                "phpstan",
+                "phpstan.phar"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.11-dev"
+                    "dev-master": "0.12-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "PHPStan\\": [
-                        "src/"
-                    ]
-                }
+                "files": [
+                    "bootstrap.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "time": "2019-10-22T20:20:22+00:00"
+            "time": "2020-02-16T14:00:29+00:00"
         },
         {
             "name": "phpstan/phpstan-mockery",
-            "version": "0.11.3",
+            "version": "0.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-mockery.git",
-                "reference": "8f3f0dc0bbc8c413224459a25f89a2cef5924871"
+                "reference": "c2cdbe2dc06dbd03d090c2036f1355f43f5286a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-mockery/zipball/8f3f0dc0bbc8c413224459a25f89a2cef5924871",
-                "reference": "8f3f0dc0bbc8c413224459a25f89a2cef5924871",
+                "url": "https://api.github.com/repos/phpstan/phpstan-mockery/zipball/c2cdbe2dc06dbd03d090c2036f1355f43f5286a4",
+                "reference": "c2cdbe2dc06dbd03d090c2036f1355f43f5286a4",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.0",
                 "php": "~7.1",
-                "phpstan/phpdoc-parser": "^0.3",
-                "phpstan/phpstan": "^0.11.4"
+                "phpstan/phpstan": "^0.12"
             },
             "require-dev": {
-                "consistence/coding-standard": "^3.0.1",
+                "consistence/coding-standard": "^3.5",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "ergebnis/composer-normalize": "^2.0.2",
                 "jakub-onderka/php-parallel-lint": "^1.0",
-                "mockery/mockery": "^1.1",
+                "mockery/mockery": "^1.2.4",
                 "phing/phing": "^2.16.0",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-strict-rules": "^0.11",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpstan/phpstan-strict-rules": "^0.12",
                 "phpunit/phpunit": "^7.2",
-                "slevomat/coding-standard": "^4.6.3"
+                "slevomat/coding-standard": "^4.7.2",
+                "squizlabs/php_codesniffer": "^3.3.2"
             },
             "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.11-dev"
+                    "dev-master": "0.12-dev"
                 },
                 "phpstan": {
                     "includes": [
@@ -5361,45 +5325,44 @@
                 "MIT"
             ],
             "description": "PHPStan Mockery extension",
-            "time": "2019-08-15T06:50:55+00:00"
+            "time": "2020-01-10T12:08:26+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "0.11.2",
+            "version": "0.12.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "fbf2ad56c3b13189d29655e226c9b1da47c2fad9"
+                "reference": "26394996368b6d033d012547d3197f4e07e23021"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/fbf2ad56c3b13189d29655e226c9b1da47c2fad9",
-                "reference": "fbf2ad56c3b13189d29655e226c9b1da47c2fad9",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/26394996368b6d033d012547d3197f4e07e23021",
+                "reference": "26394996368b6d033d012547d3197f4e07e23021",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.0",
                 "php": "~7.1",
-                "phpstan/phpdoc-parser": "^0.3",
-                "phpstan/phpstan": "^0.11.4"
+                "phpstan/phpstan": "^0.12.4"
             },
             "conflict": {
                 "phpunit/phpunit": "<7.0"
             },
             "require-dev": {
-                "consistence/coding-standard": "^3.0.1",
+                "consistence/coding-standard": "^3.5",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "ergebnis/composer-normalize": "^2.0.2",
                 "jakub-onderka/php-parallel-lint": "^1.0",
                 "phing/phing": "^2.16.0",
-                "phpstan/phpstan-strict-rules": "^0.11",
+                "phpstan/phpstan-strict-rules": "^0.12",
                 "phpunit/phpunit": "^7.0",
                 "satooshi/php-coveralls": "^1.0",
-                "slevomat/coding-standard": "^4.5.2"
+                "slevomat/coding-standard": "^4.7.2"
             },
             "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.11-dev"
+                    "dev-master": "0.12-dev"
                 },
                 "phpstan": {
                     "includes": [
@@ -5418,7 +5381,7 @@
                 "MIT"
             ],
             "description": "PHPUnit extensions and rules for PHPStan",
-            "time": "2019-05-17T17:50:16+00:00"
+            "time": "2020-01-10T12:07:21+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -5563,8 +5526,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Simple template engine.",

--- a/api/phpstan.neon
+++ b/api/phpstan.neon
@@ -1,3 +1,6 @@
 includes:
   - vendor/phpstan/phpstan-mockery/extension.neon
   - vendor/phpstan/phpstan-phpunit/extension.neon
+parameters:
+  autoload_directories:
+    - app/DoctrineMigrations

--- a/api/src/AppBundle/Entity/Report/Document.php
+++ b/api/src/AppBundle/Entity/Report/Document.php
@@ -4,8 +4,9 @@ namespace AppBundle\Entity\Report;
 
 use AppBundle\Entity\Ndr\Ndr;
 use AppBundle\Entity\Traits\CreationAudit;
+use AppBundle\Entity\User;
+use DateTime;
 use Doctrine\ORM\Mapping as ORM;
-use Gedmo\Mapping\Annotation as Gedmo;
 use JMS\Serializer\Annotation as JMS;
 
 /**
@@ -21,6 +22,12 @@ use JMS\Serializer\Annotation as JMS;
 class Document
 {
     use CreationAudit;
+
+    const SYNC_STATUS_QUEUED = 'QUEUED';
+    const SYNC_STATUS_IN_PROGRESS = 'IN_PROGRESS';
+    const SYNC_STATUS_SUCCESS = 'SUCCESS';
+    const SYNC_STATUS_TEMPORARY_ERROR = 'TEMPORARY_ERROR';
+    const SYNC_STATUS_PERMANENT_ERROR = 'PERMANENT_ERROR';
 
     /**
      * @var int
@@ -96,6 +103,39 @@ class Document
      * @ORM\JoinColumn(name="report_submission_id", referencedColumnName="id", onDelete="SET NULL")
      */
     private $reportSubmission;
+
+    /**
+     * @var string|null
+     * @JMS\Type("string")
+     * @JMS\Groups({"document-synchronisation"})
+     * @ORM\Column(name="synchronisation_status", type="string", options={"default": null}, nullable=true)
+     */
+    private $synchronisationStatus;
+
+    /**
+     * @var DateTime|null
+     * @JMS\Type("DateTime")
+     * @JMS\Groups({"document-synchronisation"})
+     * @ORM\Column(name="synchronisation_time", type="datetime", options={"default": null}, nullable=true)
+     */
+    private $synchronisationTime;
+
+    /**
+     * @var string|null
+     * @JMS\Type("string")
+     * @JMS\Groups({"document-synchronisation"})
+     * @ORM\Column(name="synchronisation_error", type="string", options={"default": null}, nullable=true)
+     */
+    private $synchronisationError;
+
+    /**
+     * @var User|null
+     * @JMS\Type("AppBundle\Entity\User")
+     * @JMS\Groups({"document-synchronisation"})
+     * @ORM\ManyToOne(targetEntity="AppBundle\Entity\User")
+     * @ORM\JoinColumn(name="synchronised_by", referencedColumnName="id", onDelete="SET NULL")
+     */
+    private $synchronisedBy;
 
     /**
      * Document constructor.
@@ -259,5 +299,87 @@ class Document
     private function isTransactionDocument()
     {
         return strpos('DigiRepTransactions', $this->getFileName());
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSynchronisationStatus(): ?string
+    {
+        return $this->synchronisationStatus;
+    }
+
+    /**
+     * @param string $status
+     * @return $this
+     */
+    public function setSynchronisationStatus(?string $status)
+    {
+        if (!in_array($status, array(
+            self::SYNC_STATUS_QUEUED,
+            self::SYNC_STATUS_IN_PROGRESS,
+            self::SYNC_STATUS_SUCCESS,
+            self::SYNC_STATUS_TEMPORARY_ERROR,
+            self::SYNC_STATUS_PERMANENT_ERROR,
+        ))) {
+            throw new \InvalidArgumentException('Invalid synchronisation status');
+        }
+
+        $this->synchronisationStatus = $status;
+        return $this;
+    }
+
+    /**
+     * @return DateTime|null
+     */
+    public function getSynchronisationTime(): ?DateTime
+    {
+        return $this->synchronisationTime;
+    }
+
+    /**
+     * @param DateTime $time
+     * @return $this
+     */
+    public function setSynchronisationTime(?DateTime $time)
+    {
+        $this->synchronisationTime = $time;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSynchronisationError(): ?string
+    {
+        return $this->synchronisationError;
+    }
+
+    /**
+     * @param string $error
+     * @return $this
+     */
+    public function setSynchronisationError(?string $error)
+    {
+        $this->synchronisationError = $error;
+        return $this;
+    }
+
+    /**
+     * @return User|null
+     */
+    public function getSynchronisedBy(): ?User
+    {
+        return $this->synchronisedBy;
+    }
+
+    /**
+     * @param User $user
+     * @return $this
+     */
+    public function setSynchronisedBy(?User $user)
+    {
+        $this->synchronisedBy = $user;
+        return $this;
     }
 }

--- a/api/src/AppBundle/Entity/Report/ReportSubmission.php
+++ b/api/src/AppBundle/Entity/Report/ReportSubmission.php
@@ -61,7 +61,7 @@ class ReportSubmission
     private $ndr;
 
     /**
-     * @var ArrayCollection
+     * @var ArrayCollection<int, Document>
      *
      * @JMS\Type("array<AppBundle\Entity\Report\Document>")
      * @JMS\Groups({"report-submission", "report-submission-documents"})
@@ -85,6 +85,7 @@ class ReportSubmission
     private $archivedBy;
 
     /**
+     * @var bool
      * @JMS\Type("boolean")
      * @JMS\Groups({"report-submission"})
      * @ORM\Column(name="downloadable", type="boolean", options={ "default": true}, nullable=false)
@@ -168,7 +169,7 @@ class ReportSubmission
     }
 
     /**
-     * @return ArrayCollection|Document[]
+     * @return ArrayCollection<int, Document>
      */
     public function getDocuments()
     {

--- a/api/src/AppBundle/Entity/Report/ReportSubmission.php
+++ b/api/src/AppBundle/Entity/Report/ReportSubmission.php
@@ -74,7 +74,7 @@ class ReportSubmission
     private $documents;
 
     /**
-     * @var User
+     * @var User|null
      *
      * @JMS\Type("AppBundle\Entity\User")
      * @JMS\Groups({"report-submission"})
@@ -90,6 +90,14 @@ class ReportSubmission
      * @ORM\Column(name="downloadable", type="boolean", options={ "default": true}, nullable=false)
      */
     private $downloadable;
+
+    /**
+     * @var string|null
+     * @JMS\Type("string")
+     * @JMS\Groups({"report-submission"})
+     * @ORM\Column(name="opg_uuid", type="string", length=36, nullable=true)
+     */
+    private $uuid;
 
     /**
      * ReportSubmission constructor.
@@ -182,7 +190,7 @@ class ReportSubmission
     }
 
     /**
-     * @return User
+     * @return User|null
      */
     public function getArchivedBy()
     {
@@ -217,6 +225,26 @@ class ReportSubmission
     public function setDownloadable($downloadable)
     {
         $this->downloadable = $downloadable;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUuid(): ?string
+    {
+        return $this->uuid;
+    }
+
+    /**
+     * @param string|null $uuid
+     *
+     * @return $this
+     */
+    public function setUuid(?string $uuid)
+    {
+        $this->uuid = $uuid;
 
         return $this;
     }

--- a/client/composer.json
+++ b/client/composer.json
@@ -65,9 +65,10 @@
         }
     ],
     "require-dev": {
-        "phpstan/phpstan": "^0.11.19",
-        "phpstan/phpstan-mockery": "^0.11.3",
-        "phpstan/phpstan-phpunit": "^0.11.2",
+        "phpstan/phpstan": "^0.12.0",
+        "phpstan/phpstan-mockery": "^0.12.0",
+        "phpstan/phpstan-phpunit": "^0.12.0",
+        "jangregor/phpstan-prophecy": "^0.6.2",
         "pact-foundation/pact-php": "^5.0"
     }
 }

--- a/client/composer.lock
+++ b/client/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ab26a6cac40f7c10769400eff213f07",
+    "content-hash": "2aef1fcedb84866be618b81a370af3ff",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -7097,6 +7097,66 @@
             "time": "2019-12-03T09:12:46+00:00"
         },
         {
+            "name": "jangregor/phpstan-prophecy",
+            "version": "0.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Jan0707/phpstan-prophecy.git",
+                "reference": "9f3422fa720d3dbd28ffba40f06aeba1edfecef9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Jan0707/phpstan-prophecy/zipball/9f3422fa720d3dbd28ffba40f06aeba1edfecef9",
+                "reference": "9f3422fa720d3dbd28ffba40f06aeba1edfecef9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "phpstan/phpstan": "^0.12.0"
+            },
+            "conflict": {
+                "phpspec/prophecy": "<1.7,>=2.0",
+                "phpunit/phpunit": "<6.0,>=10.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.1.1",
+                "ergebnis/license": "~0.1.0",
+                "ergebnis/php-cs-fixer-config": "~1.1.2",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/phpunit": "^6.0 || ^7.0"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "src/extension.neon"
+                    ]
+                },
+                "violinist": {
+                    "allow_updates_beyond_constraint": 0,
+                    "one_pull_request_per_package": 1,
+                    "update_with_dependencies": 1
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JanGregor\\Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Gregor Emge-Triebel",
+                    "email": "jan@jangregor.me"
+                }
+            ],
+            "description": "Provides a phpstan/phpstan extension for phpspec/prophecy",
+            "time": "2020-02-17T16:55:34+00:00"
+        },
+        {
             "name": "jean85/pretty-package-versions",
             "version": "1.2",
             "source": {
@@ -8085,114 +8145,78 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.11.19",
+            "version": "0.12.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "63cc502f6957b7f74efbac444b4cf219dcadffd7"
+                "reference": "ca5f2b7cf81c6d8fba74f9576970399c5817e03b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/63cc502f6957b7f74efbac444b4cf219dcadffd7",
-                "reference": "63cc502f6957b7f74efbac444b4cf219dcadffd7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ca5f2b7cf81c6d8fba74f9576970399c5817e03b",
+                "reference": "ca5f2b7cf81c6d8fba74f9576970399c5817e03b",
                 "shasum": ""
             },
             "require": {
-                "composer/xdebug-handler": "^1.3.0",
-                "jean85/pretty-package-versions": "^1.0.3",
-                "nette/bootstrap": "^2.4 || ^3.0",
-                "nette/di": "^2.4.7 || ^3.0",
-                "nette/neon": "^2.4.3 || ^3.0",
-                "nette/robot-loader": "^3.0.1",
-                "nette/schema": "^1.0",
-                "nette/utils": "^2.4.5 || ^3.0",
-                "nikic/php-parser": "^4.2.3",
-                "php": "~7.1",
-                "phpstan/phpdoc-parser": "^0.3.5",
-                "symfony/console": "~3.2 || ~4.0",
-                "symfony/finder": "~3.2 || ~4.0"
-            },
-            "conflict": {
-                "symfony/console": "3.4.16 || 4.1.5"
-            },
-            "require-dev": {
-                "brianium/paratest": "^2.0 || ^3.0",
-                "consistence/coding-standard": "^3.5",
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-                "ext-intl": "*",
-                "ext-mysqli": "*",
-                "ext-simplexml": "*",
-                "ext-soap": "*",
-                "ext-zip": "*",
-                "jakub-onderka/php-parallel-lint": "^1.0",
-                "localheinz/composer-normalize": "^1.1.0",
-                "phing/phing": "^2.16.0",
-                "phpstan/phpstan-deprecation-rules": "^0.11",
-                "phpstan/phpstan-php-parser": "^0.11",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-strict-rules": "^0.11",
-                "phpunit/phpunit": "^7.5.14 || ^8.0",
-                "slevomat/coding-standard": "^4.7.2",
-                "squizlabs/php_codesniffer": "^3.3.2"
+                "php": "^7.1"
             },
             "bin": [
-                "bin/phpstan"
+                "phpstan",
+                "phpstan.phar"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.11-dev"
+                    "dev-master": "0.12-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "PHPStan\\": [
-                        "src/"
-                    ]
-                }
+                "files": [
+                    "bootstrap.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "time": "2019-10-22T20:20:22+00:00"
+            "time": "2020-02-16T14:00:29+00:00"
         },
         {
             "name": "phpstan/phpstan-mockery",
-            "version": "0.11.3",
+            "version": "0.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-mockery.git",
-                "reference": "8f3f0dc0bbc8c413224459a25f89a2cef5924871"
+                "reference": "c2cdbe2dc06dbd03d090c2036f1355f43f5286a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-mockery/zipball/8f3f0dc0bbc8c413224459a25f89a2cef5924871",
-                "reference": "8f3f0dc0bbc8c413224459a25f89a2cef5924871",
+                "url": "https://api.github.com/repos/phpstan/phpstan-mockery/zipball/c2cdbe2dc06dbd03d090c2036f1355f43f5286a4",
+                "reference": "c2cdbe2dc06dbd03d090c2036f1355f43f5286a4",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.0",
                 "php": "~7.1",
-                "phpstan/phpdoc-parser": "^0.3",
-                "phpstan/phpstan": "^0.11.4"
+                "phpstan/phpstan": "^0.12"
             },
             "require-dev": {
-                "consistence/coding-standard": "^3.0.1",
+                "consistence/coding-standard": "^3.5",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "ergebnis/composer-normalize": "^2.0.2",
                 "jakub-onderka/php-parallel-lint": "^1.0",
-                "mockery/mockery": "^1.1",
+                "mockery/mockery": "^1.2.4",
                 "phing/phing": "^2.16.0",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-strict-rules": "^0.11",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpstan/phpstan-strict-rules": "^0.12",
                 "phpunit/phpunit": "^7.2",
-                "slevomat/coding-standard": "^4.6.3"
+                "slevomat/coding-standard": "^4.7.2",
+                "squizlabs/php_codesniffer": "^3.3.2"
             },
             "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.11-dev"
+                    "dev-master": "0.12-dev"
                 },
                 "phpstan": {
                     "includes": [
@@ -8210,45 +8234,44 @@
                 "MIT"
             ],
             "description": "PHPStan Mockery extension",
-            "time": "2019-08-15T06:50:55+00:00"
+            "time": "2020-01-10T12:08:26+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "0.11.2",
+            "version": "0.12.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "fbf2ad56c3b13189d29655e226c9b1da47c2fad9"
+                "reference": "26394996368b6d033d012547d3197f4e07e23021"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/fbf2ad56c3b13189d29655e226c9b1da47c2fad9",
-                "reference": "fbf2ad56c3b13189d29655e226c9b1da47c2fad9",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/26394996368b6d033d012547d3197f4e07e23021",
+                "reference": "26394996368b6d033d012547d3197f4e07e23021",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.0",
                 "php": "~7.1",
-                "phpstan/phpdoc-parser": "^0.3",
-                "phpstan/phpstan": "^0.11.4"
+                "phpstan/phpstan": "^0.12.4"
             },
             "conflict": {
                 "phpunit/phpunit": "<7.0"
             },
             "require-dev": {
-                "consistence/coding-standard": "^3.0.1",
+                "consistence/coding-standard": "^3.5",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "ergebnis/composer-normalize": "^2.0.2",
                 "jakub-onderka/php-parallel-lint": "^1.0",
                 "phing/phing": "^2.16.0",
-                "phpstan/phpstan-strict-rules": "^0.11",
+                "phpstan/phpstan-strict-rules": "^0.12",
                 "phpunit/phpunit": "^7.0",
                 "satooshi/php-coveralls": "^1.0",
-                "slevomat/coding-standard": "^4.5.2"
+                "slevomat/coding-standard": "^4.7.2"
             },
             "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.11-dev"
+                    "dev-master": "0.12-dev"
                 },
                 "phpstan": {
                     "includes": [
@@ -8267,7 +8290,7 @@
                 "MIT"
             ],
             "description": "PHPUnit extensions and rules for PHPStan",
-            "time": "2019-05-17T17:50:16+00:00"
+            "time": "2020-01-10T12:07:21+00:00"
         }
     ],
     "aliases": [],

--- a/client/phpstan.neon
+++ b/client/phpstan.neon
@@ -1,3 +1,7 @@
 includes:
   - vendor/phpstan/phpstan-mockery/extension.neon
   - vendor/phpstan/phpstan-phpunit/extension.neon
+  - vendor/jangregor/phpstan-prophecy/src/extension.neon
+parameters:
+  autoload_directories:
+    - tests/phpunit

--- a/client/src/AppBundle/Entity/Report/Document.php
+++ b/client/src/AppBundle/Entity/Report/Document.php
@@ -31,7 +31,7 @@ class Document implements DocumentInterface
     /**
      * @param ExecutionContextInterface $context
      */
-    public function isValidForReport(ExecutionContextInterface $context)
+    public function isValidForReport(ExecutionContextInterface $context): void
     {
         if (!($this->getFile() instanceof UploadedFile)) {
             return;
@@ -235,10 +235,12 @@ class Document implements DocumentInterface
 
     /**
      * @param bool $isReportPdf
+     * @return $this
      */
     public function setIsReportPdf($isReportPdf)
     {
         $this->isReportPdf = $isReportPdf;
+        return $this;
     }
 
     /**

--- a/client/src/AppBundle/Entity/Report/Document.php
+++ b/client/src/AppBundle/Entity/Report/Document.php
@@ -5,6 +5,8 @@ namespace AppBundle\Entity\Report;
 use AppBundle\Entity\DocumentInterface;
 use AppBundle\Entity\Report\Traits\HasReportTrait;
 use AppBundle\Entity\Traits\CreationAudit;
+use AppBundle\Entity\User;
+use DateTime;
 use JMS\Serializer\Annotation as JMS;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -17,6 +19,11 @@ class Document implements DocumentInterface
 {
     const FILE_NAME_MAX_LENGTH = 255;
     const MAX_UPLOAD_PER_REPORT = 100;
+    const SYNC_STATUS_QUEUED = 'QUEUED';
+    const SYNC_STATUS_IN_PROGRESS = 'IN_PROGRESS';
+    const SYNC_STATUS_SUCCESS = 'SUCCESS';
+    const SYNC_STATUS_TEMPORARY_ERROR = 'TEMPORARY_ERROR';
+    const SYNC_STATUS_PERMANENT_ERROR = 'PERMANENT_ERROR';
 
     use CreationAudit;
     use HasReportTrait;
@@ -36,6 +43,11 @@ class Document implements DocumentInterface
         }
 
         $fileOriginalName = $this->getFile()->getClientOriginalName();
+
+        if (is_null($fileOriginalName)) {
+            $context->buildViolation('document.file.errors.invalidName')->atPath('file')->addViolation();
+            return;
+        }
 
         if (strlen($fileOriginalName) > self::FILE_NAME_MAX_LENGTH) {
             $context->buildViolation('document.file.errors.maxMessage')->atPath('file')->addViolation();
@@ -109,6 +121,34 @@ class Document implements DocumentInterface
      * @JMS\Groups({"document-report-subnmission"})
      */
     private $reportSubmission;
+
+    /**
+     * @var string|null
+     * @JMS\Type("string")
+     * @JMS\Groups({"document-synchronisation"})
+     */
+    private $synchronisationStatus;
+
+    /**
+     * @var DateTime|null
+     * @JMS\Type("DateTime")
+     * @JMS\Groups({"document-synchronisation"})
+     */
+    private $synchronisationTime;
+
+    /**
+     * @var string|null
+     * @JMS\Type("string")
+     * @JMS\Groups({"document-synchronisation"})
+     */
+    private $synchronisationError;
+
+    /**
+     * @var User|null
+     * @JMS\Type("AppBundle\Entity\User")
+     * @JMS\Groups({"document-synchronisation"})
+     */
+    private $synchronisedBy;
 
     /**
      * @return int
@@ -207,6 +247,88 @@ class Document implements DocumentInterface
     public function getReportSubmission()
     {
         return $this->reportSubmission;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSynchronisationStatus(): ?string
+    {
+        return $this->synchronisationStatus;
+    }
+
+    /**
+     * @param string $status
+     * @return $this
+     */
+    public function setSynchronisationStatus(?string $status)
+    {
+        if (!in_array($status, array(
+            self::SYNC_STATUS_QUEUED,
+            self::SYNC_STATUS_IN_PROGRESS,
+            self::SYNC_STATUS_SUCCESS,
+            self::SYNC_STATUS_TEMPORARY_ERROR,
+            self::SYNC_STATUS_PERMANENT_ERROR,
+        ))) {
+            throw new \InvalidArgumentException('Invalid synchronisation status');
+        }
+
+        $this->synchronisationStatus = $status;
+        return $this;
+    }
+
+    /**
+     * @return DateTime|null
+     */
+    public function getSynchronisationTime(): ?DateTime
+    {
+        return $this->synchronisationTime;
+    }
+
+    /**
+     * @param DateTime $time
+     * @return $this
+     */
+    public function setSynchronisationTime(?DateTime $time)
+    {
+        $this->synchronisationTime = $time;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSynchronisationError(): ?string
+    {
+        return $this->synchronisationError;
+    }
+
+    /**
+     * @param string $error
+     * @return $this
+     */
+    public function setSynchronisationError(?string $error)
+    {
+        $this->synchronisationError = $error;
+        return $this;
+    }
+
+    /**
+     * @return User|null
+     */
+    public function getSynchronisedBy(): ?User
+    {
+        return $this->synchronisedBy;
+    }
+
+    /**
+     * @param User $user
+     * @return $this
+     */
+    public function setSynchronisedBy(?User $user)
+    {
+        $this->synchronisedBy = $user;
+        return $this;
     }
 
     /**

--- a/client/src/AppBundle/Entity/Report/ReportSubmission.php
+++ b/client/src/AppBundle/Entity/Report/ReportSubmission.php
@@ -52,6 +52,12 @@ class ReportSubmission
     private $downloadable;
 
     /**
+     * @var string|null
+     * @JMS\Type("string")
+     */
+    private $uuid;
+
+    /**
      * @return int
      */
     public function getId()
@@ -175,6 +181,26 @@ class ReportSubmission
     public function setDownloadable($downloadable)
     {
         $this->downloadable = $downloadable;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUuid(): ?string
+    {
+        return $this->uuid;
+    }
+
+    /**
+     * @param string|null $uuid
+     *
+     * @return $this
+     */
+    public function setUuid(?string $uuid)
+    {
+        $this->uuid = $uuid;
 
         return $this;
     }

--- a/client/src/AppBundle/Entity/Report/ReportSubmission.php
+++ b/client/src/AppBundle/Entity/Report/ReportSubmission.php
@@ -3,7 +3,7 @@
 namespace AppBundle\Entity\Report;
 
 use AppBundle\Entity\Ndr\Ndr;
-use AppBundle\Entity\ReportInterface;
+use AppBundle\Entity\Report\Document;
 use AppBundle\Entity\User;
 use AppBundle\Entity\Traits\CreationAudit;
 use DateTime;
@@ -36,6 +36,8 @@ class ReportSubmission
     private $ndr;
 
     /**
+     * @var Document[]
+     *
      * @JMS\Type("array<AppBundle\Entity\Report\Document>")
      */
     private $documents = [];
@@ -126,8 +128,8 @@ class ReportSubmission
     }
 
     /**
-     * @param  array            $documents
-     * @return ReportSubmission
+     * @param  Document[] $documents
+     * @return $this
      */
     public function setDocuments($documents)
     {

--- a/client/src/AppBundle/Resources/translations/validators.en.yml
+++ b/client/src/AppBundle/Resources/translations/validators.en.yml
@@ -187,6 +187,7 @@ document:
       maxSizeMessage: "The file you selected to upload is too big. Please check your file size is less than 15mb."
       alreadyPresent: "You have already uploaded a file with this name. Please rename your file before uploading again."
       maxDocumentsPerReport: "You have reached the maximum number of attachments for this report"
+      invalidName: "Your file has an invalid name"
       maxMessage: "The file name can't be longer than 255 letters"
       fileSize: "Your uploaded file exceeded the maximum size of 15M"
       risky: "Unfortunately, our antivirus check found a problem with this file and we are unable to upload it. Please choose another file"

--- a/client/src/AppBundle/Resources/views/FlashMessages/missing-documents.html.twig
+++ b/client/src/AppBundle/Resources/views/FlashMessages/missing-documents.html.twig
@@ -2,6 +2,6 @@
 
 <ul>
     {% for missingDocument in missingDocuments %}
-        <li>{{ missingDocument.reportSubmission.caseNumber }} - {{ missingDocument.fileName }}</li>
+        <li>{{ missingDocument.reportSubmission.report.client.caseNumber }} - {{ missingDocument.fileName }}</li>
     {% endfor %}
 </ul>

--- a/client/tests/phpunit/Service/DocumentDownloaderTest.php
+++ b/client/tests/phpunit/Service/DocumentDownloaderTest.php
@@ -40,7 +40,7 @@ class DocumentDownloaderTest extends TestCase
         $this->zipFileCreator = self::prophesize(DocumentsZipFileCreator::class);
     }
 
-    private function generateReportSubmission($caseNumber)
+    private function generateReportSubmission(string $caseNumber): ReportSubmission
     {
         $client = new Client();
         $client->setCaseNumber($caseNumber);
@@ -54,7 +54,7 @@ class DocumentDownloaderTest extends TestCase
         return $reportSubmission;
     }
 
-    public function testGenerateDownloadResponse()
+    public function testGenerateDownloadResponse(): void
     {
         $sut = new DocumentDownloader($this->documentService->reveal(), $this->reportSubmissionService->reveal(), $this->zipFileCreator->reveal());
 
@@ -68,7 +68,7 @@ class DocumentDownloaderTest extends TestCase
         self::assertEquals('attachment; filename="test-file.zip";', $response->headers->get('Content-Disposition'));
     }
 
-    public function testRetrieveDocumentsFromS3ByReportSubmissionIds()
+    public function testRetrieveDocumentsFromS3ByReportSubmissionIds(): void
     {
         $request = new Request();
         $ids = [1, 2];
@@ -101,7 +101,7 @@ class DocumentDownloaderTest extends TestCase
         self::assertEmpty($missingDocuments);
     }
 
-    public function testProcessDownloadMissingDocument()
+    public function testProcessDownloadMissingDocument(): void
     {
         $request = new Request();
         $session = new Session(new MockArraySessionStorage());
@@ -138,7 +138,7 @@ class DocumentDownloaderTest extends TestCase
         self::assertEquals($missingDocument, $missingDocument);
     }
 
-    public function testSetMissingDocsFlashMessage()
+    public function testSetMissingDocsFlashMessage(): void
     {
         $this->documentService->createMissingDocumentsFlashMessage(Argument::type('Array'))->willReturn('flash message');
 
@@ -164,7 +164,7 @@ class DocumentDownloaderTest extends TestCase
         self::assertEquals('flash message', $actualFlash);
     }
 
-    public function testZipDownloadedDocuments()
+    public function testZipDownloadedDocuments(): void
     {
         $retrievedDocs = [new RetrievedDocument()];
         $this->zipFileCreator->createZipFilesFromRetrievedDocuments($retrievedDocs)->shouldBeCalled()->willReturn([new ZipArchive()]);
@@ -172,25 +172,5 @@ class DocumentDownloaderTest extends TestCase
         $sut = new DocumentDownloader($this->documentService->reveal(), $this->reportSubmissionService->reveal(), $this->zipFileCreator->reveal());
 
         $sut->zipDownloadedDocuments($retrievedDocs);
-    }
-
-    protected function generateTestZipFiles(ZipArchive $zip, array $zipFileContent)
-    {
-        $zipFiles = [];
-
-        foreach($zipFileContent as $fileName => $content) {
-            $zipFile = "/tmp/${fileName}";
-            file_put_contents($zipFile, $content);
-
-            $zip->open($zipFile, ZipArchive::CREATE | ZipArchive::OVERWRITE | ZipArchive::CHECKCONS);
-            $zip->addFile($zipFile, $zipFile);
-
-            $zipFiles[] = $zipFile;
-
-            $zip->close();
-            unset($zip);
-        }
-
-        return $zipFiles;
     }
 }

--- a/client/tests/phpunit/Service/DocumentServiceTest.php
+++ b/client/tests/phpunit/Service/DocumentServiceTest.php
@@ -99,19 +99,10 @@ class DocumentServiceTest extends TestCase
         $this->doc4->getFileName()->willReturn('file-name4.pdf');
     }
 
-
-    public static function cleanUpDataProvider()
-    {
-        return [
-            [0], // s3 failures NOT ignored -> hard delete gets called
-            [1], // s3 failures ignored -> hard delete gets called
-        ];
-    }
-
     /**
      * @doesNotPerformAssertions
      */
-    public function testRemoveDocumentFromS3()
+    public function testRemoveDocumentFromS3(): void
     {
         $docId = 1;
         $document = new Document();
@@ -130,7 +121,7 @@ class DocumentServiceTest extends TestCase
 
     }
 
-    public function testRemoveDocumentWithS3Failure()
+    public function testRemoveDocumentWithS3Failure(): void
     {
         $docId = 1;
 
@@ -149,7 +140,7 @@ class DocumentServiceTest extends TestCase
 
     }
 
-    public function testRetrieveDocumentsFromS3ByReportSubmission()
+    public function testRetrieveDocumentsFromS3ByReportSubmission(): void
     {
         /** @var S3Storage|ObjectProphecy $storage */
         $storage = self::prophesize(S3Storage::class);
@@ -162,8 +153,11 @@ class DocumentServiceTest extends TestCase
             ->shouldBeCalled()
             ->willReturn(new ArrayCollection([$this->doc1->reveal(), $this->doc2->reveal()]));
 
+        /** @var ObjectProphecy|LoggerInterface $logger */
         $logger = self::prophesize(LoggerInterface::class);
+        /** @var ObjectProphecy|RestClient $restClient */
         $restClient = self::prophesize(RestClient::class);
+        /** @var ObjectProphecy|Environment $twig */
         $twig = self::prophesize(Environment::class);
 
         $sut = new DocumentService($storage->reveal(), $restClient->reveal(), $logger->reveal(), $twig->reveal());
@@ -183,7 +177,7 @@ class DocumentServiceTest extends TestCase
         self::assertEmpty($missing);
     }
 
-    public function testMissingDocumentsFileNamesAreReturnedIfNotRetrievable()
+    public function testMissingDocumentsFileNamesAreReturnedIfNotRetrievable(): void
     {
         /** @var S3Storage|ObjectProphecy $storage */
         $storage = self::prophesize(S3Storage::class);
@@ -197,8 +191,11 @@ class DocumentServiceTest extends TestCase
             ->shouldBeCalled()
             ->willReturn(new ArrayCollection([$this->doc1->reveal(), $this->doc2->reveal()]));
 
+        /** @var ObjectProphecy|LoggerInterface $logger */
         $logger = self::prophesize(LoggerInterface::class);
+        /** @var ObjectProphecy|RestClient $restClient */
         $restClient = self::prophesize(RestClient::class);
+        /** @var ObjectProphecy|Environment $twig */
         $twig = self::prophesize(Environment::class);
 
         $sut = new DocumentService($storage->reveal(), $restClient->reveal(), $logger->reveal(), $twig->reveal());
@@ -217,7 +214,7 @@ class DocumentServiceTest extends TestCase
         self::assertEquals([$expectedMissingDoc], $missing);
     }
 
-    public function testRetrieveDocumentsFromS3ByReportSubmissions()
+    public function testRetrieveDocumentsFromS3ByReportSubmissions(): void
     {
         /** @var S3Storage|ObjectProphecy $storage */
         $storage = self::prophesize(S3Storage::class);
@@ -237,8 +234,11 @@ class DocumentServiceTest extends TestCase
             ->shouldBeCalled()
             ->willReturn(new ArrayCollection([$this->doc3->reveal()]));
 
+        /** @var ObjectProphecy|LoggerInterface $logger */
         $logger = self::prophesize(LoggerInterface::class);
+        /** @var ObjectProphecy|RestClient $restClient */
         $restClient = self::prophesize(RestClient::class);
+        /** @var ObjectProphecy|Environment $twig */
         $twig = self::prophesize(Environment::class);
 
         $sut = new DocumentService($storage->reveal(), $restClient->reveal(), $logger->reveal(), $twig->reveal());
@@ -266,7 +266,7 @@ class DocumentServiceTest extends TestCase
         self::assertEmpty($missing);
     }
 
-    public function testRetrieveDocumentsFromS3ByReportSubmissionsMissingDocs()
+    public function testRetrieveDocumentsFromS3ByReportSubmissionsMissingDocs(): void
     {
         /** @var S3Storage|ObjectProphecy $storage */
         $storage = self::prophesize(S3Storage::class);
@@ -289,8 +289,11 @@ class DocumentServiceTest extends TestCase
             ->shouldBeCalled()
             ->willReturn(new ArrayCollection([$this->doc3->reveal(), $this->doc4->reveal()]));
 
+        /** @var ObjectProphecy|LoggerInterface $logger */
         $logger = self::prophesize(LoggerInterface::class);
+        /** @var ObjectProphecy|RestClient $restClient */
         $restClient = self::prophesize(RestClient::class);
+        /** @var ObjectProphecy|Environment $twig */
         $twig = self::prophesize(Environment::class);
 
         $sut = new DocumentService($storage->reveal(), $restClient->reveal(), $logger->reveal(), $twig->reveal());
@@ -322,17 +325,25 @@ class DocumentServiceTest extends TestCase
         self::assertEquals([$expectedMissingDoc1, $expectedMissingDoc2], $missing);
     }
 
-    public function testCreateMissingDocumentsFlashMessage()
+    public function testCreateMissingDocumentsFlashMessage(): void
     {
         $missingDoc = new MissingDocument();
         $missingDocuments = [$missingDoc];
 
         $expectedFlash = 'some flash message here';
 
+        /** @var ObjectProphecy|S3Storage $storage */
         $storage = self::prophesize(S3Storage::class);
+
+        /** @var ObjectProphecy|LoggerInterface $logger */
         $logger = self::prophesize(LoggerInterface::class);
+
+        /** @var ObjectProphecy|RestClient $restClient */
         $restClient = self::prophesize(RestClient::class);
+
+        /** @var ObjectProphecy|Environment $twig */
         $twig = self::prophesize(Environment::class);
+
         $twig->render('AppBundle:FlashMessages:missing-documents.html.twig', ['missingDocuments' => $missingDocuments])
             ->shouldBeCalled()
             ->willReturn($expectedFlash);
@@ -343,7 +354,7 @@ class DocumentServiceTest extends TestCase
         self::assertEquals($expectedFlash, $actualFlash);
     }
 
-    private function generateReportSubmission($caseNumber)
+    private function generateReportSubmission(string $caseNumber): ReportSubmission
     {
         $client = new Client();
         $client->setCaseNumber($caseNumber);
@@ -357,7 +368,7 @@ class DocumentServiceTest extends TestCase
         return $reportSubmission;
     }
 
-    public function testTwigTemplate()
+    public function testTwigTemplate(): void
     {
         $reportSubmission1 = $this->generateReportSubmission('CaseNumber1');
         $reportSubmission2 = $this->generateReportSubmission('CaseNumber2');

--- a/client/tests/phpunit/Service/DocumentServiceTest.php
+++ b/client/tests/phpunit/Service/DocumentServiceTest.php
@@ -163,14 +163,7 @@ class DocumentServiceTest extends TestCase
             ->shouldBeCalled()
             ->willReturn(new ArrayCollection([$this->doc1->reveal(), $this->doc2->reveal()]));
 
-        /** @var ObjectProphecy|LoggerInterface $logger */
-        $logger = self::prophesize(LoggerInterface::class);
-        /** @var ObjectProphecy|RestClient $restClient */
-        $restClient = self::prophesize(RestClient::class);
-        /** @var ObjectProphecy|Environment $twig */
-        $twig = self::prophesize(Environment::class);
-
-        $sut = new DocumentService($storage->reveal(), $restClient->reveal(), $logger->reveal(), $twig->reveal());
+        $sut = new DocumentService($storage->reveal(), $this->restClient->reveal(), $this->logger->reveal(), $this->twig->reveal());
         [$documents, $missing] = $sut->retrieveDocumentsFromS3ByReportSubmission($reportSubmission->reveal());
 
         $expectedRetrievedDoc1 = new RetrievedDocument();
@@ -201,14 +194,7 @@ class DocumentServiceTest extends TestCase
             ->shouldBeCalled()
             ->willReturn(new ArrayCollection([$this->doc1->reveal(), $this->doc2->reveal()]));
 
-        /** @var ObjectProphecy|LoggerInterface $logger */
-        $logger = self::prophesize(LoggerInterface::class);
-        /** @var ObjectProphecy|RestClient $restClient */
-        $restClient = self::prophesize(RestClient::class);
-        /** @var ObjectProphecy|Environment $twig */
-        $twig = self::prophesize(Environment::class);
-
-        $sut = new DocumentService($storage->reveal(), $restClient->reveal(), $logger->reveal(), $twig->reveal());
+        $sut = new DocumentService($storage->reveal(), $this->restClient->reveal(), $this->logger->reveal(), $this->twig->reveal());
         [$documents, $missing] = $sut->retrieveDocumentsFromS3ByReportSubmission($reportSubmission->reveal());
 
         $expectedRetrievedDoc = new RetrievedDocument();
@@ -244,14 +230,7 @@ class DocumentServiceTest extends TestCase
             ->shouldBeCalled()
             ->willReturn(new ArrayCollection([$this->doc3->reveal()]));
 
-        /** @var ObjectProphecy|LoggerInterface $logger */
-        $logger = self::prophesize(LoggerInterface::class);
-        /** @var ObjectProphecy|RestClient $restClient */
-        $restClient = self::prophesize(RestClient::class);
-        /** @var ObjectProphecy|Environment $twig */
-        $twig = self::prophesize(Environment::class);
-
-        $sut = new DocumentService($storage->reveal(), $restClient->reveal(), $logger->reveal(), $twig->reveal());
+        $sut = new DocumentService($storage->reveal(), $this->restClient->reveal(), $this->logger->reveal(), $this->twig->reveal());
 
         [$documents, $missing] = $sut->retrieveDocumentsFromS3ByReportSubmissions(
             [$reportSubmission->reveal(), $reportSubmission2->reveal()]
@@ -299,14 +278,7 @@ class DocumentServiceTest extends TestCase
             ->shouldBeCalled()
             ->willReturn(new ArrayCollection([$this->doc3->reveal(), $this->doc4->reveal()]));
 
-        /** @var ObjectProphecy|LoggerInterface $logger */
-        $logger = self::prophesize(LoggerInterface::class);
-        /** @var ObjectProphecy|RestClient $restClient */
-        $restClient = self::prophesize(RestClient::class);
-        /** @var ObjectProphecy|Environment $twig */
-        $twig = self::prophesize(Environment::class);
-
-        $sut = new DocumentService($storage->reveal(), $restClient->reveal(), $logger->reveal(), $twig->reveal());
+        $sut = new DocumentService($storage->reveal(), $this->restClient->reveal(), $this->logger->reveal(), $this->twig->reveal());
 
         [$documents, $missing] = $sut->retrieveDocumentsFromS3ByReportSubmissions(
             [$reportSubmission->reveal(), $reportSubmission2->reveal()]
@@ -342,15 +314,6 @@ class DocumentServiceTest extends TestCase
 
         $expectedFlash = 'some flash message here';
 
-        /** @var ObjectProphecy|S3Storage $storage */
-        $storage = self::prophesize(S3Storage::class);
-
-        /** @var ObjectProphecy|LoggerInterface $logger */
-        $logger = self::prophesize(LoggerInterface::class);
-
-        /** @var ObjectProphecy|RestClient $restClient */
-        $restClient = self::prophesize(RestClient::class);
-
         /** @var ObjectProphecy|Environment $twig */
         $twig = self::prophesize(Environment::class);
 
@@ -358,7 +321,7 @@ class DocumentServiceTest extends TestCase
             ->shouldBeCalled()
             ->willReturn($expectedFlash);
 
-        $sut = new DocumentService($storage->reveal(), $restClient->reveal(), $logger->reveal(), $twig->reveal());
+        $sut = new DocumentService($this->s3Storage->reveal(), $this->restClient->reveal(), $this->logger->reveal(), $twig->reveal());
         $actualFlash = $sut->createMissingDocumentsFlashMessage($missingDocuments);
 
         self::assertEquals($expectedFlash, $actualFlash);


### PR DESCRIPTION
## Purpose
When we integrate with the API, we will automatically send documents to Sirius so that users don’t have to. However, users need to be aware of any failures or delay in the integration. Therefore, we will log which documents/submissions have been synchronised, which are queued, and which have failed.

Fixes DDPB-3237

## Approach
I've added the new fields to the Document model, and also a new `uuid` field for ReportSubmission, which we'll need for making subsequent API requests to Sirius.

I also wanted to do PHPStan properly in this ticket, so I upgraded it in both API and client, and added phpstan-prophecy on the client (with our current tests it isn't needed on API). The rest of the work was tidying up based on PHPStan's feedback. Most significantly, I retyped a bunch of variables in unit tests.

## Learning
The latest version of PHPStan is insistent on return types, either from actual type-hinting or from PHPDoc comments. That should make us specify functions more accurately in-place, and reduce the confusion of cross-file dependencies.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work
  - N/A
- [x] The product team have approved these changes
  - N/A
