### PR TITLE
DDPB-3250: Prevent auth error from tripping alarm

### DIFF
--- a/client/src/AppBundle/Controller/UserController.php
+++ b/client/src/AppBundle/Controller/UserController.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class UserController extends AbstractController
@@ -79,7 +80,11 @@ class UserController extends AbstractController
             $deputyProvider = $this->get('deputy_provider');
 
             // login user into API
-            $deputyProvider->login(['token' => $token]);
+            try {
+                $deputyProvider->login(['token' => $token]);
+            } catch (UsernameNotFoundException $e) {
+                return $this->renderError('This activation link is not working or has already been used');
+            }
 
             /** @var string */
             $data = json_encode([

--- a/client/src/AppBundle/Controller/UserController.php
+++ b/client/src/AppBundle/Controller/UserController.php
@@ -12,6 +12,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -29,7 +30,7 @@ class UserController extends AbstractController
      *   "action" = "(activate|password-reset)"
      * })
      */
-    public function activateUserAction(Request $request, $action, $token)
+    public function activateUserAction(Request $request, string $action, string $token): Response
     {
         /** @var TranslatorInterface */
         $translator = $this->get('translator');
@@ -128,7 +129,7 @@ class UserController extends AbstractController
      * @Route("/user/activate/password/send/{token}", name="activation_link_send")
      * @Template("AppBundle:User:activateLinkSend.html.twig")
      */
-    public function activateLinkSendAction(Request $request, $token)
+    public function activateLinkSendAction(string $token): Response
     {
         // check $token is correct
         $user = $this->getRestClient()->loadUserByToken($token);
@@ -145,10 +146,11 @@ class UserController extends AbstractController
     }
 
     /**
+     * @return array<mixed>
      * @Route("/user/activate/password/sent/{token}", name="activation_link_sent")
      * @Template("AppBundle:User:activateLinkSent.html.twig")
      */
-    public function activateLinkSentAction(Request $request, $token)
+    public function activateLinkSentAction(string $token): array
     {
         return [
             'token'            => $token,
@@ -164,6 +166,7 @@ class UserController extends AbstractController
      * - Lay
      * - PA
      *
+     * @return array<mixed>|Response
      * @Route("/user/details", name="user_details")
      * @Template("AppBundle:User:details.html.twig")
      */
@@ -200,6 +203,7 @@ class UserController extends AbstractController
     }
 
     /**
+     * @return array<mixed>|Response
      * @Route("/password-managing/forgotten", name="password_forgotten")
      * @Template("AppBundle:User:passwordForgotten.html.twig")
      **/
@@ -244,15 +248,17 @@ class UserController extends AbstractController
     }
 
     /**
+     * @return array<mixed>
      * @Route("/password-managing/sent", name="password_sent")
      * @Template("AppBundle:User:passwordSent.html.twig")
-     **/
-    public function passwordSentAction()
+     */
+    public function passwordSentAction(): array
     {
         return [];
     }
 
     /**
+     * @return array<mixed>|Response
      * @Route("/register", name="register")
      * @Template("AppBundle:User:register.html.twig")
      */
@@ -333,7 +339,7 @@ class UserController extends AbstractController
     /**
      * @Route("/user/agree-terms-use/{token}", name="user_agree_terms_use")
      */
-    public function agreeTermsUseAction(Request $request, $token)
+    public function agreeTermsUseAction(Request $request, string $token): Response
     {
         $user = $this->getRestClient()->loadUserByToken($token);
 
@@ -361,31 +367,28 @@ class UserController extends AbstractController
 
     /**
      * @param EntityDir\User $user
-     *
-     * @return array [string FormType, array of JMS groups]
+     * @return array<mixed> [string FormType, array of JMS groups]
      */
-    private function getFormAndJmsGroupBasedOnUserRole(EntityDir\User $user)
+    private function getFormAndJmsGroupBasedOnUserRole(EntityDir\User $user): array
     {
         // define form, route, JMS groups
         switch ($user->getRoleName()) {
-            case EntityDir\User::ROLE_ADMIN:
-            case EntityDir\User::ROLE_AD:
-            case EntityDir\User::ROLE_SUPER_ADMIN:
-                return [FormDir\User\UserDetailsBasicType::class, ['user_details_basic']];
-
             case EntityDir\User::ROLE_LAY_DEPUTY:
                 return [FormDir\User\UserDetailsFullType::class, ['user_details_full']];
 
             case EntityDir\User::ROLE_PA_NAMED:
             case EntityDir\User::ROLE_PA_ADMIN:
             case EntityDir\User::ROLE_PA_TEAM_MEMBER:
-                return [FormDir\User\UserDetailsPaType::class, ['user_details_org']];
-
-            // prof reuses pa so far
             case EntityDir\User::ROLE_PROF_NAMED:
             case EntityDir\User::ROLE_PROF_ADMIN:
             case EntityDir\User::ROLE_PROF_TEAM_MEMBER:
                 return [FormDir\User\UserDetailsPaType::class, ['user_details_org']];
+
+            case EntityDir\User::ROLE_ADMIN:
+            case EntityDir\User::ROLE_AD:
+            case EntityDir\User::ROLE_SUPER_ADMIN:
+            default:
+                return [FormDir\User\UserDetailsBasicType::class, ['user_details_basic']];
         }
     }
 }


### PR DESCRIPTION
## Purpose
This code should be unreachable, but is sometimes called (presumably because of the dual authorization providers). Rather than throwing a critical exception, just show an error message to the user.

Fixes DDPB-3250

## Approach
I caught the exception and showed a user-friendly error message instead. This will prompt the user to fix the problem (by sending a new activation email) and not alert the service team.

Also fixed a few PHPStan issues.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work
  - N/A, since we don't know the exact circumstances under which this occurs. We could mock out the API to provide a contradictory response, but it would be a lot of work for something that we're guessing at.
- [x] The product team have approved these changes
  - N/A
