### PR TITLE
DDPB-3252: Add retention period to automatically-created log groups

### DIFF
--- a/environment/api_rds.tf
+++ b/environment/api_rds.tf
@@ -62,6 +62,8 @@ resource "aws_rds_cluster" "api" {
   enable_http_endpoint         = local.account.always_on ? false : true
   preferred_maintenance_window = "sun:01:00-sun:01:30"
 
+  depends_on = [aws_cloudwatch_log_group.redeployer_lambda]
+
   tags = merge(
     local.default_tags,
     {
@@ -72,6 +74,11 @@ resource "aws_rds_cluster" "api" {
   lifecycle {
     ignore_changes = [engine_version, master_password]
   }
+}
+
+resource "aws_cloudwatch_log_group" "redeployer_lambda" {
+  name              = "/aws/rds/cluster/api-${local.environment}/postgresql"
+  retention_in_days = 180
 }
 
 # resource "aws_rds_cluster_instance" "api" {

--- a/shared/sns.tf
+++ b/shared/sns.tf
@@ -10,6 +10,8 @@ module "notify_slack" {
 
   lambda_function_name = "notify-slack"
 
+  cloudwatch_log_group_retention_in_days = 14
+
   slack_webhook_url = data.aws_secretsmanager_secret_version.slack_webhook_url.secret_string
   slack_channel     = local.account.name == "production" ? "#opg-digideps-team" : "#opg-digideps-devs"
   slack_username    = "aws"
@@ -36,6 +38,8 @@ module "notify_slack_us-east-1" {
   create           = local.account.name != "development"
 
   lambda_function_name = "notify-slack"
+
+  cloudwatch_log_group_retention_in_days = 14
 
   slack_webhook_url = data.aws_secretsmanager_secret_version.slack_webhook_url.secret_string
   slack_channel     = local.account.name == "production" ? "#opg-digideps-team" : "#opg-digideps-devs"


### PR DESCRIPTION
## Purpose
In #252 we added a retention period to our manually-created log groups. However, we also have a few log groups which are automatically created by AWS with no retention period.

We need to bring these log groups under our control and give them suitable retention periods.

Fixes DDPB-3252

## Approach
For the RDS cluster, I created a log group with the anticipated name and made it a dependency of the lambda (to ensure it's created first). I did this in all environments even though they're not all using clustered databases yet, so we're settled for the future.

I did the same for the redeployer lambda, but also removed the `logs:CreateLogGroup` permission since it's no longer necessary. I reduced the time to 14 days, which is still longer than we _really_ need.

For the slack notification lambda, I just set the `cloudwatch_log_group_retention_in_days` variable of the module.

## Learning
I wasn't aware that AWS would create related resources like this. It's a little frustrating for our ephemeral environments, since it means the resources aren't deleted when the environment is destroyed.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work
  - N/A
- [x] The product team have approved these changes
  - N/A