### PR TITLE
DDPB-3264: Write unit tests for activation/reset emails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,11 +366,11 @@ jobs:
           command: |
             docker-compose up -d pact-mock
             sleep 1
-            docker run
-                --rm
-                --network=project_default
-                --env-file=client/docker/env/frontend.env
-                client:latest
+            docker run \
+                --rm \
+                --network=project_default \
+                --env-file=client/docker/env/frontend.env \
+                client:latest \
                 bin/phpunit -c tests/phpunit --log-junit=tests/junit.xml
             docker-compose exec pact-mock cat /tmp/pacts/complete_the_deputy_report-opg_data.json > pact.json
             docker-compose exec pact-mock cat tests/junit.xml > junit.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,12 +366,20 @@ jobs:
           command: |
             docker-compose up -d pact-mock
             sleep 1
-            docker run --rm --network=project_default client:latest bin/phpunit -c tests/phpunit
+            docker run
+                --rm
+                --network=project_default
+                --env-file=client/docker/env/frontend.env
+                client:latest
+                bin/phpunit -c tests/phpunit --log-junit=tests/junit.xml
             docker-compose exec pact-mock cat /tmp/pacts/complete_the_deputy_report-opg_data.json > pact.json
+            docker-compose exec pact-mock cat tests/junit.xml > junit.xml
             docker-compose stop pact-mock
       - store_artifacts:
           path: pact.json
           destination: Pact file
+      - store_test_results:
+          path: junit.xml
 
   run-task:
     executor: terraform/terraform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,15 +371,12 @@ jobs:
                 --network=project_default \
                 --env-file=client/docker/env/frontend.env \
                 client:latest \
-                bin/phpunit -c tests/phpunit --log-junit=tests/junit.xml
+                bin/phpunit -c tests/phpunit
             docker-compose exec pact-mock cat /tmp/pacts/complete_the_deputy_report-opg_data.json > pact.json
-            docker-compose exec pact-mock cat tests/junit.xml > junit.xml
             docker-compose stop pact-mock
       - store_artifacts:
           path: pact.json
           destination: Pact file
-      - store_test_results:
-          path: junit.xml
 
   run-task:
     executor: terraform/terraform

--- a/client/app/config/config_dev.yml
+++ b/client/app/config/config_dev.yml
@@ -38,13 +38,6 @@ services:
     Alphagov\Notifications\Client:
         alias: AppBundle\Service\Mailer\NotifyClientMock
 
-    AppBundle\Service\Mailer\NotifyClientMock:
-        arguments:
-            $config:
-                httpClient: '@Http\Adapter\Guzzle6\Client'
-                apiKey: '%env(NOTIFY_API_KEY)%'
-            $logger: '@logger'
-
 monolog:
    handlers:
        main:

--- a/client/app/config/config_test.yml
+++ b/client/app/config/config_test.yml
@@ -3,8 +3,6 @@ imports:
 
 framework:
     test: ~
-    session:
-       storage_id: session.storage.mock_file
 
 services:
     AppBundle\Service\Mailer\MailSender:

--- a/client/app/config/config_test.yml
+++ b/client/app/config/config_test.yml
@@ -3,6 +3,8 @@ imports:
 
 framework:
     test: ~
+    session:
+       storage_id: session.storage.mock_file
 
 services:
     AppBundle\Service\Mailer\MailSender:

--- a/client/app/config/config_test.yml
+++ b/client/app/config/config_test.yml
@@ -18,10 +18,3 @@ services:
 
     Alphagov\Notifications\Client:
         alias: AppBundle\Service\Mailer\NotifyClientMock
-
-    AppBundle\Service\Mailer\NotifyClientMock:
-        arguments:
-            $config:
-                httpClient: '@Http\Adapter\Guzzle6\Client'
-                apiKey: '%env(NOTIFY_API_KEY)%'
-            $logger: '@logger'

--- a/client/app/config/config_unittest.yml
+++ b/client/app/config/config_unittest.yml
@@ -1,0 +1,8 @@
+imports:
+    - { resource: config_test.yml }
+
+framework:
+    test: ~
+    session:
+       storage_id: session.storage.mock_file
+    csrf_protection: false

--- a/client/app/config/services_mail.yml
+++ b/client/app/config/services_mail.yml
@@ -28,6 +28,8 @@ services:
         calls:
             - [ addSwiftMailer, [ 'default', '@mailer.swift_mailers.default'] ]
 
+    AppBundle\Service\Mailer\MailSenderInterface: '@AppBundle\Service\Mailer\MailSender'
+
     Alphagov\Notifications\Client:
         class: Alphagov\Notifications\Client
         arguments:

--- a/client/app/config/services_mail.yml
+++ b/client/app/config/services_mail.yml
@@ -35,5 +35,12 @@ services:
                 httpClient: '@Http\Adapter\Guzzle6\Client'
                 apiKey: '%env(NOTIFY_API_KEY)%'
 
+    AppBundle\Service\Mailer\NotifyClientMock:
+        arguments:
+            $config:
+                httpClient: '@Http\Adapter\Guzzle6\Client'
+                apiKey: '%env(NOTIFY_API_KEY)%'
+            $logger: '@logger'
+
     Http\Adapter\Guzzle6\Client:
         class: Http\Adapter\Guzzle6\Client

--- a/client/src/AppBundle/Controller/Admin/IndexController.php
+++ b/client/src/AppBundle/Controller/Admin/IndexController.php
@@ -75,7 +75,12 @@ class IndexController extends AbstractController
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
      * @Template("AppBundle:Admin/Index:addUser.html.twig")
      */
-    public function addUserAction(Request $request)
+    public function addUserAction(
+        Request $request,
+        RestClient $restClient,
+        MailFactory $mailFactory,
+        MailSenderInterface $mailSender
+    )
     {
         $form = $this->createForm(FormDir\Admin\AddUserType::class, new EntityDir\User());
 
@@ -88,10 +93,10 @@ class IndexController extends AbstractController
                 }
 
                 /** @var EntityDir\User $user */
-                $user = $this->getRestClient()->post('user', $form->getData(), ['admin_add_user'], 'User');
+                $user = $restClient->post('user', $form->getData(), ['admin_add_user'], 'User');
 
-                $activationEmail = $this->getMailFactory()->createActivationEmail($user);
-                $this->getMailSender()->send($activationEmail, ['text', 'html']);
+                $activationEmail = $mailFactory->createActivationEmail($user);
+                $mailSender->send($activationEmail, ['text', 'html']);
 
                 $this->addFlash(
                     'notice',

--- a/client/src/AppBundle/Controller/Admin/IndexController.php
+++ b/client/src/AppBundle/Controller/Admin/IndexController.php
@@ -96,7 +96,7 @@ class IndexController extends AbstractController
                 $user = $restClient->post('user', $form->getData(), ['admin_add_user'], 'User');
 
                 $activationEmail = $mailFactory->createActivationEmail($user);
-                $mailSender->send($activationEmail, ['text', 'html']);
+                $mailSender->send($activationEmail);
 
                 $this->addFlash(
                     'notice',
@@ -493,7 +493,7 @@ class IndexController extends AbstractController
             $user = $restClient->userRecreateToken($email, 'pass-reset');
             $resetPasswordEmail = $mailFactory->createActivationEmail($user);
 
-            $mailSender->send($resetPasswordEmail, ['text', 'html']);
+            $mailSender->send($resetPasswordEmail);
         } catch (\Throwable $e) {
             $logger->debug($e->getMessage());
         }

--- a/client/src/AppBundle/Controller/Org/OrganisationController.php
+++ b/client/src/AppBundle/Controller/Org/OrganisationController.php
@@ -291,8 +291,6 @@ class OrganisationController extends AbstractController
             $logger = $this->get('logger');
             $logger->debug($e->getMessage());
 
-            throw $e;
-
             $this->addFlash(
                 'error',
                 'An activation email could not be sent.'

--- a/client/src/AppBundle/Controller/Org/OrganisationController.php
+++ b/client/src/AppBundle/Controller/Org/OrganisationController.php
@@ -108,7 +108,7 @@ class OrganisationController extends AbstractController
                     $currentUser = $this->getUser();
 
                     $invitationEmail = $this->getMailFactory()->createInvitationEmail($user, $currentUser->getFullName());
-                    $this->getMailSender()->send($invitationEmail, ['text', 'html']);
+                    $this->getMailSender()->send($invitationEmail);
 
                     $this->getRestClient()->put('v2/organisation/' . $organisation->getId() . '/user/' . $user->getId(), '');
                 }
@@ -280,7 +280,7 @@ class OrganisationController extends AbstractController
             $currentUser = $this->getUser();
 
             $invitationEmail = $this->getMailFactory()->createInvitationEmail($user, $currentUser->getFullName());
-            $this->getMailSender()->send($invitationEmail, ['text', 'html']);
+            $this->getMailSender()->send($invitationEmail);
 
             $this->addFlash(
                 'notice',

--- a/client/src/AppBundle/Controller/Org/OrganisationController.php
+++ b/client/src/AppBundle/Controller/Org/OrganisationController.php
@@ -260,7 +260,7 @@ class OrganisationController extends AbstractController
     }
 
     /**
-     * @Route("{orgId}/send-activation-link/{userId}", name="org_organisation_send_activation_link")
+     * @Route("/{orgId}/send-activation-link/{userId}", name="org_organisation_send_activation_link")
      * @return \Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
     public function resendActivationEmailAction(Request $request, int $orgId, int $userId)
@@ -290,6 +290,8 @@ class OrganisationController extends AbstractController
             /** @var LoggerInterface */
             $logger = $this->get('logger');
             $logger->debug($e->getMessage());
+
+            throw $e;
 
             $this->addFlash(
                 'error',

--- a/client/src/AppBundle/Controller/UserController.php
+++ b/client/src/AppBundle/Controller/UserController.php
@@ -141,7 +141,7 @@ class UserController extends AbstractController
         $this->getRestClient()->userRecreateToken($user->getEmail(), 'activate');
 
         $activationEmail = $this->getMailFactory()->createActivationEmail($user);
-        $this->getMailSender()->send($activationEmail, ['text', 'html']);
+        $this->getMailSender()->send($activationEmail);
 
         return $this->redirect($this->generateUrl('activation_link_sent', ['token' => $token]));
     }
@@ -229,7 +229,7 @@ class UserController extends AbstractController
 
                 $resetPasswordEmail = $this->getMailFactory()->createResetPasswordEmail($user);
 
-                $this->getMailSender()->send($resetPasswordEmail, ['text', 'html']);
+                $this->getMailSender()->send($resetPasswordEmail);
                 $logger->warning('Email sent to ' . $disguisedEmail);
             } catch (RestClientException $e) {
                 $logger->warning('Email ' . $emailAddress . ' not found');

--- a/client/src/AppBundle/Service/Mailer/MailSenderInterface.php
+++ b/client/src/AppBundle/Service/Mailer/MailSenderInterface.php
@@ -6,5 +6,5 @@ use AppBundle\Model\Email;
 
 interface MailSenderInterface
 {
-    public function send(Email $email, array $groups, $transport);
+    public function send(Email $email, array $groups);
 }

--- a/client/src/AppBundle/Service/Mailer/MailSenderInterface.php
+++ b/client/src/AppBundle/Service/Mailer/MailSenderInterface.php
@@ -6,5 +6,5 @@ use AppBundle\Model\Email;
 
 interface MailSenderInterface
 {
-    public function send(Email $email, array $groups);
+    public function send(Email $email, array $groups = ['text']);
 }

--- a/client/tests/phpunit/Controller/AbstractControllerTestCase.php
+++ b/client/tests/phpunit/Controller/AbstractControllerTestCase.php
@@ -2,10 +2,12 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Client;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Role\Role;
 
 abstract class AbstractControllerTestCase extends WebTestCase
 {
@@ -15,5 +17,26 @@ abstract class AbstractControllerTestCase extends WebTestCase
     public function setUp(): void
     {
         $this->client = static::createClient(['environment' => 'unittest', 'debug' => false]);
+    }
+
+    protected function mockLoggedInUser(array $roleNames, User $user = null): void
+    {
+        $container = $this->client->getContainer();
+
+        $roles = array_map(function () {
+            return new Role('ROLE_ADMIN');
+        }, $roleNames);
+
+        $token = self::prophesize(TokenInterface::class);
+        $token->getUser()->willReturn(is_null($user) ? new User() : $user);
+        $token->serialize()->willReturn('');
+        $token->isAuthenticated()->willReturn(true);
+        $token->getRoles()->willReturn($roles);
+
+        $tokenStorage = self::prophesize(TokenStorage::class);
+        $tokenStorage->getToken()->willReturn($token);
+        $tokenStorage->setToken(null)->willReturn();
+
+        $container->set('security.token_storage', $tokenStorage->reveal());
     }
 }

--- a/client/tests/phpunit/Controller/AbstractControllerTestCase.php
+++ b/client/tests/phpunit/Controller/AbstractControllerTestCase.php
@@ -2,56 +2,35 @@
 
 namespace AppBundle\Controller;
 
+use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DependencyInjection\Container;
 
 abstract class AbstractControllerTestCase extends WebTestCase
 {
-    /** @var Container */
-    protected $container;
-
-    /** @var Controller */
-    protected $sut;
-
-    public static function setUpBeforeClass(): void
-    {
-        self::bootKernel(['environment' => 'unittest']);
-    }
+    /** @var Client */
+    protected $frameworkBundleClient;
 
     public function setUp(): void
     {
-        $this->container = self::$kernel->getContainer();
+        $this->frameworkBundleClient = static::createClient(['environment' => 'unittest', 'debug' => false]);
     }
 
-    public function tearDown(): void
-    {
-        // purposefully not calling parent class, which shuts down the kernel
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        self::ensureKernelShutdown();
-        self::$kernel = null;
-    }
-
-    public function getRouteMap()
-    {
-        return [];
-    }
-
-    /**
+   /**
+     * @param string $method
+     * @param string $uri
+     * @param array  $parameters
+     * @param array  $files
+     * @param array  $server
+     *
+     * @return Response
      * @dataProvider getRouteMap
-     */
-    public function testRoutes(string $url, string $action, array $params = []): void
+    */
+    protected function httpRequest($method, $uri, array $parameters = [], array $files = [], array $server = [])
     {
-        $client = self::createClient(['environment' => 'unittest']);
-        $router = $client->getContainer()->get('router');
-        $match = $router->match($url);
+        $this->frameworkBundleClient->request($method, $uri, $parameters, $files, $server);
 
-        self::assertEquals(get_class($this->sut) . '::' . $action, $match['_controller']);
-        foreach ($params as $key => $expectedValue) {
-            self::assertEquals($expectedValue, $match[$key]);
-        }
+        return $this->frameworkBundleClient->getResponse();
     }
 }

--- a/client/tests/phpunit/Controller/AbstractControllerTestCase.php
+++ b/client/tests/phpunit/Controller/AbstractControllerTestCase.php
@@ -60,8 +60,8 @@ abstract class AbstractControllerTestCase extends WebTestCase
             $user->setId(1);
         }
 
-        $roles = array_map(function () {
-            return new Role('ROLE_ADMIN');
+        $roles = array_map(function ($roleName) {
+            return new Role($roleName);
         }, $roleNames);
 
         $token = new UsernamePasswordToken($user, 'password', 'mock', $roles);

--- a/client/tests/phpunit/Controller/AbstractControllerTestCase.php
+++ b/client/tests/phpunit/Controller/AbstractControllerTestCase.php
@@ -8,6 +8,7 @@ use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Role\Role;
@@ -17,7 +18,7 @@ abstract class AbstractControllerTestCase extends WebTestCase
     /** @var Client */
     protected $client;
 
-    /** @var RestClient&ObjectProphecy */
+    /** @var RestClient|ObjectProphecy */
     protected $restClient;
 
     public function setUp(): void
@@ -33,6 +34,7 @@ abstract class AbstractControllerTestCase extends WebTestCase
      */
     protected function injectProphecyService(string $className, callable $callback, array $aliases = []): ObjectProphecy
     {
+        /** @var Container $container */
         $container = $this->client->getContainer();
 
         $prophet = self::prophesize($className);

--- a/client/tests/phpunit/Controller/AbstractControllerTestCase.php
+++ b/client/tests/phpunit/Controller/AbstractControllerTestCase.php
@@ -10,27 +10,10 @@ use Symfony\Component\DependencyInjection\Container;
 abstract class AbstractControllerTestCase extends WebTestCase
 {
     /** @var Client */
-    protected $frameworkBundleClient;
+    protected $client;
 
     public function setUp(): void
     {
-        $this->frameworkBundleClient = static::createClient(['environment' => 'unittest', 'debug' => false]);
-    }
-
-   /**
-     * @param string $method
-     * @param string $uri
-     * @param array  $parameters
-     * @param array  $files
-     * @param array  $server
-     *
-     * @return Response
-     * @dataProvider getRouteMap
-    */
-    protected function httpRequest($method, $uri, array $parameters = [], array $files = [], array $server = [])
-    {
-        $this->frameworkBundleClient->request($method, $uri, $parameters, $files, $server);
-
-        return $this->frameworkBundleClient->getResponse();
+        $this->client = static::createClient(['environment' => 'unittest', 'debug' => false]);
     }
 }

--- a/client/tests/phpunit/Controller/AbstractControllerTestCase.php
+++ b/client/tests/phpunit/Controller/AbstractControllerTestCase.php
@@ -32,7 +32,7 @@ abstract class AbstractControllerTestCase extends WebTestCase
     /**
      * Create a prophet for a Symfony service and overwrite it in the client container
      */
-    protected function injectProphecyService(string $className, callable $callback, array $aliases = []): ObjectProphecy
+    protected function injectProphecyService(string $className, callable $callback = null, array $aliases = []): ObjectProphecy
     {
         /** @var Container $container */
         $container = $this->client->getContainer();
@@ -44,7 +44,9 @@ abstract class AbstractControllerTestCase extends WebTestCase
             $container->set($alias, $prophet->reveal());
         }
 
-        call_user_func($callback, $prophet);
+        if (is_callable($callback)) {
+            call_user_func($callback, $prophet);
+        }
 
         return $prophet;
     }

--- a/client/tests/phpunit/Controller/AdminIndexControllerTest.php
+++ b/client/tests/phpunit/Controller/AdminIndexControllerTest.php
@@ -29,7 +29,7 @@ class AdminIndexControllerTest extends AbstractControllerTestCase
         });
 
         $this->injectProphecyService(MailSender::class, function($mailSender) {
-            $mailSender->send(new Email(), Argument::cetera())->shouldBeCalled()->willReturn();
+            $mailSender->send(new Email())->shouldBeCalled()->willReturn();
         });
 
         $crawler = $this->client->request('GET', "/admin/user-add");
@@ -55,7 +55,7 @@ class AdminIndexControllerTest extends AbstractControllerTestCase
         });
 
         $this->injectProphecyService(MailSender::class, function ($mailSender) {
-            $mailSender->send(new Email(), Argument::cetera())->shouldBeCalled()->willReturn();
+            $mailSender->send(new Email())->shouldBeCalled()->willReturn();
         });
 
         $this->injectProphecyService(LoggerInterface::class, function ($logger) {

--- a/client/tests/phpunit/Controller/AdminIndexControllerTest.php
+++ b/client/tests/phpunit/Controller/AdminIndexControllerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace AppBundle\Controller;
+
+use AppBundle\Controller\Admin\IndexController;
+use AppBundle\Entity\User;
+use AppBundle\Model\Email;
+use AppBundle\Service\Client\RestClient;
+use AppBundle\Service\Mailer\MailFactory;
+use AppBundle\Service\Mailer\MailSenderInterface;
+use AppBundle\Service\OrgService;
+use Exception;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+class AdminIndexControllerTest extends WebTestCase
+{
+    /** @var OrgService&ObjectProphecy */
+    private $orgService;
+
+    /** @var IndexController */
+    private $sut;
+
+    /** @var RouterInterface */
+    private static $router;
+
+    public static function setUpBeforeClass(): void
+    {
+        $client = self::createClient();
+        self::$router = $client->getContainer()->get('router');
+    }
+
+    public function setUp(): void
+    {
+        $this->orgService = self::prophesize(OrgService::class);
+        $this->sut = new IndexController($this->orgService->reveal());
+    }
+
+    public function getRouteMap()
+    {
+        return [
+            ['/admin/', 'indexAction'],
+            ['/admin/user-add', 'addUserAction'],
+            ['/admin/edit-user', 'editUserAction'],
+            ['/admin/send-activation-link/test@email.com', 'sendUserActivationLinkAction', ['email' => 'test@email.com']],
+        ];
+    }
+
+    /**
+     * @dataProvider getRouteMap
+     */
+    public function testRoutes(string $url, string $action, array $params = []): void
+    {
+        $match = self::$router->match($url);
+
+        self::assertEquals(get_class($this->sut) . '::' . $action, $match['_controller']);
+        foreach ($params as $key => $expectedValue) {
+            self::assertEquals($expectedValue, $match[$key]);
+        }
+    }
+
+    public function testSendActivationLink(): void
+    {
+        $emailAddress = 'test@gmail.example';
+
+        $mailFactory = self::prophesize(MailFactory::class);
+        $mailSender = self::prophesize(MailSenderInterface::class);
+        $logger = self::prophesize(LoggerInterface::class);
+        $restClient = self::prophesize(RestClient::class);
+
+        $restClient->userRecreateToken($emailAddress, 'pass-reset')->shouldBeCalled()->willReturn(new User());
+        $mailFactory->createActivationEmail(new User())->shouldBeCalled()->willReturn(new Email());
+        $mailSender->send(new Email(), Argument::cetera())->shouldBeCalled()->willReturn();
+        $logger->log(Argument::cetera())->shouldNotBeCalled();
+
+        $response = $this->sut->sendUserActivationLinkAction($emailAddress, $mailFactory->reveal(), $mailSender->reveal(), $logger->reveal(), $restClient->reveal());
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('[Link sent]', $response->getContent());
+    }
+
+    public function testSendActivationLinkSwallowsFailures(): void
+    {
+        $emailAddress = 'test@gmail.example';
+
+        $mailFactory = self::prophesize(MailFactory::class);
+        $mailSender = self::prophesize(MailSenderInterface::class);
+        $logger = self::prophesize(LoggerInterface::class);
+        $restClient = self::prophesize(RestClient::class);
+
+        $restClient
+            ->userRecreateToken($emailAddress, 'pass-reset')
+            ->shouldBeCalled()
+            ->willThrow(new Exception('Intentional test exception'));
+
+        $logger->debug('Intentional test exception')->shouldBeCalled();
+
+        $response = $this->sut->sendUserActivationLinkAction($emailAddress, $mailFactory->reveal(), $mailSender->reveal(), $logger->reveal(), $restClient->reveal());
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString('[Link sent]', $response->getContent());
+    }
+}

--- a/client/tests/phpunit/Controller/AdminIndexControllerTest.php
+++ b/client/tests/phpunit/Controller/AdminIndexControllerTest.php
@@ -11,9 +11,6 @@ use AppBundle\Service\Mailer\MailSender;
 use Exception;
 use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Role\Role;
 
 class AdminIndexControllerTest extends AbstractControllerTestCase
 {
@@ -24,19 +21,7 @@ class AdminIndexControllerTest extends AbstractControllerTestCase
     {
         parent::setUp();
 
-        $container = $this->client->getContainer();
-
-        $token = self::prophesize(TokenInterface::class);
-        $token->getUser()->willReturn(new User());
-        $token->serialize()->willReturn('');
-        $token->isAuthenticated()->willReturn(true);
-        $token->getRoles()->willReturn([new Role('ROLE_ADMIN')]);
-
-        $tokenStorage = self::prophesize(TokenStorage::class);
-        $tokenStorage->getToken()->willReturn($token);
-        $tokenStorage->setToken(null)->willReturn();
-
-        $container->set('security.token_storage', $tokenStorage->reveal());
+        $this->mockLoggedInUser(['ROLE_ADMIN']);
     }
 
     public function testSendActivationLink(): void

--- a/client/tests/phpunit/Controller/AdminIndexControllerTest.php
+++ b/client/tests/phpunit/Controller/AdminIndexControllerTest.php
@@ -97,9 +97,14 @@ class AdminIndexControllerTest extends WebTestCase
     // Partial-mock IndexController and interrupt Controller functions
     public function testAddUserWithMockery(): void
     {
+        $form = self::prophesize(Form::class);
+        $form->handleRequest(Argument::type(Request::class))->willReturn();
+        $form->isValid()->willReturn(false);
+        $form->createView()->willReturn('form-view');
+
         $sut = \Mockery::mock(IndexController::class);
         $sut->shouldAllowMockingProtectedMethods();
-        $sut->shouldReceive('createForm')->andReturn(self::prophesize(Form::class)->reveal());
+        $sut->shouldReceive('createForm')->andReturn($form->reveal());
         $sut->makePartial();
 
         // --------

--- a/client/tests/phpunit/Controller/AdminIndexControllerTest.php
+++ b/client/tests/phpunit/Controller/AdminIndexControllerTest.php
@@ -5,7 +5,6 @@ namespace AppBundle\Controller;
 use AppBundle\Controller\Admin\IndexController;
 use AppBundle\Entity\User;
 use AppBundle\Model\Email;
-use AppBundle\Service\Client\RestClient;
 use AppBundle\Service\Mailer\MailFactory;
 use AppBundle\Service\Mailer\MailSender;
 use Exception;

--- a/client/tests/phpunit/Controller/AdminIndexControllerTest.php
+++ b/client/tests/phpunit/Controller/AdminIndexControllerTest.php
@@ -24,7 +24,7 @@ class AdminIndexControllerTest extends AbstractControllerTestCase
     {
         parent::setUp();
 
-        $container = $this->frameworkBundleClient->getContainer();
+        $container = $this->client->getContainer();
 
         $token = self::prophesize(TokenInterface::class);
         $token->getUser()->willReturn(new User());
@@ -42,7 +42,7 @@ class AdminIndexControllerTest extends AbstractControllerTestCase
     public function testSendActivationLink(): void
     {
         $emailAddress = 'test@gmail.example';
-        $container = $this->frameworkBundleClient->getContainer();
+        $container = $this->client->getContainer();
 
         $mailFactory = self::prophesize(MailFactory::class);
         $mailSender = self::prophesize(MailSender::class);
@@ -59,7 +59,8 @@ class AdminIndexControllerTest extends AbstractControllerTestCase
         $container->set('logger', $logger->reveal());
         $container->set(RestClient::class, $restClient->reveal());
 
-        $response = $this->httpRequest('GET', "/admin/send-activation-link/{$emailAddress}");
+        $this->client->request('GET', "/admin/send-activation-link/{$emailAddress}");
+        $response = $this->client->getResponse();
 
         self::assertEquals(200, $response->getStatusCode());
         self::assertStringContainsString('[Link sent]', $response->getContent());
@@ -68,7 +69,7 @@ class AdminIndexControllerTest extends AbstractControllerTestCase
     public function testSendActivationLinkSwallowsFailures(): void
     {
         $emailAddress = 'test@gmail.example';
-        $container = $this->frameworkBundleClient->getContainer();
+        $container = $this->client->getContainer();
 
         $mailFactory = self::prophesize(MailFactory::class);
         $mailSender = self::prophesize(MailSender::class);
@@ -87,7 +88,8 @@ class AdminIndexControllerTest extends AbstractControllerTestCase
         $container->set('logger', $logger->reveal());
         $container->set(RestClient::class, $restClient->reveal());
 
-        $response = $this->httpRequest('GET', "/admin/send-activation-link/{$emailAddress}");
+        $this->client->request('GET', "/admin/send-activation-link/{$emailAddress}");
+        $response = $this->client->getResponse();
 
         self::assertEquals(200, $response->getStatusCode());
         self::assertStringContainsString('[Link sent]', $response->getContent());

--- a/client/tests/phpunit/Controller/AdminIndexControllerTest.php
+++ b/client/tests/phpunit/Controller/AdminIndexControllerTest.php
@@ -2,7 +2,6 @@
 
 namespace AppBundle\Controller;
 
-use AppBundle\Controller\Admin\IndexController;
 use AppBundle\Entity\User;
 use AppBundle\Model\Email;
 use AppBundle\Service\Mailer\MailFactory;
@@ -10,12 +9,10 @@ use AppBundle\Service\Mailer\MailSender;
 use Exception;
 use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 class AdminIndexControllerTest extends AbstractControllerTestCase
 {
-    /** @var IndexController */
-    protected $sut;
-
     public function setUp(): void
     {
         parent::setUp();
@@ -36,10 +33,6 @@ class AdminIndexControllerTest extends AbstractControllerTestCase
         });
 
         $crawler = $this->client->request('GET', "/admin/user-add");
-        $response = $this->client->getResponse();
-
-        self::assertEquals(200, $response->getStatusCode());
-
         $button = $crawler->selectButton('Save user');
 
         $this->client->submit($button->form(), [
@@ -70,10 +63,12 @@ class AdminIndexControllerTest extends AbstractControllerTestCase
         }, ['logger']);
 
         $this->client->request('GET', "/admin/send-activation-link/{$emailAddress}");
+
+        /** @var Response $response */
         $response = $this->client->getResponse();
 
         self::assertEquals(200, $response->getStatusCode());
-        self::assertStringContainsString('[Link sent]', $response->getContent());
+        self::assertEquals('[Link sent]', $response->getContent());
     }
 
     public function testSendActivationLinkSwallowsFailures(): void
@@ -90,9 +85,11 @@ class AdminIndexControllerTest extends AbstractControllerTestCase
         }, ['logger']);
 
         $this->client->request('GET', "/admin/send-activation-link/{$emailAddress}");
+
+        /** @var Response $response */
         $response = $this->client->getResponse();
 
         self::assertEquals(200, $response->getStatusCode());
-        self::assertStringContainsString('[Link sent]', $response->getContent());
+        self::assertEquals('[Link sent]', $response->getContent());
     }
 }

--- a/client/tests/phpunit/Controller/AdminIndexControllerTest.php
+++ b/client/tests/phpunit/Controller/AdminIndexControllerTest.php
@@ -12,42 +12,29 @@ use AppBundle\Service\OrgService;
 use Exception;
 use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Role\Role;
 
-class AdminIndexControllerTest extends WebTestCase
+class AdminIndexControllerTest extends AbstractControllerTestCase
 {
     /** @var IndexController */
-    private $sut;
-
-    /** @var Container */
-    private $container;
-
-    /** @var RouterInterface */
-    private static $router;
-
-    public static function setUpBeforeClass(): void
-    {
-        $client = self::createClient(['environment' => 'unittest']);
-        self::$router = $client->getContainer()->get('router');
-    }
+    protected $sut;
 
     public function setUp(): void
     {
+        parent::setUp();
+
         $token = self::prophesize(TokenInterface::class);
         $token->getUser()->willReturn(new User());
         $token->isAuthenticated()->willReturn(true);
         $token->getRoles()->willReturn([new Role('ROLE_ADMIN')]);
+
         $tokenStorage = self::prophesize(TokenStorage::class);
         $tokenStorage->getToken()->willReturn($token);
 
-        $this->container = self::$kernel->getContainer();
         $this->container->set('security.token_storage', $tokenStorage->reveal());
 
         $this->sut = new IndexController(self::prophesize(OrgService::class)->reveal());
@@ -63,20 +50,6 @@ class AdminIndexControllerTest extends WebTestCase
         ];
     }
 
-    /**
-     * @dataProvider getRouteMap
-     */
-    public function testRoutes(string $url, string $action, array $params = []): void
-    {
-        $match = self::$router->match($url);
-
-        self::assertEquals(get_class($this->sut) . '::' . $action, $match['_controller']);
-        foreach ($params as $key => $expectedValue) {
-            self::assertEquals($expectedValue, $match[$key]);
-        }
-    }
-
-    // Use a real container
     public function testAddUserSubmit(): void
     {
         $this->sut->setContainer($this->container);

--- a/client/tests/phpunit/Controller/ManageControllerTest.php
+++ b/client/tests/phpunit/Controller/ManageControllerTest.php
@@ -18,14 +18,6 @@ class ManageControllerTest extends AbstractControllerTestCase
         ];
     }
 
-    public function getRouteMap()
-    {
-        return [
-            ['/manage/availability', 'availabilityAction'],
-            ['/manage/elb', 'elbAction'],
-        ];
-    }
-
     /**
      * @dataProvider availabilityProvider
      */
@@ -46,12 +38,10 @@ class ManageControllerTest extends AbstractControllerTestCase
         $container->set('snc_redis.default', $redisMock);
 
         // api mock
-        $restClient = m::mock('AppBundle\Service\Client\RestClient');
-        $restClient->shouldReceive('get')->with('manage/availability', 'array')->andReturn([
+        $this->restClient->get('manage/availability', 'array')->shouldBeCalled()->willReturn([
             'healthy' => $apiHealthy,
             'errors' => $apiHealthy ? '' : 'api_errors',
         ]);
-        $container->set('rest_client', $restClient);
 
         // smtp mock
         $smtpMock = m::mock('Swift_Transport');

--- a/client/tests/phpunit/Controller/ManageControllerTest.php
+++ b/client/tests/phpunit/Controller/ManageControllerTest.php
@@ -33,7 +33,7 @@ class ManageControllerTest extends AbstractControllerTestCase
         $redisHealthy, $apiHealthy, $smtpDefault, $smtpSecure, $wkhtmltopdfError, $clamReturnCode,
         $statusCode, array $mustContain)
     {
-        $container = $this->frameworkBundleClient->getContainer();
+        $container = $this->client->getContainer();
 
         //redis mock
         $redisMock = m::mock('Predis\Client');
@@ -86,7 +86,8 @@ class ManageControllerTest extends AbstractControllerTestCase
         $container->set('guzzle_file_scanner_client', $guzzleMock);
 
         // dispatch /manage/availability and status code and check response
-        $response = $this->httpRequest('GET', '/manage/availability');
+        $this->client->request('GET', '/manage/availability');
+        $response = $this->client->getResponse();
 
         $this->assertEquals($statusCode, $response->getStatusCode(), $response->getContent());
         foreach ($mustContain as $m) {
@@ -96,7 +97,8 @@ class ManageControllerTest extends AbstractControllerTestCase
 
     public function testElb()
     {
-        $response = $this->httpRequest('GET', '/manage/elb');
+        $this->client->request('GET', '/manage/elb');
+        $response = $this->client->getResponse();
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertStringContainsString('OK', $response->getContent());

--- a/client/tests/phpunit/Controller/OrganisationControllerTest.php
+++ b/client/tests/phpunit/Controller/OrganisationControllerTest.php
@@ -5,10 +5,10 @@ namespace AppBundle\Controller;
 use AppBundle\Entity\Organisation;
 use AppBundle\Entity\User;
 use AppBundle\Model\Email;
-use AppBundle\Model\SelfRegisterData;
 use AppBundle\Service\Mailer\MailFactory;
 use AppBundle\Service\Mailer\MailSender;
 use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\Response;
 
 class OrganisationControllerTest extends AbstractControllerTestCase
 {
@@ -55,6 +55,7 @@ class OrganisationControllerTest extends AbstractControllerTestCase
             'organisation_member[roleName]' => 'ROLE_PROF_ADMIN',
         ]);
 
+        /** @var Response $response */
         $response = $this->client->getResponse();
 
         self::assertEquals(302, $response->getStatusCode());
@@ -91,6 +92,7 @@ class OrganisationControllerTest extends AbstractControllerTestCase
             'organisation_member[roleName]' => 'ROLE_PROF_ADMIN',
         ]);
 
+        /** @var Response $response */
         $response = $this->client->getResponse();
 
         self::assertEquals(302, $response->getStatusCode());
@@ -125,9 +127,12 @@ class OrganisationControllerTest extends AbstractControllerTestCase
 
         $this->client->request('GET', "/org/settings/organisation/14/send-activation-link/17");
         $this->client->followRedirect();
+
+        /** @var Response $response */
         $response = $this->client->getResponse();
 
         self::assertEquals(200, $response->getStatusCode());
+        self::assertIsString($response->getContent());
         self::assertStringContainsString('An activation email has been sent to the user', $response->getContent());
     }
 }

--- a/client/tests/phpunit/Controller/OrganisationControllerTest.php
+++ b/client/tests/phpunit/Controller/OrganisationControllerTest.php
@@ -36,14 +36,16 @@ class OrganisationControllerTest extends AbstractControllerTestCase
         $this->restClient->post('user', Argument::any(), ['org_team_add'], 'User')->shouldBeCalled()->willReturn($user);
         $this->restClient->put('v2/organisation/14/user/21', '')->shouldBeCalled()->willReturn($user);
 
-        $this->injectProphecyService(MailSender::class, function($mailSender) use ($emailAddress) {
-            $mailSender->send(Argument::that(function ($email) use ($emailAddress) {
+        $mailSender = $this->injectProphecyService(MailSender::class);
+        $mailSender
+            ->send(Argument::that(function ($email) use ($emailAddress) {
                 return $email instanceof Email
                     && $email->getToEmail() === $emailAddress
                     && $email->getTemplate() === MailFactory::INVITATION_TEMPLATE_ID
                     && strpos($email->getParameters()['link'], "user/activate/invitation-token") !== false;
-            }), Argument::cetera())->shouldBeCalled()->willReturn();
-        });
+            }))
+            ->shouldBeCalled()
+            ->willReturn();
 
         $crawler = $this->client->request('GET', "/org/settings/organisation/14/add-user");
         $button = $crawler->selectButton('Save');
@@ -116,14 +118,16 @@ class OrganisationControllerTest extends AbstractControllerTestCase
         $this->restClient->get('v2/organisation/14', 'Organisation')->shouldBeCalled()->willReturn($organisation);
         $this->restClient->userRecreateToken($emailAddress, 'pass-reset')->shouldBeCalled()->willReturn($invitedUser);
 
-        $this->injectProphecyService(MailSender::class, function($mailSender) use ($emailAddress) {
-            $mailSender->send(Argument::that(function ($email) use ($emailAddress) {
+        $mailSender = $this->injectProphecyService(MailSender::class);
+        $mailSender
+            ->send(Argument::that(function ($email) use ($emailAddress) {
                 return $email instanceof Email
                     && $email->getToEmail() === $emailAddress
                     && $email->getTemplate() === MailFactory::INVITATION_TEMPLATE_ID
                     && strpos($email->getParameters()['link'], "user/activate/invitation-token") !== false;
-            }), Argument::cetera())->shouldBeCalled()->willReturn();
-        });
+            }))
+            ->shouldBeCalled()
+            ->willReturn();
 
         $this->client->request('GET', "/org/settings/organisation/14/send-activation-link/17");
         $this->client->followRedirect();

--- a/client/tests/phpunit/Controller/OrganisationControllerTest.php
+++ b/client/tests/phpunit/Controller/OrganisationControllerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace AppBundle\Controller;
+
+use AppBundle\Entity\Organisation;
+use AppBundle\Entity\User;
+use AppBundle\Model\Email;
+use AppBundle\Model\SelfRegisterData;
+use AppBundle\Service\Mailer\MailFactory;
+use AppBundle\Service\Mailer\MailSender;
+use Prophecy\Argument;
+
+class OrganisationControllerTest extends AbstractControllerTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testAddAction(): void
+    {
+        $this->mockLoggedInUser(['ROLE_PROF_ADMIN']);
+
+        $emailAddress = 'invited@mailbox.example';
+        $user = (new User())
+            ->setId(21)
+            ->setEmail($emailAddress)
+            ->setRegistrationToken('invitation-token');
+
+        $organisation = (new Organisation())
+            ->setId(14)
+            ->setName('Test organisation');
+
+        $this->restClient->get('v2/organisation/14', 'Organisation')->shouldBeCalled()->willReturn($organisation);
+        $this->restClient->get("user/get-team-names-by-email/$emailAddress", 'User')->shouldBeCalled()->willReturn(new User());
+        $this->restClient->post('user', Argument::any(), ['org_team_add'], 'User')->shouldBeCalled()->willReturn($user);
+        $this->restClient->put('v2/organisation/14/user/21', '')->shouldBeCalled()->willReturn($user);
+
+        $this->injectProphecyService(MailSender::class, function($mailSender) use ($emailAddress) {
+            $mailSender->send(Argument::that(function ($email) use ($emailAddress) {
+                return $email instanceof Email
+                    && $email->getToEmail() === $emailAddress
+                    && $email->getTemplate() === MailFactory::INVITATION_TEMPLATE_ID
+                    && strpos($email->getParameters()['link'], "user/activate/invitation-token") !== false;
+            }), Argument::cetera())->shouldBeCalled()->willReturn();
+        });
+
+        $crawler = $this->client->request('GET', "/org/settings/organisation/14/add-user");
+        $button = $crawler->selectButton('Save');
+
+        $this->client->submit($button->form(), [
+            'organisation_member[firstname]' => 'Aron',
+            'organisation_member[lastname]' => 'Samora',
+            'organisation_member[email]' => $emailAddress,
+            'organisation_member[roleName]' => 'ROLE_PROF_ADMIN',
+        ]);
+
+        $response = $this->client->getResponse();
+
+        self::assertEquals(302, $response->getStatusCode());
+    }
+
+    public function testAddActionInsertsExistingUsers(): void
+    {
+        $this->mockLoggedInUser(['ROLE_PROF_ADMIN']);
+
+        $user = (new User())
+            ->setId(21)
+            ->setEmail('existing@mailbox.example')
+            ->setRegistrationToken('invitation-token');
+
+        $organisation = (new Organisation())
+            ->setId(14)
+            ->setName('Test organisation');
+
+        $this->restClient->get('v2/organisation/14', 'Organisation')->shouldBeCalled()->willReturn($organisation);
+        $this->restClient->get("user/get-team-names-by-email/existing@mailbox.example", 'User')->shouldBeCalled()->willReturn($user);
+        $this->restClient->put('v2/organisation/14/user/21', '')->shouldBeCalled()->willReturn($user);
+
+        $this->injectProphecyService(MailSender::class, function($mailSender) {
+            $mailSender->send(Argument::cetera())->shouldNotBeCalled();
+        });
+
+        $crawler = $this->client->request('GET', "/org/settings/organisation/14/add-user");
+        $button = $crawler->selectButton('Save');
+
+        $this->client->submit($button->form(), [
+            'organisation_member[firstname]' => 'Aron',
+            'organisation_member[lastname]' => 'Samora',
+            'organisation_member[email]' => 'existing@mailbox.example',
+            'organisation_member[roleName]' => 'ROLE_PROF_ADMIN',
+        ]);
+
+        $response = $this->client->getResponse();
+
+        self::assertEquals(302, $response->getStatusCode());
+    }
+
+    public function testResendActivationEmailAction(): void
+    {
+        $this->mockLoggedInUser(['ROLE_PROF_ADMIN']);
+
+        $emailAddress = 'invited@mailbox.example';
+        $invitedUser = (new User())
+            ->setId(17)
+            ->setEmail($emailAddress)
+            ->setRegistrationToken('invitation-token');
+
+        $organisation = (new Organisation())
+            ->setId(14)
+            ->setName('Test organisation')
+            ->setUsers([$invitedUser]);
+
+        $this->restClient->get('v2/organisation/14', 'Organisation')->shouldBeCalled()->willReturn($organisation);
+        $this->restClient->userRecreateToken($emailAddress, 'pass-reset')->shouldBeCalled()->willReturn($invitedUser);
+
+        $this->injectProphecyService(MailSender::class, function($mailSender) use ($emailAddress) {
+            $mailSender->send(Argument::that(function ($email) use ($emailAddress) {
+                return $email instanceof Email
+                    && $email->getToEmail() === $emailAddress
+                    && $email->getTemplate() === MailFactory::INVITATION_TEMPLATE_ID
+                    && strpos($email->getParameters()['link'], "user/activate/invitation-token") !== false;
+            }), Argument::cetera())->shouldBeCalled()->willReturn();
+        });
+
+        $this->client->request('GET', "/org/settings/organisation/14/send-activation-link/17");
+        $this->client->followRedirect();
+        $response = $this->client->getResponse();
+
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertStringContainsString('An activation email has been sent to the user', $response->getContent());
+    }
+}

--- a/client/tests/phpunit/Controller/UserControllerTest.php
+++ b/client/tests/phpunit/Controller/UserControllerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace AppBundle\Controller;
+
+use AppBundle\Entity\User;
+use AppBundle\Model\Email;
+use AppBundle\Service\Mailer\MailSender;
+use Prophecy\Argument;
+
+class UserControllerTest extends AbstractControllerTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testPasswordForgottenAction(): void
+    {
+        $emailAddress = 'test@mailbox.example';
+        $user = new User();
+        $user->setEmail($emailAddress);
+        $user->setRegistrationToken('test');
+
+        $this->restClient->userRecreateToken($emailAddress, 'pass-reset')->shouldBeCalled()->willReturn($user);
+
+        $this->injectProphecyService(MailSender::class, function($mailSender) use ($emailAddress) {
+            $mailSender->send(Argument::that(function ($email) use ($emailAddress) {
+                return $email instanceof Email
+                    && $email->getToEmail() === $emailAddress
+                    && strpos($email->getParameters()['resetLink'], 'user/password-reset/test') !== false;
+            }), Argument::cetera())->shouldBeCalled()->willReturn();
+        });
+
+        $crawler = $this->client->request('GET', "/password-managing/forgotten");
+        $response = $this->client->getResponse();
+
+        self::assertEquals(200, $response->getStatusCode());
+
+        $button = $crawler->selectButton('Reset your password');
+
+        $this->client->submit($button->form(), [
+            'password_forgotten[email]' => $emailAddress,
+        ]);
+    }
+}

--- a/client/tests/phpunit/Controller/UserControllerTest.php
+++ b/client/tests/phpunit/Controller/UserControllerTest.php
@@ -28,14 +28,16 @@ class UserControllerTest extends AbstractControllerTestCase
         $this->restClient->loadUserByToken($token)->shouldBeCalled()->willReturn($user);
         $this->restClient->userRecreateToken($emailAddress, 'activate')->shouldBeCalled()->willReturn($user);
 
-        $this->injectProphecyService(MailSender::class, function($mailSender) use ($emailAddress, $token) {
-            $mailSender->send(Argument::that(function ($email) use ($emailAddress, $token) {
+        $mailSender = $this->injectProphecyService(MailSender::class);
+        $mailSender
+            ->send(Argument::that(function ($email) use ($emailAddress, $token) {
                 return $email instanceof Email
                     && $email->getToEmail() === $emailAddress
                     && $email->getTemplate() === MailFactory::ACTIVATION_TEMPLATE_ID
                     && strpos($email->getParameters()['activationLink'], "user/activate/$token") !== false;
-            }), Argument::cetera())->shouldBeCalled()->willReturn();
-        });
+            }))
+            ->shouldBeCalled()
+            ->willReturn();
 
         $this->client->request('GET', "/user/activate/password/send/$token");
         $this->client->followRedirect();
@@ -68,14 +70,16 @@ class UserControllerTest extends AbstractControllerTestCase
 
         $this->restClient->registerUser($data)->willReturn($user);
 
-        $this->injectProphecyService(MailSender::class, function($mailSender) {
-            $mailSender->send(Argument::that(function ($email) {
+        $mailSender = $this->injectProphecyService(MailSender::class);
+        $mailSender
+            ->send(Argument::that(function ($email) {
                 return $email instanceof Email
                     && $email->getToEmail() === 'd.brauchla@mailbox.example'
                     && $email->getTemplate() === MailFactory::ACTIVATION_TEMPLATE_ID
                     && strpos($email->getParameters()['activationLink'], 'user/activate/selfregister-token') !== false;
-            }), Argument::cetera())->shouldBeCalled()->willReturn();
-        });
+            }))
+            ->shouldBeCalled()
+            ->willReturn();
 
         $this->client->submit($button->form(), [
             'self_registration[firstname]' => $data->getFirstname(),
@@ -105,14 +109,16 @@ class UserControllerTest extends AbstractControllerTestCase
 
         $this->restClient->userRecreateToken($emailAddress, 'pass-reset')->shouldBeCalled()->willReturn($user);
 
-        $this->injectProphecyService(MailSender::class, function($mailSender) use ($emailAddress) {
-            $mailSender->send(Argument::that(function ($email) use ($emailAddress) {
+        $mailSender = $this->injectProphecyService(MailSender::class);
+        $mailSender
+            ->send(Argument::that(function ($email) use ($emailAddress) {
                 return $email instanceof Email
                     && $email->getToEmail() === $emailAddress
                     && $email->getTemplate() === MailFactory::RESET_PASSWORD_TEMPLATE_ID
                     && strpos($email->getParameters()['resetLink'], 'user/password-reset/test') !== false;
-            }), Argument::cetera())->shouldBeCalled()->willReturn();
-        });
+            }))
+            ->shouldBeCalled()
+            ->willReturn();
 
         $crawler = $this->client->request('GET', "/password-managing/forgotten");
 

--- a/client/tests/phpunit/Controller/UserControllerTest.php
+++ b/client/tests/phpunit/Controller/UserControllerTest.php
@@ -4,6 +4,8 @@ namespace AppBundle\Controller;
 
 use AppBundle\Entity\User;
 use AppBundle\Model\Email;
+use AppBundle\Model\SelfRegisterData;
+use AppBundle\Service\Mailer\MailFactory;
 use AppBundle\Service\Mailer\MailSender;
 use Prophecy\Argument;
 
@@ -12,6 +14,80 @@ class UserControllerTest extends AbstractControllerTestCase
     public function setUp(): void
     {
         parent::setUp();
+    }
+
+    public function testActivateLinkSendAction(): void
+    {
+        $emailAddress = 'test@mailbox.example';
+        $token = 'token';
+        $user = new User();
+        $user->setEmail($emailAddress);
+        $user->setRegistrationToken('token');
+
+        $this->restClient->loadUserByToken($token)->shouldBeCalled()->willReturn($user);
+        $this->restClient->userRecreateToken($emailAddress, 'activate')->shouldBeCalled()->willReturn($user);
+
+        $this->injectProphecyService(MailSender::class, function($mailSender) use ($emailAddress) {
+            $mailSender->send(Argument::that(function ($email) use ($emailAddress) {
+                return $email instanceof Email
+                    && $email->getToEmail() === $emailAddress
+                    && $email->getTemplate() === MailFactory::ACTIVATION_TEMPLATE_ID
+                    && strpos($email->getParameters()['activationLink'], "user/activate/$token") !== false;
+            }), Argument::cetera())->shouldBeCalled()->willReturn();
+        });
+
+        $this->client->request('GET', "/user/activate/password/send/$token");
+        $this->client->followRedirect();
+        $response = $this->client->getResponse();
+
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertStringContainsString('Check your email inbox, we&#039;ve sent you an email with a new link.', $response->getContent());
+    }
+
+    public function testRegisterAction(): void
+    {
+        $crawler = $this->client->request('GET', '/register');
+        $button = $crawler->selectButton('Sign up');
+
+        $data = new SelfRegisterData();
+        $data->setFirstname('Denis');
+        $data->setLastname('Brauchla');
+        $data->setPostcode('DB1 9FI');
+        $data->setEmail('d.brauchla@mailbox.example');
+        $data->setClientFirstname('Abraham');
+        $data->setClientLastname('Ruhter');
+        $data->setCaseNumber('13859388');
+
+        $user = (new User())
+            ->setEmail('d.brauchla@mailbox.example')
+            ->setRegistrationToken('selfregister-token');
+
+        $this->restClient->registerUser($data)->willReturn($user);
+
+        $this->injectProphecyService(MailSender::class, function($mailSender) {
+            $mailSender->send(Argument::that(function ($email) {
+                return $email instanceof Email
+                    && $email->getToEmail() === 'd.brauchla@mailbox.example'
+                    && $email->getTemplate() === MailFactory::ACTIVATION_TEMPLATE_ID
+                    && strpos($email->getParameters()['activationLink'], 'user/activate/selfregister-token') !== false;
+            }), Argument::cetera())->shouldBeCalled()->willReturn();
+        });
+
+        $this->client->submit($button->form(), [
+            'self_registration[firstname]' => $data->getFirstname(),
+            'self_registration[lastname]' => $data->getLastname(),
+            'self_registration[postcode]' => $data->getPostcode(),
+            'self_registration[email][first]' => $data->getEmail(),
+            'self_registration[email][second]' => $data->getEmail(),
+            'self_registration[clientFirstname]' => $data->getClientFirstname(),
+            'self_registration[clientLastname]' => $data->getClientLastname(),
+            'self_registration[caseNumber]' => $data->getCaseNumber(),
+        ]);
+
+        $response = $this->client->getResponse();
+
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertStringContainsString('We\'ve sent you a link to <strong class="bold-small">d.brauchla@mailbox.example</strong>', $response->getContent());
     }
 
     public function testPasswordForgottenAction(): void
@@ -27,6 +103,7 @@ class UserControllerTest extends AbstractControllerTestCase
             $mailSender->send(Argument::that(function ($email) use ($emailAddress) {
                 return $email instanceof Email
                     && $email->getToEmail() === $emailAddress
+                    && $email->getTemplate() === MailFactory::RESET_PASSWORD_TEMPLATE_ID
                     && strpos($email->getParameters()['resetLink'], 'user/password-reset/test') !== false;
             }), Argument::cetera())->shouldBeCalled()->willReturn();
         });
@@ -41,5 +118,11 @@ class UserControllerTest extends AbstractControllerTestCase
         $this->client->submit($button->form(), [
             'password_forgotten[email]' => $emailAddress,
         ]);
+
+        $this->client->followRedirect();
+        $response = $this->client->getResponse();
+
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertStringContainsString('We have sent a new registration link to your email', $response->getContent());
     }
 }

--- a/client/tests/phpunit/Resources/views/Components/PaginatorTest.php
+++ b/client/tests/phpunit/Resources/views/Components/PaginatorTest.php
@@ -22,7 +22,7 @@ class PaginatorTest extends WebTestCase
             return $a . '/' . http_build_query($b);
         });
 
-        $this->frameworkBundleClient = static::createClient(['environment' => 'test', 'debug' => true]);
+        $this->frameworkBundleClient = static::createClient(['environment' => 'test', 'debug' => false]);
         $container = $this->frameworkBundleClient->getContainer();
         $container->set('router', $this->mockRouter);
 

--- a/client/tests/phpunit/Resources/views/Report/FormattedTest.php
+++ b/client/tests/phpunit/Resources/views/Report/FormattedTest.php
@@ -42,7 +42,7 @@ class FormattedTest extends WebTestCase
 
     public function setUp(): void
     {
-        $this->frameworkBundleClient = static::createClient(['environment' => 'test', 'debug' => true]);
+        $this->frameworkBundleClient = static::createClient(['environment' => 'test', 'debug' => false]);
         $request = new Request();
         $request->create('/');
         $this->container = $this->frameworkBundleClient->getContainer();


### PR DESCRIPTION
## Purpose
In the process of switching to Notify, we’ve stopped checking email sending in our end-to-end tests. Instead, we should write unit tests for the relevant controllers to ensure emails are being sent as expected.

This is particularly essential for our activation and password reset emails, since they are critical for users to access DigiDeps. Unlike other emails, there is no work around and they permanently break the user journey.

We are prioritising writing these tests to give a clear plan of  how we can increase coverage to other controllers/emails.

Fixes DDPB-3264

## Approach
I went around most ways of writing unit tests and mocking things in Symfony, and settled on a method that I think works quite smoothly and is ripe for extending.

It uses Symfony's `createClient` function to create a driver for the tests, but:
- Uses a new `unittest` environment which has CSRF and Redis sessions switched off (to make testing easier)
- Exposes the client's `Container` so that services can easily be overwritten.

This allows you to easily prophesize a service and mock calls to it:
```php
$this->injectProphecyService(MailSender::class, function($mailSender) {
    $mailSender->send(Argument::cetera())->shouldNotBeCalled();
});

$crawler = $this->client->request('GET', "/org/settings/organisation/14/add-user");
```

I also added some helper functions: `injectProphecyService` (used above) quickly replaces a service with a prophet which you can hook into. `mockLoggedInUser` mocks token storage and rest client services so that you're treated as a logged in user with the supplied role(s).

## Learning
I hit a lot of stumbling blocks on this, which was frustrating but a lot of useful learning. A few take-aways:
- If you use `'debug' => true` in the client, the tests take several times longer
- By default, the client reloads the kernel between each request (deregistering our mocks). This is disabled with `$client->disableReboot()`
- You need to manually follow redirects (we could turn this on by default, but it would disrupt tests that don't want it)
- Some services need to registered twice: once with their class name and once with the shortcut (e.g. `RestClient` and `rest_client`)
- We have to remember to mock things we don't need (e.g. if you don't mock `Predis`, it'll interact with the real Redis service)
- Because Twig isn't mocked by default, you often need to provide more data than the action actually needs. You can mitigate this by mocking Twig or by using dummies (e.g. `new User()` rather than `self::prophesize(User::class)`
  - On the flip side, not mocking Twig means that we can test the templates/translations which can be clearer

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work
  - Ohhhh boy have I
- [x] The product team have approved these changes
  - N/A
