### PR TITLE
DDPB-3240: Add auto-sizing to full review checklist textinput

### DIFF
--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/fullReviewChecklist.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/fullReviewChecklist.html.twig
@@ -57,6 +57,7 @@
 
         {{ form_input(form.answers.decisionExplanation, page ~ '.form.finalDecisionExplanation', {
             inputClass: 'govuk-!-width-full',
+            formGroupClass: 'js-auto-size'
         }) }}
 
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">


### PR DESCRIPTION
## Purpose
Based on user feedback the final review comments box has been updated to auto-size as users type. This brings it in line with existing designs for text input fields.

Fixes DDPB-3240

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
