### PR TITLE
DDPB-3241: Updates wording of full review outcome option

### DIFF
--- a/client/src/AppBundle/Resources/translations/admin-checklist.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin-checklist.en.yml
@@ -221,7 +221,7 @@ checklistPage:
           sent an acknowledgment to the deputy(s)
       fullReviewOptions:
         satisfied: No further action required
-        furtherCaseworkRequired: Further case work/actions are required
+        furtherCaseworkRequired:  I have closed the review but further case work/actions are required
         escalate: Case escalated
     finalDecisionExplanation:
       label: Reason for final decision

--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/fullReviewChecklist.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/fullReviewChecklist.html.twig
@@ -50,7 +50,7 @@
 
         <a name="anchor-full-review-finalDecision"></a>
         {{ form_checkbox_group(form.decision, (page ~ '.form.finalDecision'), {
-            classes: 'govuk-radios--inline govuk-radios--small',
+            classes: 'govuk-radios--small',
             legendClass: 'govuk-fieldset__legend--m',
             formGroupClass: 'govuk-!-margin-bottom-1',
         }) }}


### PR DESCRIPTION
## Purpose
Offer an option with the wording "I have closed the Review but further case work/actions are required" in the full review decision question.

Fixes DDPB-3241

## Approach
As it happens, there is already an option which reads "Further case work/actions". This text just needs rewording, to make the intent of that option more clear, as opposed to adding a new option.


## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
