### PR TITLE
DDPB-3275: Set serverless auto pause timeout to 15 minutes

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -11,7 +11,7 @@ RUN npm install
 
 # Check linting
 RUN npm run lint
-RUN npm audit
+RUN npm audit --production
 
 # Build assets
 RUN NODE_ENV=production npm run build

--- a/environment/api_rds.tf
+++ b/environment/api_rds.tf
@@ -62,6 +62,10 @@ resource "aws_rds_cluster" "api" {
   enable_http_endpoint         = local.account.always_on ? false : true
   preferred_maintenance_window = "sun:01:00-sun:01:30"
 
+  scaling_configuration {
+    seconds_until_auto_pause = 900
+  }
+
   depends_on = [aws_cloudwatch_log_group.api_cluster]
 
   tags = merge(


### PR DESCRIPTION
## Purpose
Our serverless databases auto pause after 5 minutes, which impedes testing because cross-referencing a particular result often takes longer than that. We should increase it to 15 minutes to give people a little more time before being timed out.

Fixes DDPB-3275

## Approach
I upped the auto pause timeout to 15 minutes.

## Learning
This will cost us slightly more (because we have to pay for 10 minutes more of DB ACUs each time), but we're talking about thruppence which seems like a fair price for a bit more breathing room.

## Checklist
- [ ] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work
  -  N/A
- [x] The product team have approved these changes
  -  N/A
