### PR TITLE
DDPB-3233: Update client search to prevent default search

### DIFF
--- a/api/src/AppBundle/Entity/Repository/ClientRepository.php
+++ b/api/src/AppBundle/Entity/Repository/ClientRepository.php
@@ -122,7 +122,7 @@ class ClientRepository extends EntityRepository
 
     /**
      * @param $caseNumber
-     * @return |null
+     * @return array<mixed>|null
      */
     public function getArrayByCaseNumber($caseNumber)
     {

--- a/api/src/AppBundle/Entity/Repository/ClientRepository.php
+++ b/api/src/AppBundle/Entity/Repository/ClientRepository.php
@@ -121,6 +121,22 @@ class ClientRepository extends EntityRepository
     }
 
     /**
+     * @param $caseNumber
+     * @return |null
+     */
+    public function getArrayByCaseNumber($caseNumber)
+    {
+        $query = $this
+            ->getEntityManager()
+            ->createQuery('SELECT c FROM AppBundle\Entity\Client c WHERE c.caseNumber = ?1')
+            ->setParameter(1, $caseNumber);
+
+        $result = $query->getArrayResult();
+
+        return count($result) === 0 ? null : $result[0];
+    }
+
+    /**
      * @param ClientSearchFilter $filter
      */
     public function setSearchFilter(ClientSearchFilter $filter): void

--- a/api/src/AppBundle/v2/Controller/ClientController.php
+++ b/api/src/AppBundle/v2/Controller/ClientController.php
@@ -5,6 +5,7 @@ namespace AppBundle\v2\Controller;
 use AppBundle\Entity\Repository\ClientRepository;
 use AppBundle\v2\Assembler\ClientAssembler;
 use AppBundle\v2\Transformer\ClientTransformer;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -45,7 +46,7 @@ class ClientController
      * @param $id
      * @return JsonResponse
      */
-    public function getByIdAction($id)
+    public function getByIdAction(int $id): JsonResponse
     {
         if (null === ($data = $this->repository->getArrayById($id))) {
             throw new NotFoundHttpException(sprintf('Client id %s not found', $id));
@@ -54,6 +55,26 @@ class ClientController
         $dto = $this->assembler->assembleFromArray($data);
 
         $transformedDto = $this->transformer->transform($dto);
+
+        return $this->buildSuccessResponse($transformedDto);
+    }
+
+    /**
+     * @Route("/case-number/{caseNumber}", methods={"GET"})
+     * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
+     *
+     * @param string $caseNumber
+     * @return JsonResponse
+     */
+    public function getByCaseNumber(string $caseNumber): JsonResponse
+    {
+        if (null === ($data = $this->repository->getArrayByCaseNumber($caseNumber))) {
+            throw new NotFoundHttpException(sprintf('Client with case number %s not found', $caseNumber));
+        }
+
+        $dto = $this->assembler->assembleFromArray($data);
+
+        $transformedDto = $this->transformer->transform($dto, ['reports', 'ndr', 'organisation', 'namedDeputy']);
 
         return $this->buildSuccessResponse($transformedDto);
     }

--- a/behat/tests/bootstrap/Common/ReportTrait.php
+++ b/behat/tests/bootstrap/Common/ReportTrait.php
@@ -204,6 +204,7 @@ trait ReportTrait
         $endDate = self::$currentReportCache['endDate'];
 
         $this->clickOnBehatLink('admin-client-search');
+        $this->clickOnBehatLink('search_clients_search');
         $this->clickOnBehatLink("client-detail-$client");
         $this->iShouldSeeTheRegionInTheRegion("report-$startDate-to-$endDate", 'report-group-incomplete');
     }

--- a/behat/tests/bootstrap/Common/ReportTrait.php
+++ b/behat/tests/bootstrap/Common/ReportTrait.php
@@ -203,9 +203,7 @@ trait ReportTrait
         $startDate = self::$currentReportCache['startDate'];
         $endDate = self::$currentReportCache['endDate'];
 
-        $this->clickOnBehatLink('admin-client-search');
-        $this->clickOnBehatLink('search_clients_search');
-        $this->clickOnBehatLink("client-detail-$client");
+        $this->visitAdminPath("/admin/client/case-number/$client/details");
         $this->iShouldSeeTheRegionInTheRegion("report-$startDate-to-$endDate", 'report-group-incomplete');
     }
 

--- a/behat/tests/bootstrap/Common/SiteNavigationTrait.php
+++ b/behat/tests/bootstrap/Common/SiteNavigationTrait.php
@@ -49,6 +49,7 @@ trait SiteNavigationTrait
     {
         $this->visitAdminPath('/');
         $this->clickOnBehatLink('admin-client-search');
+        $this->clickOnBehatLink('search_clients_search');
         $this->clickOnBehatLink('client-detail-' . $caseNumber);
         $this->clickLinkInsideElement('checklist', 'report-' . $period);
     }

--- a/behat/tests/bootstrap/Common/SiteNavigationTrait.php
+++ b/behat/tests/bootstrap/Common/SiteNavigationTrait.php
@@ -47,10 +47,15 @@ trait SiteNavigationTrait
      */
     public function iOpenChecklistForClient($period, $caseNumber)
     {
-        $this->visitAdminPath('/');
-        $this->clickOnBehatLink('admin-client-search');
-        $this->clickOnBehatLink('search_clients_search');
-        $this->clickOnBehatLink('client-detail-' . $caseNumber);
+        $this->visitAdminPath("/admin/client/case-number/$caseNumber/details");
         $this->clickLinkInsideElement('checklist', 'report-' . $period);
+    }
+
+    /**
+     * @When I visit the client page for :caseNumber
+     */
+    public function iVisitClientPageOnAdmin($caseNumber)
+    {
+        $this->visitAdminPath("/admin/client/case-number/$caseNumber/details");
     }
 }

--- a/behat/tests/bootstrap/CourtOrderManagement/CourtOrderManagementTrait.php
+++ b/behat/tests/bootstrap/CourtOrderManagement/CourtOrderManagementTrait.php
@@ -10,8 +10,7 @@ trait CourtOrderManagementTrait
     public function aSuperAdminDischargesDeputyFromClient($caseNumber)
     {
         $this->iAmLoggedInToAdminAsWithPassword('super-admin@publicguardian.gov.uk', 'Abcd1234');
-        $this->clickLink('Clients');
-        $this->clickLink('John ' . $caseNumber . '-client');
+        $this->visitAdminPath("/admin/client/case-number/$caseNumber/details");
         $this->clickLink('Discharge deputy');
         $this->clickLink('Discharge deputy');
     }

--- a/behat/tests/bootstrap/ReportManagement/ReportManagementTrait.php
+++ b/behat/tests/bootstrap/ReportManagement/ReportManagementTrait.php
@@ -144,6 +144,7 @@ trait ReportManagementTrait
 
         $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'Abcd1234');
         $this->clickOnBehatLink('admin-client-search');
+        $this->clickOnBehatLink('search_clients_search');
         $this->clickOnBehatLink('client-detail-'.$client);
 
         $adjustment = intval($adjustment);
@@ -162,6 +163,7 @@ trait ReportManagementTrait
 
         $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'Abcd1234');
         $this->clickOnBehatLink('admin-client-search');
+        $this->clickOnBehatLink('search_clients_search');
         $this->clickOnBehatLink('client-detail-'.$client);
 
         $expectedDueDate = new \DateTime($adjustment);

--- a/behat/tests/bootstrap/ReportManagement/ReportManagementTrait.php
+++ b/behat/tests/bootstrap/ReportManagement/ReportManagementTrait.php
@@ -143,9 +143,7 @@ trait ReportManagementTrait
         $endDate = self::$currentReportCache['endDate'];
 
         $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'Abcd1234');
-        $this->clickOnBehatLink('admin-client-search');
-        $this->clickOnBehatLink('search_clients_search');
-        $this->clickOnBehatLink('client-detail-'.$client);
+        $this->visitAdminPath("/admin/client/case-number/$client/details");
 
         $adjustment = intval($adjustment);
         $expectedDueDate = (new \DateTime())->modify("+$adjustment weeks");
@@ -162,9 +160,7 @@ trait ReportManagementTrait
         $endDate = self::$currentReportCache['endDate'];
 
         $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'Abcd1234');
-        $this->clickOnBehatLink('admin-client-search');
-        $this->clickOnBehatLink('search_clients_search');
-        $this->clickOnBehatLink('client-detail-'.$client);
+        $this->visitAdminPath("/admin/client/case-number/$client/details");
 
         $expectedDueDate = new \DateTime($adjustment);
         $this->iShouldSeeInTheRegion($expectedDueDate->format('j F Y'), "report-$startDate-to-$endDate-due-date");

--- a/behat/tests/features/admin/04-client-details.feature
+++ b/behat/tests/features/admin/04-client-details.feature
@@ -3,12 +3,12 @@ Feature: Client details
 
   Scenario: Client information contains report type
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    When I click on "admin-client-search, client-detail-102-4-6"
+    When I click on "admin-client-search, search_clients_search, client-detail-102-4-6"
     Then I should see "OPG102-4-6" in the "report-2016-to-2017" region
 
   Scenario: Client details contain named deputy information
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    When I click on "admin-client-search, client-detail-102-4-6"
+    When I click on "admin-client-search, search_clients_search, client-detail-102-4-6"
     Then I should see "Named Deputy 102-4-6"
     And I should see "Victoria Road" in the "deputy-details" region
     And I should see "SW1" in the "deputy-details" region
@@ -18,7 +18,7 @@ Feature: Client details
 
   Scenario: Lay client details contain named deputy information
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    When I click on "admin-client-search, client-detail-103"
+    When I click on "admin-client-search, search_clients_search, client-detail-103"
     Then I should see "Lay Deputy 103"
     And I should see "Victoria Road" in the "deputy-details" region
     And I should see "SW1" in the "deputy-details" region

--- a/behat/tests/features/admin/04-client-details.feature
+++ b/behat/tests/features/admin/04-client-details.feature
@@ -3,12 +3,12 @@ Feature: Client details
 
   Scenario: Client information contains report type
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    When I click on "admin-client-search, search_clients_search, client-detail-102-4-6"
+    When I visit the client page for "102-4-6"
     Then I should see "OPG102-4-6" in the "report-2016-to-2017" region
 
   Scenario: Client details contain named deputy information
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    When I click on "admin-client-search, search_clients_search, client-detail-102-4-6"
+    When I visit the client page for "102-4-6"
     Then I should see "Named Deputy 102-4-6"
     And I should see "Victoria Road" in the "deputy-details" region
     And I should see "SW1" in the "deputy-details" region
@@ -18,7 +18,7 @@ Feature: Client details
 
   Scenario: Lay client details contain named deputy information
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    When I click on "admin-client-search, search_clients_search, client-detail-103"
+    When I visit the client page for "103"
     Then I should see "Lay Deputy 103"
     And I should see "Victoria Road" in the "deputy-details" region
     And I should see "SW1" in the "deputy-details" region

--- a/behat/tests/features/deputy/01-registration-steps/04-add-client-and-report.feature
+++ b/behat/tests/features/deputy/01-registration-steps/04-add-client-and-report.feature
@@ -95,9 +95,7 @@ Feature: deputy / user / add client and report
   @ndr
   Scenario: New NDR report shown in admin panel
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    When I click on "admin-client-search"
-    And I fill in "search_clients_q" with "33333333"
-    And I follow "Cly3 Hent3"
+    When I visit the client page for "33333333"
     Then the URL should match "/admin/client/\d+/details"
     And I should see the "report-ndr" region in the "report-group-active" region
 

--- a/behat/tests/features/deputy/02-ndr/11-report-submission.feature
+++ b/behat/tests/features/deputy/02-ndr/11-report-submission.feature
@@ -3,7 +3,7 @@ Feature: Admin NDR submitted
   @ndr
   Scenario: Admin client search returns NDR client
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    And I click on "admin-client-search"
+    And I click on "admin-client-search, search_clients_search"
     Then each text should be present in the corresponding region:
     | Cly3 Hent3 | client-33333333 |
     # Cant check how many clients because number may change depending on how many suites are run

--- a/behat/tests/features/deputy/02-ndr/11-report-submission.feature
+++ b/behat/tests/features/deputy/02-ndr/11-report-submission.feature
@@ -23,15 +23,10 @@ Feature: Admin NDR submitted
     And I click on "search_clients_search"
     And each text should be present in the corresponding region:
     | Cly3 Hent3 | client-33333333 |
-    And I click on "client-details" in the "client-33333333" region
-    And I save the current URL as "admin-client-search-client-33333333"
 
   @ndr
   Scenario: Admin client page shows NDR report complete
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    When I click on "admin-client-search"
-    And I fill in "search_clients_q" with "ndr"
-    And I follow "John ndr-client"
-    Then the URL should match "/admin/client/\d+/details"
-    And I should see the "report-ndr" region in the "report-group-submitted" region
+    When I visit the client page for "ndr"
+    Then I should see the "report-ndr" region in the "report-group-submitted" region
     And I should see "NDR" in the "report-ndr" region

--- a/behat/tests/features/deputy/03-report/01-102/23-report-resubmission.feature
+++ b/behat/tests/features/deputy/03-report/01-102/23-report-resubmission.feature
@@ -3,7 +3,7 @@ Feature: Admin unsubmit report (from client page)
   @deputy
   Scenario: Admin client page + search
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    And I click on "admin-client-search, "search_clients_search"
+    And I click on "admin-client-search, search_clients_search"
     And I click on "client-details" in the "client-102" region
     And I save the current URL as "admin-client-search-client-102"
 

--- a/behat/tests/features/deputy/03-report/01-102/23-report-resubmission.feature
+++ b/behat/tests/features/deputy/03-report/01-102/23-report-resubmission.feature
@@ -1,16 +1,9 @@
 Feature: Admin unsubmit report (from client page)
 
   @deputy
-  Scenario: Admin client page + search
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    And I click on "admin-client-search, search_clients_search"
-    And I click on "client-details" in the "client-102" region
-    And I save the current URL as "admin-client-search-client-102"
-
-  @deputy
   Scenario: Admin unsubmits report and changes report due date and reporting period
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    And I go to the URL previously saved as "admin-client-search-client-102"
+    When I visit the client page for "102"
     # reports page
     Then the URL should match "/admin/client/\d+/details"
     Then I should see the "report-2016" region in the "report-group-submitted" region
@@ -112,7 +105,7 @@ Feature: Admin unsubmit report (from client page)
   Scenario: admin sees new submission and client page updated
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     # check report being resubmitted
-    And I go to the URL previously saved as "admin-client-search-client-102"
+    When I visit the client page for "102"
     Then I should see the "report-2016" region in the "report-group-submitted" region
     # check there is a new submission, with all the documents
     When I click on "admin-documents"

--- a/behat/tests/features/deputy/03-report/01-102/23-report-resubmission.feature
+++ b/behat/tests/features/deputy/03-report/01-102/23-report-resubmission.feature
@@ -3,15 +3,7 @@ Feature: Admin unsubmit report (from client page)
   @deputy
   Scenario: Admin client page + search
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    And I click on "admin-client-search"
-    Then each text should be present in the corresponding region:
-      | John 102-client | client-102 |
-    When I fill in the following:
-      | search_clients_q | 102-client |
-    And I click on "search_clients_search"
-    Then I should see the "client-row" region exactly "1" times
-    And each text should be present in the corresponding region:
-      | John 102-client | client-102 |
+    And I click on "admin-client-search, "search_clients_search"
     And I click on "client-details" in the "client-102" region
     And I save the current URL as "admin-client-search-client-102"
 

--- a/behat/tests/features/deputy/03-report/01-102/24-lodging-checklist.feature
+++ b/behat/tests/features/deputy/03-report/01-102/24-lodging-checklist.feature
@@ -4,7 +4,7 @@ Feature: Admin report checklist
   Scenario: Case manager submits empty checklist for the report 102
     Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
     # Navigate to checklist via search
-    And I click on "admin-client-search"
+    And I click on "admin-client-search, search_clients_search"
     Then each text should be present in the corresponding region:
       | John 102-client | client-102 |
     When I fill in the following:

--- a/behat/tests/features/deputy/03-report/01-102/24-lodging-checklist.feature
+++ b/behat/tests/features/deputy/03-report/01-102/24-lodging-checklist.feature
@@ -3,19 +3,7 @@ Feature: Admin report checklist
   @deputy
   Scenario: Case manager submits empty checklist for the report 102
     Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
-    # Navigate to checklist via search
-    And I click on "admin-client-search, search_clients_search"
-    Then each text should be present in the corresponding region:
-      | John 102-client | client-102 |
-    When I fill in the following:
-      | search_clients_q | 102-client |
-    And I click on "search_clients_search"
-    Then I should see the "client-row" region exactly "1" times
-    And each text should be present in the corresponding region:
-      | John 102-client | client-102 |
-    And I click on "client-details" in the "client-102" region
-    Then the URL should match "/admin/client/\d+/details"
-    # Begin scenario
+    When I visit the client page for "102"
     And I click on "checklist" in the "report-2016" region
     Then the URL should match "/admin/report/\d+/checklist"
     And each text should be present in the corresponding region:

--- a/behat/tests/features/deputy/03-report/04-post-submit/00-report-download-admin.feature
+++ b/behat/tests/features/deputy/03-report/04-post-submit/00-report-download-admin.feature
@@ -3,8 +3,7 @@ Feature: As an admin user, in order to ensure correct report PDFs can always be 
   @deputy @download-reports
   Scenario: Case manager user downloads a report that has been submitted
     Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
-    And I click on "admin-client-search"
-    When I click on "client-detail-102"
+    And I click on "admin-client-search, search_clients_search, client-detail-102"
     Then I should not see "Download"
 #    And I follow "Download"
 #    Then the response status code should be 200
@@ -14,6 +13,5 @@ Feature: As an admin user, in order to ensure correct report PDFs can always be 
   @deputy @download-reports
   Scenario: Case manager cannot download a non submitted report
     Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
-    And I click on "admin-client-search"
-    When I click on "client-detail-103-5"
+    And I click on "admin-client-search, search_clients_search, client-detail-103-5"
     Then I should not see "Download"

--- a/behat/tests/features/deputy/03-report/04-post-submit/00-report-download-admin.feature
+++ b/behat/tests/features/deputy/03-report/04-post-submit/00-report-download-admin.feature
@@ -3,7 +3,7 @@ Feature: As an admin user, in order to ensure correct report PDFs can always be 
   @deputy @download-reports
   Scenario: Case manager user downloads a report that has been submitted
     Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
-    And I click on "admin-client-search, search_clients_search, client-detail-102"
+    When I visit the client page for "102"
     Then I should not see "Download"
 #    And I follow "Download"
 #    Then the response status code should be 200
@@ -13,5 +13,5 @@ Feature: As an admin user, in order to ensure correct report PDFs can always be 
   @deputy @download-reports
   Scenario: Case manager cannot download a non submitted report
     Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
-    And I click on "admin-client-search, search_clients_search, client-detail-103-5"
+    When I visit the client page for "103-5"
     Then I should not see "Download"

--- a/behat/tests/features/pa/03-report/05-report-resubmission.feature
+++ b/behat/tests/features/pa/03-report/05-report-resubmission.feature
@@ -4,12 +4,7 @@ Feature: Admin unsubmit and client re-submit
   Scenario: Admin unsubmits report for client 02100014
     Given I load the application status from "pa-report-submitted"
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    And I click on "admin-client-search"
-    When I fill in the following:
-      | search_clients_q | 02100014 |
-    And I click on "search_clients_search"
-    And I click on "client-details" in the "client-02100014" region
-    And I save the current URL as "admin-client-02100014.url"
+    When I visit the client page for "02100014"
     Then I should see the "report-2016-to-2017" region in the "report-group-submitted" region
     And I click on "manage" in the "report-2016-to-2017" region
     # unsubmit decisions, PA deputy expenses
@@ -43,6 +38,6 @@ Feature: Admin unsubmit and client re-submit
   @deputy
   Scenario: Admin checks report was re-submitted
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    And I go to the URL previously saved as "admin-client-02100014.url"
+    When I visit the client page for "02100014"
     Then I should see the "report-2016-to-2017" region in the "report-group-submitted" region
     # restore previous status

--- a/behat/tests/features/prof/05-organisation/04-organisation-updates-acl.feature
+++ b/behat/tests/features/prof/05-organisation/04-organisation-updates-acl.feature
@@ -32,7 +32,7 @@ Feature: Organisation deputyship updates
     Then I should see the "client-01000010" region
     # Assert client still associated with same org
     Then I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
-    And I click on "admin-client-search, search_clients_search, client-detail-01000010"
+    When I visit the client page for "01000010"
     # Assert same organisation
     And I should see "PA OPG" in the "assigned-organisation" region
     # Assert new named deputy within same organisation
@@ -47,7 +47,7 @@ Feature: Organisation deputyship updates
     Then I should see the "client-1138393T" region
     # Assert client associated with new org
     Then I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
-    And I click on "admin-client-search, search_clients_search, client-detail-1138393t"
+    When I visit the client page for "1138393t"
     # Assert same named deputy within new organisation
     Then each text should be present in the corresponding region:
       | Your Organisation (example.com1)                        | assigned-organisation |
@@ -69,7 +69,7 @@ Feature: Organisation deputyship updates
     # Assert client associated with new org
     Then I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
     # Assert new organisation for new client
-    Then I click on "admin-client-search, search_clients_search, client-detail-11498120"
+    When I visit the client page for "11498120"
     Then each text should be present in the corresponding region:
       | Your Organisation (example.com2)      | assigned-organisation |
       | NEW DEP3 NEW SURNAME3                 | named-deputy-fullname |

--- a/behat/tests/features/prof/05-organisation/04-organisation-updates-acl.feature
+++ b/behat/tests/features/prof/05-organisation/04-organisation-updates-acl.feature
@@ -32,7 +32,7 @@ Feature: Organisation deputyship updates
     Then I should see the "client-01000010" region
     # Assert client still associated with same org
     Then I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
-    And I click on "admin-client-search, client-detail-01000010"
+    And I click on "admin-client-search, search_clients_search, client-detail-01000010"
     # Assert same organisation
     And I should see "PA OPG" in the "assigned-organisation" region
     # Assert new named deputy within same organisation
@@ -47,7 +47,7 @@ Feature: Organisation deputyship updates
     Then I should see the "client-1138393T" region
     # Assert client associated with new org
     Then I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
-    And I click on "admin-client-search, client-detail-1138393t"
+    And I click on "admin-client-search, search_clients_search, client-detail-1138393t"
     # Assert same named deputy within new organisation
     Then each text should be present in the corresponding region:
       | Your Organisation (example.com1)                        | assigned-organisation |
@@ -69,7 +69,7 @@ Feature: Organisation deputyship updates
     # Assert client associated with new org
     Then I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
     # Assert new organisation for new client
-    Then I click on "admin-client-search, client-detail-11498120"
+    Then I click on "admin-client-search, search_clients_search, client-detail-11498120"
     Then each text should be present in the corresponding region:
       | Your Organisation (example.com2)      | assigned-organisation |
       | NEW DEP3 NEW SURNAME3                 | named-deputy-fullname |

--- a/behat/tests/features/v2/courtOrderManagement/discharge-deputy.feature
+++ b/behat/tests/features/v2/courtOrderManagement/discharge-deputy.feature
@@ -31,5 +31,5 @@ Feature: Manually discharge deputies from a court order
       | client   | deputy    | deputy_type | report_type        | court_date |
       | 84775409 | Deputy329 | PA          | Health and Welfare | 2017-03-30 |
     When I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    And I click on "admin-client-search, search_clients_search, client-detail-84775409"
+    When I visit the client page for "84775409"
     Then I should not see "Discharge deputy"

--- a/behat/tests/features/v2/courtOrderManagement/discharge-deputy.feature
+++ b/behat/tests/features/v2/courtOrderManagement/discharge-deputy.feature
@@ -31,5 +31,5 @@ Feature: Manually discharge deputies from a court order
       | client   | deputy    | deputy_type | report_type        | court_date |
       | 84775409 | Deputy329 | PA          | Health and Welfare | 2017-03-30 |
     When I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    And I click on "admin-client-search, client-detail-84775409"
+    And I click on "admin-client-search, search_clients_search, client-detail-84775409"
     Then I should not see "Discharge deputy"

--- a/client/src/AppBundle/Controller/Admin/Client/ClientController.php
+++ b/client/src/AppBundle/Controller/Admin/Client/ClientController.php
@@ -36,6 +36,20 @@ class ClientController extends AbstractController
     }
 
     /**
+     * @Route("/case-number/{caseNumber}/details", name="admin_client_by_case_number_details")
+     * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
+     * @param string $caseNumber
+     *
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     */
+    public function detailsByCaseNumberAction($caseNumber)
+    {
+        $client = $this->getRestClient()->get('v2/client/case-number/' . $caseNumber, 'Client');
+
+        return $this->redirectToRoute('admin_client_details', ['id' => $client->getId()]);
+    }
+
+    /**
      * @Route("/{id}/discharge", name="admin_client_discharge", requirements={"id":"\d+"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      * @param $id

--- a/client/src/AppBundle/Controller/Admin/Client/SearchController.php
+++ b/client/src/AppBundle/Controller/Admin/Client/SearchController.php
@@ -3,7 +3,8 @@
 namespace AppBundle\Controller\Admin\Client;
 
 use AppBundle\Controller\AbstractController;
-use AppBundle\Form as FormDir;
+use AppBundle\Form\Admin\SearchClientType;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -16,32 +17,56 @@ class SearchController extends AbstractController
 {
     /**
      * @Route("/search", name="admin_client_search")
-     * //TODO define Security group (AD to remove?)
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
      * @Template("AppBundle:Admin/Client/Search:search.html.twig")
      */
     public function searchAction(Request $request)
     {
-        $filters = [
-            'limit'       => 100,
-            'offset'      => $request->get('offset', '0'),
-            'q'           => '',
-            'order_by'    => 'id',
-            'sort_order'  => 'DESC',
-        ];
+        $searchQuery = $request->query->get('search_clients');
+        $form = $this->createForm(SearchClientType::class, null, ['method' => 'GET']);
 
-        $form = $this->createForm(FormDir\Admin\SearchClientType::class, null, ['method' => 'GET']);
+
+        if (null === $searchQuery) {
+            return $this->buildViewParams($form);
+        }
+
         $form->handleRequest($request);
         if ($form->isValid()) {
-            $filters = $form->getData() + $filters;
+            $filters = $form->getData() + $this->getDefaultFilters($request);
         }
 
         $clients = $this->getRestClient()->get('client/get-all?' . http_build_query($filters), 'Client[]');
 
+        return $this->buildViewParams($form, $clients, $filters);
+    }
+
+    /**
+     * @param \Symfony\Component\Form\FormInterface $form
+     * @param array $clients
+     * @param array $filters
+     * @return array|string
+     */
+    private function buildViewParams(FormInterface $form, array $clients = [], array $filters = []): array
+    {
         return [
-            'form'    => $form->createView(),
-            'clients'   => $clients,
-            'filters' => $filters,
+            'form' => $form->createView(),
+            'clients' => $clients,
+            'filters' => $filters
+        ];
+    }
+
+    /**
+     * @param Request $request
+     * @return array
+     */
+    private function getDefaultFilters(Request $request): array
+    {
+        return [
+            'limit' => 100,
+            'offset' => $request->get('offset', '0'),
+            'q' => '',
+            'order_by' => 'id',
+            'sort_order' => 'DESC',
         ];
     }
 }

--- a/client/src/AppBundle/Resources/views/Admin/Client/Search/search.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Search/search.html.twig
@@ -23,6 +23,7 @@
     <hr>
 
     {# LIST #}
+    {% if app.request.get('search_clients') is not null %}
 
     <div class="behat-region-clients client-list">
 
@@ -71,11 +72,12 @@
                     {% endfor %}
                 {% else %}
                     <tr>
-                        <td colspan="2">{{ (page ~ '.clientTable.noResults') | trans  }}</td>
+                        <td colspan="3">{{ (page ~ '.clientTable.noResults') | trans  }}</td>
                     </tr>
                 {% endif %}
             </tbody>
         </table>
     </div>
+    {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
## Purpose
Prevents client search page from searching and returning full list on page load. Pressing submit with empty criteria will return that full list if required.

Fixes DDPB-3233

## Approach
The implementation itself is a straightforward case of not firing the query if no params are sent in the request, i.e on initial page load.

This had a knock on effect to several behat tests which rely on the results returning in order to navigate to a client detail page. To bypass this cumbersome navigation, I have created an endpoint that retrieves client data by `caseNumber`: our tests always have access to a case number so we can hit this new URL directly, instead of navigating via the search. The new endpoint itself simply retrieves the ID of that case and performs a redirect to the exist id based URL.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
