### PR TITLE
upload pact file to pact broker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,16 +362,27 @@ jobs:
           name: Load docker images
           command: docker load -i ~/project/docker-images.tar
       - run:
+          name: install aws cli
+          command: |
+            pip3 install awscli --upgrade --user
+            aws --version
+      - run:
+          name: Set environment
+          command: |
+            ~/project/.circleci/set_env.sh >> $BASH_ENV
+            ~/project/.circleci/set_env_pact.sh >> $BASH_ENV
+      - run:
           name: Run tests
           command: |
             docker-compose up -d pact-mock
-            sleep 1
-            docker run \
-                --rm \
-                --network=project_default \
-                --env-file=client/docker/env/frontend.env \
-                client:latest \
-                bin/phpunit -c tests/phpunit
+            sleep 3
+            docker run --rm --network=project_default \
+            -e PACT_BROKER_HTTP_AUTH_PASS \
+            -e PACT_BROKER_HTTP_AUTH_USER \
+            -e PACT_CONSUMER_VERSION \
+            -e PACT_BROKER_BASE_URL \
+            -e PACT_TAG \
+            client:latest bin/phpunit -c tests/phpunit
             docker-compose exec pact-mock cat /tmp/pacts/complete_the_deputy_report-opg_data.json > pact.json
             docker-compose stop pact-mock
       - store_artifacts:

--- a/.circleci/set_env_pact.sh
+++ b/.circleci/set_env_pact.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -e
+#account is shared-prod as all env use prod.
+ACCOUNT="997462338508"
+PACT_BROKER_USER="admin"
+PACT_BROKER_URL="pact-broker.api.opg.service.justice.gov.uk"
+
+export SECRETSTRING=$(aws sts assume-role \
+--role-arn "arn:aws:iam::${ACCOUNT}:role/get-pact-secret-production" \
+--role-session-name AWSCLI-Session | \
+jq -r '.Credentials.SessionToken + " " + .Credentials.SecretAccessKey + " " + .Credentials.AccessKeyId' 2>/dev/null)
+
+#local export so they only exist in this stage
+export AWS_ACCESS_KEY_ID=$(echo "${SECRETSTRING}" | awk -F' ' '{print $3}' 2>/dev/null)
+export AWS_SECRET_ACCESS_KEY=$(echo "${SECRETSTRING}" | awk -F' ' '{print $2}' 2>/dev/null)
+export AWS_SESSION_TOKEN=$(echo "${SECRETSTRING}" | awk -F' ' '{print $1}' 2>/dev/null)
+
+export PACT_BROKER_PASS=$(aws secretsmanager get-secret-value \
+--secret-id pactbroker_admin \
+--region eu-west-1 | jq -r '.SecretString' 2>/dev/null)
+
+if [[ -z "${PACT_BROKER_PASS}" ]]
+then
+  echo "Error setting env var PACT_BROKER_PASS"
+else
+  echo "Env var PACT_BROKER_PASS has been set"
+fi
+
+CONSUMER_VERSION=${CIRCLE_SHA1:0:7}
+
+echo "export PACT_TAG=${CIRCLE_BRANCH}"
+echo "export PACT_BROKER_BASE_URL=${PACT_BROKER_URL}"
+echo "export PACT_CONSUMER_VERSION=${CONSUMER_VERSION}"
+echo "export PACT_BROKER_HTTP_AUTH_USER=${PACT_BROKER_USER}"
+echo "export PACT_BROKER_HTTP_AUTH_PASS=${PACT_BROKER_PASS}"

--- a/client/tests/phpunit/Pact/Listener/PactTestListener.php
+++ b/client/tests/phpunit/Pact/Listener/PactTestListener.php
@@ -2,8 +2,11 @@
 
 namespace AppBundle\Pact\Listener;
 
+use GuzzleHttp\Psr7\Uri;
+use PhpPact\Broker\Service\BrokerHttpClient;
 use PhpPact\Http\GuzzleClient;
 use PhpPact\Standalone\Exception\MissingEnvVariableException;
+use PhpPact\Standalone\MockService\MockServer;
 use PhpPact\Standalone\MockService\MockServerConfigInterface;
 use PhpPact\Standalone\MockService\MockServerEnvConfig;
 use PhpPact\Standalone\MockService\Service\MockServerHttpService;
@@ -82,7 +85,31 @@ class PactTestListener implements TestListener
             } else {
                 $httpService = new MockServerHttpService(new GuzzleClient(), $this->mockServerConfig);
                 $httpService->verifyInteractions();
-                $httpService->getPactJson();
+                $json = $httpService->getPactJson();
+            }
+
+            //requires these to exist
+            if (($pactBrokerUri = \getenv('PACT_BROKER_BASE_URL')) &&
+                ($consumerVersion = \getenv('PACT_CONSUMER_VERSION')) &&
+                ($tag = \getenv('PACT_TAG'))
+            ) {
+                $clientConfig = [];
+                if (($user = \getenv('PACT_BROKER_HTTP_AUTH_USER')) &&
+                    ($pass = \getenv('PACT_BROKER_HTTP_AUTH_PASS'))
+                ) {
+                    $clientConfig = [
+                        'auth' => [$user, $pass],
+                    ];
+                }
+                $headers = [];
+                $pactBrokerUriFull = 'https://' . $pactBrokerUri . '/';
+                $client = new GuzzleClient($clientConfig);
+                $brokerHttpService = new BrokerHttpClient($client, new Uri($pactBrokerUriFull), $headers);
+                $brokerHttpService->tag($this->mockServerConfig->getConsumer(), $consumerVersion, $tag);
+                $brokerHttpService->publishJson($json, $consumerVersion);
+                print 'Pact file has been uploaded to the Broker successfully.';
+            } else {
+                print 'One or more environment variables not set';
             }
         }
     }


### PR DESCRIPTION
## Purpose
Once the consumer (digideps) has created the contract, it needs to be uploaded to the pact broker so the provider can verify it.

Fixes IN-135

## Approach
I pass in various env vars to allow the the pact to be uploaded to the pact broker. I have put these at the circle level so it can still be run locally and just not send to a pact broker (if you don't want to set it up manually to do so)

## Learning
I decided to allow digideps user to assume a role with limited access to the broker secret on the broker account rather than duplicate the secret in digideps. This is good if the secret needs to be rotated etc..

I'm sure the PHP could be improved but it's functional.
## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
