### PR TITLE
DDPB-3161: Show synchronisation status in admin panel

### DIFF
--- a/api/app/DoctrineMigrations/Version232.php
+++ b/api/app/DoctrineMigrations/Version232.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version232 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE report_submission ADD archived BOOLEAN DEFAULT \'false\' NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE report_submission DROP archived');
+    }
+}

--- a/api/app/config/services/event_listeners.yml
+++ b/api/app/config/services/event_listeners.yml
@@ -11,10 +11,10 @@ services:
     kernel.listener.responseConverter:
         alias: AppBundle\EventListener\RestInputOuputFormatter
 
-    doctrine.listener:
-        class: AppBundle\EventListener\DoctrineListener
+    AppBundle\EventListener\DoctrineListener:
         tags:
             - { name: doctrine.event_listener, event: prePersist, method: prePersist }
+            - { name: doctrine.event_listener, event: preUpdate, method: preUpdate }
             - { name: doctrine.event_listener, event: preRemove, method: preRemove }
 
     AppBundle\EventListener\FixDefaultSchemaListener:

--- a/api/src/AppBundle/Controller/Report/ReportSubmissionController.php
+++ b/api/src/AppBundle/Controller/Report/ReportSubmissionController.php
@@ -29,6 +29,7 @@ class ReportSubmissionController extends RestController
         'user-rolename',
         'user-teamname',
         'documents',
+        'document-synchronisation',
     ];
 
     /**

--- a/api/src/AppBundle/Controller/Report/ReportSubmissionController.php
+++ b/api/src/AppBundle/Controller/Report/ReportSubmissionController.php
@@ -82,6 +82,7 @@ class ReportSubmissionController extends RestController
 
         $data = $this->deserializeBodyContent($request);
         if (!empty($data['archive'])) {
+            $reportSubmission->setArchived(true);
             $reportSubmission->setArchivedBy($this->getUser());
         }
 

--- a/api/src/AppBundle/Entity/Report/ReportSubmission.php
+++ b/api/src/AppBundle/Entity/Report/ReportSubmission.php
@@ -80,7 +80,7 @@ class ReportSubmission
      * @JMS\Groups({"report-submission"})
      * @ORM\Column(name="archived", type="boolean", options={"default": false}, nullable=false)
      */
-    private $archived;
+    private $archived = false;
 
     /**
      * @var User|null

--- a/api/src/AppBundle/Entity/Report/ReportSubmission.php
+++ b/api/src/AppBundle/Entity/Report/ReportSubmission.php
@@ -74,6 +74,15 @@ class ReportSubmission
     private $documents;
 
     /**
+     * @var bool
+     *
+     * @JMS\Type("boolean")
+     * @JMS\Groups({"report-submission"})
+     * @ORM\Column(name="archived", type="boolean", options={"default": false}, nullable=false)
+     */
+    private $archived;
+
+    /**
      * @var User|null
      *
      * @JMS\Type("AppBundle\Entity\User")
@@ -186,6 +195,18 @@ class ReportSubmission
         if (!$this->documents->contains(($document))) {
             $this->documents->add($document);
         }
+
+        return $this;
+    }
+
+    public function getArchived(): bool
+    {
+        return $this->archived;
+    }
+
+    public function setArchived(bool $archived): ReportSubmission
+    {
+        $this->archived = $archived;
 
         return $this;
     }

--- a/api/src/AppBundle/Entity/Repository/ReportSubmissionRepository.php
+++ b/api/src/AppBundle/Entity/Repository/ReportSubmissionRepository.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Entity\Repository;
 
 use AppBundle\Entity\Client;
+use AppBundle\Entity\Report\Document;
 use AppBundle\Entity\Report\ReportSubmission;
 use AppBundle\Entity\User;
 use Doctrine\ORM\EntityRepository;
@@ -191,5 +192,24 @@ class ReportSubmissionRepository extends EntityRepository
         $this->_em->getFilters()->enable('softdeleteable');
 
         return $reportSubmission;
+    }
+
+    public function updateArchivedStatus(ReportSubmission $reportSubmission): void
+    {
+        if ($reportSubmission->getDocuments() && !$reportSubmission->getArchived()) {
+            $allSynced = true;
+
+            foreach ($reportSubmission->getDocuments() as $document) {
+                if ($document->getSynchronisationStatus() !== Document::SYNC_STATUS_SUCCESS) {
+                    $allSynced = false;
+                }
+            }
+
+            if ($allSynced) {
+                $reportSubmission->setArchived(true);
+                $this->_em->persist($reportSubmission);
+                $this->_em->flush();
+            }
+        }
     }
 }

--- a/api/src/AppBundle/Entity/Repository/ReportSubmissionRepository.php
+++ b/api/src/AppBundle/Entity/Repository/ReportSubmissionRepository.php
@@ -31,6 +31,7 @@ class ReportSubmissionRepository extends EntityRepository
     ) {
         $statusFilters = [
             'new' => 'rs.archivedBy IS NULL',
+            'pending' => 'rs.archivedBy IS NULL',
             'archived' => 'rs.archivedBy IS NOT NULL',
         ];
 

--- a/api/src/AppBundle/Entity/Repository/ReportSubmissionRepository.php
+++ b/api/src/AppBundle/Entity/Repository/ReportSubmissionRepository.php
@@ -30,9 +30,9 @@ class ReportSubmissionRepository extends EntityRepository
         $order = 'ASC'
     ) {
         $statusFilters = [
-            'new' => 'rs.archivedBy IS NULL AND NOT EXISTS (SELECT 1 FROM AppBundle:Report\Document d WHERE d.reportSubmission = rs AND d.synchronisationStatus IS NOT NULL)',
-            'pending' => 'rs.archivedBy IS NULL AND EXISTS (SELECT 1 FROM AppBundle:Report\Document d WHERE d.reportSubmission = rs AND d.synchronisationStatus IS NOT NULL)',
-            'archived' => 'rs.archivedBy IS NOT NULL',
+            'new' => 'rs.archived = false AND NOT EXISTS (SELECT 1 FROM AppBundle:Report\Document d WHERE d.reportSubmission = rs AND d.synchronisationStatus IS NOT NULL)',
+            'pending' => 'rs.archived = false AND EXISTS (SELECT 1 FROM AppBundle:Report\Document d WHERE d.reportSubmission = rs AND d.synchronisationStatus IS NOT NULL)',
+            'archived' => 'rs.archived = true',
         ];
 
         // BASE QUERY BUILDER with filters (for both count and results)

--- a/api/src/AppBundle/Entity/Repository/ReportSubmissionRepository.php
+++ b/api/src/AppBundle/Entity/Repository/ReportSubmissionRepository.php
@@ -30,8 +30,8 @@ class ReportSubmissionRepository extends EntityRepository
         $order = 'ASC'
     ) {
         $statusFilters = [
-            'new' => 'rs.archivedBy IS NULL',
-            'pending' => 'rs.archivedBy IS NULL',
+            'new' => 'rs.archivedBy IS NULL AND NOT EXISTS (SELECT 1 FROM AppBundle:Report\Document d WHERE d.reportSubmission = rs AND d.synchronisationStatus IS NOT NULL)',
+            'pending' => 'rs.archivedBy IS NULL AND EXISTS (SELECT 1 FROM AppBundle:Report\Document d WHERE d.reportSubmission = rs AND d.synchronisationStatus IS NOT NULL)',
             'archived' => 'rs.archivedBy IS NOT NULL',
         ];
 

--- a/api/src/AppBundle/EventListener/DoctrineListener.php
+++ b/api/src/AppBundle/EventListener/DoctrineListener.php
@@ -39,6 +39,18 @@ class DoctrineListener
         }
     }
 
+    public function preUpdate(LifecycleEventArgs $args)
+    {
+        $entity = $args->getEntity();
+        $entityManager = $args->getEntityManager();
+
+        if ($entity instanceof EntityDir\Report\Document && !is_null($entity->getReportSubmission())) {
+            /** @var EntityDir\Repository\ReportSubmissionRepository $reportSubmissionRepo */
+            $reportSubmissionRepo = $entityManager->getRepository(EntityDir\Report\ReportSubmission::class);
+            $reportSubmissionRepo->updateArchivedStatus($entity->getReportSubmission());
+        }
+    }
+
     public function preRemove(LifecycleEventArgs $args)
     {
         $entity = $args->getEntity();

--- a/api/tests/AppBundle/ControllerReport/ReportControllerTest.php
+++ b/api/tests/AppBundle/ControllerReport/ReportControllerTest.php
@@ -331,7 +331,7 @@ class ReportControllerTest extends AbstractTestController
             'mustSucceed' => true,
             'AuthToken'   => self::$tokenAdmin,
         ])['data'];
-        $this->assertEquals(['new' => 1, 'archived' => 0], $data['counts']);
+        $this->assertEquals(['new' => 1, 'pending' => 0, 'archived' => 0], $data['counts']);
         $this->assertEquals('file2.pdf', $data['records'][0]['documents'][0]['file_name']);
 
         return $report->getId();

--- a/api/tests/AppBundle/ControllerReport/ReportSubmissionControllerTest.php
+++ b/api/tests/AppBundle/ControllerReport/ReportSubmissionControllerTest.php
@@ -43,6 +43,11 @@ class ReportSubmissionControllerTest extends AbstractTestController
             // add documents, needed for future tests
             $document = new Document($report);
             $document->setFileName('file1.pdf')->setStorageReference('storageref1')->setReportSubmission($submission);
+
+            if ($i === 2) {
+                $document->setSynchronisationStatus(Document::SYNC_STATUS_QUEUED);
+            }
+
             self::fixtures()->persist($document, $submission);
         }
 
@@ -73,7 +78,7 @@ class ReportSubmissionControllerTest extends AbstractTestController
 
         // assert submission (only one expected)
         $data = $reportsGetAllRequest(['status'=>'new']);
-        $this->assertEquals(['new'=>5, 'archived'=>0], $data['counts']);
+        $this->assertEquals(['new'=>4, 'pending' => 1, 'archived'=>0], $data['counts']);
 
         $submission4 = $this->getSubmissionByCaseNumber($data['records'], '1000004');
         $this->assertNotEmpty($submission4['id']);
@@ -108,29 +113,40 @@ class ReportSubmissionControllerTest extends AbstractTestController
 
         // check counts after submission
         $data = $reportsGetAllRequest([]);
-        $this->assertEquals(['new'=>4, 'archived'=>1], $data['counts']);
+        $this->assertEquals(['new'=>3, 'pending' => 1, 'archived'=>1], $data['counts']);
         $this->assertCount(5, $data['records']);
 
         // check filters and counts
         $data = $reportsGetAllRequest(['q'=>'1000000']);
-        $this->assertEquals(['new'=>1, 'archived'=>0], $data['counts']);
+        $this->assertEquals(['new'=>1, 'pending' => 0, 'archived'=>0], $data['counts']);
         $this->assertCount(1, $data['records']);
 
         $data = $reportsGetAllRequest(['q'=>'1000000', 'status'=>'new']);
-        $this->assertEquals(['new'=>1, 'archived'=>0], $data['counts']);
+        $this->assertEquals(['new'=>1, 'pending' => 0, 'archived'=>0], $data['counts']);
         $this->assertCount(1, $data['records']);
 
-        $this->assertEquals(['new'=>1, 'archived'=>0], $reportsGetAllRequest(['status'=>'new', 'q'=>'c0'])['counts']); // client name
-        $this->assertEquals(['new'=>1, 'archived'=>0], $reportsGetAllRequest(['status'=>'new', 'q'=>'l0'])['counts']); //client surname
-        $this->assertEquals(['new'=>4, 'archived'=>1], $reportsGetAllRequest(['status'=>'new', 'q'=>'test'])['counts']); // deputy name
-        $this->assertEquals(['new'=>1, 'archived'=>1], $reportsGetAllRequest(['created_by_role'=>'ROLE_LAY_DEPUTY'])['counts']);
+        $data = $reportsGetAllRequest(['q'=>'1000002', 'status'=>'new']);
+        $this->assertEquals(['new'=>0, 'pending' => 1, 'archived'=>0], $data['counts']);
+        $this->assertCount(0, $data['records']);
+
+        $data = $reportsGetAllRequest(['q'=>'1000002', 'status'=>'pending']);
+        $this->assertEquals(['new'=>0, 'pending' => 1, 'archived'=>0], $data['counts']);
+        $this->assertCount(1, $data['records']);
+
+        $this->assertEquals(['new'=>1, 'pending' => 0, 'archived'=>0], $reportsGetAllRequest(['status'=>'new', 'q'=>'c0'])['counts']); // client name
+        $this->assertEquals(['new'=>1, 'pending' => 0, 'archived'=>0], $reportsGetAllRequest(['status'=>'new', 'q'=>'l0'])['counts']); //client surname
+        $this->assertEquals(['new'=>3, 'pending' => 1, 'archived'=>1], $reportsGetAllRequest(['status'=>'new', 'q'=>'test'])['counts']); // deputy name
+        $this->assertEquals(['new'=>1, 'pending' => 0, 'archived'=>1], $reportsGetAllRequest(['created_by_role'=>'ROLE_LAY_DEPUTY'])['counts']);
         // since this filter works with the role being a prefix, ROLE_PA would include all the ROLE_PA* ones
         // a better version would calculate all the inheritance
-        $this->assertEquals(['new'=>3, 'archived'=>0], $reportsGetAllRequest(['created_by_role'=>'ROLE_PA'])['counts']);
+        $this->assertEquals(['new'=>2, 'pending' => 1, 'archived'=>0], $reportsGetAllRequest(['created_by_role'=>'ROLE_PA'])['counts']);
 
         // check pagination and limit
         $submissions = $reportsGetAllRequest(['status'=>'new', 'q'=>'test'])['records'];
-        $this->assertEquals(['1000000', '1000001','1000002','1000003'], $this->getOrderedCaseNumbersFromSubmissions($submissions));
+        $this->assertEquals(['1000000', '1000001', '1000003'], $this->getOrderedCaseNumbersFromSubmissions($submissions));
+
+        $submissions = $reportsGetAllRequest(['status'=>'new', 'q'=>'test', 'orderBy'=>'id', 'limit' => 2, 'offset' => 1])['records'];
+        $this->assertEquals(['1000001', '1000003'], $this->getOrderedCaseNumbersFromSubmissions($submissions));
     }
 
     private function getOrderedCaseNumbersFromSubmissions($submissions)

--- a/api/tests/AppBundle/Entity/Repository/ReportSubmissionRepositoryTest.php
+++ b/api/tests/AppBundle/Entity/Repository/ReportSubmissionRepositoryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\AppBundle\Entity\Repository;
+
+use AppBundle\Entity\Report\Document;
+use AppBundle\Entity\Report\ReportSubmission;
+use AppBundle\Entity\Repository\ReportSubmissionRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Prophecy\Argument;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class ReportSubmissionRepositoryTest extends WebTestCase
+{
+    /**
+     * @dataProvider updateArchivedStatusDataProvider
+     */
+    public function testUpdateArchivedStatus($isArchived, $docStatuses, $shouldArchive)
+    {
+        $em = self::prophesize(EntityManagerInterface::class);
+        $metaClass = self::prophesize(ClassMetadata::class);
+
+        $docs = array_map(function ($status) {
+            $doc = self::prophesize(Document::class);
+            $doc->getSynchronisationStatus()->willReturn($status);
+            return $doc;
+        }, $docStatuses);
+
+        $reportSubmission = self::prophesize(ReportSubmission::class);
+        $reportSubmission->getDocuments()->shouldBeCalled()->willReturn($docs);
+        $reportSubmission->getArchived()->shouldBeCalled()->willReturn($isArchived);
+
+        if ($shouldArchive) {
+            $reportSubmission->setArchived(true)->shouldBeCalled();
+        } else {
+            $reportSubmission->setArchived(Argument::any())->shouldNotBeCalled();
+        }
+
+        $sut = new ReportSubmissionRepository($em->reveal(), $metaClass->reveal());
+
+        $sut->updateArchivedStatus($reportSubmission->reveal());
+    }
+
+    public function updateArchivedStatusDataProvider()
+    {
+        return [
+            'Manual documents' => [false, [null, null], false],
+            'One synced document' => [false, [Document::SYNC_STATUS_SUCCESS], true],
+            'Two documents, one synced' => [false, [Document::SYNC_STATUS_SUCCESS, DOCUMENT::SYNC_STATUS_PERMANENT_ERROR], false],
+            'Two synced documents' => [false, [Document::SYNC_STATUS_SUCCESS, Document::SYNC_STATUS_SUCCESS], true],
+            'Two synced documents, already archived' => [true, [Document::SYNC_STATUS_SUCCESS, Document::SYNC_STATUS_SUCCESS], false],
+        ];
+    }
+}

--- a/behat/tests/features/deputy/03-report/01-102/21-check-and-submit.feature
+++ b/behat/tests/features/deputy/03-report/01-102/21-check-and-submit.feature
@@ -144,8 +144,10 @@ Feature: Report submit
         Then I should see the "report-submission" region exactly 1 times
         And each text should be present in the corresponding region:
             | John 102 | report-submission-1 |
-            | 102 | report-submission-1 |
-            | Report + docs | report-submission-1 |
+            | 102      | report-submission-1 |
+        And each text should be present in the corresponding region:
+            | DigiRep-2016_2020-03-20_102.pdf | report-submission-documents-1 |
+            | good.png                        | report-submission-documents-1 |
 
     @deputy
     Scenario: admin can download individual report flies
@@ -173,9 +175,11 @@ Feature: Report submit
         And I click on "tab-archived"
         Then each text should be present in the corresponding region:
             | John 102 | report-submission-1 |
-            | 102 | report-submission-1 |
-            | Report + docs | report-submission-1 |
-            | AU | report-submission-1 |
+            | 102      | report-submission-1 |
+            | AU       | report-submission-1 |
+        Then each text should be present in the corresponding region:
+            | DigiRep-2016_2020-03-20_102.pdf | report-submission-documents-1 |
+            | good.png                        | report-submission-documents-1 |
 
     @deputy
     Scenario: assert 2nd year report has been created

--- a/behat/tests/features/deputy/03-report/01-102/21-check-and-submit.feature
+++ b/behat/tests/features/deputy/03-report/01-102/21-check-and-submit.feature
@@ -146,8 +146,9 @@ Feature: Report submit
             | John 102 | report-submission-1 |
             | 102      | report-submission-1 |
         And each text should be present in the corresponding region:
-            | DigiRep-2016_2020-03-20_102.pdf | report-submission-documents-1 |
-            | good.png                        | report-submission-documents-1 |
+            | DigiRep-2016             | report-submission-documents-1 |
+            | DigiRepTransactions-2016 | report-submission-documents-1 |
+            | good.png                 | report-submission-documents-1 |
 
     @deputy
     Scenario: admin can download individual report flies
@@ -178,8 +179,9 @@ Feature: Report submit
             | 102      | report-submission-1 |
             | AU       | report-submission-1 |
         Then each text should be present in the corresponding region:
-            | DigiRep-2016_2020-03-20_102.pdf | report-submission-documents-1 |
-            | good.png                        | report-submission-documents-1 |
+            | DigiRep-2016             | report-submission-documents-1 |
+            | DigiRepTransactions-2016 | report-submission-documents-1 |
+            | good.png                 | report-submission-documents-1 |
 
     @deputy
     Scenario: assert 2nd year report has been created

--- a/client/docker/env/frontend.env
+++ b/client/docker/env/frontend.env
@@ -20,7 +20,7 @@ NONADMIN_HOST=https://digideps.local
 ADMIN_HOST=https://admin.digideps.local
 
 # Due to validation checks when instantiating Notify client this needs to be in a valid JWT format - the value is fake
-NOTIFY_API_KEY=test-3256fbd6-df6e-43ea-862c-7120440ba955-0d210a57-4532-461e-9f15-bd6c474f10f6
+NOTIFY_API_KEY=fakekey-1234fbd6-df6e-43ea-862c-7120440ba955-42e755b4-752b-437d-aafa-9939773bf7e4
 
 # use simple alpha and underscore for bucketname. Fakes3 failing otherwise
 S3_BUCKETNAME=pa-uploads-local

--- a/client/docker/env/frontend.env
+++ b/client/docker/env/frontend.env
@@ -20,7 +20,7 @@ NONADMIN_HOST=https://digideps.local
 ADMIN_HOST=https://admin.digideps.local
 
 # Due to validation checks when instantiating Notify client this needs to be in a valid JWT format - the value is fake
-NOTIFY_API_KEY=fakekey-1234fbd6-df6e-43ea-862c-7120440ba955-42e755b4-752b-437d-aafa-9939773bf7e4
+NOTIFY_API_KEY=test-3256fbd6-df6e-43ea-862c-7120440ba955-0d210a57-4532-461e-9f15-bd6c474f10f6
 
 # use simple alpha and underscore for bucketname. Fakes3 failing otherwise
 S3_BUCKETNAME=pa-uploads-local

--- a/client/src/AppBundle/Controller/Admin/ReportSubmissionController.php
+++ b/client/src/AppBundle/Controller/Admin/ReportSubmissionController.php
@@ -50,6 +50,8 @@ class ReportSubmissionController extends AbstractController
      * @Route("/documents/list", name="admin_documents", methods={"GET", "POST"})
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
      * @Template("AppBundle:Admin/ReportSubmission:index.html.twig")
+     *
+     * @return array<mixed>|Response
      */
     public function indexAction(Request $request)
     {
@@ -93,7 +95,7 @@ class ReportSubmissionController extends AbstractController
      * @Route("/documents/list/download", name="admin_documents_download", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
      */
-    public function downloadDocuments(Request $request)
+    public function downloadDocuments(Request $request): Response
     {
         $reportSubmissionIds =
             !empty($request->query->get('reportSubmissionIds')) ? json_decode(urldecode($request->query->get('reportSubmissionIds'))) : null;
@@ -119,7 +121,7 @@ class ReportSubmissionController extends AbstractController
      * @Route("/documents/{submissionId}/{documentId}/download", name="admin_document_download", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
      */
-    public function downloadIndividualDocument(int $submissionId, int $documentId)
+    public function downloadIndividualDocument(int $submissionId, int $documentId): Response
     {
         $client = $this->getRestClient();
 
@@ -156,6 +158,8 @@ class ReportSubmissionController extends AbstractController
      * @Route("/documents/list/download_ready", name="admin_documents_download_ready", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
      * @Template("AppBundle:Admin/ReportSubmission:download-ready.html.twig")
+     *
+     * @return array<mixed>
      */
     public function downloadReady(Request $request)
     {
@@ -166,7 +170,7 @@ class ReportSubmissionController extends AbstractController
      * Process a post
      *
      * @param Request $request request
-     *
+     * @return Response|void
      */
     private function processPost(Request $request)
     {
@@ -209,8 +213,6 @@ class ReportSubmissionController extends AbstractController
                         $this->addFlash('error', 'There was an error downloading the requested documents: ' . $e->getMessage());
                         return $this->redirectToRoute('admin_documents');
                     }
-
-                    break;
             }
         }
     }
@@ -218,10 +220,10 @@ class ReportSubmissionController extends AbstractController
     /**
      * Archive multiple documents based on the supplied ids
      *
-     * @param array $checkedBoxes ids selected by the user
+     * @param array<int, int|string> $checkedBoxes ids selected by the user
      *
      */
-    private function processArchive($checkedBoxes)
+    private function processArchive($checkedBoxes): void
     {
         foreach ($checkedBoxes as $reportSubmissionId) {
             $this->getRestClient()->put("report-submission/{$reportSubmissionId}", ['archive'=>true]);
@@ -230,7 +232,7 @@ class ReportSubmissionController extends AbstractController
 
     /**
      * @param  Request $request
-     * @return array
+     * @return array<mixed>
      */
     private static function getFiltersFromRequest(Request $request)
     {

--- a/client/src/AppBundle/Controller/Admin/ReportSubmissionController.php
+++ b/client/src/AppBundle/Controller/Admin/ReportSubmissionController.php
@@ -72,15 +72,16 @@ class ReportSubmissionController extends AbstractController
             return $s->isDownloadable();
         }));
 
-        $isNewPage = $currentFilters['status'] == 'new';
+        if ($currentFilters['status'] === 'archived') {
+            $postActions = [self::ACTION_DOWNLOAD];
+        } else {
+            $postActions = [self::ACTION_DOWNLOAD, self::ACTION_ARCHIVE];
+        }
 
         return [
             'filters' => $currentFilters,
             'records' => $records,
-            'postActions' => $isNewPage ? [
-                self::ACTION_DOWNLOAD,
-                self::ACTION_ARCHIVE,
-            ] : [self::ACTION_DOWNLOAD],
+            'postActions' => $postActions,
             'counts'  => [
                 'new'      => $ret['counts']['new'],
                 'pending'  => $ret['counts']['pending'],

--- a/client/src/AppBundle/Controller/Admin/ReportSubmissionController.php
+++ b/client/src/AppBundle/Controller/Admin/ReportSubmissionController.php
@@ -81,10 +81,11 @@ class ReportSubmissionController extends AbstractController
             ] : [self::ACTION_DOWNLOAD],
             'counts'  => [
                 'new'      => $ret['counts']['new'],
+                'pending'  => $ret['counts']['pending'],
                 'archived' => $ret['counts']['archived'],
             ],
             'nOfdownloadableSubmissions' => $nOfdownloadableSubmissions,
-            'isNewPage' => $isNewPage,
+            'currentTab' => $currentFilters['status'],
         ];
     }
 

--- a/client/src/AppBundle/Resources/assets/javascripts/main.js
+++ b/client/src/AppBundle/Resources/assets/javascripts/main.js
@@ -7,6 +7,7 @@ var Stickyfill = require('stickyfilljs')
 var limitChars = require('./modules/characterLimiter.js')
 var cookieBanner = require('./modules/cookieBanner.js')
 var detailsExpander = require('./modules/detailsExpander.js')
+var DetachedDetails = require('./modules/detached-details.js')
 var formatCurrency = require('./modules/formatcurrency.js')
 var Ga = require('./modules/ga.js')
 var moneyTransfer = require('./modules/moneyTransfer.js')
@@ -62,6 +63,11 @@ $(document).ready(function () {
 
   // Table Multi Select
   tableMultiSelect()
+
+  // Detached details/summary
+  document.querySelectorAll('[data-module="opg-detached-details"]').forEach(function ($el) {
+    new DetachedDetails($el).init()
+  })
 
   // Initialising the Show Hide Content GOVUK module
   var showHideContent = new ShowHideContent()

--- a/client/src/AppBundle/Resources/assets/javascripts/modules/detached-details.js
+++ b/client/src/AppBundle/Resources/assets/javascripts/modules/detached-details.js
@@ -1,0 +1,82 @@
+var KEY_ENTER = 13
+var KEY_SPACE = 32
+
+function DetachedDetails ($module) {
+  this.$module = $module
+  this.$summary = $module.querySelector('.govuk-details__summary')
+  this.$content = document.querySelector('#' + $module.getAttribute('aria-controls'))
+}
+
+// Initialize component
+DetachedDetails.prototype.init = function () {
+  // Check for module
+  if (!this.$module) {
+    return
+  }
+
+  this.handleInputs(this.$summary, this.handleClick.bind(this))
+
+  this.draw()
+}
+
+DetachedDetails.prototype.handleClick = function (e) {
+  e.preventDefault()
+
+  if (this.$module.getAttribute('open') === null) {
+    this.$module.setAttribute('open', 'open')
+  } else {
+    this.$module.removeAttribute('open')
+  }
+
+  this.draw()
+}
+
+// Update visual status of elements
+DetachedDetails.prototype.draw = function () {
+  const isOpen = this.$module.getAttribute('open') !== null
+
+  this.$summary.setAttribute('aria-expanded', (isOpen ? 'true' : 'false'))
+  this.$content.setAttribute('aria-hidden', (isOpen ? 'false' : 'true'))
+
+  this.$content.style.display = (isOpen ? '' : 'none')
+}
+
+/**
+* Handle cross-modal click events
+* @param {object} node element
+* @param {function} callback function
+*/
+DetachedDetails.prototype.handleInputs = function (node, callback) {
+  node.addEventListener('keypress', function (event) {
+    var target = event.target
+    // When the key gets pressed - check if it is enter or space
+    if (event.keyCode === KEY_ENTER || event.keyCode === KEY_SPACE) {
+      if (target.nodeName.toLowerCase() === 'summary') {
+        // Prevent space from scrolling the page
+        // and enter from submitting a form
+        event.preventDefault()
+        // Click to let the click event do all the necessary action
+        if (target.click) {
+          target.click()
+        } else {
+          // except Safari 5.1 and under don't support .click() here
+          callback(event)
+        }
+      }
+    }
+  })
+
+  // Prevent keyup to prevent clicking twice in Firefox when using space key
+  node.addEventListener('keyup', function (event) {
+    var target = event.target
+    if (event.keyCode === KEY_SPACE) {
+      if (target.nodeName.toLowerCase() === 'summary') {
+        event.preventDefault()
+      }
+    }
+  })
+
+  node.addEventListener('click', callback)
+}
+
+module.exports = DetachedDetails

--- a/client/src/AppBundle/Resources/assets/javascripts/modules/table-multiselect.js
+++ b/client/src/AppBundle/Resources/assets/javascripts/modules/table-multiselect.js
@@ -1,18 +1,23 @@
 /* globals $ */
+const checkedClass = 'opg-table__row--checked'
+
 module.exports = function () {
+  const $disabledButtons = $('[data-js="disabled-button"]')
+  $disabledButtons.prop('disabled', true);
+
   // Select all checkbox change
   $('.js-checkbox-all').change(function () {
-    $('.js-disabled').removeAttr('disabled')
+    $disabledButtons.prop('disabled', false)
 
     // Change all '.js-checkbox' checked status
     $('.js-checkbox').prop('checked', $(this).prop('checked'))
 
     // Toggle checked class on other checkboxes
     if ($(this).prop('checked')) {
-      $('.js-checkbox').parents('tr').addClass('checked')
+      $('.js-checkbox').parents('tr').addClass(checkedClass)
     } else {
-      $('.js-checkbox').parents('tr').removeClass('checked')
-      $('.js-disabled').attr('disabled', 'disabled')
+      $('.js-checkbox').parents('tr').removeClass(checkedClass)
+      $disabledButtons.prop('disabled', true)
     }
 
     var caseString = $('.js-checkbox:checked').length === 1 ? ' case' : ' cases'
@@ -21,9 +26,9 @@ module.exports = function () {
 
   // '.js-checkbox' change
   $('.js-checkbox').change(function () {
-    $('.js-disabled').removeAttr('disabled')
+    $disabledButtons.prop('disabled', false)
 
-    $(this).parents('tr').toggleClass('checked')
+    $(this).parents('tr').toggleClass(checkedClass)
 
     // uncheck 'select all', if one of the listed checkbox item is unchecked
     if ($(this).prop('checked') === false) {
@@ -35,7 +40,7 @@ module.exports = function () {
     if ($('.js-checkbox:checked').length === $('.js-checkbox').length) {
       $('.js-checkbox-all').prop('checked', true)
     } else if ($('.js-checkbox:checked').length === 0) {
-      $('.js-disabled').attr('disabled', 'disabled')
+      $disabledButtons.prop('disabled', true)
     }
 
     var caseString = $('.js-checkbox:checked').length === 1 ? ' case' : ' cases'

--- a/client/src/AppBundle/Resources/assets/javascripts/modules/table-multiselect.js
+++ b/client/src/AppBundle/Resources/assets/javascripts/modules/table-multiselect.js
@@ -2,48 +2,39 @@
 const checkedClass = 'opg-table__row--checked'
 
 module.exports = function () {
-  const $disabledButtons = $('[data-js="disabled-button"]')
-  $disabledButtons.prop('disabled', true);
+  const $checkboxAll = $('[data-js="multiselect-checkbox-all"]')
+  const $checkboxes = $('[data-js="multiselect-checkbox"]')
+  const $selectedCounter = $('[data-js="multiselect-selected-count"]')
+  const $disabledButtons = $('[data-js="multiselect-disabled-button"]')
+
+  $disabledButtons.prop('disabled', true)
+
+  function updateText () {
+    const selectedCount = $checkboxes.filter(':checked').length
+    const caseString = selectedCount === 1 ? ' case' : ' cases'
+    $selectedCounter.text(selectedCount + caseString)
+  }
 
   // Select all checkbox change
-  $('.js-checkbox-all').change(function () {
-    $disabledButtons.prop('disabled', false)
+  $checkboxAll.change(function () {
+    const isChecked = $checkboxAll.prop('checked')
 
-    // Change all '.js-checkbox' checked status
-    $('.js-checkbox').prop('checked', $(this).prop('checked'))
+    $checkboxes.prop('checked', isChecked)
+    $checkboxes.parents('tr').toggleClass(checkedClass, isChecked)
+    $disabledButtons.prop('disabled', !isChecked)
 
-    // Toggle checked class on other checkboxes
-    if ($(this).prop('checked')) {
-      $('.js-checkbox').parents('tr').addClass(checkedClass)
-    } else {
-      $('.js-checkbox').parents('tr').removeClass(checkedClass)
-      $disabledButtons.prop('disabled', true)
-    }
-
-    var caseString = $('.js-checkbox:checked').length === 1 ? ' case' : ' cases'
-    $('#numberOfCases').text($('.js-checkbox:checked').length + caseString)
+    updateText()
   })
 
-  // '.js-checkbox' change
-  $('.js-checkbox').change(function () {
-    $disabledButtons.prop('disabled', false)
+  // Individual checkbox change
+  $checkboxes.change(function (e) {
+    const $currentCheckbox = $(e.currentTarget)
+    const selectedCount = $checkboxes.filter(':checked').length
 
-    $(this).parents('tr').toggleClass(checkedClass)
+    $currentCheckbox.parents('tr').toggleClass(checkedClass)
+    $disabledButtons.prop('disabled', selectedCount === 0)
+    $checkboxAll.prop('checked', selectedCount === $checkboxes.length)
 
-    // uncheck 'select all', if one of the listed checkbox item is unchecked
-    if ($(this).prop('checked') === false) {
-      // change 'select all' checked status to false
-      $('.js-checkbox-all').prop('checked', false)
-    }
-
-    // check 'select all' if all checkbox items are checked
-    if ($('.js-checkbox:checked').length === $('.js-checkbox').length) {
-      $('.js-checkbox-all').prop('checked', true)
-    } else if ($('.js-checkbox:checked').length === 0) {
-      $disabledButtons.prop('disabled', true)
-    }
-
-    var caseString = $('.js-checkbox:checked').length === 1 ? ' case' : ' cases'
-    $('#numberOfCases').text($('.js-checkbox:checked').length + caseString)
+    updateText()
   })
 }

--- a/client/src/AppBundle/Resources/assets/scss/_digideps.scss
+++ b/client/src/AppBundle/Resources/assets/scss/_digideps.scss
@@ -25,4 +25,5 @@
 @import "digideps/headings";
 @import "digideps/cookie-banner";
 @import "digideps/sticky-menu";
+@import "digideps/text";
 // @import "digideps/debug";

--- a/client/src/AppBundle/Resources/assets/scss/digideps/_table-multiselect.scss
+++ b/client/src/AppBundle/Resources/assets/scss/digideps/_table-multiselect.scss
@@ -1,28 +1,6 @@
 // ==========================================================================
 // TABLE MULTISELECT
 // Select all/many rows on a table in the admin
-
-// Various custom form styles
-.table-clickable {
-
-    .multiple-choice--smaller {
-        margin: 0;
-        padding: 10px 0 0 10px;
-
-        .multiple-choice {
-            padding-left: 10px;
-
-            label {
-                padding: 0 10px 30px 12px;
-            }
-        }
-    }
-
-    tr {
-        // Highlight which row is selected
-        &.checked {
-            background-color: lighten($focus-colour, 25%);
-        }
-    }
+.opg-table__row--checked {
+    background-color: lighten($focus-colour, 25%);
 }
-

--- a/client/src/AppBundle/Resources/assets/scss/digideps/_text.scss
+++ b/client/src/AppBundle/Resources/assets/scss/digideps/_text.scss
@@ -9,3 +9,7 @@
 .opg-text--danger {
     color: govuk-colour('red');
 }
+
+.opg-text--wrap {
+    word-break: break-all;
+}

--- a/client/src/AppBundle/Resources/assets/scss/digideps/_text.scss
+++ b/client/src/AppBundle/Resources/assets/scss/digideps/_text.scss
@@ -1,0 +1,11 @@
+.opg-text--secondary {
+    color: $govuk-secondary-text-colour;
+}
+
+.opg-text--success {
+    color: govuk-colour('green');
+}
+
+.opg-text--danger {
+    color: govuk-colour('red');
+}

--- a/client/src/AppBundle/Resources/translations/admin-documents.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin-documents.en.yml
@@ -16,9 +16,10 @@ page:
   resultsTable:
     header:
       all: All
-      clientAndCaseNo: Client and case no
+      client: Client
+      caseNumber: Case number
       deputy: Deputy
-      period: Period
+      period: Reporting period
       documents: Documents
       submitted: Submitted
       user: User

--- a/client/src/AppBundle/Resources/translations/admin-documents.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin-documents.en.yml
@@ -24,6 +24,7 @@ page:
       submitted: Submitted
       user: User
     noDocumentsFound: No documents found
+    automaticallyArchived: Automatically archived by automation
   table:
     rows:
       documents: "{0} No documents | {1} 1 document | ]1,Inf[ %count% documents"

--- a/client/src/AppBundle/Resources/translations/admin-documents.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin-documents.en.yml
@@ -21,7 +21,6 @@ page:
       period: Period
       documents: Documents
       submitted: Submitted
-      discharged: Discharged
       user: User
     noDocumentsFound: No documents found
   table:

--- a/client/src/AppBundle/Resources/translations/admin-documents.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin-documents.en.yml
@@ -2,8 +2,9 @@ page:
   htmlTitle: Administration - Submissions
   pageTitle: Submitted reports and supporting documents
   tabs:
-    new.label: "New"
-    archived.label: "Archived"
+    new.label: New
+    pending.label: Pending
+    archived.label: Synchronised
   searchForm:
     search:
       label: Client, deputy or case number

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/_document-sync-table.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/_document-sync-table.html.twig
@@ -2,15 +2,15 @@
 
 {% macro syncStatus(status, document) %}
     {% if status == 'QUEUED' %}
-        <span style="color:darkgray">Queued</span>
+        <span class="opg-text--secondary">Queued</span>
     {% elseif status == 'IN_PROGRESS' %}
-        <span style="color:darkgray">In progress</span>
+        <span class="opg-text--secondary">In progress</span>
     {% elseif status == 'SUCCESS' %}
-        <strong style="color:green">Success</strong>
+        <strong class="opg-text--success">Success</strong>
     {% elseif status == 'PERMANENT_ERROR' %}
-        <strong style="color:red">Permanent fail</strong>
+        <strong class="opg-text--danger">Permanent fail</strong>
     {% elseif status == 'TEMPORARY_ERROR' %}
-        <span style="color:brown">Temporary fail</span>
+        <span class="opg-text--danger">Temporary fail</span>
     {% else %}
 
     {% endif %}

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/_document-sync-table.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/_document-sync-table.html.twig
@@ -30,7 +30,7 @@
         <tbody class="govuk-table__body">
             {% for document in documents %}
                 <tr class="govuk-table__row">
-                    <td class="govuk-table__cell govuk-!-font-size-14">{{ document.fileName }}</td>
+                    <td class="govuk-table__cell govuk-!-font-size-14 opg-text--wrap    ">{{ document.fileName }}</td>
                     <td class="govuk-table__cell govuk-!-font-size-14">
                         <a href="{{ path('admin_document_download', { submissionId: reportSubmission.id, documentId: document.id }) }}">
                             {{- 'page.postactions.download' | trans -}}

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/_document-sync-table.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/_document-sync-table.html.twig
@@ -30,7 +30,7 @@
         <tbody class="govuk-table__body">
             {% for document in documents %}
                 <tr class="govuk-table__row">
-                    <td class="govuk-table__cell govuk-!-font-size-14 opg-text--wrap    ">{{ document.fileName }}</td>
+                    <td class="govuk-table__cell govuk-!-font-size-14 opg-text--wrap">{{ document.fileName }}</td>
                     <td class="govuk-table__cell govuk-!-font-size-14">
                         <a href="{{ path('admin_document_download', { submissionId: reportSubmission.id, documentId: document.id }) }}">
                             {{- 'page.postactions.download' | trans -}}

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/_document-sync-table.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/_document-sync-table.html.twig
@@ -16,7 +16,7 @@
     {% endif %}
 {% endmacro %}
 
-<div class="govuk-inset-text">
+<div class="govuk-details__text">
     <table class="govuk-table">
         <thead class="govuk-table__head">
             <tr class="govuk-table__row">

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/_document-sync-table.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/_document-sync-table.html.twig
@@ -1,18 +1,18 @@
 {% trans_default_domain "admin-documents" %}
 
 {% macro syncStatus(status, document) %}
-    {% if status == 'QUEUED' %}
-        <span class="opg-text--secondary">Queued</span>
-    {% elseif status == 'IN_PROGRESS' %}
-        <span class="opg-text--secondary">In progress</span>
-    {% elseif status == 'SUCCESS' %}
-        <strong class="opg-text--success">Success</strong>
-    {% elseif status == 'PERMANENT_ERROR' %}
-        <strong class="opg-text--danger">Permanent fail</strong>
-    {% elseif status == 'TEMPORARY_ERROR' %}
-        <span class="opg-text--danger">Temporary fail</span>
-    {% else %}
+    {% set DocumentClass = 'AppBundle\\Entity\\Report\\Document' %}
 
+    {% if status == class_const(DocumentClass, 'SYNC_STATUS_QUEUED') %}
+        <span class="opg-text--secondary">Queued</span>
+    {% elseif status == class_const(DocumentClass, 'SYNC_STATUS_IN_PROGRESS') %}
+        <span class="opg-text--secondary">In progress</span>
+    {% elseif status == class_const(DocumentClass, 'SYNC_STATUS_SUCCESS') %}
+        <strong class="opg-text--success">Success</strong>
+    {% elseif status == class_const(DocumentClass, 'SYNC_STATUS_PERMANENT_ERROR') %}
+        <strong class="opg-text--danger">Permanent fail</strong>
+    {% elseif status == class_const(DocumentClass, 'SYNC_STATUS_TEMPORARY_ERROR') %}
+        <span class="opg-text--danger">Temporary fail</span>
     {% endif %}
 {% endmacro %}
 

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/_document-sync-table.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/_document-sync-table.html.twig
@@ -45,7 +45,9 @@
                         {% endif %}
                     </td>
                     <td class="govuk-table__cell govuk-!-font-size-14">
-                        {{ document.synchronisationTime | date('j F Y g:ia') }}
+                        {% if document.synchronisationTime %}
+                            {{ document.synchronisationTime | date('j F Y g:ia') }}
+                        {% endif %}
                     </td>
                 </tr>
             {% endfor %}

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/_document-sync-table.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/_document-sync-table.html.twig
@@ -1,0 +1,54 @@
+{% trans_default_domain "admin-documents" %}
+
+{% macro syncStatus(status, document) %}
+    {% if status == 'QUEUED' %}
+        <span style="color:darkgray">Queued</span>
+    {% elseif status == 'IN_PROGRESS' %}
+        <span style="color:darkgray">In progress</span>
+    {% elseif status == 'SUCCESS' %}
+        <strong style="color:green">Success</strong>
+    {% elseif status == 'PERMANENT_ERROR' %}
+        <strong style="color:red">Permanent fail</strong>
+    {% elseif status == 'TEMPORARY_ERROR' %}
+        <span style="color:brown">Temporary fail</span>
+    {% else %}
+
+    {% endif %}
+{% endmacro %}
+
+<div class="govuk-inset-text">
+    <table class="govuk-table">
+        <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header govuk-!-font-size-14">Document</th>
+                <th scope="col" class="govuk-table__header govuk-!-font-size-14"><span class="govuk-visually-hidden">Download</span></th>
+                <th scope="col" class="govuk-table__header govuk-!-font-size-14">Status</th>
+                <th scope="col" class="govuk-table__header govuk-!-font-size-14">Information</th>
+                <th scope="col" class="govuk-table__header govuk-!-font-size-14">Time</th>
+            </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+            {% for document in documents %}
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell govuk-!-font-size-14">{{ document.fileName }}</td>
+                    <td class="govuk-table__cell govuk-!-font-size-14">
+                        <a href="{{ path('admin_document_download', { submissionId: reportSubmission.id, documentId: document.id }) }}">
+                            {{- 'page.postactions.download' | trans -}}
+                        </a>
+                    </td>
+                    <td class="govuk-table__cell govuk-!-font-size-14">
+                        {{ _self.syncStatus(document.synchronisationStatus, document) }}
+                    </td>
+                    <td class="govuk-table__cell govuk-!-font-size-14">
+                        {% if document.synchronisationError %}
+                            <strong>Error:</strong> {{ document.synchronisationError }}
+                        {% endif %}
+                    </td>
+                    <td class="govuk-table__cell govuk-!-font-size-14">
+                        {{ document.synchronisationTime | date('j F Y g:ia') }}
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
@@ -105,7 +105,7 @@
                 </div>
             {% endif %}
         </div>
-        <table class="check-your-answers table-clickable push--bottom">
+        <table class="govuk-table table-clickable push--bottom">
             <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                     {% if nOfdownloadableSubmissions > 0 %}

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
@@ -26,18 +26,18 @@
     {% set filtersToPreserveAfterArchiving = filtersToPreserveInPagination %}
 
     {# search form #}
-    <form action="{{ path(baseRoute, {'status': filters.status}) }}" method="GET" class="search push--ends">
+    <form action="{{ path(baseRoute, {'status': filters.status}) }}" method="GET">
         <fieldset>
             <legend class="govuk-visually-hidden">{{ 'search' | trans({}, 'common') }}</legend>
-            <div class="govuk-grid-row push-half--bottom">
-                <div class="govuk-grid-column-one-third">
-                    <label for="search" class="form-label text">{{ 'page.searchForm.search.label' | trans }}</label>
-                    <input type="text" id="search" name="q" value="{{ filters.q }}" class="js-search-focus govuk-input govuk-grid-column-full">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-one-third govuk-form-group">
+                    <label for="search" class="govuk-label">{{ 'page.searchForm.search.label' | trans }}</label>
+                    <input type="text" id="search" name="q" value="{{ filters.q }}" class="govuk-input">
                     <input type="hidden" name="status" value="{{ filters.status }}" />
                 </div>
-                <div class="govuk-grid-column-one-third">
-                    <label for="created_by_role" class="form-label">{{ 'role' | trans({}, 'common' ) }}</label>
-                    <select name="created_by_role" id="created_by_role" class="search-dropdown govuk-input govuk-!-width-two-thirds">
+                <div class="govuk-grid-column-one-third govuk-form-group">
+                    <label for="created_by_role" class="govuk-label">{{ 'role' | trans({}, 'common' ) }}</label>
+                    <select name="created_by_role" id="created_by_role" class="govuk-select">
                         <option value="">All</option>
                         {% for value, label in {
                             'ROLE_PA_%': 'Public authority',
@@ -49,9 +49,9 @@
                     </select>
                 </div>
             </div>
-            <input id="search_submit" class="button flush--bottom behat-link-search" type="submit" value="Search">
+            <input id="search_submit" class="govuk-button behat-link-search" type="submit" value="Search">
             {% if filters.q or filters.created_by_role %}
-                <a href="{{ path(baseRoute, {'status': filters.status}) }}" class="govuk-link button-link">Clear filters</a>
+                <a href="{{ path(baseRoute, {'status': filters.status}) }}" class="govuk-button govuk-button--secondary">Clear filters</a>
             {% endif %}
         </fieldset>
     </form>
@@ -87,19 +87,25 @@
     {# table with records #}
     {% if  records | length %}
     <form name="multiForm" id="multiForm" action="{{ path(baseRoute, {'status': filters.status} | merge(filtersToPreserveInTabs)) }}" method="POST">
-        {% if nOfdownloadableSubmissions > 0 %}
-            {% for action in postActions %}
-                <input
-                    type="submit"
-                    id="action-{{ action }}"
-                    value="{{ ('page.postactions.' ~ action) | trans }}"
-                    name="multiAction"
-                    class="behat-link-{{ action }} button button-secondary push-half--bottom push-half--right js-disabled"
-                />
-            {% endfor %}
-            <p class="right text--right"><span id="numberOfCases">0 cases</span> selected</p>
-        {% endif %}
-        <table class="govuk-table table-clickable push--bottom">
+        <div class="govuk-grid-row">
+            {% if nOfdownloadableSubmissions > 0 %}
+                <div class="govuk-grid-column-two-thirds">
+                    {% for action in postActions %}
+                        <input
+                            type="submit"
+                            id="action-{{ action }}"
+                            value="{{ ('page.postactions.' ~ action) | trans }}"
+                            name="multiAction"
+                            class="behat-link-{{ action }} govuk-button govuk-button--secondary js-disabled"
+                        />
+                    {% endfor %}
+                </div>
+                <div class="govuk-grid-column-one-third text--right">
+                    <span id="numberOfCases">0 cases</span> selected
+                </div>
+            {% endif %}
+        </div>
+        <table class="check-your-answers table-clickable push--bottom">
             <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                     {% if nOfdownloadableSubmissions > 0 %}

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
@@ -156,7 +156,11 @@
                           </td>
                         {% endif %}
                         <td class="govuk-table__cell">
-                            {{ client.fullname }}
+                            <div class="govuk-details govuk-!-margin-bottom-0" aria-controls="docs-table-{{ reportSubmission.id }}" data-module="opg-detached-details">
+                                <a href="#" role="button" class="govuk-details__summary">
+                                    {{ client.fullname }}
+                                </a>
+                            </div>
                         </td>
                         <td class="govuk-table__cell">
                             <div class="govuk-tag">
@@ -197,7 +201,7 @@
                         </td>
                     </tr>
 
-                    <tr>
+                    <tr id="docs-table-{{ reportSubmission.id }}">
                         <td colspan="7">
                             {{ include('AppBundle:Admin/ReportSubmission:_document-sync-table.html.twig', { reportSubmission: reportSubmission, documents: reportSubmission.documents }) }}
                         </td>

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
@@ -182,7 +182,11 @@
                         </td>
                         {% if currentTab == 'archived' %}
                             <td class="govuk-table__cell">
-                                <span title="{{ reportSubmission.archivedBy.firstname }} {{ reportSubmission.archivedBy.lastname }}">{{ reportSubmission.archivedBy.firstname | first }}{{ reportSubmission.archivedBy.lastname | first }}</span>
+                                {% if reportSubmission.archivedBy %}
+                                    <span title="{{ reportSubmission.archivedBy.firstname }} {{ reportSubmission.archivedBy.lastname }}">{{ reportSubmission.archivedBy.firstname | first }}{{ reportSubmission.archivedBy.lastname | first }}</span>
+                                {% else %}
+                                    <span title="{{ 'page.resultsTable.automaticallyArchived' | trans }}">-</span>
+                                {% endif %}
                             </td>
                         {% endif %}
                     </tr>

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
@@ -126,10 +126,9 @@
                     <th scope="col" class="govuk-table__header"><span class="visually-hidden">{{ 'page.resultsTable.header.documents' | trans }}</span></th>
                     <th scope="col" class="govuk-table__header">{{ 'page.resultsTable.header.caseNumber' | trans }}</th>
                     <th scope="col" class="govuk-table__header">{{ 'page.resultsTable.header.submitted' | trans }}</th>
-                    {% if not isNewPage %}
+                    {% if currentTab == 'archived' %}
                         <th>{{ 'page.resultsTable.header.user' | trans }}</th>
                     {% endif %}
-                    <th scope="col" class="govuk-table__header">{{ 'page.resultsTable.header.discharged' | trans }}</th>
                 </tr>
             </thead>
             <tbody class="govuk-table__body">
@@ -181,24 +180,11 @@
                             {# show hour and time #}
                             {{ submissionDate | date('g:ia') }}
                         </td>
-                        {% if not isNewPage %}
+                        {% if currentTab == 'archived' %}
                             <td class="govuk-table__cell">
                                 <span title="{{ reportSubmission.archivedBy.firstname }} {{ reportSubmission.archivedBy.lastname }}">{{ reportSubmission.archivedBy.firstname | first }}{{ reportSubmission.archivedBy.lastname | first }}</span>
                             </td>
                         {% endif %}
-                        <td class="govuk-table__cell width-tenth">
-                            {% set dischargedDate = client.deletedAt %}
-                            {% if dischargedDate is defined and dischargedDate is not null %}
-                                {% if ("now" | date('Y-m-d') == dischargedDate | date('Y-m-d')) %}
-                                    Today
-                                {% else %}
-                                    {{ dischargedDate | date('d/m/Y') }}
-                                {% endif %}
-                                <br/>
-                                {# show hour and time #}
-                                {{ dischargedDate | date('g:ia') }}
-                            {% endif %}
-                        </td>
                     </tr>
 
                     <tr id="docs-table-{{ reportSubmission.id }}">

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
@@ -187,7 +187,7 @@
                         {% endif %}
                     </tr>
 
-                    <tr id="docs-table-{{ reportSubmission.id }}">
+                    <tr id="docs-table-{{ reportSubmission.id }}" class="behat-region-report-submission-documents-{{ loop.index }}">
                         <td colspan="7">
                             {{ include('AppBundle:Admin/ReportSubmission:_document-sync-table.html.twig', { reportSubmission: reportSubmission, documents: reportSubmission.documents }) }}
                         </td>

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
@@ -196,6 +196,12 @@
                             {% endif %}
                         </td>
                     </tr>
+
+                    <tr>
+                        <td colspan="7">
+                            {{ include('AppBundle:Admin/ReportSubmission:_document-sync-table.html.twig', { reportSubmission: reportSubmission, documents: reportSubmission.documents }) }}
+                        </td>
+                    </tr>
                 {% endfor %}
             </tbody>
         </table>

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
@@ -123,7 +123,7 @@
                       </th>
                     {% endif %}
                     <th scope="col" class="govuk-table__header">{{ 'page.resultsTable.header.client' | trans }}</th>
-                    <th scope="col" class="govuk-table__header"><span class="visually-hidden">{{ 'page.resultsTable.header.documents' | trans }}</span></th>
+                    <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">{{ 'page.resultsTable.header.documents' | trans }}</span></th>
                     <th scope="col" class="govuk-table__header">{{ 'page.resultsTable.header.caseNumber' | trans }}</th>
                     <th scope="col" class="govuk-table__header">{{ 'page.resultsTable.header.submitted' | trans }}</th>
                     {% if currentTab == 'archived' %}

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
@@ -96,7 +96,8 @@
                             id="action-{{ action }}"
                             value="{{ ('page.postactions.' ~ action) | trans }}"
                             name="multiAction"
-                            class="behat-link-{{ action }} govuk-button govuk-button--secondary js-disabled"
+                            class="behat-link-{{ action }} govuk-button govuk-button--secondary"
+                            data-js="disabled-button"
                         />
                     {% endfor %}
                 </div>
@@ -105,14 +106,19 @@
                 </div>
             {% endif %}
         </div>
-        <table class="govuk-table table-clickable push--bottom">
+        <table class="govuk-table govuk-checkboxes govuk-checkboxes--small">
             <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                     {% if nOfdownloadableSubmissions > 0 %}
-                      <th scope="col" class="govuk-table__header width-twentieth multiple-choice--smaller">
-                        <div class="multiple-choice">
-                            <input type="checkbox" id="select-all" name="select-all" value="all" class="js-checkbox-all">
-                            <label for="select-all"><span class="govuk-visually-hidden">{{ 'page.resultsTable.header.all' | trans }}</span></label>
+                      <th scope="col" class="govuk-table__header govuk-!-padding-left-4 govuk-!-padding-top-0">
+                        <div class="govuk-checkboxes__item">
+                            <input type="checkbox" id="select-all" name="select-all" value="all" class="govuk-checkboxes__input js-checkbox-all">
+                            <label for="select-all" class="govuk-label govuk-checkboxes__label">
+                                &nbsp;
+                                <span class="govuk-visually-hidden">
+                                    {{ 'page.resultsTable.header.all' | trans }}
+                                </span>
+                            </label>
                         </div>
                       </th>
                     {% endif %}
@@ -134,25 +140,27 @@
                     {% set client = report ? report.client : ndr.client %}
                     {# Period: report.period #}
                     {# Type: report.type #}
-                    <tr class="govuk-table__row behat-region-report-submission behat-region-report-submission-{{ loop.index }} align--top">
+                    <tr class="govuk-table__row behat-region-report-submission behat-region-report-submission-{{ loop.index }}">
                         {% if nOfdownloadableSubmissions > 0 %}
-                          <td class="govuk-table__cell width-twentieth multiple-choice--smaller">
+                          <td class="govuk-table__cell govuk-!-padding-left-4">
                             {% if reportSubmission.isDownloadable %}
-                            <div class="multiple-choice">
+                            <div class="govuk-checkboxes__item">
                                 <input type="checkbox" id="cb{{ reportSubmission.id }}" name="checkboxes[{{ reportSubmission.id }}]"
-                                       class="js-checkbox">
-                                <label for="cb{{ reportSubmission.id }}">
-                                    <span class="govuk-visually-hidden">Select {{ client.caseNumber }}</span>
+                                       class="js-checkbox govuk-checkboxes__input">
+                                <label for="cb{{ reportSubmission.id }}" class="govuk-label govuk-checkboxes__label">
+                                    <span class="govuk-visually-hidden">
+                                        Select {{ client.caseNumber }}
+                                    </span>
                                 </label>
                             </div>
                             {% endif %}
                           </td>
                         {% endif %}
-                        <td class="govuk-table__cell width-fifth">
-                            {{ client.fullname }}<br>
-                            <span class="govuk-caption-m">{{ client.caseNumber }}</span>
+                        <td class="govuk-table__cell">
+                            <strong>{{ client.fullname }}</strong><br>
+                            {{ client.caseNumber }}
                         </td>
-                        <td class="govuk-table__cell width-fifth">
+                        <td class="govuk-table__cell">
                             {% if reportSubmission.createdBy %}
                                 {% set createdBy = reportSubmission.createdBy %}
                                 {{ createdBy.fullname }}
@@ -162,7 +170,7 @@
                                 {% endif %}
                             {% endif %}
                         </td>
-                        <td class="govuk-table__cell width-eighth">
+                        <td class="govuk-table__cell">
                             {% if report %}
                                 {{ report.period | replace({'to': '-'}) }}
                             {% endif %}
@@ -171,9 +179,9 @@
                             {% endif %}
                         </td>
                         <td class="govuk-table__cell">
-                            <details class="push--bottom">
-                                <summary>
-                                    <span class="summary">
+                            <details class="govuk-details" data-module="govuk-details">
+                                <summary class="govuk-details__summary">
+                                    <span class="govuk-details__summary-text">
                                         {% if reportSubmission.hasReportPdf() %}
                                             {{ 'page.table.rows.documentsWithReport' | transchoice(reportSubmission.documents | length) }}
                                         {% else %}
@@ -181,8 +189,8 @@
                                         {% endif %}
                                     </span>
                                 </summary>
-                                <div class="opg-indented-block">
-                                    <ul class="govuk-list list-group" id="docs">
+                                <div class="govuk-details__text">
+                                    <ul class="govuk-list" id="docs">
                                         {% for document in reportSubmission.documents %}
                                             <li>
                                                 {{ document.fileName }}
@@ -195,7 +203,7 @@
                                 </div>
                             </details>
                         </td>
-                        <td class="govuk-table__cell width-tenth">
+                        <td class="govuk-table__cell">
                             {% set submissionDate = reportSubmission.createdOn %}
                             {# shows "Today" or "d/m/Y"e #}
                             {% if ("now" | date('Y-m-d') == submissionDate | date('Y-m-d')) %}

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
@@ -60,17 +60,26 @@
 
     <div class="govuk-tabs" data-module="govuk-tabs">
         <ul class="govuk-tabs__list" role="tablist">
-            <li class="govuk-tabs__list-item {% if isNewPage %}govuk-tabs__list-item--selected{% endif %}">
+            <li class="govuk-tabs__list-item {% if currentTab == 'new' %}govuk-tabs__list-item--selected{% endif %}">
                 <a class="govuk-tabs__tab behat-link-tab-new" href="{{ path(baseRoute, {'status': 'new'} | merge(filtersToPreserveInTabs) ) }}" role="tab" tabindex="0">
                     {{ 'page.tabs.new.label' | trans }}
                 </a>
-                <span class="govuk-tag">{{ counts.new }}</span>
+                {% if counts.new %}
+                    <span class="govuk-tag">{{ counts.new }}</span>
+                {% endif %}
             </li>
-            <li class="govuk-tabs__list-item {% if not isNewPage %}govuk-tabs__list-item--selected{% endif %}">
+            <li class="govuk-tabs__list-item {% if currentTab == 'pending' %}govuk-tabs__list-item--selected{% endif %}">
+                <a class="govuk-tabs__tab behat-link-tab-pending" href="{{ path(baseRoute, {'status': 'pending'} | merge(filtersToPreserveInTabs) ) }}" role="tab" tabindex="0">
+                    {{ 'page.tabs.pending.label' | trans }}
+                </a>
+                {% if counts.pending %}
+                    <span class="govuk-tag">{{ counts.pending }}</span>
+                {% endif %}
+            </li>
+            <li class="govuk-tabs__list-item {% if currentTab == 'archived' %}govuk-tabs__list-item--selected{% endif %}">
                 <a class="govuk-tabs__tab behat-link-tab-archived" href="{{ path(baseRoute, {'status': 'archived'} | merge(filtersToPreserveInTabs)) }}" role="tab" tabindex="0">
                     {{ 'page.tabs.archived.label' | trans }}
                 </a>
-                <span class="govuk-tag opg-tag--not-started">{{ counts.archived }}</span>
             </li>
         </ul>
     </div>

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
@@ -58,7 +58,7 @@
 
     {# tabs #}
 
-    <div class="govuk-tabs" data-module="govuk-tabs">
+    <div class="govuk-tabs">
         <ul class="govuk-tabs__list" role="tablist">
             <li class="govuk-tabs__list-item {% if currentTab == 'new' %}govuk-tabs__list-item--selected{% endif %}">
                 <a class="govuk-tabs__tab behat-link-tab-new" href="{{ path(baseRoute, {'status': 'new'} | merge(filtersToPreserveInTabs) ) }}" role="tab" tabindex="0">

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
@@ -110,7 +110,7 @@
             <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                     {% if nOfdownloadableSubmissions > 0 %}
-                      <th scope="col" class="govuk-table__header govuk-!-padding-left-4 govuk-!-padding-top-0">
+                      <th scope="col" class="govuk-table__header govuk-!-padding-left-4 govuk-!-padding-top-0 govuk-!-padding-bottom-0">
                         <div class="govuk-checkboxes__item">
                             <input type="checkbox" id="select-all" name="select-all" value="all" class="govuk-checkboxes__input" data-js="multiselect-checkbox-all">
                             <label for="select-all" class="govuk-label govuk-checkboxes__label">
@@ -122,10 +122,9 @@
                         </div>
                       </th>
                     {% endif %}
-                    <th scope="col" class="govuk-table__header">{{ 'page.resultsTable.header.clientAndCaseNo' | trans }}</th>
-                    <th scope="col" class="govuk-table__header">{{ 'page.resultsTable.header.deputy' | trans }}</th>
-                    <th scope="col" class="govuk-table__header">{{ 'period' | trans({}, 'common') }}</th>
-                    <th scope="col" class="govuk-table__header">{{ 'page.resultsTable.header.documents' | trans }}</th>
+                    <th scope="col" class="govuk-table__header">{{ 'page.resultsTable.header.client' | trans }}</th>
+                    <th scope="col" class="govuk-table__header"><span class="visually-hidden">{{ 'page.resultsTable.header.documents' | trans }}</span></th>
+                    <th scope="col" class="govuk-table__header">{{ 'page.resultsTable.header.caseNumber' | trans }}</th>
                     <th scope="col" class="govuk-table__header">{{ 'page.resultsTable.header.submitted' | trans }}</th>
                     {% if not isNewPage %}
                         <th>{{ 'page.resultsTable.header.user' | trans }}</th>
@@ -142,7 +141,7 @@
                     {# Type: report.type #}
                     <tr class="govuk-table__row behat-region-report-submission behat-region-report-submission-{{ loop.index }}">
                         {% if nOfdownloadableSubmissions > 0 %}
-                          <td class="govuk-table__cell govuk-!-padding-left-4">
+                          <td class="govuk-table__cell govuk-!-padding-left-4 govuk-!-padding-top-1">
                             {% if reportSubmission.isDownloadable %}
                             <div class="govuk-checkboxes__item">
                                 <input type="checkbox" id="cb{{ reportSubmission.id }}" name="checkboxes[{{ reportSubmission.id }}]"
@@ -157,51 +156,15 @@
                           </td>
                         {% endif %}
                         <td class="govuk-table__cell">
-                            <strong>{{ client.fullname }}</strong><br>
+                            {{ client.fullname }}
+                        </td>
+                        <td class="govuk-table__cell">
+                            <div class="govuk-tag">
+                                {{ reportSubmission.documents | length }}
+                            </div>
+                        </td>
+                        <td class="govuk-table__cell">
                             {{ client.caseNumber }}
-                        </td>
-                        <td class="govuk-table__cell">
-                            {% if reportSubmission.createdBy %}
-                                {% set createdBy = reportSubmission.createdBy %}
-                                {{ createdBy.fullname }}
-                                ({{ createdBy.roleFullName }})
-                                {% if createdBy.isDeputyOrg %}
-                                    <br/>{{ reportSubmission.createdBy.paTeamName }}
-                                {% endif %}
-                            {% endif %}
-                        </td>
-                        <td class="govuk-table__cell">
-                            {% if report %}
-                                {{ report.period | replace({'to': '-'}) }}
-                            {% endif %}
-                            {% if ndr %}
-                                {{ 'ndr' | trans({}, 'common') }}
-                            {% endif %}
-                        </td>
-                        <td class="govuk-table__cell">
-                            <details class="govuk-details" data-module="govuk-details">
-                                <summary class="govuk-details__summary">
-                                    <span class="govuk-details__summary-text">
-                                        {% if reportSubmission.hasReportPdf() %}
-                                            {{ 'page.table.rows.documentsWithReport' | transchoice(reportSubmission.documents | length) }}
-                                        {% else %}
-                                            {{ 'page.table.rows.documents' | transchoice(reportSubmission.documents | length) }}
-                                        {% endif %}
-                                    </span>
-                                </summary>
-                                <div class="govuk-details__text">
-                                    <ul class="govuk-list" id="docs">
-                                        {% for document in reportSubmission.documents %}
-                                            <li>
-                                                {{ document.fileName }}
-                                                (<a href="{{ path('admin_document_download', {submissionId: reportSubmission.id, documentId: document.id}) }}">
-                                                    {{- 'page.postactions.download' | trans -}}
-                                                </a>)
-                                            </li>
-                                        {% endfor %}
-                                    </ul>
-                                </div>
-                            </details>
                         </td>
                         <td class="govuk-table__cell">
                             {% set submissionDate = reportSubmission.createdOn %}
@@ -209,9 +172,8 @@
                             {% if ("now" | date('Y-m-d') == submissionDate | date('Y-m-d')) %}
                                 Today
                             {% else %}
-                                {{ submissionDate | date('d/m/Y') }}
+                                {{ submissionDate | date('j F Y') }}
                             {% endif %}
-                            <br/>
                             {# show hour and time #}
                             {{ submissionDate | date('g:ia') }}
                         </td>

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
@@ -97,12 +97,12 @@
                             value="{{ ('page.postactions.' ~ action) | trans }}"
                             name="multiAction"
                             class="behat-link-{{ action }} govuk-button govuk-button--secondary"
-                            data-js="disabled-button"
+                            data-js="multiselect-disabled-button"
                         />
                     {% endfor %}
                 </div>
                 <div class="govuk-grid-column-one-third text--right">
-                    <span id="numberOfCases">0 cases</span> selected
+                    <span data-js="multiselect-selected-count">0 cases</span> selected
                 </div>
             {% endif %}
         </div>
@@ -112,7 +112,7 @@
                     {% if nOfdownloadableSubmissions > 0 %}
                       <th scope="col" class="govuk-table__header govuk-!-padding-left-4 govuk-!-padding-top-0">
                         <div class="govuk-checkboxes__item">
-                            <input type="checkbox" id="select-all" name="select-all" value="all" class="govuk-checkboxes__input js-checkbox-all">
+                            <input type="checkbox" id="select-all" name="select-all" value="all" class="govuk-checkboxes__input" data-js="multiselect-checkbox-all">
                             <label for="select-all" class="govuk-label govuk-checkboxes__label">
                                 &nbsp;
                                 <span class="govuk-visually-hidden">
@@ -146,7 +146,7 @@
                             {% if reportSubmission.isDownloadable %}
                             <div class="govuk-checkboxes__item">
                                 <input type="checkbox" id="cb{{ reportSubmission.id }}" name="checkboxes[{{ reportSubmission.id }}]"
-                                       class="js-checkbox govuk-checkboxes__input">
+                                       class="govuk-checkboxes__input" data-js="multiselect-checkbox">
                                 <label for="cb{{ reportSubmission.id }}" class="govuk-label govuk-checkboxes__label">
                                     <span class="govuk-visually-hidden">
                                         Select {{ client.caseNumber }}

--- a/client/src/AppBundle/Resources/views/Layouts/admin_moj_template.html.twig
+++ b/client/src/AppBundle/Resources/views/Layouts/admin_moj_template.html.twig
@@ -2,13 +2,8 @@
 
 {% trans_default_domain "layout" %}
 
-{% if navSection is not defined %}
-    {% set navSection = '' %}
-{% endif %}
-
-
-{% macro navLink(path, labelKey, isSelected, classes = "text") -%}
-    <a href="{{ path(path) }}" class="moj-primary-navigation__link {{ classes }}" {% if isSelected %}aria-current="page"{% endif %}>
+{% macro navLink(path, labelKey, classes = "") -%}
+    <a href="{{ path(path) }}" class="moj-primary-navigation__link {{ classes }}" {% if app.request.get('_route') == path %}aria-current="page"{% endif %}>
         {{- labelKey | trans -}}
     </a>
 {%- endmacro %}

--- a/client/src/AppBundle/Resources/views/Layouts/admin_moj_template.html.twig
+++ b/client/src/AppBundle/Resources/views/Layouts/admin_moj_template.html.twig
@@ -2,8 +2,12 @@
 
 {% trans_default_domain "layout" %}
 
-{% macro navLink(path, labelKey, classes = "") -%}
-    <a href="{{ path(path) }}" class="moj-primary-navigation__link {{ classes }}" {% if app.request.get('_route') == path %}aria-current="page"{% endif %}>
+{% if navSection is not defined %}
+    {% set navSection = '' %}
+{% endif %}
+
+{% macro navLink(path, labelKey, isSelected, classes = "") -%}
+    <a href="{{ path(path) }}" class="moj-primary-navigation__link {{ classes }}" {% if isSelected %}aria-current="page"{% endif %}>
         {{- labelKey | trans -}}
     </a>
 {%- endmacro %}

--- a/client/src/AppBundle/Twig/ComponentsExtension.php
+++ b/client/src/AppBundle/Twig/ComponentsExtension.php
@@ -6,6 +6,7 @@ use AppBundle\Entity\User;
 use AppBundle\Service\ReportSectionsLinkService;
 use Symfony\Component\Translation\TranslatorInterface;
 use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 use Twig_Environment;
 
 class ComponentsExtension extends AbstractExtension
@@ -38,6 +39,9 @@ class ComponentsExtension extends AbstractExtension
             new \Twig_SimpleFunction('accordionLinks', [$this, 'renderAccordionLinks']),
             new \Twig_SimpleFunction('section_link_params', function ($report, $sectionId, $offset) {
                 return $this->reportSectionsLinkService->getSectionParams($report, $sectionId, $offset);
+            }),
+            new TwigFunction('class_const', function($className, $constant) {
+                return constant("$className::$constant");
             }),
         ];
     }

--- a/client/tests/phpunit/Controller/AdminReportSubmissionControllerTest.php
+++ b/client/tests/phpunit/Controller/AdminReportSubmissionControllerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace AppBundle\Controller;
+
+use AppBundle\Entity\Client;
+use AppBundle\Entity\Report\Document;
+use AppBundle\Entity\Report\Report;
+use AppBundle\Entity\Report\ReportSubmission;
+use AppBundle\Entity\User;
+use Prophecy\Argument;
+
+class AdminReportSubmissionControllerTest extends AbstractControllerTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->restClient
+            ->get(Argument::containingString('report-submission'), 'array')
+            ->willReturn([
+                'counts' => [
+                    'new' => 2,
+                    'pending' => 15,
+                    'archived' => 3827,
+                ],
+                'records' => ['placeholder']
+            ]);
+
+        $this->mockLoggedInUser(['ROLE_ADMIN']);
+    }
+
+    public function testIndexActionShowsInfo(): void
+    {
+        $this->restClient
+            ->arrayToEntities(ReportSubmission::class . '[]', ['placeholder'])
+            ->shouldBeCalled()
+            ->willReturn([
+                $this
+                    ->generateReportSubmission('48745952', 'Jonas', 'Ishibashi')
+                    ->setDocuments([
+                        $this->generateDocument('report.pdf'),
+                        $this->generateDocument('bill-scanned.jpg'),
+                    ]),
+            ]);
+
+        $crawler = $this->client->request('GET', '/admin/documents/list');
+
+        self::assertStringContainsString(2, $crawler->filter('.behat-link-tab-new + .govuk-tag')->text());
+        self::assertStringContainsString(15, $crawler->filter('.behat-link-tab-pending + .govuk-tag')->text());
+
+        $submissionRow = $crawler->filter('.behat-region-report-submission-1')->first();
+        self::assertStringContainsString('48745952', $submissionRow->text());
+        self::assertStringContainsString('Jonas Ishibashi', $submissionRow->text());
+
+        $documentsRow = $crawler->filter('.behat-region-report-submission-documents-1')->first();
+        self::assertStringContainsString('report.pdf', $documentsRow->text());
+        self::assertStringContainsString('bill-scanned.jpg', $documentsRow->text());
+    }
+
+    public function testIndexActionShowsSynchronisationStatus(): void
+    {
+        $this->restClient
+            ->arrayToEntities(ReportSubmission::class . '[]', ['placeholder'])
+            ->shouldBeCalled()
+            ->willReturn([
+                $this
+                    ->generateReportSubmission('72549273', 'Reynaldo', 'Noud')
+                    ->setDocuments([
+                        $this->generateDocument('ready-doc.pdf', Document::SYNC_STATUS_QUEUED),
+                        $this->generateDocument('in-progress-doc.pdf', Document::SYNC_STATUS_IN_PROGRESS),
+                        $this->generateDocument('complete-doc.pdf', Document::SYNC_STATUS_SUCCESS),
+                        $this->generateDocument('temp-error-doc.pdf', Document::SYNC_STATUS_TEMPORARY_ERROR)
+                            ->setSynchronisationError('S3 is unavailable'),
+                        $this->generateDocument('permanent-error-doc.pdf', Document::SYNC_STATUS_PERMANENT_ERROR)
+                            ->setSynchronisationError('Invalid file type application/json'),
+                    ]),
+            ]);
+
+        $crawler = $this->client->request('GET', '/admin/documents/list?status=pending');
+
+        $documentRows = $crawler->filter('.behat-region-report-submission-documents-1 table > tbody > tr');
+
+        self::assertStringContainsString('Queued', $documentRows->eq(0)->text());
+        self::assertStringContainsString('In progress', $documentRows->eq(1)->text());
+        self::assertStringContainsString('Success', $documentRows->eq(2)->text());
+        self::assertStringContainsString('Temporary fail', $documentRows->eq(3)->text());
+        self::assertStringContainsString('Error: S3 is unavailable', $documentRows->eq(3)->text());
+        self::assertStringContainsString('Permanent fail', $documentRows->eq(4)->text());
+        self::assertStringContainsString('Error: Invalid file type application/json', $documentRows->eq(4)->text());
+    }
+
+    public function testIndexActionShowsWhoArchivedBy(): void
+    {
+        $user = (new User())
+            ->setFirstname('Solomon')
+            ->setLastname('Pinedo');
+
+        $this->restClient
+            ->arrayToEntities(ReportSubmission::class . '[]', ['placeholder'])
+            ->shouldBeCalled()
+            ->willReturn([
+                $this
+                    ->generateReportSubmission('72549273', 'Reynaldo', 'Noud')
+                    ->setArchivedBy($user)
+            ]);
+
+        $crawler = $this->client->request('GET', '/admin/documents/list?status=archived');
+
+        $archivedBy = $crawler->filter('.behat-region-report-submission-1 td:last-child > span');
+
+        self::assertEquals('SP', $archivedBy->text());
+        self::assertEquals('Solomon Pinedo', $archivedBy->attr('title'));
+    }
+
+    private function generateReportSubmission(
+        string $caseNumber,
+        string $firstname,
+        string $lastname,
+        string $type = Report::TYPE_102
+    ): ReportSubmission
+    {
+        $client = (new Client())
+            ->setCaseNumber($caseNumber)
+            ->setFirstname($firstname)
+            ->setLastname($lastname);
+
+        $report = (new Report())
+            ->setType($type)
+            ->setClient($client);
+
+        return (new ReportSubmission())
+            ->setReport($report);
+    }
+
+    private function generateDocument(string $fileName, string $syncStatus = null)
+    {
+        $document = (new Document())
+            ->setFileName($fileName);
+
+        if (!is_null($syncStatus)) {
+            $document->setSynchronisationStatus($syncStatus);
+        }
+
+        return $document;
+    }
+}

--- a/environment/api_service.tf
+++ b/environment/api_service.tf
@@ -68,6 +68,7 @@ locals {
       "protocol": "tcp"
     }],
     "volumesFrom": [],
+    "stopTimeout": 60,
     "healthCheck": {
       "command": [
         "CMD-SHELL",


### PR DESCRIPTION
## Purpose
When we integrate with the API, we will automatically send documents to Sirius so that users don’t have to. However, users need to be aware of any failures or delay in the integration. Therefore, we will show on the documents page which documents/submissions have been synchronised, which are queued, and which have failed.

Fixes DDPB-3161

## Approach
Working back-to-front:

- Updated the `GET /report-submission` API endpoint to return a new subset of submissions called "pending". These are submissions which have _at least document_ whose sync status is not `null`. "New" submissions have all documents as `null`.
  - This makes the queries a bit more complex, but the performance impact is minimal because there are very few non-archived submissions
- Updated design of report submissions page to give more context/information to document status, per design
  - Tidied up some of the existing DOM/CSS/JavaScript
- Added new "detached-details" JavaScript module which allows you to have a [details](https://design-system.service.gov.uk/components/details/)-like component without using the markup that requires them to be side-by-side
- Created unit tests for the client controller, stealing code from DDPB-3204 which will cause merge conflicts somewhere down the line
- Updated Behat tests to match new markup
  - I haven't added Behat tests for the new tab because it's hard to recreate at this point without writing straight into the database

## Learning
I created a new `class_const` function in Twig which can be used to get a constant from a class. This let's you compare constant values without having to hard code them in Twig.

```
{% if document.syncStatus == class_const('AppBundle\\Entity\\Report\\Document', 'SYNC_STATUS_QUEUED') %}
```

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [x] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [x] There are no deprecated CSS classes noted in the profiler
- [x] Translations are used and the profiler doesn't identify any missing
