### PR TITLE
DDPB-3232: Update design for Notification page to new design layout

### DIFF
--- a/client/src/AppBundle/Resources/views/Admin/Client/Client/details.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Client/details.html.twig
@@ -3,6 +3,8 @@
 {% trans_default_domain "admin-clients" %}
 {% set page = 'clientDetails' %}
 
+{% set navSection = 'clients' %}
+
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 
 {% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}

--- a/client/src/AppBundle/Resources/views/Admin/Client/Search/search.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Search/search.html.twig
@@ -3,6 +3,8 @@
 {% trans_default_domain "admin-clients" %}
 {% set page = 'clientSearch' %}
 
+{% set navSection = 'clients' %}
+
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 

--- a/client/src/AppBundle/Resources/views/Admin/Index/addUser.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Index/addUser.html.twig
@@ -3,6 +3,8 @@
 {% trans_default_domain "admin" %}
 {% set page = 'addUser' %}
 
+{% set navSection = 'users' %}
+
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 {% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}

--- a/client/src/AppBundle/Resources/views/Admin/Index/editUser.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Index/editUser.html.twig
@@ -3,6 +3,8 @@
 {% trans_default_domain "admin" %}
 {% set page = 'editUser' %}
 
+{% set navSection = 'users' %}
+
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 {% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}

--- a/client/src/AppBundle/Resources/views/Admin/Index/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Index/index.html.twig
@@ -3,6 +3,8 @@
 {% trans_default_domain "admin" %}
 {% set page = 'home' %}
 
+{% set navSection = 'users' %}
+
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 

--- a/client/src/AppBundle/Resources/views/Admin/Index/upload.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Index/upload.html.twig
@@ -3,6 +3,8 @@
 {% trans_default_domain "admin" %}
 {% set page = 'upload' %}
 
+{% set navSection = 'users' %}
+
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 {% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}

--- a/client/src/AppBundle/Resources/views/Admin/Index/uploadOrgUsers.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Index/uploadOrgUsers.html.twig
@@ -3,6 +3,8 @@
 {% trans_default_domain "admin" %}
 {% set page = 'uploadPA' %}
 
+{% set navSection = 'users' %}
+
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 {% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}

--- a/client/src/AppBundle/Resources/views/Admin/Index/uploadUsers.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Index/uploadUsers.html.twig
@@ -3,6 +3,8 @@
 {% trans_default_domain "admin" %}
 {% set page = 'uploadUsers' %}
 
+{% set navSection = 'users' %}
+
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 {% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}

--- a/client/src/AppBundle/Resources/views/Admin/Organisation/add-user.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Organisation/add-user.html.twig
@@ -3,6 +3,7 @@
 
 {% trans_default_domain "admin-organisation-users" %}
 {% set page = 'addPage' %}
+{% set navSection = 'organisations' %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans({ '%organisation%': organisation.name }) }}{% endblock %}

--- a/client/src/AppBundle/Resources/views/Admin/Organisation/form.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Organisation/form.html.twig
@@ -8,6 +8,8 @@
     {% set page = 'addPage' %}
 {% endif %}
 
+{% set navSection = 'organisations' %}
+
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 

--- a/client/src/AppBundle/Resources/views/Admin/Organisation/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Organisation/index.html.twig
@@ -4,6 +4,8 @@
 {% trans_default_domain "admin-organisations" %}
 {% set page = 'indexPage' %}
 
+{% set navSection = 'organisations' %}
+
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 

--- a/client/src/AppBundle/Resources/views/Admin/Organisation/view.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Organisation/view.html.twig
@@ -4,6 +4,8 @@
 {% trans_default_domain "admin-organisations" %}
 {% set page = 'viewPage' %}
 
+{% set navSection = 'organisations' %}
+
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ organisation.name }}{% endblock %}
 

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/index.html.twig
@@ -3,6 +3,8 @@
 {% trans_default_domain "admin-documents" %}
 {% set transOptions = {} %}
 
+{% set navSection = 'submissions' %}
+
 {% set baseRoute = 'admin_documents' %}
 
 {% block htmlTitle %}{{ 'page.htmlTitle' | trans }}{% endblock %}

--- a/client/src/AppBundle/Resources/views/Admin/Setting/serviceNotification.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Setting/serviceNotification.html.twig
@@ -1,7 +1,8 @@
 {% extends 'AppBundle:Layouts:application.html.twig' %}
 
 {% trans_default_domain "admin-settings" %}
-{% set transOptions = {} %}
+
+{% set navSection = 'notifications' %}
 
 {% block htmlTitle %}{{ 'page.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'page.pageTitle' | trans }}{% endblock %}

--- a/client/src/AppBundle/Resources/views/Admin/Setting/serviceNotification.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Setting/serviceNotification.html.twig
@@ -21,7 +21,8 @@
                 }) }}
 
                 {{ form_checkbox_group(form.enabled, 'serviceNotifications.form.enabled', {
-                    'legendClass' : 'govuk-fieldset__legend--m'
+                    formGroupClass: 'govuk-radios--inline',
+                    legendClass: 'govuk-fieldset__legend--m',
                 }) }}
 
                 {{ form_submit(form.save, 'serviceNotifications.form.save', {'buttonClass': 'behat-link-save'}) }}

--- a/client/src/AppBundle/Resources/views/Admin/Stats/metrics.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Stats/metrics.html.twig
@@ -3,6 +3,8 @@
 {% trans_default_domain "admin-metrics" %}
 {% set page = 'indexPage' %}
 
+{% set navSection = 'metrics' %}
+
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 

--- a/client/src/AppBundle/Resources/views/Admin/Stats/stats.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Stats/stats.html.twig
@@ -3,6 +3,8 @@
 {% trans_default_domain "admin" %}
 {% set page = 'statsPage' %}
 
+{% set navSection = 'metrics' %}
+
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 {% block pageTitleClass %}heading-large{% endblock %}

--- a/client/src/AppBundle/Resources/views/Layouts/admin_moj_template.html.twig
+++ b/client/src/AppBundle/Resources/views/Layouts/admin_moj_template.html.twig
@@ -2,8 +2,13 @@
 
 {% trans_default_domain "layout" %}
 
-{% macro navLink(path, labelKey, classes = "text") -%}
-    <a href="{{ path(path) }}" class="moj-primary-navigation__link {{ classes }}" {% if app.request.get('_route') == path %}aria-current="page"{% endif %}>
+{% if navSection is not defined %}
+    {% set navSection = '' %}
+{% endif %}
+
+
+{% macro navLink(path, labelKey, isSelected, classes = "text") -%}
+    <a href="{{ path(path) }}" class="moj-primary-navigation__link {{ classes }}" {% if isSelected %}aria-current="page"{% endif %}>
         {{- labelKey | trans -}}
     </a>
 {%- endmacro %}
@@ -65,34 +70,54 @@
                 <ul class="moj-primary-navigation__list">
                     {% if is_granted('ROLE_ADMIN') %}
                         <li class="moj-primary-navigation__item">
-                            {{ _self.navLink('admin_homepage', 'nav.adminArea', 'behat-link-admin-homepage') }}
+                            {{ _self.navLink(
+                                'admin_homepage',
+                                'nav.adminArea',
+                                navSection == 'users',
+                                'behat-link-admin-homepage'
+                            ) }}
                         </li>
-
                         <li class="moj-primary-navigation__item">
-                            {{ _self.navLink('admin_client_search', 'nav.adminClients', 'behat-link-admin-client-search') }}
+                            {{ _self.navLink(
+                                'admin_client_search',
+                                'nav.adminClients',
+                                navSection == 'clients',
+                                'behat-link-admin-client-search'
+                            ) }}
                         </li>
-
                         <li class="moj-primary-navigation__item">
-                            {{ _self.navLink('admin_organisation_homepage', 'nav.adminOrganisations', 'behat-link-admin-organisations') }}
+                            {{ _self.navLink(
+                                'admin_organisation_homepage',
+                                'nav.adminOrganisations',
+                                navSection == 'organisations',
+                                'behat-link-admin-organisations'
+                            ) }}
                         </li>
-
                         <li class="moj-primary-navigation__item">
-                            {{ _self.navLink('admin_documents', 'nav.adminDocuments', 'behat-link-admin-documents') }}
+                            {{ _self.navLink(
+                                'admin_documents',
+                                'nav.adminDocuments',
+                                navSection == 'submissions',
+                                'behat-link-admin-documents'
+                            ) }}
                         </li>
-
                         <li class="moj-primary-navigation__item">
-                            {{ _self.navLink('admin_setting_service_notifications', 'nav.serviceNotification', 'behat-link-admin-settings') }}
+                            {{ _self.navLink(
+                                'admin_setting_service_notifications',
+                                'nav.serviceNotification',
+                                navSection == 'notifications',
+                                'behat-link-admin-settings'
+                            ) }}
                         </li>
-
                         <li class="moj-primary-navigation__item">
-                            {{ _self.navLink('admin_metrics', 'nav.adminStats') }}
+                            {{ _self.navLink('admin_metrics', 'nav.adminStats', navSection == 'metrics') }}
                         </li>
                     {% elseif is_granted('ROLE_AD') %}
                         <li class="moj-primary-navigation__item">
-                            {{ _self.navLink('ad_homepage', 'nav.adArea') }}
+                            {{ _self.navLink('ad_homepage', 'nav.adArea', navSection == 'ad') }}
                         </li>
                         <li class="moj-primary-navigation__item">
-                            {{ _self.navLink('admin_homepage', 'nav.adminArea') }}
+                            {{ _self.navLink('admin_homepage', 'nav.adminArea', navSection == 'users') }}
                         </li>
                     {% endif %}
                 </ul>


### PR DESCRIPTION
## Purpose
Update the service notification page to match the new design.

Fixes DDPB-3232

## Approach
I addressed most of this in #262, but I hadn't updated the layout of the radio buttons so this is fixed now.

I've also noticed that my "current page" approach on the nav in #262 didn't account for child pages. For example `/clients` would mark you as being on the "Clients" page, but `/clients/add` wouldn't. I replaced the calculation with an explicit `navSection` variable that each page can set to mark which element of the nav should be highlighted (if any). I updated all the major admin pages to set this variable.

## Learning
I was tempted to identify the nav page by globbing the URL (for example, and pages starting `/clients` would mark "Clients" as the current page), but I've had trouble with this before where URLs aren't consistent and are hard to change. For example, in DigiDeps, the users page is just `/` rather than `/users`.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work
  - N/A
- [x] The product team have approved these changes
