### PR TITLE
DDPB-3279: Remove the function for changing user email address and roles

### DIFF
--- a/behat/tests/features/UserManagement/editingUserDetails.feature
+++ b/behat/tests/features/UserManagement/editingUserDetails.feature
@@ -25,7 +25,6 @@ Feature: Editing Deputy and Client details
       | profile_addressCountry | GB |
       | profile_phoneMain | 07911111111111 |
       | profile_phoneAlternative | |
-      | profile_email | hena.mercia@test.com |
     When I fill in the following:
       | profile_firstname |  |
       | profile_lastname |  |
@@ -33,7 +32,6 @@ Feature: Editing Deputy and Client details
       | profile_addressPostcode | |
       | profile_addressCountry | |
       | profile_phoneMain |   |
-      | profile_email | |
     And I press "profile_save"
     Then the following fields should have an error:
       | profile_firstname |
@@ -42,7 +40,6 @@ Feature: Editing Deputy and Client details
       | profile_addressPostcode |
       | profile_addressCountry |
       | profile_phoneMain |
-      | profile_email |
     When I press "profile_save"
     Then the form should be invalid
     When I fill in the following:
@@ -53,9 +50,8 @@ Feature: Editing Deputy and Client details
       | profile_address3 | London |
       | profile_addressPostcode | SW1H 9AA |
       | profile_addressCountry | GB |
-      | profile_phoneMain | 020 3334 3556  |
-      | profile_phoneAlternative | 020 1234 5679  |
-      | profile_email | hena.mercia@test.com |
+      | profile_phoneMain | 020 3334 3556 |
+      | profile_phoneAlternative | 020 1234 5679 |
     And I press "profile_save"
     Then the form should be valid
 

--- a/behat/tests/features/deputy/04-user/04-user-edit.feature
+++ b/behat/tests/features/deputy/04-user/04-user-edit.feature
@@ -16,7 +16,6 @@ Feature: deputy / report / edit user
              | profile_addressCountry | GB |
              | profile_phoneMain | 07911111111111   |
              | profile_phoneAlternative | |
-             | profile_email | behat-lay-deputy-102@publicguardian.gov.uk |
         When I fill in the following:
             | profile_firstname |  |
             | profile_lastname |  |
@@ -24,7 +23,6 @@ Feature: deputy / report / edit user
             | profile_addressPostcode | |
             | profile_addressCountry | |
             | profile_phoneMain |   |
-            | profile_email | |
         And I press "profile_save"
         Then the following fields should have an error:
             | profile_firstname |
@@ -33,7 +31,6 @@ Feature: deputy / report / edit user
             | profile_addressPostcode |
             | profile_addressCountry |
             | profile_phoneMain |
-            | profile_email |
       And I press "profile_save"
         Then the form should be invalid
         When I fill in the following:
@@ -46,7 +43,6 @@ Feature: deputy / report / edit user
            | profile_addressCountry | GB |
            | profile_phoneMain | 020 3334 3556  |
            | profile_phoneAlternative | 020 1234 5679  |
-           | profile_email | behat-lay-deputy-102@publicguardian.gov.uk |
       And I press "profile_save"
         Then the form should be valid
         And I should be on "/deputyship-details/your-details"

--- a/behat/tests/features/pa/01-registration-steps/01-admin-add-pa-users-and-activate.feature
+++ b/behat/tests/features/pa/01-registration-steps/01-admin-add-pa-users-and-activate.feature
@@ -131,38 +131,12 @@ Feature: Add PA users and activate PA user (journey)
     When I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "user-behat-pa2publicguardiangovuk" in the "user-behat-pa2publicguardiangovuk" region
     Then the following fields should have the corresponding values:
-      | admin_email          | behat-pa2@publicguardian.gov.uk |
       | admin_firstname      | Pa User                         |
       | admin_lastname       | Two                             |
-      | admin_roleNameDeputy | ROLE_PA_NAMED                   |
     When I fill in the following:
-      | admin_email      | behat-pa2-edited@publicguardian.gov.uk |
       | admin_firstname  | Edited Pa User                             |
       | admin_lastname   | Edited Two                                 |
     And I press "admin_save"
     Then the form should be valid
     When I click on "admin_cancel"
-    Then I should not see the "user-behat-pa2publicguardiangovuk" region
-    And I should see "Edited Pa User Edited Two" in the "user-behat-pa2-editedpublicguardiangovuk" region
-    And I should see "behat-pa2-edited@publicguardian.gov.uk" in the "user-behat-pa2-editedpublicguardiangovuk" region
-    When I go to "/logout"
-    # try logging in with the new email
-    And I am logged in as "behat-pa2-edited@publicguardian.gov.uk" with password "Abcd1234"
-    Then I should see the "client-02200001" region
-
-  Scenario: Edit PA2 user email to an existing email
-    Given I load the application status from "pa-users-uploaded"
-    When I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    And I click on "user-behat-pa2publicguardiangovuk" in the "user-behat-pa2publicguardiangovuk" region
-    And I fill in the following:
-      | admin_email      | behat-pa3@publicguardian.gov.uk |
-      | admin_firstname  | Pa User                             |
-      | admin_lastname   | Three                               |
-    And I press "admin_save"
-    Then the following fields should have an error:
-      | admin_email |
-    When I click on "admin_cancel"
-    # edit did not occur due to re used email
-    Then I should see the "user-behat-pa2publicguardiangovuk" region
-    And I should see "Pa User Two" in the "user-behat-pa2publicguardiangovuk" region
-    And I should see "behat-pa2@publicguardian.gov.uk" in the "user-behat-pa2publicguardiangovuk" region
+    And I should see "Edited Pa User Edited Two" in the "user-behat-pa2publicguardiangovuk" region

--- a/behat/tests/features/pa/02-team/01-team-setup.feature
+++ b/behat/tests/features/pa/02-team/01-team-setup.feature
@@ -124,7 +124,6 @@ Feature: PA team setup
     Then the following fields should have the corresponding values:
       | team_member_account_firstname | Robert Team member                              |
       | team_member_account_lastname  | Black                                           |
-      | team_member_account_email     | behat-pa1-team-member@publicguardian.gov.uk |
       | team_member_account_jobTitle  | Solicitor helper                                |
       | team_member_account_phoneMain | 10000000003                                     |
     And I should not see a "team_member_account_roleName_0" element
@@ -132,7 +131,6 @@ Feature: PA team setup
     When I fill in the following:
       | team_member_account_firstname | Bobby Team member                               |
       | team_member_account_lastname  | BlackAndBlue                                    |
-      | team_member_account_email     | behat-pa1-team-member@publicguardian.gov.uk |
       | team_member_account_jobTitle  | Helper solicitor                                |
       | team_member_account_phoneMain | +4410000000003                                  |
     And I press "team_member_account_save"
@@ -256,35 +254,6 @@ Feature: PA team setup
     Then the form should be valid
     And I save the application status into "team-users-complete"
     And I should see the "client-02300001" region
-
-  Scenario: PA_ADMIN3 logs in and edits PA_TEAM_MEMBER using existing email address
-    Given I am logged in as "behat-pa3@publicguardian.gov.uk" with password "Abcd1234"
-    When I click on "org-settings, user-accounts"
-    # edit PA named
-    When I click on "edit" in the "team-user-behat-pa3-team-memberpublicguardiangovuk" region
-    And I fill in the following:
-      | team_member_account_firstname | Edited PA3                                |
-      | team_member_account_lastname  | Edited Team Member                        |
-      | team_member_account_email     | behat-pa3-admin@publicguardian.gov.uk |
-    And I press "team_member_account_save"
-    Then the following fields should have an error:
-      | team_member_account_email |
-
-  Scenario: PA_ADMIN3 logs in and edits PA_TEAM_MEMBER using existing email address for a deleted user
-    Given I am logged in as "behat-pa3@publicguardian.gov.uk" with password "Abcd1234"
-    When I click on "org-settings, user-accounts"
-    # delete existing admin user
-    And I click on "delete" in the "team-user-behat-pa3-adminpublicguardiangovuk" region
-    And I click on "confirm"
-    # edit PA named
-    When I click on "edit" in the "team-user-behat-pa3-team-memberpublicguardiangovuk" region
-    And I fill in the following:
-      | team_member_account_firstname | Edited PA3                                |
-      | team_member_account_lastname  | Edited Team Member                        |
-      | team_member_account_email     | behat-pa3-admin@publicguardian.gov.uk |
-    And I press "team_member_account_save"
-    Then the form should be valid
-    And I should see "behat-pa3-admin@publicguardian.gov.uk" in the "team-user-behat-pa3-adminpublicguardiangovuk" region
 
   Scenario: PA_ADMIN3 logs in and adds PA_TEAM_MEMBER using existing email address
     Given I load the application status from "team-users-complete"

--- a/behat/tests/features/pa/04-dashboard-client-profile/13-settings.feature
+++ b/behat/tests/features/pa/04-dashboard-client-profile/13-settings.feature
@@ -23,7 +23,6 @@ Feature: PA settings
     Then I fill in the following:
       | profile_firstname  | John Named Chap                       |
       | profile_lastname   | Greenish                              |
-      | profile_email      | behat-pa1@publicguardian.gov.uk   |
       | profile_jobTitle   | Solicitor General                     |
       | profile_phoneMain  | 10000000011                           |
       | profile_address1         | 123 Streetname |
@@ -46,7 +45,6 @@ Feature: PA settings
     Then I fill in the following:
       | profile_firstname  | Mark Admin Chap                           |
       | profile_lastname   | Yellowish                                 |
-      | profile_email      | behat-pa1-admin@publicguardian.gov.uk |
       | profile_jobTitle   | Solicitor Assistant                       |
       | profile_phoneMain  | 10000000012                               |
     And I press "profile_save"
@@ -79,18 +77,15 @@ Feature: PA settings
     When I fill in the following:
       | profile_firstname  |                                                 |
       | profile_lastname   |                                                 |
-      | profile_email      |                                                 |
       | profile_jobTitle   |                                                 |
       | profile_phoneMain  |                                                 |
     And I press "profile_save"
     Then the following fields should have an error:
       | profile_firstname        |
       | profile_lastname         |
-      | profile_email            |
     When I fill in the following:
       | profile_firstname        | Tim Team Member                                 |
       | profile_lastname         | Chap                                            |
-      | profile_email            | behat-pa3-team-member@publicguardian.gov.uk |
       | profile_jobTitle         | Solicitor helper                                |
       | profile_phoneMain        | 30000000123                                     |
       | profile_address1         | 123 SomeRoad                                    |
@@ -168,12 +163,3 @@ Feature: PA settings
     Then the form should be valid
     And the url should match "/login"
     And I should see "Sign in with your new password"
-
-  Scenario: Named PA logs in and changes email to an existing one (expected error)
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd2345"
-    When I click on "org-settings, profile-show, profile-edit"
-    When I fill in the following:
-      | profile_email       | behat-pa2@publicguardian.gov.uk  |
-    And I press "profile_save"
-    Then the following fields should have an error:
-      | profile_email  |

--- a/behat/tests/features/prof/01-registration-steps/01-admin-add-pa-users-and-activate.feature
+++ b/behat/tests/features/prof/01-registration-steps/01-admin-add-pa-users-and-activate.feature
@@ -178,38 +178,12 @@ Feature: Add PROF users and activate PROF user (journey)
     When I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "user-behat-prof2publicguardiangovuk" in the "user-behat-prof2publicguardiangovuk" region
     Then the following fields should have the corresponding values:
-      | admin_email          | behat-prof2@publicguardian.gov.uk |
       | admin_firstname      | Pa User                           |
       | admin_lastname       | Two                               |
-      | admin_roleNameDeputy | ROLE_PROF_NAMED                   |
     When I fill in the following:
-      | admin_email      | behat-prof2-edited@publicguardian.gov.uk |
       | admin_firstname  | Edited Pa User                             |
       | admin_lastname   | Edited Two                                 |
     And I press "admin_save"
     Then the form should be valid
     When I click on "admin_cancel"
-    Then I should not see the "user-behat-prof2publicguardiangovuk" region
-    And I should see "Edited Pa User Edited Two" in the "user-behat-prof2-editedpublicguardiangovuk" region
-    And I should see "behat-prof2-edited@publicguardian.gov.uk" in the "user-behat-prof2-editedpublicguardiangovuk" region
-    When I go to "/logout"
-    # try logging in with the new email
-    And I am logged in as "behat-prof2-edited@publicguardian.gov.uk" with password "Abcd1234"
-    Then I should see the "client-32000001" region
-
-  Scenario: Edit PROF2 user email to an existing email
-    Given I load the application status from "prof-users-uploaded"
-    When I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    And I click on "user-behat-prof2publicguardiangovuk" in the "user-behat-prof2publicguardiangovuk" region
-    And I fill in the following:
-      | admin_email      | behat-prof3@publicguardian.gov.uk |
-      | admin_firstname  | Pa User                             |
-      | admin_lastname   | Three                               |
-    And I press "admin_save"
-    Then the following fields should have an error:
-      | admin_email |
-    When I click on "admin_cancel"
-    # edit did not occur due to re used email
-    Then I should see the "user-behat-prof2publicguardiangovuk" region
-    And I should see "Pa User Two" in the "user-behat-prof2publicguardiangovuk" region
-    And I should see "behat-prof2@publicguardian.gov.uk" in the "user-behat-prof2publicguardiangovuk" region
+    And I should see "Edited Pa User Edited Two" in the "user-behat-prof2publicguardiangovuk" region

--- a/behat/tests/features/prof/02-team/01-team-setup.feature
+++ b/behat/tests/features/prof/02-team/01-team-setup.feature
@@ -124,7 +124,6 @@ Feature: PROF team setup
     Then the following fields should have the corresponding values:
       | team_member_account_firstname | Robert Team member                              |
       | team_member_account_lastname  | Black                                           |
-      | team_member_account_email     | behat-prof1-team-member@publicguardian.gov.uk |
       | team_member_account_jobTitle  | Solicitor helper                                |
       | team_member_account_phoneMain | 10000000003                                     |
     And I should not see a "team_member_account_roleName_0" element
@@ -132,7 +131,6 @@ Feature: PROF team setup
     When I fill in the following:
       | team_member_account_firstname | Bobby Team member                               |
       | team_member_account_lastname  | BlackAndBlue                                    |
-      | team_member_account_email     | behat-prof1-team-member@publicguardian.gov.uk |
       | team_member_account_jobTitle  | Helper solicitor                                |
       | team_member_account_phoneMain | +4410000000003                                  |
     And I press "team_member_account_save"
@@ -256,32 +254,3 @@ Feature: PROF team setup
     Then the form should be valid
     And I save the application status into "prof-team-users-complete"
     And I should see the "client-33000001" region
-
-  Scenario: PROF_ADMIN3 logs in and edits PROF_TEAM_MEMBER using existing email address
-    Given I am logged in as "behat-prof3@publicguardian.gov.uk" with password "Abcd1234"
-    When I click on "org-settings, user-accounts"
-    # edit PROF named
-    When I click on "edit" in the "team-user-behat-prof3-team-memberpublicguardiangovuk" region
-    And I fill in the following:
-      | team_member_account_firstname | Edited PROF3                                |
-      | team_member_account_lastname  | Edited Team Member                        |
-      | team_member_account_email     | behat-prof3-admin@publicguardian.gov.uk |
-    And I press "team_member_account_save"
-    Then the following fields should have an error:
-      | team_member_account_email |
-
-  Scenario: PROF_ADMIN3 logs in and edits PROF_TEAM_MEMBER using existing email address for a deleted user
-    Given I am logged in as "behat-prof3@publicguardian.gov.uk" with password "Abcd1234"
-    When I click on "org-settings, user-accounts"
-    # delete existing admin user
-    And I click on "delete" in the "team-user-behat-prof3-adminpublicguardiangovuk" region
-    And I click on "confirm"
-    # edit PROF named
-    When I click on "edit" in the "team-user-behat-prof3-team-memberpublicguardiangovuk" region
-    And I fill in the following:
-      | team_member_account_firstname | Edited PROF3                                |
-      | team_member_account_lastname  | Edited Team Member                        |
-      | team_member_account_email     | behat-prof3-admin@publicguardian.gov.uk |
-    And I press "team_member_account_save"
-    Then the form should be valid
-    And I should see "behat-prof3-admin@publicguardian.gov.uk" in the "team-user-behat-prof3-adminpublicguardiangovuk" region

--- a/behat/tests/features/prof/04-dashboard-client-profile/13-settings.feature
+++ b/behat/tests/features/prof/04-dashboard-client-profile/13-settings.feature
@@ -24,7 +24,6 @@ Feature: PROF settings
     Then I fill in the following:
       | profile_firstname  | John Named Chap                       |
       | profile_lastname   | Greenish                              |
-      | profile_email      | behat-prof1@publicguardian.gov.uk   |
       | profile_jobTitle   | Solicitor General                     |
       | profile_phoneMain  | 10000000011                           |
       | profile_address1         | 123 Streetname |
@@ -47,7 +46,6 @@ Feature: PROF settings
     Then I fill in the following:
       | profile_firstname  | Mark Admin Chap                           |
       | profile_lastname   | Yellowish                                 |
-      | profile_email      | behat-prof1-admin@publicguardian.gov.uk |
       | profile_jobTitle   | Solicitor Assistant                       |
       | profile_phoneMain  | 10000000012                               |
     And I press "profile_save"
@@ -80,18 +78,15 @@ Feature: PROF settings
     When I fill in the following:
       | profile_firstname  |                                                 |
       | profile_lastname   |                                                 |
-      | profile_email      |                                                 |
       | profile_jobTitle   |                                                 |
       | profile_phoneMain  |                                                 |
     And I press "profile_save"
     Then the following fields should have an error:
       | profile_firstname        |
       | profile_lastname         |
-      | profile_email            |
     When I fill in the following:
       | profile_firstname        | Tim Team Member                                 |
       | profile_lastname         | Chap                                            |
-      | profile_email            | behat-prof3-team-member@publicguardian.gov.uk |
       | profile_jobTitle         | Solicitor helper                                |
       | profile_phoneMain        | 30000000123                                     |
       | profile_address1         | 123 SomeRoad                                    |

--- a/client/src/AppBundle/Controller/Admin/IndexController.php
+++ b/client/src/AppBundle/Controller/Admin/IndexController.php
@@ -159,7 +159,7 @@ class IndexController extends AbstractController
             ]);
         }
 
-        $form = $this->createForm(FormDir\Admin\AddUserType::class, $user);
+        $form = $this->createForm(FormDir\Admin\EditUserType::class, $user);
         $form->handleRequest($request);
 
         if ($form->isValid()) {

--- a/client/src/AppBundle/Form/Admin/EditUserType.php
+++ b/client/src/AppBundle/Form/Admin/EditUserType.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace AppBundle\Form\Admin;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type as FormTypes;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class EditUserType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('firstname', FormTypes\TextType::class)
+            ->add('lastname', FormTypes\TextType::class)
+            ->add('addressPostcode', FormTypes\TextType::class)
+            ->add('save', FormTypes\SubmitType::class);
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
+            $user = $event->getData();
+            $form = $event->getForm();
+
+            if ($user->isLayDeputy()) {
+                $form->add('ndrEnabled', FormTypes\CheckboxType::class);
+            }
+        });
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'translation_domain' => 'admin',
+            'validation_groups' => ['admin_add_user'],
+        ]);
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'admin';
+    }
+}

--- a/client/src/AppBundle/Form/Org/OrganisationMemberType.php
+++ b/client/src/AppBundle/Form/Org/OrganisationMemberType.php
@@ -8,6 +8,8 @@ use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type as FormTypes;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints;
 
@@ -30,12 +32,6 @@ class OrganisationMemberType extends AbstractType
                     new Constraints\NotBlank(['message' => 'user.lastname.notBlankOtherUser']),
                 ]
             ])
-            ->add('email', FormTypes\TextType::class, [
-                'required' => true,
-                'constraints' => [
-                    new Email(),
-                ]
-            ])
             ->add('jobTitle', FormTypes\TextType::class, ['required' => !empty($targetUser)])
             ->add('phoneMain', FormTypes\TextType::class, ['required' => !empty($targetUser)])
             ->add('roleName', FormTypes\ChoiceType::class, [
@@ -50,6 +46,20 @@ class OrganisationMemberType extends AbstractType
                     new Constraints\NotBlank(['message' => 'user.role.notBlankPa']),
                 ]
             ]);
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
+            $user = $event->getData();
+            $form = $event->getForm();
+
+            if (!$user || null === $user->getId()) {
+                $form->add('email', FormTypes\TextType::class, [
+                    'required' => true,
+                    'constraints' => [
+                        new Email(),
+                    ]
+                ]);
+            }
+        });
 
         $builder->add('save', FormTypes\SubmitType::class);
     }

--- a/client/src/AppBundle/Form/Org/TeamMemberAccountType.php
+++ b/client/src/AppBundle/Form/Org/TeamMemberAccountType.php
@@ -7,6 +7,8 @@ use AppBundle\Entity\User;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type as FormTypes;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -24,9 +26,6 @@ class TeamMemberAccountType extends AbstractType
         $builder
             ->add('firstname', FormTypes\TextType::class, ['required' => true])
             ->add('lastname', FormTypes\TextType::class, ['required' => true])
-            ->add('email', FormTypes\TextType::class, [
-                'required' => true
-            ])
             ->add('jobTitle', FormTypes\TextType::class, ['required' => !empty($targetUser)])
             ->add('phoneMain', FormTypes\TextType::class, ['required' => !empty($targetUser)]);
 
@@ -47,6 +46,18 @@ class TeamMemberAccountType extends AbstractType
                 ]);
             }
         }
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
+            $user = $event->getData();
+            $form = $event->getForm();
+
+            if (!$user || null === $user->getId()) {
+                $form->add('email', FormTypes\TextType::class, [
+                    'required' => true
+                ]);
+            }
+        });
+
         $builder->add('save', FormTypes\SubmitType::class);
     }
 

--- a/client/src/AppBundle/Form/Settings/ProfileType.php
+++ b/client/src/AppBundle/Form/Settings/ProfileType.php
@@ -28,8 +28,7 @@ class ProfileType extends AbstractType
             ->add('addressPostcode', FormTypes\TextType::class)
             ->add('addressCountry', FormTypes\CountryType::class, ['preferred_choices' => ['', 'GB'], 'placeholder' => 'Please select ...',])
             ->add('phoneMain', FormTypes\TextType::class, ['required' => true])
-            ->add('phoneAlternative', FormTypes\TextType::class)
-            ->add('email', FormTypes\TextType::class, ['required' => true]);
+            ->add('phoneAlternative', FormTypes\TextType::class);
 
         if ($loggedInUser->isDeputyOrg()) {
             $builder->add('jobTitle', FormTypes\TextType::class, ['required' => true]);
@@ -37,8 +36,8 @@ class ProfileType extends AbstractType
 
         if ($loggedInUser->isOrgAdministrator()) {
             $builder->add('removeAdmin', FormTypes\CheckboxType::class, [
-                    'mapped' => false
-                ]);
+                'mapped' => false
+            ]);
         }
 
         $builder->add('save', FormTypes\SubmitType::class);

--- a/client/src/AppBundle/Resources/views/Admin/Index/editUser.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Index/editUser.html.twig
@@ -20,28 +20,13 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-
-    {{ form_input(form.email,'addUserForm.email') }}
     {{ form_input(form.firstname,'addUserForm.firstname') }}
     {{ form_input(form.lastname,'addUserForm.lastname') }}
     {{ form_input(form.addressPostcode,'addUserForm.addressPostcode', {inputClass: 'govuk-!-width-one-third'}) }}
 
-    {% set deputyRole %}
-        {{ form_select(form.roleNameDeputy,'addUserForm.roleNameDeputy') }}
+    {% if 'ROLE_LAY_DEPUTY' == user.roleName %}
         {{ form_checkbox(form.ndrEnabled, 'addUserForm.ndrEnabled') }}
-    {% endset %}
-
-    {% set adminRole %}
-        {{ form_select(form.roleNameStaff,'addUserForm.roleNameStaff') }}
-    {%  endset %}
-
-    {{ form_checkbox_group(form.roleType, 'addUserForm.roleType', {
-        disabled: true,
-        items: [
-            { conditional: deputyRole },
-            { conditional: adminRole },
-        ]
-    }) }}
+    {% endif %}
 
     {% if 'ROLE_LAY_DEPUTY' == user.roleName and reportsCount > 0 %}
         <p class="text">{{ 'editUserForm.reportsExist' | trans }}</p>

--- a/client/src/AppBundle/Resources/views/Org/Organisation/edit.html.twig
+++ b/client/src/AppBundle/Resources/views/Org/Organisation/edit.html.twig
@@ -27,7 +27,6 @@
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
     {{ form_input(form.firstname,'form.firstname') }}
     {{ form_input(form.lastname,'form.lastname') }}
-    {{ form_input(form.email,'form.email') }}
     {{ form_input(form.jobTitle, 'form.jobTitle') }}
     {{ form_input(form.phoneMain,'form.phoneMain') }}
     {{ form_checkbox_group(form.roleName, 'form.roleName', {}) }}

--- a/client/src/AppBundle/Resources/views/Org/Team/edit.html.twig
+++ b/client/src/AppBundle/Resources/views/Org/Team/edit.html.twig
@@ -28,7 +28,6 @@
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
     {{ form_input(form.firstname,'form.firstname') }}
     {{ form_input(form.lastname,'form.lastname') }}
-    {{ form_input(form.email,'form.email') }}
     {{ form_input(form.jobTitle, 'form.jobTitle') }}
     {{ form_input(form.phoneMain,'form.phoneMain') }}
 

--- a/docs/architecture/decisions/0004-user-emails-and-roles-are-immutable.md
+++ b/docs/architecture/decisions/0004-user-emails-and-roles-are-immutable.md
@@ -1,0 +1,25 @@
+# 4. User emails and roles are immutable
+
+Date: 2020-03-23
+
+## Status
+
+Accepted
+
+## Context
+
+Due to the freedom given to users and admins in changing a user's email address or role, we've had issues identifying why people have certain permissions in DigiDeps. As well as being confusing, we believe this has led to security issues where a high-authority user has had their email changed in an attempt to reuse the account, thereby granting unreasonable access to the owner of the new email address.
+
+There are rarely good reasons to change a user's email address or role. Because very little in DigiDeps belongs directly to a user, these situtations can be resolved by deleting the original account and creating a new one with the correct permissions.
+
+## Decision
+
+User email addresses and roles will henceforth be immutable: they are set when a new user is created and cannot subsequently be changed.
+
+There is one exception to this: organisation administrators will be able to switch users between team member and admin roles. This role switch is entirely internal to the organisation and doesn't affect any view/edit permissions to clients and reports.
+
+## Consequences
+
+This decision will prevent user accounts' permissions from being changed, ensuring they cannot access clients they shouldn't. It will also ensure that we can identify an account and trust its ownership/permissions have not been different throughout its history.
+
+This decision will make the process of deputies changing email address more difficult, since the address can no longer be edited in-place. However, organisations can still self-serve to invite the new email address (and delete the old one), and lay deputies can ask the helpdesk to delete their old account so they can register the new one.


### PR DESCRIPTION
## Purpose
As the OPG we want to ensure security on out products and remove the potential risks of users sharing information they shouldn't with others who are not suitable to view client and other deputy data 

We've had some recent concerns (and a security incident) which highlight the dangers of allowing users to freely change their account email addresses. Amongst other things, a high-authority user account can easily be given to a low-authority user by setting it to an email address they control.

Similarly, it's too easy to move a user account between realms (e.g. prof/PA/lay/admin) despite there being no good reason to do so and the realms being completely separate.

Fixes DDPB-3279

## Approach
I removed the email and role fields from all places where it's available:

- "Edit user" in the admin panel
- "Edit my details" for all users
- "Edit team member" for team admins
- "Edit organisation member" for organisation admins

Both fields are still available when creating new users through these methods (where suitable). Also, team and organisation admins can still switch users between admin and team member roles since this is wholly internal.

I removed any tests which used these fields and wrote an ADR to record this decision.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - Added an ADR
- [x] I have added tests to prove my work
  - N/A, but I've removed some which are no longer relevant
- [ ] The product team have approved these changes