### PR TITLE
DDBP-3287: Check report type to identify PA reports

### DIFF
--- a/api/src/AppBundle/Entity/Repository/ReportRepository.php
+++ b/api/src/AppBundle/Entity/Repository/ReportRepository.php
@@ -58,12 +58,7 @@ class ReportRepository extends EntityRepository
      */
     public function addFeesToReportIfMissing(Report $report)
     {
-        // do not add if there are no PAs associated to this client
-        $isPaF = function ($user) {
-            return $user->isPaDeputy();
-        };
-
-        if (0 === $report->getClient()->getUsers()->filter($isPaF)->count()) {
+        if (!$report->isPAreport()) {
             return null;
         }
 

--- a/api/tests/AppBundle/ControllerReport/ReportControllerTest.php
+++ b/api/tests/AppBundle/ControllerReport/ReportControllerTest.php
@@ -73,11 +73,11 @@ class ReportControllerTest extends AbstractTestController
         // pa 1
         self::$pa1 = self::fixtures()->getRepo('User')->findOneByEmail('pa@example.org');
         self::$pa1Client1 = self::fixtures()->createClient(self::$pa1, ['setFirstname' => 'pa1Client1', 'setCaseNumber' => '11111111']);
-        self::$pa1Client1Report1 = self::fixtures()->createReport(self::$pa1Client1);
+        self::$pa1Client1Report1 = self::fixtures()->createReport(self::$pa1Client1, ['setType' => Report::TYPE_102_6]);
         self::$pa1Client2 = self::fixtures()->createClient(self::$pa1, ['setFirstname' => 'pa1Client2', 'setCaseNumber' => '22222222']);
-        self::$pa1Client2Report1 = self::fixtures()->createReport(self::$pa1Client2);
+        self::$pa1Client2Report1 = self::fixtures()->createReport(self::$pa1Client2, ['setType' => Report::TYPE_102_6]);
         self::$pa1Client3 = self::fixtures()->createClient(self::$pa1, ['setFirstname' => 'pa1Client3', 'setCaseNumber' => '33333333']);
-        self::$pa1Client3Report1 = self::fixtures()->createReport(self::$pa1Client3);
+        self::$pa1Client3Report1 = self::fixtures()->createReport(self::$pa1Client3, ['setType' => Report::TYPE_102_6]);
 
         // pa 2
         self::$pa2Admin = self::fixtures()->getRepo('User')->findOneByEmail('pa_admin@example.org');

--- a/api/tests/AppBundle/Entity/Repository/ReportRepositoryTest.php
+++ b/api/tests/AppBundle/Entity/Repository/ReportRepositoryTest.php
@@ -61,10 +61,7 @@ class ReportRepositoryTest extends WebTestCase
     public function testAddFeesToReportIfMissingForNonPAUser()
     {
 
-        $mockUser = m::mock(User::class);
-        $mockUser->shouldReceive('isPaDeputy')->andReturn(false);
-
-        $this->mockClient->shouldReceive('getUsers')->andReturn(new ArrayCollection([$mockUser]));
+        $this->mockReport->shouldReceive('isPAReport')->andReturn(false);
 
         $this->assertNull($this->sut->addFeesToReportIfMissing($this->mockReport));
     }
@@ -76,10 +73,8 @@ class ReportRepositoryTest extends WebTestCase
         $this->mockReport->shouldReceive('addFee')->times(count(Fee::$feeTypeIds))->andReturnSelf();
 
         $this->mockEm->shouldReceive('persist')->times(count(Fee::$feeTypeIds));
-        $mockUser = m::mock(User::class);
-        $mockUser->shouldReceive('isPaDeputy')->andReturn(true);
 
-        $this->mockClient->shouldReceive('getUsers')->andReturn(new ArrayCollection([$mockUser]));
+        $this->mockReport->shouldReceive('isPAReport')->andReturn(true);
 
         $this->assertEquals(7, $this->sut->addFeesToReportIfMissing($this->mockReport));
     }
@@ -92,10 +87,7 @@ class ReportRepositoryTest extends WebTestCase
 
         $this->mockEm->shouldReceive('persist')->never();
 
-        $mockUser = m::mock(User::class);
-        $mockUser->shouldReceive('isPaDeputy')->andReturn(true);
-
-        $this->mockClient->shouldReceive('getUsers')->andReturn(new ArrayCollection([$mockUser]));
+        $this->mockReport->shouldReceive('isPAReport')->andReturn(true);
 
         $this->assertEquals(0, $this->sut->addFeesToReportIfMissing($this->mockReport));
     }


### PR DESCRIPTION
## Purpose
In the "PA fees and expenses" section, we don't add any `Fee` records unless the user selects that they have fees to add. The function that adds the records additionally checks that the user has a named PA deputy in the `deputy_case` table. However, this is no longer always the case with the advent of organisations.

Fixes DDPB-3287

## Approach
Used the `Report::isPaReport` method to check whether a report is a PA one.

## Learning
We could've caught this from tests, but because we still support teams (and moreso because our tests are still based around them) we currently don't have test cases with pure organisations.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
  - N/A right now, might add end-to-end tests with a pure org in the future
- [x] The product team have approved these changes
