### PR TITLE
DDPB-2900: Update supporting documents content

### DIFF
--- a/client/src/AppBundle/Resources/translations/report-documents.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-documents.en.yml
@@ -59,9 +59,6 @@ stepPage:
   htmlTitle: "Deputy report - suporting documents | GOV.UK"
   pageTitle: Supporting documents
   backLink: Back
-  form:
-    wishToUploadDocumentation:
-        label: Would you like to provide any supporting documents?
 
 summaryPage:
   htmlTitle: "Deputy report - supporting documents | GOV.UK"

--- a/client/src/AppBundle/Resources/translations/report-documents.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-documents.en.yml
@@ -59,6 +59,9 @@ stepPage:
   htmlTitle: "Deputy report - suporting documents | GOV.UK"
   pageTitle: Supporting documents
   backLink: Back
+  form:
+      wishToUploadDocumentation:
+          label: Would you like to provide any supporting documents?
 
 summaryPage:
   htmlTitle: "Deputy report - supporting documents | GOV.UK"

--- a/client/src/AppBundle/Resources/translations/report-documents.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-documents.en.yml
@@ -2,7 +2,7 @@ htmlTitle: Supporting documents | GOV.UK
 pageTitle: Supporting documents
 
 form:
-  submitButton: Upload files and attach documents
+  submitButton: Upload
   file:
     label: Attach a file
     hint: ""
@@ -22,12 +22,14 @@ removeDocument:
   linkButtonLabel: Yes, remove document
 
 attachPage:
-  pageTitle: Attach documents
+  pageTitle: Upload documents
   supportingDocuments: Supporting documents
+  step1Heading: Would you like to provide any supporting documents?
   selectHeading: 1. Select the files
   selectHelp: Please select 'Choose files' below to find your files.
-  selectHint: Currently we only accept PDF, JPG and PNG files, and they can't be larger than 15mb.
-  uploadHeading: 2. Upload the files
+  selectHint1: You only need to upload documents if we have asked you to.
+  selectHint2: You can only upload PDF, JPG or PNG files, and they must be smaller than 15MB.
+  uploadHeading: 2. Upload the files to your report
   noDocuments: No documents
   documentList: Attached documents
   documentListPrevious: Previously submitted documents

--- a/client/src/AppBundle/Resources/views/Report/Document/step1.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Document/step1.html.twig
@@ -20,12 +20,13 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <h2 class="heading-medium">{{ (page ~ '.step1Heading') | trans }}</h2>
+    <h2 class="govuk-heading-m">{{ (page ~ '.step1Heading') | trans }}</h2>
 
     <div class="govuk-inset-text">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
                 {{ (page ~ '.selectHint1') | trans }}
+                <br>
                 <p>{{ (page ~ '.selectHint2') | trans }}</p>
             </div>
         </div>
@@ -37,7 +38,7 @@
                 {{ form_checkbox_group(form.wishToProvideDocumentation, 'form.wishToProvideDocumentation', {
                     'useFormGroup': false,
                     'fieldSetClass' : 'inline',
-                    'legendClass' : 'form-label-bold'
+                    'legendClass' : 'govuk-fieldset__legend--m'
                 }) }}
             </div>
         </div>

--- a/client/src/AppBundle/Resources/views/Report/Document/step1.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Document/step1.html.twig
@@ -27,7 +27,7 @@
             <div class="govuk-grid-column-two-thirds">
                 {{ (page ~ '.selectHint1') | trans }}
                 <br>
-                <p>{{ (page ~ '.selectHint2') | trans }}</p>
+                {{ (page ~ '.selectHint2') | trans }}
             </div>
         </div>
     </div>

--- a/client/src/AppBundle/Resources/views/Report/Document/step1.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Document/step1.html.twig
@@ -3,6 +3,8 @@
 {% import 'AppBundle:Macros:macros.html.twig' as macros %}
 
 {% set translationDomain = "report-documents" %}
+{% set page = "attachPage" %}
+
 {% trans_default_domain translationDomain %}
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
@@ -18,16 +20,25 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
+    <h2 class="heading-medium">{{ (page ~ '.step1Heading') | trans }}</h2>
+
+    <div class="govuk-inset-text">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                {{ (page ~ '.selectHint1') | trans }}
+                <p>{{ (page ~ '.selectHint2') | trans }}</p>
+            </div>
+        </div>
+    </div>
+
     {% if step == 1 %}
         <div class="form-section push--bottom">
             <div class="form-group flush--bottom {% if not form.wishToProvideDocumentation.vars.valid %}form-group-error{% endif %}">
                 {{ form_checkbox_group(form.wishToProvideDocumentation, 'form.wishToProvideDocumentation', {
                     'useFormGroup': false,
                     'fieldSetClass' : 'inline',
-                    'legendClass' : 'form-label-bold',
-                    'legendText' : 'stepPage.form.wishToUploadDocumentation.label' | trans(transOptions, translationDomain),
+                    'legendClass' : 'form-label-bold'
                 }) }}
-
             </div>
         </div>
 
@@ -38,4 +49,3 @@
     {{ form_end(form) }}
 
 {% endblock %}
-

--- a/client/src/AppBundle/Resources/views/Report/Document/step2.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Document/step2.html.twig
@@ -31,7 +31,7 @@
             <div class="govuk-grid-column-two-thirds">
                 <strong>{{ (page ~ '.selectHint1') | trans }}</strong>
                 <br>
-                <p>{{ (page ~ '.selectHint2') | trans }}</p>
+                {{ (page ~ '.selectHint2') | trans }}
              </div>
         </div>
     </div>

--- a/client/src/AppBundle/Resources/views/Report/Document/step2.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Document/step2.html.twig
@@ -29,7 +29,8 @@
     <div class="govuk-inset-text">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-                <b>{{ (page ~ '.selectHint1') | trans }}</b>
+                <strong>{{ (page ~ '.selectHint1') | trans }}</strong>
+                <br>
                 <p>{{ (page ~ '.selectHint2') | trans }}</p>
              </div>
         </div>

--- a/client/src/AppBundle/Resources/views/Report/Document/step2.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Document/step2.html.twig
@@ -24,9 +24,15 @@
 
     <h2 class="heading-medium">{{ (page ~ '.selectHeading') | trans }}</h2>
 
-    <div class="text">
-        <p>{{ (page ~ '.selectHelp') | trans }}</p>
-        <p>{{ (page ~ '.selectHint') | trans }}</p>
+    <p>{{ (page ~ '.selectHelp') | trans }}</p>
+
+    <div class="govuk-inset-text">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <b>{{ (page ~ '.selectHint1') | trans }}</b>
+                <p>{{ (page ~ '.selectHint2') | trans }}</p>
+             </div>
+        </div>
     </div>
 
     {{ form_start(form, {'attr': {'id': 'upload_form', 'class': 'push-double--bottom'}}) }}


### PR DESCRIPTION
## Purpose
Adds an inset hint advising deputy that they only need to provide supporting docs if requested to and some minor wording changes.

Fixes DDPB-2900.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [x] Translations are used and the profiler doesn't identify any missing
