### PR TITLE
DDPB-3293: Fix YAML configuration in preparation for Symfony 4

### DIFF
--- a/client/app/config/services_mail.yml
+++ b/client/app/config/services_mail.yml
@@ -18,7 +18,7 @@ services:
 
     AppBundle\Service\Mailer\MailFactory:
         arguments:
-            $emailParams: %email_params%
+            $emailParams: "%email_params%"
             $baseURLs:
                 front: '%env(NONADMIN_HOST)%'
                 admin: '%env(ADMIN_HOST)%'

--- a/client/src/AppBundle/Resources/translations/admin-clients.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin-clients.en.yml
@@ -25,7 +25,7 @@ clientDetails:
 clientDischarge:
   htmlTitle: Administration - Clients
   pageTitle: Discharge deputy from client
-  warning: %clientFirstName% %clientLastName% will be permanently detached from their named deputy. Any data previously entered into an unsubmitted report will be deleted.
+  warning: "%clientFirstName% %clientLastName% will be permanently detached from their named deputy. Any data previously entered into an unsubmitted report will be deleted."
   confirm: Discharge deputy
 
 reportManage:

--- a/client/src/AppBundle/Resources/translations/common.en.yml
+++ b/client/src/AppBundle/Resources/translations/common.en.yml
@@ -8,7 +8,6 @@ no: No
 ok: OK
 signOut: Sign out
 continue: Continue
-reviewReport: Review report
 saveAndContinue: Save and continue
 saveAndAddAnother: Save and add another
 skipLink: Skip this question for now
@@ -94,7 +93,6 @@ reportType: Report type
 ndr: NDR
 type: Type
 defaultDateHintText: For example, 18 4 2017
-namedDeputy: Named deputy
 
 # Statuses
 notCreated: Not created

--- a/client/src/AppBundle/Resources/translations/ndr-debts.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-debts.en.yml
@@ -34,7 +34,7 @@ editPage:
 summaryPage:
   weAskAbout: |
     In this section, we ask you about %client%'s debts, for example, overdue care fees, credit cards or loans.
-  moreAbout: %client%'s other debts of £%amount%
+  moreAbout: "%client%'s other debts of £%amount%"
 
 form:
   entries:

--- a/client/src/AppBundle/Resources/translations/ndr-more-info.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-more-info.en.yml
@@ -15,9 +15,7 @@ stepPage:
 
 summaryPage:
   htmlTitle: "New deputy report - any other information | GOV.UK"
-  supportTitle: Any other information
   pageTitle: Any other information
-  supportTitle: ""
   weAskAbout: |
     In this section, you can raise concerns about your deputyship and give us any other information
     you think we should have.

--- a/client/src/AppBundle/Resources/translations/ndr-visits-care.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-visits-care.en.yml
@@ -34,8 +34,8 @@ form:
   howIsCareFunded:
     label: How is the care funded?
     choices:
-      client_pays_for_all: %client% pays for all the care
-      client_gets_financial_help: %client% gets some financial help (for example, from the local authority or NHS)
+      client_pays_for_all: "%client% pays for all the care"
+      client_gets_financial_help: "%client% gets some financial help (for example, from the local authority or NHS)"
       all_care_is_paid_by_someone_else: All  %client%'s care is paid for by someone else (for example, by the local authority or NHS)
   whoIsDoingTheCaring:
     label: Who is doing the caring?
@@ -60,4 +60,3 @@ form:
     more_than_twice_a_year: More than twice a year
     once_a_year: Once a year
     less_than_once_a_year: Less than once a year
-

--- a/client/src/AppBundle/Resources/translations/report-assets.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-assets.en.yml
@@ -75,10 +75,10 @@ deletePage:
     valuationDate: Valuation date
 
 form:
-  clientAssets.label: %client%'s assets
+  clientAssets.label: "%client%'s assets"
   doesClientHaveAssets:
     label: Does %client% own any assets?
-    noAssets.label: %client% has no assets
+    noAssets.label: "%client% has no assets"
   titleSave.label: Save and continue
   title:
     label: What sort of asset is it?

--- a/client/src/AppBundle/Resources/translations/report-debts.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-debts.en.yml
@@ -34,13 +34,13 @@ editPage:
 summaryPage:
   weAskAbout: |
     In this section, we ask you about %client%'s debts, for example, overdue care fees, credit cards or loans.
-  moreAbout: %client%'s other debts of £%amount%
+  moreAbout: "%client%'s other debts of £%amount%"
 
 form:
-  clientsDebts.label: %client%'s debts
+  clientsDebts.label: "%client%'s debts"
   doesClientHaveDebts:
     label: Does %client% have any debts?
-    noDebts.label: %client% has no debts
+    noDebts.label: "%client% has no debts"
   entries:
     care-fees:
       label: Outstanding care home fees
@@ -63,4 +63,3 @@ save:
   label: Save
 
 navLink: Debts
-

--- a/client/src/AppBundle/Resources/translations/report-decisions.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-decisions.en.yml
@@ -124,7 +124,7 @@ form:
     label: What was the significant decision? Why did you make it at the time?
     hint: ""
   clientInvolvedBoolean:
-    heading: %client%'s involvement
+    heading: "%client%'s involvement"
     label: Did you involve %client% in this decision?
     hint: ""
     defaultOption: Please select...
@@ -133,5 +133,3 @@ form:
     hint: ""
   save:
     label: Save and continue
-
-

--- a/client/src/AppBundle/Resources/translations/report-money-short.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-money-short.en.yml
@@ -135,7 +135,7 @@ form:
       care_fees.label: Care fees or local authority charges for care
       holidays.label: Holidays and trips
       households_bills.label: Household bills – for example, water, gas, electricity, phone, council tax
-      personal_allowance.label: %client%'s personal allowance
+      personal_allowance.label: "%client%'s personal allowance"
       professional_fees.label: Professional fees – for example, solicitor or accountant fees
       new_investments.label: New investments – for example, buying shares, new bonds
       travel_costs.label: Travel costs – for example, bus, train, taxi fares
@@ -165,5 +165,3 @@ form:
           label: 12345345646
         save:
             label: Save payment
-
-

--- a/client/src/AppBundle/Resources/translations/report-money-transaction.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-money-transaction.en.yml
@@ -290,8 +290,6 @@ form:
         moreInformations: Please enter the type of benefit %client% gets
       client-transport-bus-train-taxi-fares:
         label: Transport (for example, bus, train, taxi fares)
-      food:
-        label: Food
       toiletries:
         label: Toiletries
       clothes:
@@ -361,4 +359,3 @@ form:
       moneyout-other:
         label: Anything else paid out
         moreInformation: Give us more information
-

--- a/client/src/AppBundle/Resources/translations/report-more-info.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-more-info.en.yml
@@ -23,9 +23,7 @@ stepPage:
 
 summaryPage:
   htmlTitle: "Deputy report - any other information | GOV.UK"
-  supportTitle: Any other information
   pageTitle: Any other information
-  supportTitle: ""
   weAskAbout: |
     In this section, we ask you to give us any other information you think we should have about
     your deputyship.

--- a/client/src/AppBundle/Resources/translations/report-visits-care.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-visits-care.en.yml
@@ -34,8 +34,8 @@ form:
     label: How is the care funded?
     hint: ""
     choices:
-      client_pays_for_all: %client% pays for all the care
-      client_gets_financial_help: %client% gets some financial help (for example, from the local authority, council or NHS)
+      client_pays_for_all: "%client% pays for all the care"
+      client_gets_financial_help: "%client% gets some financial help (for example, from the local authority, council or NHS)"
       all_care_is_paid_by_someone_else: All  %client%'s care is paid for by someone else (for example, by the local authority, council or NHS)
   whoIsDoingTheCaring:
     label: Who is doing the caring?

--- a/client/src/AppBundle/Resources/translations/report.en.yml
+++ b/client/src/AppBundle/Resources/translations/report.en.yml
@@ -23,7 +23,7 @@ codeputy:
 editReportingDates:
   htmlTitle: Annual deputy reports for client
   pageTitle: Annual deputy reports for %client%
-  title: %period% reporting period
+  title: "%period% reporting period"
   pageSectionDescription: Tell us when your reporting period starts and finishes.
   form:
     startDate:

--- a/client/src/AppBundle/Service/ApiCollector.php
+++ b/client/src/AppBundle/Service/ApiCollector.php
@@ -37,4 +37,11 @@ class ApiCollector extends DataCollector implements DataCollectorInterface
     {
         return $this->data['calls'];
     }
+
+    public function reset()
+    {
+        $this->data = [
+            'calls' => []
+        ];
+    }
 }


### PR DESCRIPTION
## Purpose
Symfony 4 has much stricter rules around YAML configuration. We should update our YAML to match these rules so that a future upgrade is easier.

Fixes DDPB-3293

## Approach
I upgraded Symfony to v4, tried to compile and fixed any errors reported from YAML syntax. This also identified a missing method in `ApiCollector`.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work
  - N/A
- [x] The product team have approved these changes
  - N/A
