### PR TITLE
DDPB-3306: Fix firefox page scroll bug

### DIFF
--- a/client/src/AppBundle/Resources/assets/javascripts/modules/textarea-autosize.js
+++ b/client/src/AppBundle/Resources/assets/javascripts/modules/textarea-autosize.js
@@ -7,8 +7,8 @@ module.exports = function (containerSelector) {
   const textArea = $(containerSelector).find("[class*='js-auto-size'] textarea")
 
   textArea.on('keyup input paste change', function (event) {
-    let $this = $(this)
-    let initialHeight = $this.height()
+    const $this = $(this)
+    const initialHeight = $this.height()
 
     $this
       .height(initialHeight - 20)

--- a/client/src/AppBundle/Resources/assets/javascripts/modules/textarea-autosize.js
+++ b/client/src/AppBundle/Resources/assets/javascripts/modules/textarea-autosize.js
@@ -4,14 +4,14 @@
 // Note that associated styles live under _.forms.scss
 
 module.exports = function (containerSelector) {
-  var textArea = $(containerSelector).find("[class*='js-auto-size'] textarea")
+  const textArea = $(containerSelector).find("[class*='js-auto-size'] textarea")
 
   textArea.on('keyup input paste change', function (event) {
-    var $this = $(event.target)
+    let $this = $(this)
+    let initialHeight = $this.height()
 
-    setTimeout(function () {
-      $this.css('height', 'auto')
-      $this.css('height', $this.prop('scrollHeight') + 'px')
-    }, 0)
+    $this
+      .height(initialHeight - 20)
+      .height($this[0].scrollHeight + 20)
   }).trigger('keyup')
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
             - ./client/src:/var/www/src:ro
             - ./client/tests:/var/www/tests
             - ./client/phpstan.neon:/var/www/phpstan.neon
+            - ./client/web:/var/www/web
         environment:
             VIRTUAL_HOST: www.digideps.local,digideps.local
             VIRTUAL_PROTO: https

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,6 @@ services:
             - ./client/src:/var/www/src:ro
             - ./client/tests:/var/www/tests
             - ./client/phpstan.neon:/var/www/phpstan.neon
-            - ./client/web:/var/www/web
         environment:
             VIRTUAL_HOST: www.digideps.local,digideps.local
             VIRTUAL_PROTO: https


### PR DESCRIPTION
## Purpose
Fixes a bug in admin autosize boxes where the page scrolls to the top of the box when a user types in an expanded text box.

Fixes DDPB-3306

## Approach
Went a bit crazy trying to replicate this until I decided to switch browser to Firefox where the page scrolls to the top of the textarea when autosizing is enabled.

I'm not taking any credit for the code - I stole it from here - https://stackoverflow.com/questions/18262729/how-to-stop-window-jumping-when-typing-in-autoresizing-textarea/60868351#60868351

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
