### PR TITLE
DDPB-3304: Transactions files incorrectly labelled as report PDFs

### DIFF
--- a/api/src/AppBundle/Entity/Report/Document.php
+++ b/api/src/AppBundle/Entity/Report/Document.php
@@ -298,7 +298,7 @@ class Document
      */
     private function isTransactionDocument()
     {
-        return strpos('DigiRepTransactions', $this->getFileName());
+        return strpos($this->getFileName(), 'DigiRepTransactions') !== false;
     }
 
     /**

--- a/client/src/AppBundle/Entity/Report/Document.php
+++ b/client/src/AppBundle/Entity/Report/Document.php
@@ -379,6 +379,6 @@ class Document implements DocumentInterface
      */
     private function isTransactionDocument()
     {
-        return strpos('DigiRepTransactions', $this->getFileName());
+        return strpos($this->getFileName(), 'DigiRepTransactions') !== false;
     }
 }

--- a/client/src/AppBundle/Service/ReportSubmissionService.php
+++ b/client/src/AppBundle/Service/ReportSubmissionService.php
@@ -89,7 +89,7 @@ class ReportSubmissionService
             $report,
             $csvContent,
             $report->createAttachmentName('DigiRepTransactions-%s_%s_%s.csv'),
-            true
+            false
         );
     }
 

--- a/client/tests/phpunit/Service/ReportSubmissionServiceTest.php
+++ b/client/tests/phpunit/Service/ReportSubmissionServiceTest.php
@@ -98,7 +98,7 @@ class ReportSubmissionServiceTest extends TestCase
 
         $this->mockFileUploader->shouldReceive('uploadFile')->with($this->mockReport, m::type('String'), m::type('String'), true);
         $this->mockCsvGenerator->shouldReceive('generateTransactionsCsv')->with($this->mockReport)->andReturn('CSV CONTENT');
-        $this->mockFileUploader->shouldReceive('uploadFile')->with($this->mockReport, m::type('String'), m::type('String'), true);
+        $this->mockFileUploader->shouldReceive('uploadFile')->with($this->mockReport, m::type('String'), m::type('String'), false);
 
         $this->sut = $this->generateSut();
 


### PR DESCRIPTION
## Purpose
Transaction CSVs are incorrectly being given the "is report PDF" flag. This should only be set for the system-generated report PDFs.

Fixes DDPB-3304

## Approach
I changed the flag in the `generateReportDocuments` function. (The `generateReportPdf` function still sets the flag for actual report PDFs)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work
- [x] The product team have approved these changes
  - N/A
