### PR TITLE
DDPB-3352: Error rendering page in Internet Explorer

### DIFF
--- a/client/src/AppBundle/Resources/assets/javascripts/main.js
+++ b/client/src/AppBundle/Resources/assets/javascripts/main.js
@@ -20,6 +20,19 @@ var uploadFile = require('./modules/uploadFile.js')
 var uploadProgressPA = require('./modules/uploadProgressPA.js')
 var uploadProgress = require('./modules/uploadProgress.js')
 
+/**
+ * Taken from govuk-frontend. Supports back to IE8
+ * See: https://github.com/alphagov/govuk-frontend/blob/063cd8e2470b62b824c6e50ca66342ac7a95d2d8/src/govuk/common.js#L6
+ */
+function nodeListForEach (nodes, callback) {
+  if (window.NodeList.prototype.forEach) {
+    return nodes.forEach(callback)
+  }
+  for (let i = 0; i < nodes.length; i++) {
+    callback.call(window, nodes[i], i, nodes)
+  }
+}
+
 window.opg = {
   Ga: Ga,
   SessionTimeoutDialog: SessionTimeoutDialog
@@ -65,8 +78,9 @@ $(document).ready(function () {
   tableMultiSelect()
 
   // Detached details/summary
-  document.querySelectorAll('[data-module="opg-detached-details"]').forEach(function ($el) {
-    new DetachedDetails($el).init()
+  var $detachedDetails = document.querySelectorAll('[data-module="opg-detached-details"]')
+  nodeListForEach($detachedDetails).each(function () {
+    new DetachedDetails(this).init()
   })
 
   // Initialising the Show Hide Content GOVUK module

--- a/client/src/AppBundle/Resources/assets/javascripts/main.js
+++ b/client/src/AppBundle/Resources/assets/javascripts/main.js
@@ -78,9 +78,9 @@ $(document).ready(function () {
   tableMultiSelect()
 
   // Detached details/summary
-  var $detachedDetails = document.querySelectorAll('[data-module="opg-detached-details"]')
-  nodeListForEach($detachedDetails).each(function () {
-    new DetachedDetails(this).init()
+  const $detachedDetails = document.querySelectorAll('[data-module="opg-detached-details"]')
+  nodeListForEach($detachedDetails, function ($el) {
+    new DetachedDetails($el).init()
   })
 
   // Initialising the Show Hide Content GOVUK module


### PR DESCRIPTION
## Purpose
JavaScript doesn’t load properly on pages in Internet Explorer due to a lack of support of querySelectorAll().forEach.

This has been resolved in the Design System [by using a polyfill hybrid](https://github.com/alphagov/govuk-frontend/blob/063cd8e2470b62b824c6e50ca66342ac7a95d2d8/src/govuk/common.js#L6).

Fixes DDPB-3352

## Approach
I've copied the polyfill across from the Design System and used it in place of `.forEach`.

## Learning
[I've added a risk](https://trello.com/c/gOmHVofD/74-poor-detection-of-javascript-errors-in-internet-explorer) about our poor detection of JavaScript errors in Internet Explorer.

## Checklist
- [ ] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work
  - N/A, we don't test JavaScript
- [x] The product team have approved these changes
  - N/A
