### PR TITLE
DDPB-2754: Apply consistent pattern to header hierarchy throughout the application

### DIFF
--- a/client/src/AppBundle/Resources/translations/admin-checklist.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin-checklist.en.yml
@@ -1,7 +1,6 @@
 checklistPage:
   htmlTitle: Administration - Report checklist
   pageTitle: Checklist
-  supportTitle: Admin
   heading:
     lodging:
         title: Lodging checklist
@@ -231,8 +230,7 @@ checklistPage:
 
 checklistSubmittedPage:
   htmlTitle: Administration - Report checklist
-  pageTitle: Admin
-  supportTitle: Checklist submitted
+  panelTitle: Checklist submitted
   downloadText: Your PDF download should start automatically. <a href="%downloadLinkUrl%" class="%downloadLinkClassList%">Click here</a> to download it if it does not download automatically.
   toChecklistButtonText: Return to checklist
   toClientListButtonText: View client list

--- a/client/src/AppBundle/Resources/translations/admin-clients.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin-clients.en.yml
@@ -30,8 +30,7 @@ clientDischarge:
 
 reportManage:
   htmlTitle: Administration - Manage report
-  pageTitle: Admin
-  supportTitle: Manage report
+  pageTitle: Manage report
   currentDueDate: "Current due date:"
   overdueBy: Overdue by %overdueDays% days
   form:

--- a/client/src/AppBundle/Resources/translations/admin-documents-download.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin-documents-download.en.yml
@@ -1,6 +1,4 @@
 page:
     htmlTitle: Administration - Documents - Download
-    pageTitle: Download Documents
-    supportTitle: Documents ready for download
+    pageTitle: Documents ready for download
     description: Some of the documents requested for download couldn't be found. All other documents are included in the Zip file below.
-

--- a/client/src/AppBundle/Resources/translations/admin.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin.en.yml
@@ -72,6 +72,7 @@ addUserForm:
 deleteConfirm:
   htmlTitle: Administration - Users
   pageTitle: Delete user
+  supportTitle: Users
   question: Are you sure that you want to delete <strong class="bold">%fullName%</strong>? This action cannot be undone.
 
 editUser:
@@ -99,8 +100,9 @@ editUserForm:
     mismatchError: Cannot change user between staff-type and deputy-type role.
 
 statsPage:
-  htmlTitle: Administration - Statistics
-  pageTitle: Report Submissions
+  htmlTitle: Administration - Download Report Submissions
+  pageTitle: Download Report Submissions
+  supportTitle: Analytics
   reportSubmissionsPara: Today's report submissions file for uploading into CASREC
   pleaseWait: Please wait ...
   dataGenerated: |
@@ -144,6 +146,7 @@ uploadPA:
 uploadUsers:
   htmlTitle: Administration - Upload users
   pageTitle: Upload lay users
+  supportTitle: Users
   heading: Upload users
   usersInTheDB: users in the database
   uploading: Uploading... please wait.<br/>Do not refresh this page

--- a/client/src/AppBundle/Resources/translations/admin.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin.en.yml
@@ -71,9 +71,7 @@ addUserForm:
 
 deleteConfirm:
   htmlTitle: Administration - Users
-  pageTitle: Admin
-  supportTitle: User management
-  heading: Delete user
+  pageTitle: Delete user
   question: Are you sure that you want to delete <strong class="bold">%fullName%</strong>? This action cannot be undone.
 
 editUser:
@@ -146,7 +144,6 @@ uploadPA:
 uploadUsers:
   htmlTitle: Administration - Upload users
   pageTitle: Upload lay users
-  supportTitle: Users
   heading: Upload users
   usersInTheDB: users in the database
   uploading: Uploading... please wait.<br/>Do not refresh this page

--- a/client/src/AppBundle/Resources/translations/client-contacts.en.yml
+++ b/client/src/AppBundle/Resources/translations/client-contacts.en.yml
@@ -1,11 +1,11 @@
 addContact:
   htmlTitle: Client profile - add contact | GOV.UK
   pageTitle: Add contact
-  supportTitle: "Client profile:"
+  supportTitle: "Client profile: %fullName%"
 editContact:
   htmlTitle: Client profile - edit contact | GOV.UK
   pageTitle: Edit contact
-  supportTitle: "Client profile:"
+  supportTitle: "Client profile: %fullName%"
 deletePage:
   htmlTitle: "Client profile - remove contact | GOV.UK"
   subject: contact

--- a/client/src/AppBundle/Resources/translations/client-notes.en.yml
+++ b/client/src/AppBundle/Resources/translations/client-notes.en.yml
@@ -1,11 +1,11 @@
 addNote:
   htmlTitle: Client profile - add note | GOV.UK
   pageTitle: Add note
-  supportTitle: "Client profile:"
+  supportTitle: "Client profile: %fullName%"
 editNote:
   htmlTitle: Client profile - edit note | GOV.UK
   pageTitle: Edit note
-  supportTitle: "Client profile:"
+  supportTitle: "Client profile: %fullName%"
 deletePage:
   htmlTitle: "Client profile - remove note | GOV.UK"
   subject: note

--- a/client/src/AppBundle/Resources/translations/co-deputy.en.yml
+++ b/client/src/AppBundle/Resources/translations/co-deputy.en.yml
@@ -1,6 +1,6 @@
 addCoDeputy:
   htmlTitle: Deputy report - Invite deputy | GOV.UK
-  pageTitle: Deputies
+  pageTitle: Invite deputy
   intro: |
     You can invite additional deputies to %clientFirstName%'s reports, all we need is their
     email address.
@@ -8,7 +8,7 @@ addCoDeputy:
 
 reinviteDeputy:
   htmlTitle: Deputy report - Reinvite deputy | GOV.UK
-  pageTitle: Deputies
+  pageTitle: Reinvite deputy
   intro: |
     Use the box below to resend an invitation to the original or alternative email address.
   submitButton: Resend invitation

--- a/client/src/AppBundle/Resources/translations/ndr-assets.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-assets.en.yml
@@ -40,7 +40,7 @@ editPage:
 
 addAnotherPage:
   htmlTitle: "New deputy report - assets | GOV.UK"
-  pageTitle: Accounts
+  pageTitle: Assets
   form:
     addAnother:
       label: The asset has been saved. Would you like to add another now?

--- a/client/src/AppBundle/Resources/translations/ndr-assets.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-assets.en.yml
@@ -9,7 +9,7 @@ startPage:
 
 existPage:
   htmlTitle: "New deputy report - assets | GOV.UK"
-  pageTitle: Assets
+  supportTitle: Assets
   form:
     noAssetToAdd:
       label: Does %client% own any assets?
@@ -40,7 +40,8 @@ editPage:
 
 addAnotherPage:
   htmlTitle: "New deputy report - assets | GOV.UK"
-  pageTitle: Assets
+  supportTitle: Assets
+  pageTitle: Add another asset?
   form:
     addAnother:
       label: The asset has been saved. Would you like to add another now?

--- a/client/src/AppBundle/Resources/translations/ndr-assets.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-assets.en.yml
@@ -40,8 +40,7 @@ editPage:
 
 addAnotherPage:
   htmlTitle: "New deputy report - assets | GOV.UK"
-  supportTitle: Assets
-  pageTitle: Add another asset?
+  pageTitle: Accounts
   form:
     addAnother:
       label: The asset has been saved. Would you like to add another now?

--- a/client/src/AppBundle/Resources/translations/ndr-debts.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-debts.en.yml
@@ -8,7 +8,7 @@ startPage:
 
 existPage:
   htmlTitle: "New deputy report - debts | GOV.UK"
-  pageTitle: Debts
+  supportTitle: Debts
   form:
     exist:
       label: Does %client% have any debts?
@@ -17,9 +17,7 @@ existPage:
 
 managementPage:
   htmlTitle: "Deputy report - debts | GOV.UK"
-  pageTitle: Debts
-  pageSectionDescription: How is the debt being managed or reduced?
-  pageHint: For example, list any regular payments to creditors or payment plans in place
+  supportTitle: Debts
   form:
     debtManagement:
       label: How is the debt being managed or reduced?
@@ -27,8 +25,8 @@ managementPage:
 
 editPage:
   htmlTitle: "New deputy report - debts | GOV.UK"
-  pageTitle: Debts
-  pageSectionDescription: Please tell us more about %client%'s debts.
+  pageTitle: Tell us more about %client%'s debts.
+  supportTitle: Debts
   pageHint: If %client% has a mortgage on a property, use the Assets section to tell us about it
 
 summaryPage:

--- a/client/src/AppBundle/Resources/translations/ndr-deputy-expenses.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-deputy-expenses.en.yml
@@ -16,7 +16,7 @@ startPage:
 
 existPage:
   htmlTitle: "Deputy report - add deputy expense | GOV.UK"
-  pageTitle: Deputy expenses
+  supportTitle: Deputy expenses
   form:
     paidForAnything:
       label: Did you pay for anything for %client% before you got your court order?
@@ -71,4 +71,3 @@ form:
     label: Add another expense
   save:
       label: Save expense
-

--- a/client/src/AppBundle/Resources/translations/ndr-more-info.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-more-info.en.yml
@@ -11,7 +11,7 @@ startPage:
 
 stepPage:
   htmlTitle: "New deputy report - any other information | GOV.UK"
-  pageTitle: Any other information
+  supportTitle: Any other information
 
 summaryPage:
   htmlTitle: "New deputy report - any other information | GOV.UK"

--- a/client/src/AppBundle/Resources/translations/ndr-visits-care.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-visits-care.en.yml
@@ -9,7 +9,7 @@ startPage:
 
 stepPage:
   htmlTitle: "Deputy report - visits and care | GOV.UK"
-  pageTitle: Visits and care
+  supportTitle: Visits and care
   backLink: Back
 
 summaryPage:

--- a/client/src/AppBundle/Resources/translations/report-actions.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-actions.en.yml
@@ -31,7 +31,7 @@ startPage:
 
 stepPage:
   htmlTitle: "Deputy report - actions you plan to take | GOV.UK"
-  pageTitle: Actions you plan to take
+  supportTitle: Actions you plan to take
   backLink: Back
 
 summaryPage:

--- a/client/src/AppBundle/Resources/translations/report-assets.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-assets.en.yml
@@ -8,7 +8,7 @@ startPage:
 
 existPage:
   htmlTitle: "Deputy report - assets | GOV.UK"
-  pageTitle: Assets
+  supportTitle: Assets
   form:
     noAssetToAdd:
       label: Does %client% own any assets?

--- a/client/src/AppBundle/Resources/translations/report-contacts.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-contacts.en.yml
@@ -7,7 +7,7 @@ startPage:
 
 existPage:
   htmlTitle: "Deputy report - add contact | GOV.UK"
-  pageTitle: Contacts
+  supportTitle: Contacts
   form:
     hasContacts:
       label: Has anyone helped you make any significant decisions for %client% during this reporting period?
@@ -93,4 +93,3 @@ form:
       defaultOption: Please select ...
   save:
       label: Save and continue
-

--- a/client/src/AppBundle/Resources/translations/report-debts.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-debts.en.yml
@@ -8,7 +8,7 @@ startPage:
 
 existPage:
   htmlTitle: "Deputy report - debts | GOV.UK"
-  pageTitle: Debts
+  supportTitle: Debts
   form:
     exist:
       label: Does %client% have any debts?
@@ -17,8 +17,8 @@ existPage:
 
 managementPage:
   htmlTitle: "Deputy report - debts | GOV.UK"
-  pageTitle: Debts
-  pageSectionDescription: How is the debt being managed or reduced?
+  supportTitle: Debts
+  pageTitle: How is the debt being managed or reduced?
   pageHint: For example, list any regular payments to creditors or payment plans in place
   form:
     debtManagement:
@@ -27,8 +27,8 @@ managementPage:
 
 editPage:
   htmlTitle: "Deputy report - debts | GOV.UK"
-  pageTitle: Debts
-  pageSectionDescription: Please tell us more about %client%'s debts.
+  supportTitle: Debts
+  pageTitle: Please tell us more about %client%'s debts.
   pageHint: If %client% has a mortgage on a property, use the Assets section to tell us about it
 
 summaryPage:

--- a/client/src/AppBundle/Resources/translations/report-decisions.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-decisions.en.yml
@@ -45,7 +45,7 @@ startPage:
 
 mentalCapacity:
   htmlTitle: "Deputy report - mental capacity | GOV.UK"
-  pageTitle: "Mental capacity"
+  supportTitle: Decisions
   form:
     hasCapacityChanged:
       label: "Has %client%'s mental capacity to make financial decisions changed?"
@@ -64,7 +64,7 @@ mentalCapacity:
 
 existPage:
   htmlTitle: "Deputy report - add decision | GOV.UK"
-  pageTitle: Decisions
+  supportTitle: Decisions
   form:
     hasDecisions:
       label: Have you made any significant decisions for %client% during this reporting period?

--- a/client/src/AppBundle/Resources/translations/report-deputy-expenses.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-deputy-expenses.en.yml
@@ -27,7 +27,7 @@ startPage:
 
 existPage:
   htmlTitle: "Deputy report - add deputy expense | GOV.UK"
-  pageTitle: Deputy expenses
+  supportTitle: Deputy expenses
   form:
     paidForAnything:
       label: Have you claimed any deputy expenses during this reporting period?

--- a/client/src/AppBundle/Resources/translations/report-gifts.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-gifts.en.yml
@@ -29,7 +29,7 @@ startPage:
 
 existPage:
   htmlTitle: "Deputy report - add gift | GOV.UK"
-  pageTitle: Gifts
+  supportTitle: Gifts
   form:
     giftsExist:
       label: Have you given any gifts to other people on %client%'s behalf during this reporting period?
@@ -94,4 +94,3 @@ form:
     hint: ""
   save:
       label: Save gift
-

--- a/client/src/AppBundle/Resources/translations/report-lifestyle.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-lifestyle.en.yml
@@ -7,9 +7,7 @@ startPage:
 
 stepPage:
   htmlTitle: "Deputy report - Health and lifestyle | GOV.UK"
-  pageTitle: Health and lifestyle
-  pageSectionDescription: |
-      todo
+  supportTitle: Health and lifestyle
 
 summaryPage:
   htmlTitle: "Deputy report - Health and lifestyle | GOV.UK"
@@ -19,7 +17,7 @@ summaryPage:
 
 form:
   careAppointments:
-    label: Describe %client%'s health and provide details of any care appointments you or %client% attended.
+    label: Describe %client%'s health and provide details of any care appointments you or %client% attended
     hint: Tell us about any health issues or incidents during the reporting period. Give details of any significant meetings with health or care professionals. We don’t need details about routine weekly appointments.
   doesClientUndertakeSocialActivities:
     label: Does %client% take part in any leisure or social activities?

--- a/client/src/AppBundle/Resources/translations/report-money-short.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-money-short.en.yml
@@ -21,18 +21,18 @@ startPage:
 categoryPage:
   moneyIn:
     htmlTitle: "Deputy report - Money in | GOV.UK"
-    pageTitle: Money in
+    supportTitle: Money in
   moneyOut:
     htmlTitle: "Deputy report - Money out | GOV.UK"
-    pageTitle: Money out
+    supportTitle: Money out
 
 existPage:
   moneyIn:
     htmlTitle: "Deputy report - Money in | GOV.UK"
-    pageTitle: Money in
+    supportTitle: Money in
   moneyOut:
     htmlTitle: "Deputy report - Money out | GOV.UK"
-    pageTitle: Money out
+    supportTitle: Money out
   form:
     moneyTransactionsShortInExist:
       label: Have there been any one-off income payments over £1,000?

--- a/client/src/AppBundle/Resources/translations/report-money-transaction.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-money-transaction.en.yml
@@ -91,6 +91,7 @@ addAnotherPage:
   moneyIn:
     htmlTitle: "Deputy report - Add another item of income | GOV.UK"
     pageTitle: Add another item
+    supportTitle: Money in
     form:
       addAnother:
         label: The item has been saved. Would you like to add another now?
@@ -100,6 +101,7 @@ addAnotherPage:
   moneyOut:
     htmlTitle: "Deputy report - Add another payment | GOV.UK"
     pageTitle: Add a payment
+    supportTitle: Money out
     form:
       addAnother:
         label: The payment has been saved. Would you like to add another now?

--- a/client/src/AppBundle/Resources/translations/report-money-transfer.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-money-transfer.en.yml
@@ -10,7 +10,7 @@ startPage:
 
 existPage:
   htmlTitle: "Deputy report - money transfers | GOV.UK"
-  pageTitle: Money transfers
+  supportTitle: Money transfers
   form:
     noTransfersToAdd:
       label: Have you made any money transfers between %client%'s accounts in this reporting period?

--- a/client/src/AppBundle/Resources/translations/report-more-info.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-more-info.en.yml
@@ -19,7 +19,7 @@ startPage:
 
 stepPage:
   htmlTitle: "Deputy report - any other information | GOV.UK"
-  pageTitle: Any other information
+  supportTitle: Any other information
 
 summaryPage:
   htmlTitle: "Deputy report - any other information | GOV.UK"

--- a/client/src/AppBundle/Resources/translations/report-pa-fee-expense.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-pa-fee-expense.en.yml
@@ -19,7 +19,7 @@ startPage:
 
 feeExistPage:
   htmlTitle: "Deputy report - Deputy fees and expenses | GOV.UK"
-  pageTitle: Deputy fees and expenses
+  supportTitle: Deputy fees and expenses
   form:
     hasFees:
       label: Have you charged the client any fees for your services during the reporting period?

--- a/client/src/AppBundle/Resources/translations/report-prof-deputy-costs-estimate.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-prof-deputy-costs-estimate.en.yml
@@ -16,7 +16,7 @@ startPage:
 
 howCharged:
   htmlTitle: "Deputy report - Deputy costs estimate | GOV.UK"
-  pageTitle: Deputy costs estimates
+  supportTitle: Deputy costs estimates
   form:
     profDeputyCostsEstimateHowCharged:
       label: "How will you be charging for your services?"
@@ -50,7 +50,7 @@ breakdown:
 
 moreInfo:
   htmlTitle: "Deputy report - Deputy costs estimate | GOV.UK"
-  pageTitle: Deputy cost estimates
+  supportTitle: Deputy cost estimates
   pageHeader: More Information
   form:
     profDeputyCostsEstimateHasMoreInfo:

--- a/client/src/AppBundle/Resources/translations/report-prof-deputy-costs.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-prof-deputy-costs.en.yml
@@ -16,7 +16,7 @@ startPage:
 
 howCharged:
   htmlTitle: "Deputy report - Deputy costs | GOV.UK"
-  pageTitle: Deputy costs
+  supportTitle: Deputy costs
   form:
     profDeputyCostsHow.label: "How did you charge for the services %client% paid you for in this reporting period?"
     profDeputyCostsHow.hint: "Select all that apply"
@@ -29,16 +29,16 @@ howCharged:
 
 previousReceivedExists:
   htmlTitle: "Deputy report - Deputy costs | GOV.UK"
-  pageTitle: Deputy costs
+  supportTitle: Deputy costs
   form:
     profDeputyCostsHasPrevious:
       label: "Has %client% paid you in this reporting period for work carried out in a previous reporting period?"
 
 previousReceived:
   htmlTitle: "Deputy report - Deputy costs | GOV.UK"
-  pageTitle: Deputy costs
-  pageSectionDescription01: Costs for earlier reporting periods
-  pageSectionDescription02: |
+  supportTitle: Deputy costs
+  pageTitle: Costs for earlier reporting periods
+  pageSectionDescription: |
     Tell us about money %client% paid you in this reporting period for
     work you carried out in a previous reporting period
   form:
@@ -57,15 +57,16 @@ previousReceived:
 
 interimExists:
   htmlTitle: "Deputy report - Deputy costs | GOV.UK"
-  pageTitle: Deputy costs
-  pageSectionDescription: Costs for this reporting period
+  supportTitle: Deputy costs
+  pageTitle: Costs for this reporting period
   form:
     profDeputyCostsHasInterim:
       label: Have you charged in line with interim billing under Practice Direction 19B for the work you carried out in this reporting period?
 
 interim:
   htmlTitle: "Deputy report - Deputy costs | GOV.UK"
-  pageTitle: Deputy costs
+  supportTitle: Deputy costs
+  pageTitle: Costs for this reporting period
   pageSectionDescription01: |
     How much has %client% paid you in this reporting period for work carried out in
     this reporting period (including VAT)?
@@ -78,13 +79,15 @@ interim:
 
 fixedCost:
   htmlTitle: "Deputy report - Deputy costs | GOV.UK"
-  pageTitle: Deputy costs
+  supportTitle: Deputy costs
+  pageTitle: Costs for this reporting period
   form:
     profDeputyFixedCost.label: "How much has %client% paid you in this reporting period for work carried out in this reporting period (including VAT)?"
 
 amountToScco:
   htmlTitle: "Deputy report - Deputy costs | GOV.UK"
-  pageTitle: Deputy costs
+  pageTitle: Costs for this reporting period
+  supportTitle: Deputy costs
   form:
     profDeputyCostsAmountToScco.label: "What amount is being submitted to SCCO for assessment this reporting period (including VAT)?"
     profDeputyCostsReasonBeyondEstimate.label: "If you charged 20% or more above your estimate from your last reporting period, tell us why."
@@ -92,7 +95,8 @@ amountToScco:
 
 breakdown:
   htmlTitle: "Deputy report - Deputy costs | GOV.UK"
-  pageTitle: Deputy costs
+  pageTitle: Costs for this reporting period
+  supportTitle: Deputy costs
   pageSectionDescription: Breakdown of additional professional deputy costs (including VAT) %client% has paid you for in this reporting period.
   pageHint: "These are any costs that are not classed as 'general management'."
   form:

--- a/client/src/AppBundle/Resources/translations/report-visits-care.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-visits-care.en.yml
@@ -9,7 +9,7 @@ startPage:
 
 stepPage:
   htmlTitle: "Deputy report - visits and care | GOV.UK"
-  pageTitle: Visits and care
+  supportTitle: Visits and care
   backLink: Back
 
 summaryPage:

--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/checklist.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/checklist.html.twig
@@ -11,7 +11,6 @@
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
-{% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}
 
 {% block pageContent %}
     <dl class="govuk-summary-list govuk-summary-list--no-border">

--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/checklistSubmitted.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/checklistSubmitted.html.twig
@@ -12,7 +12,7 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <div class="govuk-panel govuk-panel--confirmation">
-                <h1 class="govuk-panel__title">{{ (page ~ '.supportTitle') | trans }}</h1>
+                <h1 class="govuk-panel__title">{{ (page ~ '.panelTitle') | trans }}</h1>
                 <div class="govuk-panel__body">
                     {{ report.client.fullName }} - {{ ('reportTitles.' ~ report.reportTitle) | trans({}, 'report') }}
                 </div>
@@ -46,5 +46,3 @@
       window.location.href = "{{ path('admin_checklist_pdf', {'id': report.id}) }}";
     </script>
 {% endblock %}
-
-

--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/manage.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/manage.html.twig
@@ -7,10 +7,6 @@
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 
 
-{% block supportTitleBottom %}
-    <span class="heading-secondary">{{ (page ~ '.supportTitle') | trans }}</span>
-{% endblock %}
-
 {% block helpline %}{% endblock %}
 
 {% block pageContent %}

--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/manageConfirm.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/manageConfirm.html.twig
@@ -8,11 +8,6 @@
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 
-
-{% block supportTitleBottom %}
-    <span class="heading-secondary">{{ (page ~ '.supportTitle') | trans }}</span>
-{% endblock %}
-
 {% block helpline %}{% endblock %}
 
 {% block pageContent %}

--- a/client/src/AppBundle/Resources/views/Admin/Index/deleteConfirm.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Index/deleteConfirm.html.twig
@@ -3,8 +3,11 @@
 {% trans_default_domain "admin" %}
 {% set page = 'deleteConfirm' %}
 
+{% set navSection = 'users' %}
+
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
+{% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}
 
 {% block helpline %}{% endblock %}
 

--- a/client/src/AppBundle/Resources/views/Admin/Index/deleteConfirm.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Index/deleteConfirm.html.twig
@@ -6,16 +6,9 @@
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 
-
-{% block supportTitleBottom %}
-    <span class="heading-secondary">{{ (page ~ '.supportTitle') | trans }}</span>
-{% endblock %}
-
 {% block helpline %}{% endblock %}
 
 {% block pageContent %}
-
-    <h2 class="govuk-heading-m">{{ (page ~ '.heading') | trans }}</h2>
 
     <p class="text">{{ (page ~ '.question') | trans({'%fullName%': user.getFullname()}) | raw }}</p>
 
@@ -34,4 +27,3 @@
     } %}
 
 {% endblock %}
-

--- a/client/src/AppBundle/Resources/views/Admin/Index/upgradeMld.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Index/upgradeMld.html.twig
@@ -6,11 +6,6 @@
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 
-
-{% block supportTitleBottom %}
-    <span class="heading-secondary">{{ (page ~ '.supportTitle') | trans }}</span>
-{% endblock %}
-
 {% block helpline %}{% endblock %}
 
 {% block pageContent %}

--- a/client/src/AppBundle/Resources/views/Admin/ReportSubmission/download-ready.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/ReportSubmission/download-ready.html.twig
@@ -7,9 +7,6 @@
 
 {% block htmlTitle %}{{ 'page.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'page.pageTitle' | trans }}{% endblock %}
-{% block supportTitleBottom %}{{ 'page.supportTitle' | trans }}{% endblock %}
-
-
 
 {% block helpline %}{% endblock %}
 

--- a/client/src/AppBundle/Resources/views/Admin/Stats/stats.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Stats/stats.html.twig
@@ -7,8 +7,7 @@
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
-
-
+{% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}
 
 {% block helpline %}{% endblock %}
 

--- a/client/src/AppBundle/Resources/views/Admin/Stats/stats.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Stats/stats.html.twig
@@ -19,16 +19,13 @@
 
         {{ form_start(form, {attr: {class: 'search', novalidate: 'novalidate' }}) }}
 
-        <div class="govuk-form-group form-groups-inline flush--bottom">
-            {{ form_known_date(form.startDate, 'statsPage.form.fromDate', {
-                'hintText': 'statsPage.form.fromDate.hint'
-            }) }}
-        </div>
-        <div class="govuk-form-group form-groups-inline flush--bottom">
-            {{ form_known_date(form.endDate, 'statsPage.form.toDate', {
-                'hintText': 'statsPage.form.toDate.hint'
-            }) }}
-        </div>
+        {{ form_known_date(form.startDate, 'statsPage.form.fromDate', {
+            'hintText': 'statsPage.form.fromDate.hint'
+        }) }}
+
+        {{ form_known_date(form.endDate, 'statsPage.form.toDate', {
+            'hintText': 'statsPage.form.toDate.hint'
+        }) }}
 
         <div class="govuk-form-group">
             {{ form_submit(form.submitAndDownload, (page ~ '.form.submitAndDownload'), {

--- a/client/src/AppBundle/Resources/views/Components/Form/_checkboxgroup.html.twig
+++ b/client/src/AppBundle/Resources/views/Components/Form/_checkboxgroup.html.twig
@@ -3,8 +3,15 @@
 {% endif %}
 
     <fieldset class="govuk-fieldset {{ fieldSetClass }}" {% if hintText %}aria-describedby="{{ element.vars.id }}-hint"{% endif %}>
-        <legend class="govuk-fieldset__legend {{ legendClass }}">
-            {{ legendText }}
+        <legend class="govuk-fieldset__legend {{ legendClass }} {{ legend.isPageHeading ? "govuk-fieldset__legend--xl" : "" }}">
+            {% if legend.isPageHeading %}
+                {% if legend.caption %}
+                    <span class="govuk-caption-xl">{{ legend.caption }}</span>
+                {% endif %}
+                <h1 class="govuk-fieldset__heading">{{ legend.text }}</h1>
+            {% else %}
+                {{ legend.text }}
+            {% endif %}
         </legend>
 
         {% if hintText is not null %}

--- a/client/src/AppBundle/Resources/views/Components/Form/_input.html.twig
+++ b/client/src/AppBundle/Resources/views/Components/Form/_input.html.twig
@@ -1,13 +1,18 @@
 {% set describedby = '' %}
 <div id="form-group-{{ element.vars.id }}" class="govuk-form-group{% if not element.vars.valid %} govuk-form-group--error{% endif %}{% if formGroupClass is defined %} {{formGroupClass}}{% endif %}">
 
-    {% if labelRaw is defined and labelRaw %}
-        <label class="govuk-label {{ labelClass }}" for="{{ element.vars.id }}">
-            {{ labelText | raw }}
-        </label>
+    {% if label.isPageHeading %}
+        <h1 class="govuk-label-wrapper">
+            {% if label.caption %}
+                <span class="govuk-caption-xl">{{ label.caption }}</span>
+            {% endif %}
+            <label class="govuk-label govuk-label--xl {{ labelClass | default('') }}" for="{{ element.vars.id }}">
+                {{ labelRaw is defined and labelRaw ? label.text | raw : label.text }}
+            </label>
+        </h1>
     {% else %}
         <label for="{{ element.vars.id }}" class="govuk-label {{ labelClass | default('') }}">
-           {{ labelText }}
+           {{ labelRaw is defined and labelRaw ? label.text | raw : label.text }}
         </label>
     {% endif %}
 

--- a/client/src/AppBundle/Resources/views/Components/Form/_known-date.html.twig
+++ b/client/src/AppBundle/Resources/views/Components/Form/_known-date.html.twig
@@ -1,9 +1,16 @@
 <div id="form-group-{{ element.vars.id }}" class="govuk-form-group {% if not element.vars.valid %}govuk-form-group--error{% endif %}">
     <fieldset class="govuk-fieldset" aria-describedby="{{ element.vars.id }}-hint">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m {% if legendClass is defined %} {{legendClass}}{% endif %}">
-            <h3 class="govuk-fieldset__heading">
-                {{ legendText }}
-            </h3>
+        <legend class="govuk-fieldset__legend {{ legend.isPageHeading ? "govuk-fieldset__legend--xl" : "govuk-fieldset__legend--m" }} {% if legendClass is defined %} {{legendClass}}{% endif %}">
+            {% if legend.isPageHeading %}
+                {% if legend.caption %}
+                    <span class="govuk-caption-xl">{{ legend.caption }}</span>
+                {% endif %}
+                <h1 class="govuk-fieldset__heading">{{ legend.text }}</h1>
+            {% else %}
+                <h3 class="govuk-fieldset__heading">
+                    {{ legend.text }}
+                </h3>
+            {% endif %}
         </legend>
 
         <span class="govuk-hint" id="{{ element.vars.id }}-hint">{{ hintText }}</span>

--- a/client/src/AppBundle/Resources/views/Components/Form/_sort-code.html.twig
+++ b/client/src/AppBundle/Resources/views/Components/Form/_sort-code.html.twig
@@ -1,7 +1,14 @@
 <div id="form-group-{{ element.vars.id }}" class="govuk-form-group {% if not element.vars.valid %}govuk-form-group--error{% endif %}">
     <fieldset>
-        <legend class="govuk-fieldset__legend">
-            {{ legendText }}
+        <legend class="govuk-fieldset__legend {{ legend.isPageHeading ? "govuk-fieldset__legend--xl" : "" }}">
+            {% if legend.isPageHeading %}
+                {% if legend.caption %}
+                    <span class="govuk-caption-xl">{{ legend.caption }}</span>
+                {% endif %}
+                <h1 class="govuk-fieldset__heading">{{ legend.text }}</h1>
+            {% else %}
+                {{ legend.text }}
+            {% endif %}
         </legend>
 
         {{ form_errors(element) }}

--- a/client/src/AppBundle/Resources/views/Index/login-from-logout.html.twig
+++ b/client/src/AppBundle/Resources/views/Index/login-from-logout.html.twig
@@ -5,7 +5,7 @@
 
 {% block pageTitle %}{{ 'signedOut.pageTitle' | trans }}{% endblock %}
 
-{% block pageHeader %}
+{% block loginHeader %}
 
     {% if not isAdmin %}
         <p class="govuk-body-l">{{ 'signedOut.para01' | trans }}</p>

--- a/client/src/AppBundle/Resources/views/Index/login.html.twig
+++ b/client/src/AppBundle/Resources/views/Index/login.html.twig
@@ -31,7 +31,7 @@
     {% endif %}
 
     {# Content gets injected here when manually signing out (login-from-logout) #}
-    {% block pageHeader %}
+    {% block loginHeader %}
     {% endblock %}
 
     {{ form_start(form, {attr: {novalidate: 'novalidate'}}) }}

--- a/client/src/AppBundle/Resources/views/Layouts/application.html.twig
+++ b/client/src/AppBundle/Resources/views/Layouts/application.html.twig
@@ -97,24 +97,26 @@
         {% endfor %}
     {% endblock %}
 
-    <div class="moj-page-header-actions">
-        <div class="moj-page-header-actions__title">
-            <h1 class="govuk-heading-xl">
+    {% block pageHeader %}
+        <div class="moj-page-header-actions">
+            <div class="moj-page-header-actions__title">
                 {% if block("supportTitleTop") is defined and block("supportTitleTop") != "" %}
                     <span class="govuk-caption-xl">{% block supportTitleTop %}{% endblock %}</span>
                 {% endif %}
-                {% block pageTitle %} Deputy report {% endblock %}
-            </h1>
-        </div>
+                <h1 class="govuk-heading-xl">
+                    {% block pageTitle %} Deputy report {% endblock %}
+                </h1>
+            </div>
 
-        <div class="moj-page-header-actions__actions">
-            <div class="moj-button-menu">
-                <div class="moj-button-menu__wrapper">
-                    {% block actions %}{% endblock %}
+            <div class="moj-page-header-actions__actions">
+                <div class="moj-button-menu">
+                    <div class="moj-button-menu__wrapper">
+                        {% block actions %}{% endblock %}
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
+    {% endblock %}
 
 
     {% block progressBar %}{% endblock %}

--- a/client/src/AppBundle/Resources/views/Layouts/application.html.twig
+++ b/client/src/AppBundle/Resources/views/Layouts/application.html.twig
@@ -104,9 +104,6 @@
                     <span class="govuk-caption-xl">{% block supportTitleTop %}{% endblock %}</span>
                 {% endif %}
                 {% block pageTitle %} Deputy report {% endblock %}
-                {% if block("supportTitleBottom") is defined and block("supportTitleBottom") != "" %}
-                    <span class="govuk-caption-xl">{% block supportTitleBottom %}{% endblock %}</span>
-                {% endif %}
             </h1>
         </div>
 

--- a/client/src/AppBundle/Resources/views/Ndr/Asset/addAnother.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Asset/addAnother.html.twig
@@ -8,7 +8,6 @@
 
 {% block htmlTitle %}{{ 'addAnotherPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.pageTitle' | trans }}{% endblock %}
-{% block supportTitleTop %}{{ 'addAnotherPage.supportTitle' | trans }}{% endblock %}
 
 {% block breadcrumbs %}{{ macros.breadcrumbs(ndr) }}{% endblock %}
 

--- a/client/src/AppBundle/Resources/views/Ndr/Asset/addAnother.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Asset/addAnother.html.twig
@@ -8,7 +8,7 @@
 
 {% block htmlTitle %}{{ 'addAnotherPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.pageTitle' | trans }}{% endblock %}
-
+{% block supportTitleTop %}{{ 'addAnotherPage.supportTitle' | trans }}{% endblock %}
 
 {% block breadcrumbs %}{{ macros.breadcrumbs(ndr) }}{% endblock %}
 

--- a/client/src/AppBundle/Resources/views/Ndr/Asset/exist.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Asset/exist.html.twig
@@ -7,8 +7,7 @@
 {% set transOptions = {'%client%': ndr.client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'existPage.htmlTitle' | trans }}{% endblock %}
-{% block pageTitle %}{{ 'existPage.pageTitle' | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -18,15 +17,15 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <div class="push--bottom">
-        {{ form_checkbox_group(form.noAssetToAdd, 'existPage.form.noAssetToAdd', {
-            'fieldSetClass' : 'inline',
-            'labelParameters': transOptions,
-            'legendClass' : 'govuk-label--s',
-            'legendText' : 'existPage.form.noAssetToAdd.label' | trans(transOptions, translationDomain),
-            'formGroupClass': 'flush--bottom'
-        }) }}
-    </div>
+    {{ form_checkbox_group(form.noAssetToAdd, 'existPage.form.noAssetToAdd', {
+        'classes' : 'govuk-radios--inline',
+        'labelParameters': transOptions,
+        legend: {
+            isPageHeading: true,
+            caption: 'existPage.supportTitle' | trans
+        },
+        'legendText' : 'existPage.form.noAssetToAdd.label' | trans(transOptions, translationDomain),
+    }) }}
 
     {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/src/AppBundle/Resources/views/Ndr/Debt/edit.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Debt/edit.html.twig
@@ -16,10 +16,7 @@
 
 {% block pageContent %}
 
-    <h3 class="govuk-heading-s push-half--bottom">
-        {{ 'editPage.pageSectionDescription' | trans(transOptions, translationDomain) }}
-        <span class="form-hint text push-half--bottom">{{ 'editPage.pageHint' | trans(transOptions, translationDomain) }}</span>
-    </h3>
+    <p class="govuk-hint">{{ 'editPage.pageHint' | trans(transOptions, translationDomain) }}</span>
 
     {{ form_start(form, {attr: {novalidate: 'novalidate'}}) }}
 

--- a/client/src/AppBundle/Resources/views/Ndr/Debt/exist.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Debt/exist.html.twig
@@ -7,8 +7,7 @@
 {% set transOptions = {'%client%': ndr.client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'existPage.htmlTitle' | trans(transOptions) }}{% endblock %}
-{% block pageTitle %}{{ 'existPage.pageTitle' | trans(transOptions) }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -18,14 +17,14 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <div class="push--bottom">
-        {{ form_checkbox_group(form.hasDebts, 'existPage.form.exist', {
-            'fieldSetClass' : 'inline',
-            'legendClass' : 'govuk-label--s text',
-            'legendText' : 'existPage.form.exist.label' | trans(transOptions, translationDomain),
-            'formGroupClass': 'flush--bottom'
-        }) }}
-    </div>
+    {{ form_checkbox_group(form.hasDebts, 'existPage.form.exist', {
+        'fieldSetClass' : 'govuk-radios--inline',
+        'legendText' : 'existPage.form.exist.label' | trans(transOptions, translationDomain),
+        legend: {
+            isPageHeading: true,
+            caption: 'existPage.supportTitle' | trans
+        }
+    }) }}
 
     {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/src/AppBundle/Resources/views/Ndr/Debt/management.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Debt/management.html.twig
@@ -7,8 +7,7 @@
 {% set transOptions = {'%client%': ndr.client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'managementPage.htmlTitle' | trans(transOptions) }}{% endblock %}
-{% block pageTitle %}{{ 'managementPage.pageTitle' | trans(transOptions) }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
 {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -18,16 +17,12 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-        <div class="push--bottom">
-
-
-            {{  form_input(form.debtManagement,'managementPage.form.debtManagement', {
-                'labelClass': 'govuk-label--s',
-                'formGroupClass': 'flush--bottom',
-                'labelRaw': true
-            }) }}
-
-        </div>
+        {{ form_input(form.debtManagement,'managementPage.form.debtManagement', {
+            label: {
+                isPageHeading: true,
+                caption: 'managementPage.supportTitle' | trans
+            },
+        }) }}
 
         {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/src/AppBundle/Resources/views/Ndr/DeputyExpense/exist.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/DeputyExpense/exist.html.twig
@@ -7,8 +7,7 @@
 {% set transOptions = {'%client%': ndr.client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'existPage.htmlTitle' | trans }}{% endblock %}
-{% block pageTitle %}{{ 'existPage.pageTitle' | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -18,14 +17,14 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <div class="push--bottom">
     {{ form_checkbox_group(form.paidForAnything, 'existPage.form.paidForAnything', {
-        'fieldSetClass' : 'inline',
+        'classes' : 'govuk-radios--inline',
         'labelParameters': transOptions,
-        'legendClass' : 'govuk-label--s text',
-        'formGroupClass': 'flush--bottom'
+        legend: {
+            isPageHeading: true,
+            caption: 'existPage.supportTitle' | trans
+        }
     }) }}
-    </div>
 
     {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/src/AppBundle/Resources/views/Ndr/Ndr/_subsection.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Ndr/_subsection.html.twig
@@ -11,7 +11,7 @@
         </h3>
 
         {%  if description is defined and description %}
-            <p class="opg-overview-section__description">{{ (subSection ~ '.subSectionDescription') | trans({'%client%': client.firstname}, translationDomain ) }}</p>
+            <div class="opg-overview-section__description">{{ (subSection ~ '.subSectionDescription') | trans({'%client%': client.firstname}, translationDomain ) }}</div>
         {%  endif %}
     </div>
 

--- a/client/src/AppBundle/Resources/views/Ndr/Ndr/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Ndr/index.html.twig
@@ -4,8 +4,7 @@
 
 {% block htmlTitle %}{{ 'page.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'page.pageTitle' | trans }}{% endblock %}
-
-{% block supportTitleBottom %}{{ client.firstname }} {{ client.lastname }}{% endblock %}
+{% block supportTitleTop %}{{ client.fullname }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/src/AppBundle/Resources/views/Ndr/Ndr/overview.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Ndr/overview.html.twig
@@ -7,7 +7,7 @@
 
 {% block htmlTitle %}{{ 'page.htmlTitle' | trans }} {% endblock %}
 {% block pageTitle %}{{ 'heading.title' | trans }}{% endblock %}
-{% block supportTitleBottom %}{{ client.fullname }}{% endblock %}
+{% block supportTitleTop %}{{ client.fullname }}{% endblock %}
 
 {% block breadcrumbs %}{{ macros.homepage }}{% endblock %}
 

--- a/client/src/AppBundle/Resources/views/Ndr/Ndr/overview.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Ndr/overview.html.twig
@@ -12,10 +12,7 @@
 {% block breadcrumbs %}{{ macros.homepage }}{% endblock %}
 
 {% block pageContent %}
-
-    {% block pageHeader %}
-        {% include 'AppBundle:Ndr/Ndr:_header.html.twig' %}
-    {% endblock %}
+    {% include 'AppBundle:Ndr/Ndr:_header.html.twig' %}
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half">

--- a/client/src/AppBundle/Resources/views/Ndr/OtherInfo/step.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/OtherInfo/step.html.twig
@@ -6,13 +6,8 @@
 {% trans_default_domain translationDomain %}
 {% set transOptions = {'%client%': ndr.client.firstname | e } %}
 
-{% block htmlTitle %}
-    {{ 'stepPage.htmlTitle' | trans }}
-{% endblock %}
-{% block pageTitle %}
-    {{ 'stepPage.pageTitle' | trans }}
-{% endblock %}
-
+{% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans }}{% endblock %}
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -22,26 +17,27 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-        <div class="push--bottom">
-            <div class="govuk-form-group flush--bottom {% if not form.actionMoreInfo.vars.valid %}govuk-form-group--error{% endif %}">
-                {{ form_checkbox_group(form.actionMoreInfo, 'form.actionMoreInfo', {
-                    'useFormGroup': false,
-                    'fieldSetClass' : 'inline',
-                    'legendClass' : 'govuk-label--s',
-                    'legendText' : 'form.actionMoreInfo.label' | trans(transOptions),
-                    'items': [
-                        {'dataTarget': 'more-info-textarea' }
-                    ]
-                }) }}
+    <div class="govuk-form-group {% if not form.actionMoreInfo.vars.valid %}govuk-form-group--error{% endif %}">
+        {{ form_checkbox_group(form.actionMoreInfo, 'form.actionMoreInfo', {
+            'useFormGroup': false,
+            'fieldSetClass' : 'inline',
+            'legendText' : 'form.actionMoreInfo.label' | trans(transOptions),
+            legend: {
+                isPageHeading: true,
+                caption: 'stepPage.supportTitle' | trans
+            },
+            'items': [
+                {'dataTarget': 'more-info-textarea' }
+            ]
+        }) }}
 
-                <div id="more-info-textarea" class="opg-indented-block js-hidden">
-                    {{ form_input(form.actionMoreInfoDetails, 'form.actionMoreInfoDetails', {
-                        'labelClass': 'required',
-                        'labelParameters': transOptions
-                    }) }}
-                </div>
-            </div>
+        <div id="more-info-textarea" class="opg-indented-block js-hidden">
+            {{ form_input(form.actionMoreInfoDetails, 'form.actionMoreInfoDetails', {
+                'labelClass': 'required',
+                'labelParameters': transOptions
+            }) }}
         </div>
+    </div>
 
 
     {{ macros.saveAndContinueButton(form.save) }}
@@ -49,4 +45,3 @@
     {{ form_end(form) }}
 
 {% endblock %}
-

--- a/client/src/AppBundle/Resources/views/Ndr/VisitsCare/step.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/VisitsCare/step.html.twig
@@ -1,3 +1,4 @@
+
 {% extends 'AppBundle:Layouts:application.html.twig' %}
 
 {% import 'AppBundle:Macros:macros.html.twig' as macros %}
@@ -7,124 +8,119 @@
 {% set transOptions = {'%client%': ndr.client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans }}{% endblock %}
-{% block pageTitle %}{{ 'stepPage.pageTitle' | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
 {% endblock %}
+
+{% set pageCaption = 'stepPage.supportTitle' | trans %}
 
 {% block pageContent %}
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
     {% if step == 1 %}
-        <div class="push--bottom">
-
-            <div class="govuk-form-group flush--bottom {% if not form.doYouLiveWithClient.vars.valid %}govuk-form-group--error{% endif %}">
-                {{ form_checkbox_group(form.doYouLiveWithClient, 'form.doYouLiveWithClient', {
-                    'useFormGroup': false,
-                    'fieldSetClass' : 'inline',
-                    'legendClass' : 'govuk-label--s',
-                    'legendText' : 'form.doYouLiveWithClient.label' | trans(transOptions, translationDomain),
-                    'items': [
+        <div class="govuk-form-group {% if not form.doYouLiveWithClient.vars.valid %}govuk-form-group--error{% endif %}">
+            {{ form_checkbox_group(form.doYouLiveWithClient, 'form.doYouLiveWithClient', {
+                'useFormGroup': false,
+                'legendText' : 'form.doYouLiveWithClient.label' | trans(transOptions, translationDomain),
+                legend: {
+                    isPageHeading: true,
+                    caption: pageCaption
+                },
+                'items': [
                     {},
                     {'dataTarget': 'how-often-contact-client-wrapper' }
-                    ]
-                }) }}
+                ]
+            }) }}
 
-                <div id="how-often-contact-client-wrapper" class="opg-indented-block js-hidden">
-                    {{ form_input(form.howOftenDoYouContactClient, 'form.howOftenDoYouContactClient', {
-                        'labelClass': 'required',
-                        'labelParameters': transOptions
-                    }) }}
-                </div>
+            <div id="how-often-contact-client-wrapper" class="opg-indented-block js-hidden">
+                {{ form_input(form.howOftenDoYouContactClient, 'form.howOftenDoYouContactClient', {
+                    'labelClass': 'required',
+                    'labelParameters': transOptions
+                }) }}
             </div>
         </div>
     {% endif %}
 
     {% if step == 2 %}
-        <div class="push--bottom">
-
-            <div class="govuk-form-group flush--bottom {% if not form.doesClientReceivePaidCare.vars.valid %}govuk-form-group--error{% endif %}">
-                {{ form_checkbox_group(form.doesClientReceivePaidCare, 'form.doesClientReceivePaidCare', {
-                    'useFormGroup': false,
-                    'fieldSetClass' : 'inline',
-                    'legendClass' : 'govuk-label--s',
-                    'legendText' : 'form.doesClientReceivePaidCare.label' | trans(transOptions, translationDomain),
-                    'items': [
+        <div class="govuk-form-group {% if not form.doesClientReceivePaidCare.vars.valid %}govuk-form-group--error{% endif %}">
+            {{ form_checkbox_group(form.doesClientReceivePaidCare, 'form.doesClientReceivePaidCare', {
+                'useFormGroup': false,
+                'legendText' : 'form.doesClientReceivePaidCare.label' | trans(transOptions, translationDomain),
+                legend: {
+                    isPageHeading: true,
+                    caption: pageCaption
+                },
+                'items': [
                     {'dataTarget': 'how-care-funded-wrapper' },
                     {}
-                    ]
-                }) }}
+                ]
+            }) }}
 
-                <div id="how-care-funded-wrapper" class="opg-indented-block js-hidden">
-                    {{ form_checkbox_group(form.howIsCareFunded, 'form.howIsCareFunded', {
-                        'fieldSetClass': 'text',
-                        'legendClass' : 'govuk-label--s'
-                    }) }}
-                </div>
+            <div id="how-care-funded-wrapper" class="opg-indented-block js-hidden">
+                {{ form_checkbox_group(form.howIsCareFunded, 'form.howIsCareFunded', {
+                    'fieldSetClass': 'text',
+                    'legendClass' : 'govuk-label--s'
+                }) }}
             </div>
         </div>
     {% endif %}
 
     {% if step == 3 %}
-        <div class="push--bottom">
-            {{ form_input(form.whoIsDoingTheCaring,'form.whoIsDoingTheCaring', {
-                'labelClass': 'form-label',
-                'formGroupClass': 'flush--bottom',
-                'labelRaw': true
-            }) }}
-        </div>
+        {{ form_input(form.whoIsDoingTheCaring,'form.whoIsDoingTheCaring', {
+            label: {
+                isPageHeading: true,
+                caption: pageCaption
+            }
+        }) }}
     {% endif %}
 
     {% if step == 4 %}
-        <div class="push--bottom">
+        <div class="govuk-form-group {% if not form.doesClientHaveACarePlan.vars.valid %}govuk-form-group--error{% endif %}">
+            {{ form_checkbox_group(form.doesClientHaveACarePlan, 'form.doesClientHaveACarePlan', {
+                'useFormGroup': false,
+                'legendText' : 'form.doesClientHaveACarePlan.label' | trans(transOptions, translationDomain),
+                legend: {
+                    isPageHeading: true,
+                    caption: pageCaption
+                },
+                'hintText': 'form.doesClientHaveACarePlan.hint' | trans(transOptions, translationDomain),
+                'items': [
+                    {'dataTarget': 'when-care-plan-last-reviewed-wrapper'},
+                    {}
+                ]
+            }) }}
 
-            <div class="govuk-form-group flush--bottom {% if not form.doesClientHaveACarePlan.vars.valid %}govuk-form-group--error{% endif %}">
-                {{ form_checkbox_group(form.doesClientHaveACarePlan, 'form.doesClientHaveACarePlan', {
-                    'useFormGroup': false,
-                    'fieldSetClass' : 'inline',
-                    'legendClass' : 'govuk-label--s',
-                    'legendText' : 'form.doesClientHaveACarePlan.label' | trans(transOptions, translationDomain),
-                    'hintText': 'form.doesClientHaveACarePlan.hint' | trans(transOptions, translationDomain),
-                    'items': [
-                        {'dataTarget': 'when-care-plan-last-reviewed-wrapper'},
-                        {}
-                    ]
+            <div id="when-care-plan-last-reviewed-wrapper" class="opg-indented-block  js-hidden">
+                {{ form_known_date(form.whenWasCarePlanLastReviewed, 'form.whenWasCarePlanLastReviewed', {
+                    'showDay': 'false'
                 }) }}
-
-                <div id="when-care-plan-last-reviewed-wrapper" class="opg-indented-block  js-hidden">
-                    {# legendClass is-not-working #}
-                    {{ form_known_date(form.whenWasCarePlanLastReviewed, 'form.whenWasCarePlanLastReviewed', {
-                        'legendClass' : 'govuk-label--s',
-                        'showDay': 'false'
-                    }) }}
-                </div>
             </div>
         </div>
     {% endif %}
 
     {% if step == 5 %}
-        <div class="push--bottom">
-            <div class="govuk-form-group flush--bottom {% if not form.planMoveNewResidence.vars.valid %}govuk-form-group--error{% endif %}">
-                {{ form_checkbox_group(form.planMoveNewResidence, 'form.planMoveNewResidence', {
-                    'useFormGroup': false,
-                    'fieldSetClass' : 'inline',
-                    'legendClass' : 'govuk-label--s',
-                    'legendText' : 'form.planMoveNewResidence.label' | trans(transOptions, translationDomain),
-                    'items': [
+        <div class="govuk-form-group {% if not form.planMoveNewResidence.vars.valid %}govuk-form-group--error{% endif %}">
+            {{ form_checkbox_group(form.planMoveNewResidence, 'form.planMoveNewResidence', {
+                'useFormGroup': false,
+                'legendText' : 'form.planMoveNewResidence.label' | trans(transOptions, translationDomain),
+                legend: {
+                    isPageHeading: true,
+                    caption: pageCaption
+                },
+                'items': [
                     {'dataTarget': 'plan-move-residence-details-textarea'},
-                    {}]
+                    {}
+                ]
+            }) }}
+            <div id="plan-move-residence-details-textarea" class="opg-indented-block  js-hidden">
+                {{ form_input(form.planMoveNewResidenceDetails, 'form.planMoveNewResidenceDetails', {
+                    'labelClass': 'required',
+                    'labelParameters': transOptions,
+                    'hintText' : 'form.planMoveNewResidenceDetails.hint' | trans(transOptions, translationDomain)
                 }) }}
-                <div id="plan-move-residence-details-textarea" class="opg-indented-block  js-hidden">
-                    {{ form_input(form.planMoveNewResidenceDetails, 'form.planMoveNewResidenceDetails', {
-                        'labelClass': 'required',
-                        'labelParameters': transOptions,
-                        'hintText' : 'form.planMoveNewResidenceDetails.hint' | trans(transOptions, translationDomain),
-                        'labelRaw': true
-                    }) }}
-                </div>
             </div>
         </div>
     {% endif %}
@@ -139,4 +135,3 @@
     {{ form_end(form) }}
 
 {% endblock %}
-

--- a/client/src/AppBundle/Resources/views/Org/ClientProfile/addContact.html.twig
+++ b/client/src/AppBundle/Resources/views/Org/ClientProfile/addContact.html.twig
@@ -11,7 +11,7 @@
 
 
 {% block supportTitleTop %}
-    <span class="heading-secondary">{{ (page ~ '.supportTitle') | trans }} {{ client.fullname | title }}</span>
+    {{ (page ~ '.supportTitle') | trans({'%fullName%': client.fullname | title}) }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/client/src/AppBundle/Resources/views/Org/ClientProfile/addNote.html.twig
+++ b/client/src/AppBundle/Resources/views/Org/ClientProfile/addNote.html.twig
@@ -11,7 +11,7 @@
 
 
 {% block supportTitleTop %}
-    <span class="heading-secondary">{{ (page ~ '.supportTitle') | trans }} {{ client.fullname | title }}</span>
+    {{ (page ~ '.supportTitle') | trans({'%fullName%': client.fullname | title}) }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/client/src/AppBundle/Resources/views/Org/ClientProfile/editContact.html.twig
+++ b/client/src/AppBundle/Resources/views/Org/ClientProfile/editContact.html.twig
@@ -11,7 +11,7 @@
 
 
 {% block supportTitleTop %}
-    <span class="heading-secondary">{{ (page ~ '.supportTitle') | trans }} {{ client.fullname | title }}</span>
+    {{ (page ~ '.supportTitle') | trans({'%fullName%': client.fullname | title}) }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/client/src/AppBundle/Resources/views/Org/ClientProfile/editNote.html.twig
+++ b/client/src/AppBundle/Resources/views/Org/ClientProfile/editNote.html.twig
@@ -11,7 +11,7 @@
 
 
 {% block supportTitleTop %}
-    <span class="heading-secondary">{{ (page ~ '.supportTitle') | trans }} {{ client.fullname | title }}</span>
+    {{ (page ~ '.supportTitle') | trans({'%fullName%': client.fullname | title}) }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/client/src/AppBundle/Resources/views/Org/ClientProfile/overview.html.twig
+++ b/client/src/AppBundle/Resources/views/Org/ClientProfile/overview.html.twig
@@ -7,9 +7,8 @@
 {% set transOptions = {'%client%': client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'htmlTitle-ORG' | trans }}{% endblock %}
-{% block pageTitle %}
-    {{ 'pageTitle' | trans({}, 'client-profile') }} {{ client.fullname | title }}
-{% endblock %}
+{% block pageTitle %}{{ 'pageTitle' | trans({}, 'client-profile') }}{% endblock %}
+{% block supportTitleTop %}{{ client.fullname | title }}{% endblock %}
 
 {% block breadcrumbs %}
     <div class="breadcrumbs hard--bottom">

--- a/client/src/AppBundle/Resources/views/Report/Action/step.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Action/step.html.twig
@@ -8,7 +8,7 @@
 {% set append104 = report.get104TransSuffix %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans }}{% endblock %}
-{% block pageTitle %}{{ 'stepPage.pageTitle' | trans }}{% endblock %}
+{% block pageHeader %}{% endblock %}
 
 
 {% block linkBack %}
@@ -20,27 +20,27 @@
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
     {% if step == 1 %}
-        <div class="push--bottom">
-            <div class="govuk-form-group flush--bottom {% if not form.doYouExpectFinancialDecisions.vars.valid %}govuk-form-group--error{% endif %}">
-                {{ form_checkbox_group(form.doYouExpectFinancialDecisions, 'form.doYouExpectFinancialDecisions', {
-                    'useFormGroup': false,
-                    'fieldSetClass' : 'inline',
-                    'legendClass' : 'govuk-label--s',
-                    'legendText' : ('form.doYouExpectFinancialDecisions.label' ~ append104) | trans(transOptions, translationDomain),
-                    'hintText' : ('form.doYouExpectFinancialDecisions.hint' ~ append104 ) | trans(transOptions, translationDomain),
-                    'items': [
-                        {'dataTarget': 'financial-decisions-textarea' },
-                        {},
-                    ]
-                }) }}
+        <div class="govuk-form-group {% if not form.doYouExpectFinancialDecisions.vars.valid %}govuk-form-group--error{% endif %}">
+            {{ form_checkbox_group(form.doYouExpectFinancialDecisions, 'form.doYouExpectFinancialDecisions', {
+                'useFormGroup': false,
+                'legendText' : ('form.doYouExpectFinancialDecisions.label' ~ append104) | trans(transOptions, translationDomain),
+                legend: {
+                    isPageHeading: true,
+                    caption: 'stepPage.supportTitle' | trans
+                },
+                'hintText' : ('form.doYouExpectFinancialDecisions.hint' ~ append104 ) | trans(transOptions, translationDomain),
+                'items': [
+                    {'dataTarget': 'financial-decisions-textarea' },
+                    {},
+                ]
+            }) }}
 
-                <div id="financial-decisions-textarea" class="opg-indented-block js-hidden">
-                    {{ form_input(form.doYouExpectFinancialDecisionsDetails, 'form.doYouExpectFinancialDecisionsDetails', {
-                        'labelText': ('form.doYouExpectFinancialDecisionsDetails.label' ~ append104) | trans(transOptions, translationDomain),
-                        'labelClass': 'required',
-                        'labelParameters': transOptions
-                    }) }}
-                </div>
+            <div id="financial-decisions-textarea" class="opg-indented-block js-hidden">
+                {{ form_input(form.doYouExpectFinancialDecisionsDetails, 'form.doYouExpectFinancialDecisionsDetails', {
+                    'labelText': ('form.doYouExpectFinancialDecisionsDetails.label' ~ append104) | trans(transOptions, translationDomain),
+                    'labelClass': 'required',
+                    'labelParameters': transOptions
+                }) }}
             </div>
         </div>
 
@@ -61,27 +61,26 @@
     {% endif %}
 
     {% if step == 2 %}
-        <div class="push--bottom">
+        <div class="govuk-form-group {% if not form.doYouHaveConcerns.vars.valid %}govuk-form-group--error{% endif %}">
+            {{ form_checkbox_group(form.doYouHaveConcerns, 'form.doYouHaveConcerns', {
+                'useFormGroup': false,
+                'legendText' : 'form.doYouHaveConcerns.label' | trans(transOptions, translationDomain),
+                legend: {
+                    isPageHeading: true,
+                    caption: 'stepPage.supportTitle' | trans
+                },
+                'hintText' : ('form.doYouHaveConcerns.hint' ~ append104)  | trans(transOptions, translationDomain),
+                'items': [
+                    {'dataTarget': 'actions-details-textarea' },
+                    {},
+                ]
+            }) }}
 
-            <div class="govuk-form-group flush--bottom {% if not form.doYouHaveConcerns.vars.valid %}govuk-form-group--error{% endif %}">
-                {{ form_checkbox_group(form.doYouHaveConcerns, 'form.doYouHaveConcerns', {
-                    'useFormGroup': false,
-                    'fieldSetClass' : 'inline',
-                    'legendClass' : 'govuk-label--s',
-                    'legendText' : 'form.doYouHaveConcerns.label' | trans(transOptions, translationDomain),
-                    'hintText' : ('form.doYouHaveConcerns.hint' ~ append104)  | trans(transOptions, translationDomain),
-                    'items': [
-                        {'dataTarget': 'actions-details-textarea' },
-                        {},
-                    ]
+            <div id="actions-details-textarea" class="opg-indented-block js-hidden">
+                {{ form_input(form.doYouHaveConcernsDetails, 'form.doYouHaveConcernsDetails', {
+                    'labelClass': 'required',
+                    'labelParameters': transOptions
                 }) }}
-
-                <div id="actions-details-textarea" class="opg-indented-block js-hidden">
-                    {{ form_input(form.doYouHaveConcernsDetails, 'form.doYouHaveConcernsDetails', {
-                        'labelClass': 'required',
-                        'labelParameters': transOptions
-                    }) }}
-                </div>
             </div>
         </div>
     {% endif %}
@@ -95,4 +94,3 @@
     {{ form_end(form) }}
 
 {% endblock %}
-

--- a/client/src/AppBundle/Resources/views/Report/Asset/exist.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Asset/exist.html.twig
@@ -8,8 +8,7 @@
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
-{% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -19,14 +18,14 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <div class="push--bottom">
-        {{ form_checkbox_group(form.noAssetToAdd, (page ~ '.form.noAssetToAdd'), {
-            'fieldSetClass' : 'inline',
-            'labelParameters': transOptions,
-            'legendClass' : 'govuk-label--s text',
-            'formGroupClass': 'flush--bottom'
-        }) }}
-    </div>
+    {{ form_checkbox_group(form.noAssetToAdd, (page ~ '.form.noAssetToAdd'), {
+        'fieldSetClass' : 'govuk-radios--inline',
+        'labelParameters': transOptions,
+        legend: {
+            isPageHeading: true,
+            caption: (page ~ '.supportTitle') | trans
+        }
+    }) }}
 
     {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/src/AppBundle/Resources/views/Report/Contact/exist.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Contact/exist.html.twig
@@ -8,8 +8,7 @@
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
-{% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -19,28 +18,28 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-        <div class="push--bottom">
-            <div class="govuk-form-group flush--bottom {% if not form.hasContacts.vars.valid %}govuk-form-group--error{% endif %}">
-                {% set append104 = report.get104TransSuffix %}
-                {{ form_checkbox_group(form.hasContacts, (page ~ '.form.hasContacts'), {
-                    'useFormGroup': false,
-                    'fieldSetClass' : 'inline',
-                    'labelParameters': transOptions,
-                    'legendClass' : 'govuk-label--s text',
-                    'hintText': (page ~ '.form.hasContacts.hint' ~ append104) | trans(transOptions),
-                    'items': [
-                        {},
-                        {'dataTarget': 'reason-for-no-contact'}
-                    ],
-                    'formGroupClass': 'flush--bottom'
-                }) }}
+        <div class="govuk-form-group {% if not form.hasContacts.vars.valid %}govuk-form-group--error{% endif %}">
+            {% set append104 = report.get104TransSuffix %}
+            {{ form_checkbox_group(form.hasContacts, (page ~ '.form.hasContacts'), {
+                'useFormGroup': false,
+                'labelParameters': transOptions,
+                legend: {
+                    isPageHeading: true,
+                    caption: (page ~ '.supportTitle') | trans
+                },
+                'hintText': (page ~ '.form.hasContacts.hint' ~ append104) | trans(transOptions),
+                'items': [
+                    {},
+                    {'dataTarget': 'reason-for-no-contact'}
+                ],
+                'formGroupClass': 'flush--bottom'
+            }) }}
 
-                <div id="reason-for-no-contact" class="opg-indented-block js-hidden">
-                    {{ form_input(form.reasonForNoContacts, (page ~ '.form.reasonForNoContacts'), {
-                        'labelClass': 'required',
-                        'labelParameters': transOptions
-                    }) }}
-                </div>
+            <div id="reason-for-no-contact" class="opg-indented-block js-hidden">
+                {{ form_input(form.reasonForNoContacts, (page ~ '.form.reasonForNoContacts'), {
+                    'labelClass': 'required',
+                    'labelParameters': transOptions
+                }) }}
             </div>
         </div>
 

--- a/client/src/AppBundle/Resources/views/Report/Debt/edit.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Debt/edit.html.twig
@@ -8,7 +8,7 @@
 
 {% block htmlTitle %}{{ 'editPage.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageTitle %}{{ 'editPage.pageTitle' | trans(transOptions) }}{% endblock %}
-
+{% block supportTitleTop %}{{ 'editPage.supportTitle' | trans(transOptions) }}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -16,10 +16,7 @@
 
 {% block pageContent %}
 
-    <h3 class="govuk-heading-s push-half--bottom">
-        {{ 'editPage.pageSectionDescription' | trans(transOptions, translationDomain) }}
-        <span class="form-hint text push-half--bottom">{{ 'editPage.pageHint' | trans(transOptions, translationDomain) }}</span>
-    </h3>
+    <p class="govuk-hint">{{ 'editPage.pageHint' | trans(transOptions, translationDomain) }}</p>
 
     {{ form_start(form, {attr: {novalidate: 'novalidate'}}) }}
 

--- a/client/src/AppBundle/Resources/views/Report/Debt/exist.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Debt/exist.html.twig
@@ -7,8 +7,7 @@
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'existPage.htmlTitle' | trans(transOptions) }}{% endblock %}
-{% block pageTitle %}{{ 'existPage.pageTitle' | trans(transOptions) }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -18,14 +17,14 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <div class="push--bottom">
-        {{ form_checkbox_group(form.hasDebts, 'existPage.form.exist', {
-            'fieldSetClass' : 'inline',
-            'legendClass' : 'govuk-label--s text',
-            'legendText' : 'existPage.form.exist.label' | trans(transOptions, translationDomain),
-            'formGroupClass': 'flush--bottom'
-        }) }}
-    </div>
+    {{ form_checkbox_group(form.hasDebts, 'existPage.form.exist', {
+        'fieldSetClass' : 'govuk-radios--inline',
+        'legendText' : 'existPage.form.exist.label' | trans(transOptions, translationDomain),
+        legend: {
+            isPageHeading: true,
+            caption: 'existPage.supportTitle' | trans
+        }
+    }) }}
 
     {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/src/AppBundle/Resources/views/Report/Debt/management.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Debt/management.html.twig
@@ -7,8 +7,7 @@
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'managementPage.htmlTitle' | trans(transOptions) }}{% endblock %}
-{% block pageTitle %}{{ 'managementPage.pageTitle' | trans(transOptions) }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
 {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -18,16 +17,12 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-        <div class="push--bottom">
-
-
-            {{  form_input(form.debtManagement,'managementPage.form.debtManagement', {
-                'labelClass': 'govuk-label--s',
-                'formGroupClass': 'flush--bottom',
-                'labelRaw': true
-            }) }}
-
-        </div>
+        {{  form_input(form.debtManagement,'managementPage.form.debtManagement', {
+            label: {
+                isPageHeading: true,
+                caption: 'managementPage.supportTitle' | trans
+            }
+        }) }}
 
         {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/src/AppBundle/Resources/views/Report/Decision/exist.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Decision/exist.html.twig
@@ -9,8 +9,7 @@
 {% set append104 = report.get104TransSuffix %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
-{% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -20,26 +19,26 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-        <div class="push--bottom">
-            <div class="govuk-form-group flush--bottom {% if not form.hasDecisions.vars.valid %}govuk-form-group--error{% endif %}">
-                {{ form_checkbox_group(form.hasDecisions, (page ~ '.form.hasDecisions'), {
-                    'useFormGroup': false,
-                    'fieldSetClass' : 'inline',
-                    'labelParameters': transOptions,
-                    'legendClass' : 'govuk-label--s text',
-                    'items': [
-                        {},
-                        {'dataTarget': 'reason-for-no-decisions'}
-                    ],
-                    'formGroupClass': 'flush--bottom'
-                }) }}
+        <div class="govuk-form-group {% if not form.hasDecisions.vars.valid %}govuk-form-group--error{% endif %}">
+            {{ form_checkbox_group(form.hasDecisions, (page ~ '.form.hasDecisions'), {
+                'useFormGroup': false,
+                'labelParameters': transOptions,
+                legend: {
+                    isPageHeading: true,
+                    caption: (page ~ '.supportTitle') | trans
+                },
+                'items': [
+                    {},
+                    {'dataTarget': 'reason-for-no-decisions'}
+                ],
+                'formGroupClass': 'flush--bottom'
+            }) }}
 
-                <div id="reason-for-no-decisions" class="opg-indented-block js-hidden">
-                    {{ form_input(form.reasonForNoDecisions, (page ~ '.form.reasonForNoDecisions'), {
-                        'labelClass': 'required',
-                        'labelParameters': transOptions
-                    }) }}
-                </div>
+            <div id="reason-for-no-decisions" class="opg-indented-block js-hidden">
+                {{ form_input(form.reasonForNoDecisions, (page ~ '.form.reasonForNoDecisions'), {
+                    'labelClass': 'required',
+                    'labelParameters': transOptions
+                }) }}
             </div>
         </div>
 

--- a/client/src/AppBundle/Resources/views/Report/Decision/mentalAssessment.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Decision/mentalAssessment.html.twig
@@ -8,8 +8,7 @@
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
-{% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -22,6 +21,10 @@
     {{ form_known_date(form.mentalAssessmentDate, (page ~ '.form.mentalAssessmentDate'), {
         'showDay': 'false',
         'legendParameters': transOptions,
+        legend: {
+            isPageHeading: true,
+            caption: (page ~ '.supportTitle') | trans
+        }
     }) }}
 
     {{ macros.saveAndContinueButton(form.save) }}

--- a/client/src/AppBundle/Resources/views/Report/Decision/mentalCapacity.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Decision/mentalCapacity.html.twig
@@ -9,8 +9,7 @@
 {% set append104 = report.get104TransSuffix %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
-{% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -20,25 +19,25 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <div class="push--bottom">
-        <div class="govuk-form-group flush--bottom {% if not form.hasCapacityChanged.vars.valid %}govuk-form-group--error{% endif %}">
-            {% set conditionalCapacityChanged %}
-                {{ form_input(form.hasCapacityChangedDetails, (page ~ '.form.hasCapacityChangedDetails'), {
-                    'labelClass': 'required',
-                    'labelParameters': transOptions,
-                    'hintText' : (page ~ '.form.hasCapacityChangedDetails.hint') | trans(transOptions, translationDomain),
-                    'labelRaw': true
-                }) }}
-            {% endset %}
-
-            {{ form_checkbox_group(form.hasCapacityChanged, (page ~ '.form.hasCapacityChanged'), {
-                'useFormGroup': false,
-                'fieldSetClass' : 'inline',
-                'legendClass' : 'govuk-label--s',
-                'legendText' : (page ~ '.form.hasCapacityChanged.label' ~ append104) | trans(transOptions, translationDomain),
-                'items': [{'conditional': conditionalCapacityChanged}]
+    <div class="govuk-form-group {% if not form.hasCapacityChanged.vars.valid %}govuk-form-group--error{% endif %}">
+        {% set conditionalCapacityChanged %}
+            {{ form_input(form.hasCapacityChangedDetails, (page ~ '.form.hasCapacityChangedDetails'), {
+                'labelClass': 'required',
+                'labelParameters': transOptions,
+                'hintText' : (page ~ '.form.hasCapacityChangedDetails.hint') | trans(transOptions, translationDomain),
+                'labelRaw': true
             }) }}
-        </div>
+        {% endset %}
+
+        {{ form_checkbox_group(form.hasCapacityChanged, (page ~ '.form.hasCapacityChanged'), {
+            'useFormGroup': false,
+            'legendText' : (page ~ '.form.hasCapacityChanged.label' ~ append104) | trans(transOptions, translationDomain),
+            legend: {
+                isPageHeading: true,
+                caption: (page ~ '.supportTitle') | trans
+            },
+            'items': [{'conditional': conditionalCapacityChanged}]
+        }) }}
     </div>
 
     {{ macros.saveAndContinueButton(form.save) }}

--- a/client/src/AppBundle/Resources/views/Report/DeputyExpense/exist.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/DeputyExpense/exist.html.twig
@@ -7,8 +7,7 @@
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'existPage.htmlTitle' | trans }}{% endblock %}
-{% block pageTitle %}{{ 'existPage.pageTitle' | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -18,14 +17,14 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <div class="push--bottom">
     {{ form_checkbox_group(form.paidForAnything, 'existPage.form.paidForAnything', {
         'fieldSetClass' : 'inline',
         'labelParameters': transOptions,
-        'legendClass' : 'govuk-label--s text',
-        'formGroupClass': 'flush--bottom'
+        legend: {
+            isPageHeading: true,
+            caption: 'existPage.supportTitle' | trans
+        }
     }) }}
-    </div>
 
     {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/src/AppBundle/Resources/views/Report/Document/step2.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Document/step2.html.twig
@@ -12,10 +12,6 @@
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 
 
-{% block supportTitleTop %}
-    <span class="heading-secondary">{{ 'pageTitle' | trans }}</span>
-{% endblock %}
-
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
 {% endblock %}

--- a/client/src/AppBundle/Resources/views/Report/Gift/exist.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Gift/exist.html.twig
@@ -7,8 +7,7 @@
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'existPage.htmlTitle' | trans }}{% endblock %}
-{% block pageTitle %}{{ 'existPage.pageTitle' | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -18,14 +17,14 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <div class="push--bottom">
-        {{ form_checkbox_group(form.giftsExist, 'existPage.form.giftsExist', {
-            'fieldSetClass' : 'inline',
-            'labelParameters': transOptions,
-            'legendClass' : 'govuk-label--s text',
-            'formGroupClass': 'flush--bottom'
-        }) }}
-    </div>
+    {{ form_checkbox_group(form.giftsExist, 'existPage.form.giftsExist', {
+        'fieldSetClass' : 'inline',
+        'labelParameters': transOptions,
+        legend: {
+            isPageHeading: true,
+            caption: 'existPage.supportTitle' | trans
+        }
+    }) }}
 
     {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/src/AppBundle/Resources/views/Report/Lifestyle/step.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Lifestyle/step.html.twig
@@ -7,8 +7,7 @@
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans }}{% endblock %}
-{% block pageTitle %}{{ 'stepPage.pageTitle' | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -19,45 +18,43 @@
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
     {% if step == 1 %}
-        <div class="push--bottom">
-            {{ form_input(form.careAppointments, 'form.careAppointments', {
-                'labelClass': 'govuk-label--s',
-                'formGroupClass': 'flush--bottom',
-                'labelRaw': true,
-                'labelText': ('form.careAppointments.label') | trans(transOptions)
-            }) }}
-        </div>
+        {{ form_input(form.careAppointments, 'form.careAppointments', {
+            'labelText': ('form.careAppointments.label') | trans(transOptions),
+            label: {
+                isPageHeading: true,
+                caption: 'stepPage.supportTitle' | trans
+            }
+        }) }}
     {% endif %}
 
     {% if step == 2 %}
-        <div class="push--bottom">
-            <div class="govuk-form-group flush--bottom {% if not form.doesClientUndertakeSocialActivities.vars.valid %}error{% endif %}">
-                {{ form_checkbox_group(form.doesClientUndertakeSocialActivities, 'form.doesClientUndertakeSocialActivities', {
-                    'useFormGroup': false,
-                    'fieldSetClass' : 'inline',
-                    'legendClass' : 'govuk-label--s',
-                    'legendText' : 'form.doesClientUndertakeSocialActivities.label' | trans(transOptions, translationDomain),
-                    'items': [
-                    {'dataTarget': 'undertake-social-activities-yes-wrapper' },
-                    {'dataTarget': 'undertake-social-activities-no-wrapper' }
-                    ]
+        <div class="govuk-form-group {% if not form.doesClientUndertakeSocialActivities.vars.valid %}error{% endif %}">
+            {{ form_checkbox_group(form.doesClientUndertakeSocialActivities, 'form.doesClientUndertakeSocialActivities', {
+                'useFormGroup': false,
+                'legendText' : 'form.doesClientUndertakeSocialActivities.label' | trans(transOptions, translationDomain),
+                legend: {
+                    isPageHeading: true,
+                    caption: 'stepPage.supportTitle' | trans
+                },
+                'items': [
+                {'dataTarget': 'undertake-social-activities-yes-wrapper' },
+                {'dataTarget': 'undertake-social-activities-no-wrapper' }
+                ]
+            }) }}
+
+            <div id="undertake-social-activities-yes-wrapper" class="opg-indented-block js-hidden">
+                {{ form_input(form.activityDetailsYes,'form.activityDetailsYes', {
+                    'formGroupClass': 'flush--bottom',
+                    'labelRaw': true,
+                    'labelText': ('form.activityDetailsYes.label') | trans(transOptions)
                 }) }}
+            </div>
 
-                <div id="undertake-social-activities-yes-wrapper" class="opg-indented-block js-hidden">
-                    {{ form_input(form.activityDetailsYes,'form.activityDetailsYes', {
-                        'formGroupClass': 'flush--bottom',
-                        'labelRaw': true,
-                        'labelText': ('form.activityDetailsYes.label') | trans(transOptions)
-                    }) }}
-                </div>
-
-                <div id="undertake-social-activities-no-wrapper" class="opg-indented-block js-hidden">
-                    {{ form_input(form.activityDetailsNo,'form.activityDetailsNo', {
-                        'formGroupClass': 'flush--bottom',
-                        'labelText': ('form.activityDetailsNo.label') | trans(transOptions)
-                    }) }}
-                </div>
-
+            <div id="undertake-social-activities-no-wrapper" class="opg-indented-block js-hidden">
+                {{ form_input(form.activityDetailsNo,'form.activityDetailsNo', {
+                    'formGroupClass': 'flush--bottom',
+                    'labelText': ('form.activityDetailsNo.label') | trans(transOptions)
+                }) }}
             </div>
         </div>
     {% endif %}
@@ -71,4 +68,3 @@
     {{ form_end(form) }}
 
 {% endblock %}
-

--- a/client/src/AppBundle/Resources/views/Report/MoneyIn/addAnother.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/MoneyIn/addAnother.html.twig
@@ -8,7 +8,7 @@
 
 {% block htmlTitle %}{{ 'addAnotherPage.moneyIn.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.moneyIn.pageTitle' | trans }}{% endblock %}
-
+{% block supportTitleTop %}{{ 'addAnotherPage.moneyIn.supportTitle' | trans }}{% endblock %}
 
 {% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 

--- a/client/src/AppBundle/Resources/views/Report/MoneyInShort/category.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/MoneyInShort/category.html.twig
@@ -7,8 +7,8 @@
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
 {% block htmlTitle %}{{ ('categoryPage.moneyIn.htmlTitle') | trans }}{% endblock %}
-{% block pageTitle %}{{ ('categoryPage.moneyIn.pageTitle') | trans }}{% endblock %}
-
+{% block pageTitle %}{{ 'form.categoriesIn.label' | trans(transOptions) }}{% endblock %}
+{% block supportTitleTop %}{{ ('categoryPage.moneyIn.supportTitle') | trans }}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -18,12 +18,10 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <p class="text">
-        {{ 'form.categoriesIn.label' | trans(transOptions) }}
-    </p>
-    <p class="form-hint">
+    <p class="govuk-hint">
         {{ 'form.categoriesIn.hint' | trans(transOptions) }}
     </p>
+
     {% include 'AppBundle:Report/MoneyInShort:_checkboxes_list.html.twig' with {
     'elements': form.moneyShortCategoriesIn,
     } %}
@@ -33,4 +31,3 @@
     {{ form_end(form) }}
 
 {% endblock %}
-

--- a/client/src/AppBundle/Resources/views/Report/MoneyInShort/exist.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/MoneyInShort/exist.html.twig
@@ -7,8 +7,7 @@
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'existPage.moneyIn.htmlTitle' | trans }}{% endblock %}
-{% block pageTitle %}{{ 'existPage.moneyIn.pageTitle' | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -18,14 +17,14 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <div class="push--bottom">
     {{ form_checkbox_group(form.moneyTransactionsShortInExist, 'existPage.form.moneyTransactionsShortInExist', {
-        'fieldSetClass' : 'inline',
+        'fieldSetClass' : 'govuk-radios--inline',
         'labelParameters': transOptions,
-        'legendClass' : 'govuk-label--s text',
-        'formGroupClass': 'flush--bottom'
+        legend: {
+            isPageHeading: true,
+            caption: 'existPage.moneyIn.supportTitle' | trans
+        }
     }) }}
-    </div>
 
     {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/src/AppBundle/Resources/views/Report/MoneyOut/addAnother.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/MoneyOut/addAnother.html.twig
@@ -8,7 +8,7 @@
 
 {% block htmlTitle %}{{ 'addAnotherPage.moneyOut.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.moneyOut.pageTitle' | trans }}{% endblock %}
-
+{% block supportTitleTop %}{{ 'addAnotherPage.moneyOut.supportTitle' | trans }}{% endblock %}
 
 {% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 

--- a/client/src/AppBundle/Resources/views/Report/MoneyOutShort/category.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/MoneyOutShort/category.html.twig
@@ -7,8 +7,8 @@
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
 {% block htmlTitle %}{{ ('categoryPage.moneyOut.htmlTitle') | trans }}{% endblock %}
-{% block pageTitle %}{{ ('categoryPage.moneyOut.pageTitle') | trans }}{% endblock %}
-
+{% block pageTitle %}{{ 'form.categoriesOut.label' | trans(transOptions) }}{% endblock %}
+{% block supportTitleTop %}{{ ('categoryPage.moneyOut.supportTitle') | trans }}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -18,12 +18,10 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <p class="text">
-        {{ 'form.categoriesOut.label' | trans(transOptions) }}
-    </p>
-    <p class="form-hint">
+    <p class="govuk-hint">
         {{ 'form.categoriesOut.hint' | trans(transOptions) }}
     </p>
+
     {% include 'AppBundle:Report/MoneyOutShort:_checkboxes_list.html.twig' with {
     'elements': form.moneyShortCategoriesOut,
     } %}
@@ -33,4 +31,3 @@
     {{ form_end(form) }}
 
 {% endblock %}
-

--- a/client/src/AppBundle/Resources/views/Report/MoneyOutShort/exist.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/MoneyOutShort/exist.html.twig
@@ -7,8 +7,7 @@
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'existPage.moneyOut.htmlTitle' | trans }}{% endblock %}
-{% block pageTitle %}{{ 'existPage.moneyOut.pageTitle' | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -18,14 +17,14 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <div class="push--bottom">
     {{ form_checkbox_group(form.moneyTransactionsShortOutExist, 'existPage.form.moneyTransactionsShortOutExist', {
-        'fieldSetClass' : 'inline',
+        'fieldSetClass' : 'govuk-radios--inline',
         'labelParameters': transOptions,
-        'legendClass' : 'govuk-label--s text',
-        'formGroupClass': 'flush--bottom'
+        legend: {
+            isPageHeading: true,
+            caption: 'existPage.moneyOut.supportTitle' | trans
+        }
     }) }}
-    </div>
 
     {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/src/AppBundle/Resources/views/Report/MoneyTransfer/exist.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/MoneyTransfer/exist.html.twig
@@ -7,8 +7,7 @@
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'existPage.htmlTitle' | trans }}{% endblock %}
-{% block pageTitle %}{{ 'existPage.pageTitle' | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -18,17 +17,17 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-        <div class="push--bottom">
-            <div class="govuk-form-group flush--bottom {% if not form.noTransfersToAdd.vars.valid %}govuk-form-group--error{% endif %}">
-                {{ form_checkbox_group(form.noTransfersToAdd, 'existPage.form.noTransfersToAdd', {
-                    'useFormGroup': false,
-                    'fieldSetClass' : 'inline',
-                    'labelParameters': transOptions,
-                    'legendClass' : 'govuk-label--s text',
-                    'formGroupClass': 'flush--bottom'
-                }) }}
-            </div>
-        </div>
+    <div class="govuk-form-group {% if not form.noTransfersToAdd.vars.valid %}govuk-form-group--error{% endif %}">
+        {{ form_checkbox_group(form.noTransfersToAdd, 'existPage.form.noTransfersToAdd', {
+            'useFormGroup': false,
+            'fieldSetClass' : 'govuk-radios--inline',
+            'labelParameters': transOptions,
+            legend: {
+                isPageHeading: true,
+                caption: 'existPage.supportTitle' | trans
+            }
+        }) }}
+    </div>
 
     {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/src/AppBundle/Resources/views/Report/OtherInfo/step.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/OtherInfo/step.html.twig
@@ -6,13 +6,8 @@
 {% trans_default_domain translationDomain %}
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
-{% block htmlTitle %}
-    {{ 'stepPage.htmlTitle' | trans }}
-{% endblock %}
-{% block pageTitle %}
-    {{ 'stepPage.pageTitle' | trans }}
-{% endblock %}
-
+{% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans }}{% endblock %}
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -22,28 +17,27 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-        <div class="push--bottom">
-            <div class="govuk-form-group flush--bottom {% if not form.actionMoreInfo.vars.valid %}govuk-form-group--error{% endif %}">
-                {{ form_checkbox_group(form.actionMoreInfo, 'form.actionMoreInfo', {
-                    'useFormGroup': false,
-                    'fieldSetClass' : 'inline',
-                    'legendClass' : 'govuk-label--s',
-                    'items': [
-                        {'dataTarget': 'more-info-textarea' }
-                    ]
-                }) }}
+    <div class="govuk-form-group {% if not form.actionMoreInfo.vars.valid %}govuk-form-group--error{% endif %}">
+        {{ form_checkbox_group(form.actionMoreInfo, 'form.actionMoreInfo', {
+            'useFormGroup': false,
+            legend: {
+                isPageHeading: true,
+                caption: 'stepPage.supportTitle' | trans
+            },
+            'items': [
+                {'dataTarget': 'more-info-textarea' }
+            ]
+        }) }}
 
-                <div id="more-info-textarea" class="opg-indented-block js-hidden">
-                    {{ form_input(form.actionMoreInfoDetails, 'form.actionMoreInfoDetails', {
-                        'labelParameters': transOptions
-                    }) }}
-                </div>
-            </div>
+        <div id="more-info-textarea" class="opg-indented-block js-hidden">
+            {{ form_input(form.actionMoreInfoDetails, 'form.actionMoreInfoDetails', {
+                'labelParameters': transOptions
+            }) }}
         </div>
+    </div>
 
     {{ macros.saveAndContinueButton(form.save) }}
 
     {{ form_end(form) }}
 
 {% endblock %}
-

--- a/client/src/AppBundle/Resources/views/Report/PaFeeExpense/feeExist.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/PaFeeExpense/feeExist.html.twig
@@ -7,8 +7,7 @@
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'feeExistPage.htmlTitle' | trans }}{% endblock %}
-{% block pageTitle %}{{ 'feeExistPage.pageTitle' | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -18,28 +17,28 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-        <div class="push--bottom">
-            <div class="govuk-form-group flush--bottom {% if not form.hasFees.vars.valid %}govuk-form-group--error{% endif %}">
-                {{ form_checkbox_group(form.hasFees, 'feeExistPage.form.hasFees', {
-                    'useFormGroup': false,
-                    'fieldSetClass' : 'inline',
-                    'labelParameters': transOptions,
-                    'legendClass' : 'govuk-label--s text',
-                    'items': [
-                        {},
-                        {'dataTarget': 'reason-for-no-fee'}
-                    ],
-                    'formGroupClass': 'flush--bottom'
-                }) }}
+    <div class="govuk-form-group {% if not form.hasFees.vars.valid %}govuk-form-group--error{% endif %}">
+        {{ form_checkbox_group(form.hasFees, 'feeExistPage.form.hasFees', {
+            'useFormGroup': false,
+            'labelParameters': transOptions,
+            legend: {
+                isPageHeading: true,
+                caption: 'feeExistPage.supportTitle' | trans
+            },
+            'items': [
+                {},
+                {'dataTarget': 'reason-for-no-fee'}
+            ],
+            'formGroupClass': 'flush--bottom'
+        }) }}
 
-                <div id="reason-for-no-fee" class="opg-indented-block js-hidden">
-                    {{ form_input(form.reasonForNoFees, 'feeExistPage.form.reasonForNoFees', {
-                        'labelClass': 'required',
-                        'labelParameters': transOptions
-                    }) }}
-                </div>
-            </div>
+        <div id="reason-for-no-fee" class="opg-indented-block js-hidden">
+            {{ form_input(form.reasonForNoFees, 'feeExistPage.form.reasonForNoFees', {
+                'labelClass': 'required',
+                'labelParameters': transOptions
+            }) }}
         </div>
+    </div>
 
     {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/src/AppBundle/Resources/views/Report/PaFeeExpense/otherExist.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/PaFeeExpense/otherExist.html.twig
@@ -7,8 +7,7 @@
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'otherExistPage.htmlTitle' | trans }}{% endblock %}
-{% block pageTitle %}{{ 'otherExistPage.pageTitle' | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -18,14 +17,14 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <div class="push--bottom">
     {{ form_checkbox_group(form.paidForAnything, 'otherExistPage.form.paidForAnything', {
         'fieldSetClass' : 'inline',
         'labelParameters': transOptions,
-        'legendClass' : 'govuk-label--s text',
-        'formGroupClass': 'flush--bottom'
+        legend: {
+                isPageHeading: true,
+                caption: 'feeExistPage.supportTitle' | trans
+            },
     }) }}
-    </div>
 
     {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/src/AppBundle/Resources/views/Report/ProfDeputyCosts/amountToScco.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/ProfDeputyCosts/amountToScco.html.twig
@@ -9,7 +9,7 @@
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
-
+{% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}
 
 {% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 

--- a/client/src/AppBundle/Resources/views/Report/ProfDeputyCosts/breakdown.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/ProfDeputyCosts/breakdown.html.twig
@@ -8,8 +8,8 @@
 {% set page = 'breakdown' %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
-{% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
-
+{% block pageTitle %}{{ (page ~ '.pageSectionDescription') | trans }}{% endblock %}
+{% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}
 
 {% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 

--- a/client/src/AppBundle/Resources/views/Report/ProfDeputyCosts/fixedCost.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/ProfDeputyCosts/fixedCost.html.twig
@@ -9,7 +9,7 @@
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
-
+{% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}
 
 {% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
@@ -21,15 +21,11 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <div class="push--bottom">
-        {{ form_input(form.profDeputyFixedCost, page ~ '.form.profDeputyFixedCost', {
-            'inputPrefix' : '£',
-            'inputClass' : 'govuk-!-width-one-quarter js-format-currency',
-            'labelClass' : 'govuk-label--s',
-            'formGroupClass': ' form-group-value',
-            'labelParameters': {'%client%' : report.client.firstname}
-        }) }}
-    </div>
+    {{ form_input(form.profDeputyFixedCost, page ~ '.form.profDeputyFixedCost', {
+        'inputPrefix' : '£',
+        'inputClass' : 'govuk-!-width-one-quarter js-format-currency',
+        'labelParameters': {'%client%' : report.client.firstname}
+    }) }}
 
     {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/src/AppBundle/Resources/views/Report/ProfDeputyCosts/howCharged.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/ProfDeputyCosts/howCharged.html.twig
@@ -8,8 +8,7 @@
 {% set page = 'howCharged' %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
-{% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
@@ -19,22 +18,18 @@
 
 {% block pageContent %}
 
-    <h3 class="govuk-heading-s push-half--bottom">
-        {{ (page ~ '.form.profDeputyCostsHow.label') | trans(transOptions, translationDomain) }}
-    </h3>
-
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    {#<p class="text">#}
-        {#{{ (page ~ '.profDeputyCostsHow.label') | trans(transOptions) }}#}
-    {#</p>#}
-
-        <div class="govuk-form-group push--bottom {% if not form.profDeputyCostsHowCharged.vars.valid %}govuk-form-group--error{% endif %}">
-            {{ form_checkbox_group(form.profDeputyCostsHowCharged, 'report.form.profDeputyCostsHowCharged', {
-                'legendClass' : 'govuk-label--s',
-                'useFormGroup': false,
-            }) }}
-        </div>
+    <div class="govuk-form-group push--bottom {% if not form.profDeputyCostsHowCharged.vars.valid %}govuk-form-group--error{% endif %}">
+        {{ form_checkbox_group(form.profDeputyCostsHowCharged, 'report.form.profDeputyCostsHowCharged', {
+            'legendText': (page ~ '.form.profDeputyCostsHow.label') | trans(transOptions),
+            legend: {
+                isPageHeading: true,
+                caption: (page ~ '.supportTitle') | trans,
+            },
+            'useFormGroup': false,
+        }) }}
+    </div>
 
     {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/src/AppBundle/Resources/views/Report/ProfDeputyCosts/interim.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/ProfDeputyCosts/interim.html.twig
@@ -9,7 +9,7 @@
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
-
+{% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}
 
 {% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 

--- a/client/src/AppBundle/Resources/views/Report/ProfDeputyCosts/interimExists.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/ProfDeputyCosts/interimExists.html.twig
@@ -9,7 +9,7 @@
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
-
+{% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}
 
 {% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
@@ -18,20 +18,12 @@
 {% endblock %}
 
 {% block pageContent %}
-
-    <p class="govuk-heading-m">{{ (page ~ '.pageSectionDescription') | trans }}</p>
-
-
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <div class="push--bottom">
-        {{ form_checkbox_group(form.profDeputyCostsHasInterim, page ~ '.form.profDeputyCostsHasInterim', {
-            'fieldSetClass' : 'inline',
-            'labelParameters': transOptions,
-            'legendClass' : 'text',
-            'formGroupClass': 'flush--bottom'
-        }) }}
-    </div>
+    {{ form_checkbox_group(form.profDeputyCostsHasInterim, page ~ '.form.profDeputyCostsHasInterim', {
+        'fieldSetClass' : 'govuk-radios--inline',
+        'labelParameters': transOptions
+    }) }}
 
     {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/src/AppBundle/Resources/views/Report/ProfDeputyCosts/previousReceived.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/ProfDeputyCosts/previousReceived.html.twig
@@ -9,7 +9,7 @@
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
-
+{% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}
 
 {% block linkBack %}
     {% if backLink %}
@@ -24,10 +24,8 @@
 {% endblock %}
 {% block pageContent %}
 
-    <h2 class="govuk-heading-m flush--ends">{{ (page ~ '.pageSectionDescription01') | trans }}</h2>
-
     <div class="text">
-        <p>{{ (page ~ '.pageSectionDescription02') | trans(transOptions, translationDomain) }}</p>
+        <p>{{ (page ~ '.pageSectionDescription') | trans(transOptions, translationDomain) }}</p>
     </div>
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}

--- a/client/src/AppBundle/Resources/views/Report/ProfDeputyCosts/previousReceivedExists.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/ProfDeputyCosts/previousReceivedExists.html.twig
@@ -8,8 +8,7 @@
 {% set page = 'previousReceivedExists' %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
-{% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
@@ -21,14 +20,14 @@
 
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <div class="push--bottom">
-        {{ form_checkbox_group(form.profDeputyCostsHasPrevious, page ~ '.form.profDeputyCostsHasPrevious', {
-            'fieldSetClass' : 'inline',
-            'labelParameters': transOptions,
-            'legendClass' : 'govuk-label--s text',
-            'formGroupClass': 'flush--bottom'
-        }) }}
-    </div>
+    {{ form_checkbox_group(form.profDeputyCostsHasPrevious, page ~ '.form.profDeputyCostsHasPrevious', {
+        'fieldSetClass' : 'govuk-radios--inline',
+        'labelParameters': transOptions,
+        legend: {
+            isPageHeading: true,
+            caption: (page ~ '.supportTitle') | trans
+        }
+    }) }}
 
     {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/src/AppBundle/Resources/views/Report/ProfDeputyCostsEstimate/howCharged.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/ProfDeputyCostsEstimate/howCharged.html.twig
@@ -8,8 +8,7 @@
 {% set page = 'howCharged' %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
-{% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
@@ -19,21 +18,17 @@
 
 {% block pageContent %}
 
-    <h3 class="govuk-heading-s push-half--bottom">
-        {{ (page ~ '.form.profDeputyCostsEstimateHowCharged.label') | trans(transOptions, translationDomain) }}
-    </h3>
-
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <div class="push--bottom">
-
-        <div class="govuk-form-group push--bottom {% if not form.profDeputyCostsEstimateHowCharged.vars.valid %}govuk-form-group--error{% endif %}">
-            {{ form_checkbox_group(form.profDeputyCostsEstimateHowCharged, 'report.form.profDeputyCostsEstimateHowCharged', {
-                'legendClass' : 'govuk-label--s',
-                'useFormGroup': false,
-            }) }}
-        </div>
-
+    <div class="govuk-form-group {% if not form.profDeputyCostsEstimateHowCharged.vars.valid %}govuk-form-group--error{% endif %}">
+        {{ form_checkbox_group(form.profDeputyCostsEstimateHowCharged, 'report.form.profDeputyCostsEstimateHowCharged', {
+            'useFormGroup': false,
+            legendText: (page ~ '.form.profDeputyCostsEstimateHowCharged.label') | trans,
+            legend: {
+                isPageHeading: true,
+                caption: (page ~ '.supportTitle') | trans
+            }
+        }) }}
     </div>
 
     {{ macros.saveAndContinueButton(form.save) }}

--- a/client/src/AppBundle/Resources/views/Report/ProfDeputyCostsEstimate/moreInfo.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/ProfDeputyCostsEstimate/moreInfo.html.twig
@@ -6,8 +6,7 @@
 {% set page = 'moreInfo' %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
-{% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
@@ -17,29 +16,24 @@
 
 {% block pageContent %}
 
-    <h3 class="govuk-heading-s push-half--bottom">
-        {{ (page ~ '.form.profDeputyCostsEstimateHasMoreInfo.label') | trans }}
-    </h3>
-
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
-    <div class="push--bottom">
+    <div class="govuk-form-group {% if not form.profDeputyCostsEstimateHasMoreInfo.vars.valid %}govuk-form-group--error{% endif %}">
+        {{ form_checkbox_group(form.profDeputyCostsEstimateHasMoreInfo, 'form.profDeputyCostsEstimateHasMoreInfo', {
+            'useFormGroup': false,
+            legendText: (page ~ '.form.profDeputyCostsEstimateHasMoreInfo.label') | trans,
+            legend: {
+                isPageHeading: true,
+                caption: (page ~ '.supportTitle') | trans
+            },
+            'items': [
+                {'dataTarget': 'more-info-textarea' }
+            ]
+        }) }}
 
-        <div class="govuk-form-group push--bottom {% if not form.profDeputyCostsEstimateHasMoreInfo.vars.valid %}govuk-form-group--error{% endif %}">
-            {{ form_checkbox_group(form.profDeputyCostsEstimateHasMoreInfo, 'form.profDeputyCostsEstimateHasMoreInfo', {
-                'useFormGroup': false,
-                'fieldSetClass' : 'inline',
-                'legendClass' : 'govuk-label--s',
-                'items': [
-                    {'dataTarget': 'more-info-textarea' }
-                ]
-            }) }}
-
-            <div id="more-info-textarea" class="opg-indented-block js-hidden">
-                {{ form_input(form.profDeputyCostsEstimateMoreInfoDetails, 'moreInfo.form.profDeputyCostsEstimateMoreInfoDetails') }}
-            </div>
+        <div id="more-info-textarea" class="opg-indented-block js-hidden">
+            {{ form_input(form.profDeputyCostsEstimateMoreInfoDetails, 'moreInfo.form.profDeputyCostsEstimateMoreInfoDetails') }}
         </div>
-
     </div>
 
     {{ macros.saveAndContinueButton(form.save) }}

--- a/client/src/AppBundle/Resources/views/Report/Report/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Report/index.html.twig
@@ -7,10 +7,7 @@
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
-
-{% block supportTitleBottom %}
-    <span class="heading-secondary">{{ client.firstname }} {{ client.lastname }}</span>
-{% endblock %}
+{% block supportTitleTop %}{{ client.fullname }}{% endblock %}
 
 {% block breadcrumbs %}{% endblock %}
 

--- a/client/src/AppBundle/Resources/views/Report/Report/overview.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Report/overview.html.twig
@@ -23,9 +23,7 @@
         </div>
     </div>
 
-    {% block pageHeader %}
-        {% include 'AppBundle:Report/Report:_header.html.twig' %}
-    {% endblock %}
+    {% include 'AppBundle:Report/Report:_header.html.twig' %}
 
     {% if not report.isDue or report.isDue and not reportStatus.isReadyToSubmit %}
         <div class="push--top">

--- a/client/src/AppBundle/Resources/views/Report/VisitsCare/step.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/VisitsCare/step.html.twig
@@ -7,8 +7,7 @@
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans }}{% endblock %}
-{% block pageTitle %}{{ 'stepPage.pageTitle' | trans }}{% endblock %}
-
+{% block pageHeader %}{% endblock %}
 
 {% block linkBack %}
     {{ macros.linkBackStep(backLink, 'back' | trans({}, 'common')) }}
@@ -19,86 +18,82 @@
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
     {% if step == 1 %}
-        <div class="push--bottom">
+        <div class="govuk-form-group {% if not form.doYouLiveWithClient.vars.valid %}govuk-form-group--error{% endif %}">
+            {{ form_checkbox_group(form.doYouLiveWithClient, 'form.doYouLiveWithClient', {
+                'useFormGroup': false,
+                'legendText' : 'form.doYouLiveWithClient.label' | trans(transOptions, translationDomain),
+                legend: {
+                    isPageHeading: true,
+                    caption: 'stepPage.supportTitle' | trans
+                },
+                'items': [
+                    {},
+                    {'dataTarget': 'how-often-contact-client-wrapper' }
+                ]
+            }) }}
 
-            <div class="govuk-form-group flush--bottom {% if not form.doYouLiveWithClient.vars.valid %}govuk-form-group--error{% endif %}">
-                {{ form_checkbox_group(form.doYouLiveWithClient, 'form.doYouLiveWithClient', {
-                    'useFormGroup': false,
-                    'fieldSetClass' : 'inline',
-                    'legendClass' : 'govuk-label--s',
-                    'legendText' : 'form.doYouLiveWithClient.label' | trans(transOptions, translationDomain),
-                    'items': [
-                        {},
-                        {'dataTarget': 'how-often-contact-client-wrapper' }
-                    ]
+            <div id="how-often-contact-client-wrapper" class="opg-indented-block js-hidden">
+                {{ form_input(form.howOftenDoYouContactClient, 'form.howOftenDoYouContactClient', {
+                    'labelParameters': transOptions
                 }) }}
-
-                <div id="how-often-contact-client-wrapper" class="opg-indented-block js-hidden">
-                    {{ form_input(form.howOftenDoYouContactClient, 'form.howOftenDoYouContactClient', {
-                        'labelParameters': transOptions
-                    }) }}
-                </div>
             </div>
         </div>
     {% endif %}
 
     {% if step == 2 %}
-        <div class="push--bottom">
+        <div class="govuk-form-group {% if not form.doesClientReceivePaidCare.vars.valid %}govuk-form-group--error{% endif %}">
+            {{ form_checkbox_group(form.doesClientReceivePaidCare, 'form.doesClientReceivePaidCare', {
+                'useFormGroup': false,
+                'legendText' : 'form.doesClientReceivePaidCare.label' | trans(transOptions, translationDomain),
+                legend: {
+                    isPageHeading: true,
+                    caption: 'stepPage.supportTitle' | trans
+                },
+                'items': [
+                    {'dataTarget': 'how-care-funded-wrapper' },
+                    {}
+                ]
+            }) }}
 
-            <div class="govuk-form-group flush--bottom {% if not form.doesClientReceivePaidCare.vars.valid %}govuk-form-group--error{% endif %}">
-                {{ form_checkbox_group(form.doesClientReceivePaidCare, 'form.doesClientReceivePaidCare', {
-                    'useFormGroup': false,
-                    'fieldSetClass' : 'inline',
-                    'legendClass' : 'govuk-label--s',
-                    'legendText' : 'form.doesClientReceivePaidCare.label' | trans(transOptions, translationDomain),
-                    'items': [
-                        {'dataTarget': 'how-care-funded-wrapper' },
-                        {}
-                    ]
+            <div id="how-care-funded-wrapper" class="opg-indented-block js-hidden">
+                {{ form_checkbox_group(form.howIsCareFunded, 'form.howIsCareFunded', {
+                    'legendClass' : 'govuk-label--s'
                 }) }}
-
-                <div id="how-care-funded-wrapper" class="opg-indented-block js-hidden">
-                    {{ form_checkbox_group(form.howIsCareFunded, 'form.howIsCareFunded', {
-                        'legendClass' : 'govuk-label--s'
-                    }) }}
-                </div>
             </div>
         </div>
     {% endif %}
 
     {% if step == 3 %}
-        <div class="push--bottom">
-            {{ form_input(form.whoIsDoingTheCaring,'form.whoIsDoingTheCaring', {
-                'labelClass': 'govuk-label--s',
-                'formGroupClass': 'flush--bottom',
-                'labelRaw': true
-            }) }}
-        </div>
+        {{ form_input(form.whoIsDoingTheCaring,'form.whoIsDoingTheCaring', {
+            label: {
+                isPageHeading: true,
+                caption: 'stepPage.supportTitle' | trans
+            },
+        }) }}
     {% endif %}
 
     {% if step == 4 %}
-        <div class="push--bottom">
+        <div class="govuk-form-group {% if not form.doesClientHaveACarePlan.vars.valid %}govuk-form-group--error{% endif %}">
+            {{ form_checkbox_group(form.doesClientHaveACarePlan, 'form.doesClientHaveACarePlan', {
+                'useFormGroup': false,
+                'legendText' : 'form.doesClientHaveACarePlan.label' | trans(transOptions, translationDomain),
+                legend: {
+                    isPageHeading: true,
+                    caption: 'stepPage.supportTitle' | trans
+                },
+                'hintText': 'form.doesClientHaveACarePlan.hint' | trans(transOptions, translationDomain),
+                'items': [
+                    {'dataTarget': 'when-care-plan-last-reviewed-wrapper'},
+                    {}
+                ]
+            }) }}
 
-            <div class="govuk-form-group flush--bottom {% if not form.doesClientHaveACarePlan.vars.valid %}govuk-form-group--error{% endif %}">
-                {{ form_checkbox_group(form.doesClientHaveACarePlan, 'form.doesClientHaveACarePlan', {
-                    'useFormGroup': false,
-                    'fieldSetClass' : 'inline',
+            <div id="when-care-plan-last-reviewed-wrapper" class="opg-indented-block  js-hidden">
+                {# legendClass is-not-working #}
+                {{ form_known_date(form.whenWasCarePlanLastReviewed, 'form.whenWasCarePlanLastReviewed', {
                     'legendClass' : 'govuk-label--s',
-                    'legendText' : 'form.doesClientHaveACarePlan.label' | trans(transOptions, translationDomain),
-                    'hintText': 'form.doesClientHaveACarePlan.hint' | trans(transOptions, translationDomain),
-                    'items': [
-                        {'dataTarget': 'when-care-plan-last-reviewed-wrapper'},
-                        {}
-                    ]
+                    'showDay': 'false'
                 }) }}
-
-                <div id="when-care-plan-last-reviewed-wrapper" class="opg-indented-block  js-hidden">
-                    {# legendClass is-not-working #}
-                    {{ form_known_date(form.whenWasCarePlanLastReviewed, 'form.whenWasCarePlanLastReviewed', {
-                        'legendClass' : 'govuk-label--s',
-                        'showDay': 'false'
-                    }) }}
-                </div>
             </div>
         </div>
     {% endif %}
@@ -112,4 +107,3 @@
     {{ form_end(form) }}
 
 {% endblock %}
-

--- a/client/src/AppBundle/Twig/FormFieldsExtension.php
+++ b/client/src/AppBundle/Twig/FormFieldsExtension.php
@@ -122,7 +122,11 @@ class FormFieldsExtension extends AbstractExtension
             'disabled' => isset($vars['disabled']) ? $vars['disabled'] : false,
             'fieldSetClass' => isset($vars['fieldSetClass']) ? $vars['fieldSetClass'] : null,
             'formGroupClass' => isset($vars['formGroupClass']) ? $vars['formGroupClass'] : null,
-            'legendText' => $legendText,
+            'legend' => array_merge([
+                'text' => $legendText,
+                'isPageHeading' => false,
+                'caption' => false,
+            ], $vars['legend'] ?? []),
             'legendClass' => isset($vars['legendClass']) ? $vars['legendClass'] : null,
             'useFormGroup' => isset($vars['useFormGroup']) ? $vars['useFormGroup'] : true,
             'hintText' => $hintText,
@@ -241,7 +245,11 @@ class FormFieldsExtension extends AbstractExtension
         }
 
         $html = $env->render('AppBundle:Components/Form:_known-date.html.twig', [
-            'legendText' => $legendText,
+            'legend' => array_merge([
+                'text' => $legendText,
+                'isPageHeading' => false,
+                'caption' => false,
+            ], $vars['legend'] ?? []),
             'hintText' => $hintText,
             'element' => $element,
             'showDay' => $showDay,
@@ -265,10 +273,15 @@ class FormFieldsExtension extends AbstractExtension
 
         $legendText = ($legendTextTrans != $translationKey . '.legend') ? $legendTextTrans : null;
 
-        $html = $env->render('AppBundle:Components/Form:_sort-code.html.twig', ['legendText' => $legendText,
-                                                                                                'hintText' => $hintText,
-                                                                                                'element' => $element,
-                                                                                              ]);
+        $html = $env->render('AppBundle:Components/Form:_sort-code.html.twig', [
+            'legend' => array_merge([
+                'text' => $legendText,
+                'isPageHeading' => false,
+                'caption' => false,
+            ], $vars['legend'] ?? []),
+            'hintText' => $hintText,
+            'element' => $element,
+        ]);
         echo $html;
     }
 

--- a/client/src/AppBundle/Twig/FormFieldsExtension.php
+++ b/client/src/AppBundle/Twig/FormFieldsExtension.php
@@ -429,6 +429,11 @@ class FormFieldsExtension extends AbstractExtension
             'formGroupClass' => $formGroupClass,
             'labelRaw' => !empty($vars['labelRaw']),
             'preInputText' => $preInputText,
+            'label' => array_merge([
+                'text' => $labelText,
+                'isPageHeading' => false,
+                'caption' => false,
+            ], $vars['label'] ?? []),
         ];
     }
 


### PR DESCRIPTION
## Purpose
We need to apply a consistent pattern to header hierarchy throughout the application so that we comply with WCAG regulations, and the design of the application is easy for a user follow. 

Page titles should be unique and succinctly describe what the page is (e.g. the question being asked). In report sections they should be supported by captions noting the section title. In admin pages they should be supported by captions noting the area of the admin panel.

We need to remove unnecessary duplication of headings, labels and legends, and avoid skipping heading levels.

Fixes DDPB-2754

## Approach
I changed various translation files to use proper heading hierarchy, and updated the application template to put this on the page better.

I updated several `form_` functions to support making the label/legend the page title ([per the Design System](https://design-system.service.gov.uk/patterns/question-pages/#label-as-a-page-heading)) with captions.

I made use of the new `form_` settings on single-question pages to avoid heading duplication, and tidied up other bits of Twig/HTML where suitable.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work
  - N/A
- [x] The product team have approved these changes

### Frontend
- [x] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
  - Where possible
- [x] There are no deprecated CSS classes noted in the profiler
  - I cleaned out some where suitable, but didn't rebuild the templates more than necessary
- [x] Translations are used and the profiler doesn't identify any missing
