### PR TITLE
DDPB-2898: Add option to close (resubmit) an unsubmitted report

### DIFF
--- a/api/src/AppBundle/Controller/Report/ReportController.php
+++ b/api/src/AppBundle/Controller/Report/ReportController.php
@@ -483,6 +483,14 @@ class ReportController extends RestController
             ]);
         }
 
+        if (array_key_exists('submitted', $data)) {
+            $report->setSubmitted($data['submitted']);
+        }
+
+        if (array_key_exists('unsubmit_date', $data)) {
+            $report->setUnSubmitDate($data);
+        }
+
         foreach ($this->updateHandlers as $updateHandler) {
             $updateHandler->handle($report, $data);
         }

--- a/behat/tests/bootstrap/ReportManagement/ReportManagementTrait.php
+++ b/behat/tests/bootstrap/ReportManagement/ReportManagementTrait.php
@@ -3,6 +3,7 @@
 namespace DigidepsBehat\ReportManagement;
 
 use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Exception\ElementNotFoundException;
 
 trait ReportManagementTrait
 {
@@ -49,6 +50,22 @@ trait ReportManagementTrait
         $this->pressButton('manage_report_confirm[save]');
 
         $this->assertPageContainsText('OPG'.$type);
+    }
+
+    /**
+     * @When a case manager makes the following changes to the report:
+     */
+    public function aCaseManagerMakesTheFollowingChangesToTheReport(TableNode $table)
+    {
+        $this->aCaseManagerProposesToMakeTheFollowingChangesToTheReport($table);
+
+        try {
+            $this->selectOption('manage_report_confirm[confirm]', 'yes');
+        } catch (ElementNotFoundException $e) {
+
+        }
+
+        $this->pressButton('manage_report_confirm[save]');
     }
 
     /**
@@ -164,5 +181,39 @@ trait ReportManagementTrait
 
         $expectedDueDate = new \DateTime($adjustment);
         $this->iShouldSeeInTheRegion($expectedDueDate->format('j F Y'), "report-$startDate-to-$endDate-due-date");
+    }
+
+    /**
+     * @Given I visit the management page of the :startDate to :endDate report between :deputy and :client
+     */
+    public function iVisitTheManagementPageOfTheToReportBetweenAnd($startDate, $endDate, $deputy, $client)
+    {
+        $this->iHaveTheReportBetweenDeputyAndClient($startDate, $endDate, $deputy, $client);
+        $this->iVisitTheManagementPageOfTheReport();
+    }
+
+    /**
+     * @Given I visit the management page of the report
+     */
+    public function iVisitTheManagementPageOfTheReport()
+    {
+        $reportId = self::$currentReportCache['reportId'];
+
+        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'Abcd1234');
+        $this->visitAdminPath("/admin/report/$reportId/manage");
+    }
+
+    /**
+     * @Given a case manager closes the report
+     */
+    public function aCaseManagerClosesTheReport()
+    {
+        $reportId = self::$currentReportCache['reportId'];
+
+        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'Abcd1234');
+        $this->visitAdminPath("/admin/report/$reportId/manage");
+        $this->checkOption('manage_report_close[agreeCloseReport]');
+        $this->pressButton('manage_report_close[save]');
+        $this->pressButton('close_report_confirm[save]');
     }
 }

--- a/behat/tests/features/v2/reportManagement/closing-incomplete-reports.feature
+++ b/behat/tests/features/v2/reportManagement/closing-incomplete-reports.feature
@@ -1,0 +1,28 @@
+Feature: Managing reports
+  In order to ensure that deputies can submit their next report
+  As a case manager
+  I need the ability to close their previously submitted report
+
+  Scenario: Create court orders for the feature
+    Given the following court orders exist:
+      | client   | deputy   | deputy_type | report_type                                | court_date |
+      | 95465932 | Deputy92 | LAY         | Property and Financial Affairs High Assets | 2016-01-30 |
+      | 85473219 | Deputy43 | PA          | Health and Welfare                         | 2018-01-30 |
+
+  Scenario: Case manager cannot close a report that has not been unsubmitted by a case manager
+    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    And I visit the management page of the "2016" to "2017" report between "Deputy92" and "95465932"
+    Then I should not see "Close Report"
+
+  Scenario: Case manager closes a report that has been marked as incomplete by a case manager
+    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    And  I have the "2018" to "2019" report between "Deputy43" and "85473219"
+    And the report has been submitted
+    When a case manager makes the following changes to the report:
+      | incompleteSection     |
+      | Any other information |
+    Then I should see the "report-2018-to-2019" region in the "report-group-incomplete" region
+    When I visit the management page of the report
+    Then I should see "Close Report"
+    When a case manager closes the report
+    Then I should see the "report-2018-to-2019" region in the "report-group-submitted" region

--- a/client/src/AppBundle/Entity/Report/Report.php
+++ b/client/src/AppBundle/Entity/Report/Report.php
@@ -511,7 +511,7 @@ class Report implements ReportInterface, StartEndDateComparableInterface
      *
      * @return Report
      */
-    public function setUnSubmitDate(\DateTime $unSubmitDate)
+    public function setUnSubmitDate(?\DateTime $unSubmitDate)
     {
         $this->unSubmitDate = $unSubmitDate;
 

--- a/client/src/AppBundle/Form/Admin/CloseReportConfirmType.php
+++ b/client/src/AppBundle/Form/Admin/CloseReportConfirmType.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AppBundle\Form\Admin;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CloseReportConfirmType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('save', SubmitType::class);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'translation_domain' => 'admin-clients',
+        ]);
+    }
+}

--- a/client/src/AppBundle/Form/Admin/CloseReportType.php
+++ b/client/src/AppBundle/Form/Admin/CloseReportType.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace AppBundle\Form\Admin;
+
+use AppBundle\Form\Traits\HasTranslatorTrait;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class CloseReportType extends AbstractType
+{
+    use HasTranslatorTrait;
+
+    /**
+     * @param FormBuilderInterface $builder
+     * @param array $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('agreeCloseReport', CheckboxType::class, [
+                'constraints' => new NotBlank(['message' => 'report-management.close.notBlank']),
+            ])
+            ->add('save', SubmitType::class);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'translation_domain' => 'admin-clients',
+        ]);
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'manage_report_close';
+    }
+}

--- a/client/src/AppBundle/Resources/translations/admin-clients.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin-clients.en.yml
@@ -70,3 +70,12 @@ reportManage:
         before making changes to this report.
       label: Are you sure you want to mark this report as incomplete?
       warning: Once you have made the report incomplete you will not be able to undo this action.
+  closeReport:
+    form:
+      agreeCloseReport:
+        label: This report was submitted offline or was wrongly marked as incomplete
+      save:
+        label: Close report
+      confirmSave:
+        label: Confirm close report
+    confirmMessage: Are you sure you want to close this report?

--- a/client/src/AppBundle/Resources/translations/validators.en.yml
+++ b/client/src/AppBundle/Resources/translations/validators.en.yml
@@ -137,6 +137,10 @@ report-declaration:
     agree:
         notBlank: You must agree to this statement to continue
 
+report-management:
+  close:
+    notBlank: You must confirm that you want to close this report
+
 login:
     email:
         notBlank: Enter your email

--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/manage.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/manage.html.twig
@@ -81,4 +81,18 @@
 
     {{ form_end(form) }}
 
+    {% if closeForm is not null %}
+        {{ form_start(closeForm) }}
+            <legend class="govuk-fieldset__legend govuk-label--s">Close this report</legend>
+            {{ form_checkbox(closeForm.agreeCloseReport, 'reportManage.closeReport.form.agreeCloseReport', {
+                'labelClass': 'required'
+            }) }}
+            <div class="govuk-form-group">
+                {{ form_submit(closeForm.save, 'reportManage.closeReport.form.save', {
+                    'buttonClass': 'behat-link-close-report govuk-button govuk-button--warning',
+                }) }}
+            </div>
+        {{ form_end(closeForm) }}
+    {% endif %}
+
 {% endblock %}

--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/manageCloseReportConfirm.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/manageCloseReportConfirm.html.twig
@@ -1,0 +1,24 @@
+{% extends 'AppBundle:Layouts:application.html.twig' %}
+
+{% import 'AppBundle:Macros:macros.html.twig' as macros %}
+
+{% trans_default_domain "admin-clients" %}
+{% set page = 'reportManage' %}
+
+{% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
+{% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
+
+{% block supportTitleBottom %}
+    <span class="heading-secondary">{{ (page ~ '.supportTitle') | trans }}</span>
+{% endblock %}
+
+{% block helpline %}{% endblock %}
+
+{% block pageContent %}
+    <p>{{ (page ~ '.closeReport.confirmMessage') | trans }}</p>
+    {{ form_start(form) }}
+    {{ form_submit(form.save, 'reportManage.closeReport.form.confirmSave', {
+        'buttonClass': 'behat-link-close-report-confirm govuk-button',
+    }) }}
+    {{ form_end(form) }}
+{% endblock %}


### PR DESCRIPTION
## Purpose
Give case managers to "close" (resubmit) a report that has been marked as incomplete, so that the deputy can progress to the next report. As it stands, deputies need to manually resubmit on behalf on the case manager which is an unnecessary inconvenience.

Fixes DDPB-2898

## Approach
Added a separate form to the report management page, as per the design, that only renders when a report has been marked as incomplete (unsubmitted).

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
