### PR TITLE
DDPB-3163: Allow users to queue a document for upload

### DIFF
--- a/api/src/AppBundle/Controller/Report/ReportSubmissionController.php
+++ b/api/src/AppBundle/Controller/Report/ReportSubmissionController.php
@@ -7,6 +7,7 @@ use AppBundle\Entity as EntityDir;
 use AppBundle\Entity\Report\Document;
 use AppBundle\Entity\Report\ReportSubmission;
 use AppBundle\Transformer\ReportSubmission\ReportSubmissionSummaryTransformer;
+use InvalidArgumentException;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
@@ -158,6 +159,10 @@ class ReportSubmissionController extends RestController
     {
         /** @var ReportSubmission $reportSubmission */
         $reportSubmission = $this->getRepository(ReportSubmission::class)->find($id);
+
+        if ($reportSubmission->getArchived()) {
+            throw new InvalidArgumentException('Cannot queue documents for an archived report submission');
+        }
 
         foreach ($reportSubmission->getDocuments() as $document) {
             if (in_array($document->getSynchronisationStatus(), self::QUEUEABLE_STATUSES)) {

--- a/client/src/AppBundle/Controller/Admin/ReportSubmissionController.php
+++ b/client/src/AppBundle/Controller/Admin/ReportSubmissionController.php
@@ -184,7 +184,7 @@ class ReportSubmissionController extends AbstractController
         $checkedBoxes = array_keys($request->request->get('checkboxes'));
         $action = strtolower($request->request->get('multiAction'));
 
-        if (in_array($action, [self::ACTION_DOWNLOAD,self::ACTION_ARCHIVE])) {
+        if (in_array($action, [self::ACTION_DOWNLOAD, self::ACTION_ARCHIVE, self::ACTION_SYNCHRONISE])) {
             $totalChecked = count($checkedBoxes);
 
             switch ($action) {
@@ -214,6 +214,11 @@ class ReportSubmissionController extends AbstractController
                     } catch (Throwable $e) {
                         $this->addFlash('error', 'There was an error downloading the requested documents: ' . $e->getMessage());
                         return $this->redirectToRoute('admin_documents');
+                    }
+
+                case self::ACTION_SYNCHRONISE:
+                    foreach ($checkedBoxes as $reportSubmissionId) {
+                        $this->getRestClient()->put("report-submission/{$reportSubmissionId}/queue-documents", []);
                     }
             }
         }

--- a/client/src/AppBundle/Controller/Admin/ReportSubmissionController.php
+++ b/client/src/AppBundle/Controller/Admin/ReportSubmissionController.php
@@ -23,6 +23,7 @@ class ReportSubmissionController extends AbstractController
 {
     const ACTION_DOWNLOAD = 'download';
     const ACTION_ARCHIVE = 'archive';
+    const ACTION_SYNCHRONISE = 'synchronise';
 
     /**
      * @var DocumentDownloader
@@ -75,7 +76,7 @@ class ReportSubmissionController extends AbstractController
         if ($currentFilters['status'] === 'archived') {
             $postActions = [self::ACTION_DOWNLOAD];
         } else {
-            $postActions = [self::ACTION_DOWNLOAD, self::ACTION_ARCHIVE];
+            $postActions = [self::ACTION_DOWNLOAD, self::ACTION_ARCHIVE, self::ACTION_SYNCHRONISE];
         }
 
         return [

--- a/client/src/AppBundle/Controller/Admin/ReportSubmissionController.php
+++ b/client/src/AppBundle/Controller/Admin/ReportSubmissionController.php
@@ -5,6 +5,7 @@ namespace AppBundle\Controller\Admin;
 use AppBundle\Controller\AbstractController;
 use AppBundle\Entity as EntityDir;
 use AppBundle\Service\DocumentDownloader;
+use AppBundle\Service\FeatureFlagService;
 use AppBundle\Service\File\Storage\S3Storage;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -54,7 +55,7 @@ class ReportSubmissionController extends AbstractController
      *
      * @return array<mixed>|Response
      */
-    public function indexAction(Request $request)
+    public function indexAction(Request $request, FeatureFlagService $featureFlagService)
     {
         if ($request->isMethod('POST')) {
             $ret = $this->processPost($request);
@@ -76,7 +77,11 @@ class ReportSubmissionController extends AbstractController
         if ($currentFilters['status'] === 'archived') {
             $postActions = [self::ACTION_DOWNLOAD];
         } else {
-            $postActions = [self::ACTION_DOWNLOAD, self::ACTION_ARCHIVE, self::ACTION_SYNCHRONISE];
+            $postActions = [self::ACTION_DOWNLOAD, self::ACTION_ARCHIVE];
+        }
+
+        if ($featureFlagService->get(FeatureFlagService::FLAG_DOCUMENT_SYNC) === '1') {
+            $postActions[] = self::ACTION_SYNCHRONISE;
         }
 
         return [

--- a/client/src/AppBundle/Resources/translations/admin-documents.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin-documents.en.yml
@@ -11,6 +11,7 @@ page:
   postactions:
     download: Download
     archive: Archive
+    synchronise: Synchronise
     archived:
       notice: "{1} 1 document archived|]1,Inf[ %count% documents archived"
   resultsTable:

--- a/environment/admin.tf
+++ b/environment/admin.tf
@@ -23,3 +23,9 @@ data "aws_iam_policy_document" "admin_s3" {
     ]
   }
 }
+
+resource "aws_iam_role_policy" "admin_query_ssm" {
+  name   = "admin-query-ssm.${local.environment}"
+  policy = data.aws_iam_policy_document.query_ssm.json
+  role   = aws_iam_role.admin.id
+}

--- a/environment/admin_service.tf
+++ b/environment/admin_service.tf
@@ -75,6 +75,7 @@ locals {
       { "name": "ADMIN_HOST", "value": "https://${aws_route53_record.admin.fqdn}" },
       { "name": "API_URL", "value": "https://${local.api_service_fqdn}" },
       { "name": "EMAIL_SEND_INTERNAL", "value": "${local.account.is_production == 1 ? "true" : "false"}" },
+      { "name": "FEATURE_FLAG_PREFIX", "value": "${local.feature_flag_prefix}" },
       { "name": "FILESCANNER_SSLVERIFY", "value": "False" },
       { "name": "FILESCANNER_URL", "value": "https://${local.scan_service_fqdn}:8443" },
       { "name": "GA_DEFAULT", "value": "${local.account.ga_default}" },

--- a/environment/admin_sg.tf
+++ b/environment/admin_sg.tf
@@ -3,6 +3,7 @@ locals {
     ecr  = local.common_sg_rules.ecr
     logs = local.common_sg_rules.logs
     s3   = local.common_sg_rules.s3
+    ssm  = local.common_sg_rules.ssm
     pdf = {
       port        = 80
       type        = "egress"

--- a/environment/common_sg.tf
+++ b/environment/common_sg.tf
@@ -40,6 +40,13 @@ locals {
       protocol    = "tcp"
       target_type = "prefix_list_id"
       target      = data.aws_vpc_endpoint.s3_endpoint.prefix_list_id
+    },
+    ssm = {
+      port        = 443
+      type        = "egress"
+      protocol    = "tcp"
+      target_type = "security_group_id"
+      target      = data.aws_security_group.ssm_endpoint.id
     }
   }
 }

--- a/environment/document_sync.tf
+++ b/environment/document_sync.tf
@@ -3,13 +3,7 @@ locals {
     ecr  = local.common_sg_rules.ecr
     logs = local.common_sg_rules.logs
     s3   = local.common_sg_rules.s3
-    ssm = {
-      port        = 443
-      type        = "egress"
-      protocol    = "tcp"
-      target_type = "security_group_id"
-      target      = data.aws_security_group.ssm_endpoint.id
-    }
+    ssm  = local.common_sg_rules.ssm
     api = {
       port        = 443
       type        = "egress"

--- a/environment/front_service.tf
+++ b/environment/front_service.tf
@@ -76,6 +76,7 @@ locals {
       { "name": "ADMIN_HOST", "value": "https://${aws_route53_record.admin.fqdn}" },
       { "name": "API_URL", "value": "https://${local.api_service_fqdn}" },
       { "name": "EMAIL_SEND_INTERNAL", "value": "${local.account.is_production == 1 ? "true" : "false"}" },
+      { "name": "FEATURE_FLAG_PREFIX", "value": "${local.feature_flag_prefix}" },
       { "name": "FILESCANNER_SSLVERIFY", "value": "False" },
       { "name": "FILESCANNER_URL", "value": "http://${local.scan_service_fqdn}:8080" },
       { "name": "GA_DEFAULT", "value": "${local.account.ga_default}" },

--- a/environment/front_sg.tf
+++ b/environment/front_sg.tf
@@ -3,6 +3,7 @@ locals {
     ecr  = local.common_sg_rules.ecr
     logs = local.common_sg_rules.logs
     s3   = local.common_sg_rules.s3
+    ssm  = local.common_sg_rules.ssm
     cache = {
       port        = 6379
       type        = "egress"


### PR DESCRIPTION
## Purpose
We need to add a way to manually put a document in that state.

In early days of the integration, this will allow us to test that it works as anticipated with a small number of clients. Going forward, it will also allow us to retry failed documents if/when we fix the reason for failure.

Fixes DDPB-3163

## Approach
I added a new "Synchronise" button alongside the current report submission options. If clicked it will use a new API endpoint to synchronise documents of all selected report submissions.

It will only synchronise null, `TEMPORARY_ERROR` and `PERMANENT_ERROR` documents. The rest will be left as-is.

## Checklist
- [ ] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work
  - No Behat test because the setup doesn't lend itself well to Behat (need a submitted report, with a document which has failed) and it would only duplicate unit tests
- [ ] The product team have approved these changes
