### PR TITLE
DDPB-3273: Increases alarm threshold to 3

### DIFF
--- a/environment/alarms.tf
+++ b/environment/alarms.tf
@@ -16,7 +16,7 @@ resource "aws_cloudwatch_metric_alarm" "php_errors" {
   statistic           = "Sum"
   metric_name         = aws_cloudwatch_log_metric_filter.php_errors.metric_transformation[0].name
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = 1
+  threshold           = 3
   period              = 3600
   evaluation_periods  = 1
   namespace           = aws_cloudwatch_log_metric_filter.php_errors.metric_transformation[0].namespace
@@ -41,7 +41,7 @@ resource "aws_cloudwatch_metric_alarm" "nginx_errors" {
   statistic           = "Sum"
   metric_name         = aws_cloudwatch_log_metric_filter.nginx_errors.metric_transformation[0].name
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = 1
+  threshold           = 3
   period              = 3600
   evaluation_periods  = 1
   namespace           = aws_cloudwatch_log_metric_filter.nginx_errors.metric_transformation[0].namespace


### PR DESCRIPTION
## Purpose
Increase the alarm threshold for application errors from 1 per hour to 3 per hour, to help eliminate unnecessary concern and developer downtime

Fixes DDPB-3273

## Approach
Update terraform.


## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
