### PR TITLE
in-174 add pact prod version tags on prod release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,7 @@ workflows:
           requires: [ apply shared-production ]
           filters: { branches: { only: [ master ] } }
           tf_workspace: production02
+          pact_tag: true
 
       - run-task:
           name: backup production
@@ -246,6 +247,10 @@ jobs:
         description: terraform command
         default: apply
         type: string
+      pact_tag:
+        description: whether to add environment tag to pact broker
+        default: false
+        type: boolean
     environment:
       TF_TIER: << parameters.tf_tier >>
       WORKSPACE: << parameters.tf_workspace >>
@@ -271,6 +276,31 @@ jobs:
       - run:
           name: Stabilize
           command: stabilizer
+      - when:
+          condition: << parameters.pact_tag >>
+          steps:
+            - run:
+                name: set pact environment variables
+                command: ~/project/.circleci/set_env_pact.sh >> $BASH_ENV
+            - run:
+                name: tag pact commit with v<x>_production
+                command: |
+                  echo "applying production tag to pact broker on ${PACT_CONSUMER_VERSION}"
+                  STATUS_CODE=$(curl -I -s -X GET -u "${PACT_BROKER_HTTP_AUTH_USER}":"${PACT_BROKER_HTTP_AUTH_PASS}" \
+                  -H "Content-Type: application/json" \
+                  https://"${PACT_BROKER_BASE_URL}"/pacticipants/Complete%20the%20deputy%20report/versions/"${PACT_CONSUMER_VERSION}" \
+                  | grep "HTTP" | awk '{print $2}')
+
+                  if [ "${STATUS_CODE}" -eq "200" ]
+                  then
+                    STATUS_CODE=$(curl -X PUT -u "${PACT_BROKER_HTTP_AUTH_USER}":"${PACT_BROKER_HTTP_AUTH_PASS}" \
+                    -H "Content-Type: application/json" \
+                    https://"${PACT_BROKER_BASE_URL}"/pacticipants/Complete%20the%20deputy%20report/versions/"${PACT_CONSUMER_VERSION}"/tags/"${PACT_API_VERSION}_production" \
+                    | grep "HTTP" | awk '{print $2}')
+                    echo "Pact tagging completed with status code: ${STATUS_CODE}"
+                  else
+                    echo "version of provider with git commit ${GIT_COMMIT_PROVIDER}, not found"
+                  fi
   build:
     docker:
       - image: circleci/python:2.7

--- a/.circleci/set_env_pact.sh
+++ b/.circleci/set_env_pact.sh
@@ -4,6 +4,7 @@ set -e
 ACCOUNT="997462338508"
 PACT_BROKER_USER="admin"
 PACT_BROKER_URL="pact-broker.api.opg.service.justice.gov.uk"
+API_VERSION="v1"
 
 export SECRETSTRING=$(aws sts assume-role \
 --role-arn "arn:aws:iam::${ACCOUNT}:role/get-pact-secret-production" \
@@ -33,3 +34,4 @@ echo "export PACT_BROKER_BASE_URL=${PACT_BROKER_URL}"
 echo "export PACT_CONSUMER_VERSION=${CONSUMER_VERSION}"
 echo "export PACT_BROKER_HTTP_AUTH_USER=${PACT_BROKER_USER}"
 echo "export PACT_BROKER_HTTP_AUTH_PASS=${PACT_BROKER_PASS}"
+echo "export PACT_API_VERSION=${API_VERSION}"


### PR DESCRIPTION
## Purpose
The digideps side of this is just to add a tag after a deploy to production so that we can make checks on the data-deputy-reporting side against what is live.

Digideps side of in-174

## Approach
Check the pact version exists. If it does then apply a tag on on the release to prod by means of a variable in the apply job. It should be applied after the build has gone through.
## Learning
We need to do the pre check, that we get a status 200 on the consumer version, because pact allows you to do a 'put' against non existing versions.. Another interesting little quirk that one. 
Also for verify and canideploy options we are using a single combined tag that encapsulates version and production that allows us to more easily manage different api versions.
## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
