### PR TITLE
DDPB-3355: Amend mb limit for document uploads

### DIFF
--- a/behat/tests/features/deputy/03-report/01-102/08-documents.feature
+++ b/behat/tests/features/deputy/03-report/01-102/08-documents.feature
@@ -43,6 +43,13 @@ Feature: Report documents
     Then the following fields should have an error:
       | report_document_upload_files   |
 
+    # check size limit adhered
+    When I attach the file "too-big.jpg" to "report_document_upload_files"
+    And I click on "attach-file"
+    Then the following fields should have an error:
+      | report_document_upload_files   |
+    And I should see "The file you selected to upload is too big"
+
     # check good pdf gets uploaded
     When I attach the file "good.pdf" to "report_document_upload_files"
     And I click on "attach-file"

--- a/client/src/AppBundle/Entity/Report/Document.php
+++ b/client/src/AppBundle/Entity/Report/Document.php
@@ -79,7 +79,7 @@ class Document implements DocumentInterface
      *
      * @Assert\NotBlank(message="Please choose a file", groups={"document"})
      * @Assert\File(
-     *     maxSize = "15M",
+     *     maxSize = "5M",
      *     maxSizeMessage = "document.file.errors.maxSizeMessage",
      *     mimeTypes = {"application/pdf", "application/x-pdf", "image/png", "image/jpeg"},
      *     mimeTypesMessage = "document.file.errors.mimeTypesMessage",

--- a/client/src/AppBundle/Resources/assets/javascripts/modules/uploadFile.js
+++ b/client/src/AppBundle/Resources/assets/javascripts/modules/uploadFile.js
@@ -10,7 +10,7 @@ module.exports = function (containerSelector) {
     }
   })
 
-  // Show an error if file is over 15mb
+  // Show an error if file is over 5mb
   $('#upload_form').on('submit', function (e) {
     e.preventDefault()
     var fileElement = $('#report_document_upload_files')

--- a/client/src/AppBundle/Resources/assets/javascripts/modules/uploadFile.js
+++ b/client/src/AppBundle/Resources/assets/javascripts/modules/uploadFile.js
@@ -1,4 +1,6 @@
 /* globals $ */
+var UPLOAD_LIMIT = 5
+
 module.exports = function (containerSelector) {
   // Show in progress message
   $(containerSelector).on('click', function () {
@@ -17,7 +19,7 @@ module.exports = function (containerSelector) {
     // check whether browser fully supports all File API
     if (window.File && window.FileReader && window.FileList && window.Blob && fileElement[0].files.length > 0) {
       var fsize = fileElement[0].files[0].size
-      if (fsize > 15 * 1024 * 1024) {
+      if (fsize > UPLOAD_LIMIT * 1024 * 1024) {
         window.location = actionUrl + '?error=tooBig'
         return
       }

--- a/client/src/AppBundle/Resources/translations/report-documents.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-documents.en.yml
@@ -7,7 +7,7 @@ form:
     label: Attach a file
     hint: ""
   errors:
-    fileSize: "Your uploaded file exceeded the maximum size of 15M"
+    fileSize: "Your uploaded file exceeded the maximum size of 5M"
     risky: "Cannot upload file, risky content found inside. Technical details: %techDetails%"
     virusFound:  "Cannot upload file, virus found inside. Technical details: %techDetails%"
     generic: "Cannot upload file, please try again later. Technical details: %techDetails%"
@@ -28,7 +28,7 @@ attachPage:
   selectHeading: 1. Select the files
   selectHelp: Please select 'Choose files' below to find your files.
   selectHint1: You only need to upload documents if we have asked you to.
-  selectHint2: You can only upload PDF, JPG or PNG files, and they must be smaller than 15MB.
+  selectHint2: You can only upload PDF, JPG or PNG files, and they must be smaller than 5MB.
   uploadHeading: 2. Upload the files to your report
   noDocuments: No documents
   documentList: Attached documents

--- a/client/src/AppBundle/Resources/translations/validators.en.yml
+++ b/client/src/AppBundle/Resources/translations/validators.en.yml
@@ -184,12 +184,12 @@ document:
   file:
     errors:
       mimeTypesMessage: "Please upload a valid file type. Supported file types include PDF, JPG and PNG"
-      maxSizeMessage: "The file you selected to upload is too big. Please check your file size is less than 15mb."
+      maxSizeMessage: "The file you selected to upload is too big. Please check your file size is less than 5mb."
       alreadyPresent: "You have already uploaded a file with this name. Please rename your file before uploading again."
       maxDocumentsPerReport: "You have reached the maximum number of attachments for this report"
       invalidName: "Your file has an invalid name"
       maxMessage: "The file name can't be longer than 255 letters"
-      fileSize: "Your uploaded file exceeded the maximum size of 15M"
+      fileSize: "Your uploaded file exceeded the maximum size of 5M"
       risky: "Unfortunately, our antivirus check found a problem with this file and we are unable to upload it. Please choose another file"
       virusFound:  "Unfortunately, our antivirus check found a problem with this file and we are unable to upload it. Please choose another file"
       generic: "Cannot upload file, please try again later"


### PR DESCRIPTION
## Purpose
Due to size restrictions for the integration work, document file size needs to be reduced to 5MB in digideps to prevent users uploading documents that will fail to pass through to sirius.

Fixes DDPB-3355, DDPB-3354

## Approach
Updated the limit on the `Document` entity, and the frontend helper (which warns users earlier if possible).

Updated the help text to match the new limit.

## Learning
Symfony treats "5MB" as 5000000 bytes (as opposed to 5242880 bytes). This means users _might_ have a file which their computer identifies as <5MB but Symfony does not. This was the case with the previous 15MB limit too, just worth knowing about.

## Checklist
- [ ] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work
  - I've added a new test checking large files are rejected
- [ ] The product team have approved these changes
