### PR TITLE
DDPB-3268: Reduce org upload chunk size to 50

### DIFF
--- a/client/src/AppBundle/Service/OrgService.php
+++ b/client/src/AppBundle/Service/OrgService.php
@@ -43,6 +43,8 @@ class OrgService
         ],
     ];
 
+    const CHUNK_SIZE = 50;
+
     /**
      * @param RestClient $restClient
      */
@@ -197,7 +199,7 @@ class OrgService
      */
     public function process($data, $redirectUrl)
     {
-        $chunks = array_chunk($data, 100);
+        $chunks = array_chunk($data, self::CHUNK_SIZE);
 
         $response = $this->generateStreamedResponse();
 


### PR DESCRIPTION
## Purpose
The CSV upload process times out after our changes in DDPB-3267 and DDPB-3268 have been applied. The upload breaks the CSV into chunks and we believe the work inside one of these chunks is taking too long.

Fixes DDPB-3268

## Approach
I halved the chunk size from 100 to 50. By processing half as many records, each API call will take less time and use less memory.

This doubles the number of individual requests made to the API, so adds the overhead of wrapping twice as many requests. However, I believe this increase will be negligible in a process that already takes twenty minutes. Furthermore, memory savings on individual API calls might cover for this since we know memory usage is a big problem on this API endpoint.

## Learning
I attempted the upload locally and it worked fine. This is likely because I have a much smaller database without complex client and organisation relationships. However, this does highlight that we're not accounting for this sort of load during testing.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work
  - N/A
- [x] The product team have approved these changes
  - N/A
