### PR TITLE
DDPB-3272: Generate application version statically, deprecate semvertag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,6 @@ jobs:
           command: |
             export VERSION=${TF_WORKSPACE}-${CIRCLE_SHA1:0:7}
 
-            echo "$VERSION"
             echo "export VERSION=${VERSION}" >> $BASH_ENV
             echo "$VERSION" >> ~/project/VERSION
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,8 +320,12 @@ jobs:
       - run:
           name: Set version
           command: |
+            echo $CIRCLE_SHA1
             export SHORT_HASH=${CIRCLE_SHA1:0:7} >> $BASH_ENV
+            echo $SHORT_HASH
             export VERSION=${WORKSPACE}-${SHORT_HASH} >> $BASH_ENV
+            echo $WORKSPACE
+            echo $VERSION
 
             echo "$VERSION" >> ~/project/VERSION
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,15 +315,19 @@ jobs:
             - 6f:4b:55:76:0e:cd:27:7d:ad:c3:28:38:53:69:5c:32
       - checkout
       - run:
+          name: Set environment
+          command: ~/project/.circleci/set_env.sh >> $BASH_ENV
+      - run:
           name: Set version
-          command: echo "$CIRCLE_BRANCH-$SHORT_HASH" >> ~/project/VERSION
+          command: |
+            export SHORT_HASH=${CIRCLE_SHA1:0:7} >> $BASH_ENV
+            export VERSION=${WORKSPACE}-${SHORT_HASH} >> $BASH_ENV
+
+            echo "$VERSION" >> ~/project/VERSION
       - persist_to_workspace:
           root: .
           paths:
             - VERSION
-      - run:
-          name: Set environment
-          command: ~/project/.circleci/set_env.sh >> $BASH_ENV
       - run:
           name: Show version
           command: echo ${VERSION}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,10 +321,10 @@ jobs:
           name: Set version
           command: |
             echo $CIRCLE_SHA1
-            export SHORT_HASH=${CIRCLE_SHA1:0:7} >> $BASH_ENV
+            echo "export SHORT_HASH=${CIRCLE_SHA1:0:7}" >> $BASH_ENV
             echo $SHORT_HASH
-            export VERSION=${WORKSPACE}-${SHORT_HASH} >> $BASH_ENV
-            echo $WORKSPACE
+            echo "export VERSION=${TF_WORKSPACE}-${SHORT_HASH}" >> $BASH_ENV
+            echo $TF_WORKSPACE
             echo $VERSION
 
             echo "$VERSION" >> ~/project/VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,11 +321,8 @@ jobs:
             - 6f:4b:55:76:0e:cd:27:7d:ad:c3:28:38:53:69:5c:32
       - checkout
       - run:
-          name: Install semvertag
-          command: sudo pip install https://github.com/ministryofjustice/semvertag/archive/master.zip
-      - run:
-          name: Bump version
-          command: semvertag bump patch << parameters.semver_stage >> >> ~/project/VERSION
+          name: Set version
+          command: echo "$CIRCLE_BRANCH-$SHORT_HASH" >> ~/project/VERSION
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,13 +320,10 @@ jobs:
       - run:
           name: Set version
           command: |
-            echo $CIRCLE_SHA1
-            echo "export SHORT_HASH=${CIRCLE_SHA1:0:7}" >> $BASH_ENV
-            echo $SHORT_HASH
-            echo "export VERSION=${TF_WORKSPACE}-${SHORT_HASH}" >> $BASH_ENV
-            echo $TF_WORKSPACE
-            echo $VERSION
+            export VERSION=${TF_WORKSPACE}-${CIRCLE_SHA1:0:7}
 
+            echo "$VERSION"
+            echo "export VERSION=${VERSION}" >> $BASH_ENV
             echo "$VERSION" >> ~/project/VERSION
       - persist_to_workspace:
           root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ workflows:
 
       - build:
           name: build pr
-          semver_stage: --stage dev
           filters: { branches: { ignore: [ master ] } }
 
       - apply:
@@ -304,11 +303,6 @@ jobs:
   build:
     docker:
       - image: circleci/python:3
-    parameters:
-      semver_stage:
-        description: semver stage suffix
-        default: ""
-        type: string
     environment:
       AWS_REGION: eu-west-1
       AWS_CONFIG_FILE: ~/project/aws_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,7 +303,7 @@ jobs:
                   fi
   build:
     docker:
-      - image: circleci/python:2.7
+      - image: circleci/python:3
     parameters:
       semver_stage:
         description: semver stage suffix

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,12 +334,6 @@ jobs:
           name: Show version
           command: echo ${VERSION}
       - run:
-          name: Tag git
-          command: git tag ${VERSION}
-      - run:
-          name: Push git tags
-          command: git push --tags
-      - run:
           name: Docker login
           command: eval $(aws ecr get-login --region $AWS_REGION --no-include-email --profile digideps-ci)
       - run:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can then use the make files in `environment` and `shared` to set up the envi
 ```bash
 # ensure your environment is setup:
 export TF_WORKSPACE=myawesomeenvironment
-export TF_VAR_OPG_DOCKER_TAG=1.0.myawesometag
+export TF_VAR_OPG_DOCKER_TAG=mybranch-githash
 export AWS_ACCESS_KEY_ID=AKIAEXAMPLE
 export AWS_SECRET_ACCESS_KEY=cbeamsglittering
 cd environment
@@ -50,7 +50,7 @@ make
 
 # alternatively, using aws-vault:
 export TF_WORKSPACE=myawesomeenvironment
-export TF_VAR_OPG_DOCKER_TAG=1.0.myawesometag
+export TF_VAR_OPG_DOCKER_TAG=mybranch-githash
 cd environment
 aws-vault exec identity make
 ```

--- a/TECH-DEBT.md
+++ b/TECH-DEBT.md
@@ -9,7 +9,6 @@ If any debt may lead to larger risks, it should be transferred to the risk board
 
 ## Infra
 - scheduled scaling for cost saving
-- remove dependency on semvertag
 - periodically rotate CI access key
 - move public routes to main route table
 - Move to secrets per account


### PR DESCRIPTION
## Purpose
We want to deprecate semvertag because it requires Python 2.7. Since we don't use semver properly, we'll replace with a hash-based versioning system rather than a direct replacement.

Fixes DDPB-3272

## Approach
I removed semvertag and instead generated the version by combining the current branch and Git hash (`$CIRCLE_BRANCH-$SHORT_HASH`). This then allows us to upgrade the CircleCI executor to Python 3.

I removed the `git tag` step, since it seems pointless to tag a Git hash with a name including the hash (e.g. `master-0b92fed` would be a tag of commit 0b92fed).

Everything else works the same as before: the new version string is used as the tag in ECR, set as the environment variable `OPG_DOCKER_TAG` and displayed in the application footer.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevan
- [x] I have added tests to prove my work
  - N/A
- [ ] The product team have approved these changes
