### PR TITLE
Ddpb 3367

### DIFF
--- a/client/src/AppBundle/Form/Report/ReportDeclarationType.php
+++ b/client/src/AppBundle/Form/Report/ReportDeclarationType.php
@@ -33,9 +33,8 @@ class ReportDeclarationType extends AbstractType
 
         $loggedInUser = $this->tokenStorage->getToken()->getUser();
 
-        $report = $builder->getData();
         if (!$loggedInUser->isLayDeputy()) {
-            $agreedBehalfChoices = ['not_deputy' => 'agreedBehalfDeputy.not_deputy'] + $agreedBehalfChoices;
+            $agreedBehalfChoices = $agreedBehalfChoices + ['not_deputy' => 'agreedBehalfDeputy.not_deputy'];
         }
 
         $builder

--- a/client/src/AppBundle/Resources/views/Report/Report/declaration.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Report/declaration.html.twig
@@ -64,6 +64,10 @@
 
         {{ form_checkbox(form.agree, 'agree', { 'labelClass': 'required' }) }}
 
+        {% set conditional_details %}
+            {{ form_input(form.agreedBehalfDeputyExplanation, 'agreedBehalfDeputyExplanation' )}}
+        {% endset %}
+
         <div class="govuk-form-group push-half--bottom {% if not form.agreedBehalfDeputy.vars.valid %}govuk-form-group--error{% endif %}">
             {{ form_checkbox_group(form.agreedBehalfDeputy, 'agreedBehalfDeputy', {
                 'useFormGroup': false,
@@ -73,7 +77,7 @@
                     {},
                     {},
                     {},
-                    {'dataTarget': 'agreed-behalf-deputy-explanation-section' }
+                    {'conditional': conditional_details }
                 ]
             }) }}
 

--- a/client/src/AppBundle/Resources/views/Report/Report/declaration.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Report/declaration.html.twig
@@ -76,8 +76,8 @@
                 'items': [
                     {},
                     {},
+                    {'conditional': conditional_details},
                     {},
-                    {'conditional': conditional_details }
                 ]
             }) }}
         </div>

--- a/client/src/AppBundle/Resources/views/Report/Report/declaration.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Report/declaration.html.twig
@@ -72,6 +72,7 @@
                 'items': [
                     {},
                     {},
+                    {},
                     {'dataTarget': 'agreed-behalf-deputy-explanation-section' }
                 ]
             }) }}

--- a/client/src/AppBundle/Resources/views/Report/Report/declaration.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Report/declaration.html.twig
@@ -80,11 +80,6 @@
                     {'conditional': conditional_details }
                 ]
             }) }}
-
-            <div id="agreed-behalf-deputy-explanation-section" class="opg-indented-block js-hidden">
-                {{ form_input(form.agreedBehalfDeputyExplanation,'agreedBehalfDeputyExplanation') }}
-            </div>
-
         </div>
 
         <div class="push--top">


### PR DESCRIPTION
## Purpose
Fix for bug that was causing the extra details box to render when the incorrect radio option is selected.

Fixes DDPB-3367

## Approach
Straight forward case of adding a missing options object to the form renderer, which was causing the options and their corresponding config object to be out of sync.

Also updated the conditional logic to use the Govuk Design System

## Learning
This is a relatively simple bug to reintroduce - when adding a new radio option it's easy to miss that an extra config option needs passing to the `form_checkbox_group` in Twig. Something to be mindful of.

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
