### PR TITLE
DDPB-3292: Check form is submitted before checking validity

### DIFF
--- a/client/src/AppBundle/Controller/Admin/AdController.php
+++ b/client/src/AppBundle/Controller/Admin/AdController.php
@@ -41,7 +41,7 @@ class AdController extends AbstractController
 
         if ($request->isMethod('POST')) {
             $form->handleRequest($request);
-            if ($form->isValid()) {
+            if ($form->isSubmitted() && $form->isValid()) {
                 // add user
                 try {
                     $userToAdd = $form->getData(); /* @var $userToAdd EntityDir\User*/

--- a/client/src/AppBundle/Controller/Admin/Client/ReportController.php
+++ b/client/src/AppBundle/Controller/Admin/Client/ReportController.php
@@ -124,7 +124,7 @@ class ReportController extends AbstractController
         $reviewForm = $this->createForm(ReviewChecklistType::class, $reviewChecklist);
         $reviewForm->handleRequest($request);
 
-        if ($reviewForm->isValid()) {
+        if ($reviewForm->isSubmitted() && $reviewForm->isValid()) {
             /** @var SubmitButton $button */
             $button = $reviewForm->getClickedButton();
             if ($button->getName() === ReviewChecklistType::SUBMIT_ACTION) {
@@ -149,7 +149,7 @@ class ReportController extends AbstractController
             $checklist->setButtonClicked($buttonClicked->getName());
         }
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             if (!empty($checklist->getId())) {
                 $this->getRestClient()->put('report/' . $report->getId() . '/checked', $checklist, [
                     'report-checklist', 'checklist-information'
@@ -375,7 +375,7 @@ class ReportController extends AbstractController
         $form = $this->createForm(ManageReportConfirmType::class, $report);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             if ($form->has('confirm') && $form['confirm']->getData() === 'no') {
                 // User decided not to update.
                 return $this->redirect($this->generateUrl('admin_client_details', ['id'=>$report->getClient()->getId()]));

--- a/client/src/AppBundle/Controller/Admin/Client/SearchController.php
+++ b/client/src/AppBundle/Controller/Admin/Client/SearchController.php
@@ -31,7 +31,7 @@ class SearchController extends AbstractController
         }
 
         $form->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $filters = $form->getData() + $this->getDefaultFilters($request);
         }
 

--- a/client/src/AppBundle/Controller/Admin/IndexController.php
+++ b/client/src/AppBundle/Controller/Admin/IndexController.php
@@ -67,7 +67,7 @@ class IndexController extends AbstractController
 
         $form = $this->createForm(FormDir\Admin\SearchType::class, null, ['method' => 'GET']);
         $form->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $filters = $form->getData() + $filters;
         }
 
@@ -95,7 +95,7 @@ class IndexController extends AbstractController
         $form = $this->createForm(FormDir\Admin\AddUserType::class, new EntityDir\User());
 
         $form->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             // add user
             try {
                 if (!$this->isGranted(EntityDir\User::ROLE_SUPER_ADMIN) && $form->getData()->getRoleName() == EntityDir\User::ROLE_SUPER_ADMIN) {
@@ -162,7 +162,7 @@ class IndexController extends AbstractController
         $form = $this->createForm(FormDir\Admin\EditUserType::class, $user);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $updateUser = $form->getData();
 
             try {
@@ -219,7 +219,7 @@ class IndexController extends AbstractController
         if ($request->getMethod() == 'POST') {
             $ndrForm->handleRequest($request);
 
-            if ($ndrForm->isValid()) {
+            if ($ndrForm->isSubmitted() && $ndrForm->isValid()) {
                 $updateNdr = $ndrForm->getData();
                 $this->getRestClient()->put('ndr/' . $id, $updateNdr, ['start_date']);
                 $this->addFlash('notice', 'Your changes were saved');
@@ -317,7 +317,7 @@ class IndexController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $fileName = $form->get('file')->getData();
             try {
                 $csvToArray = new CsvToArray($fileName, false, true);
@@ -390,7 +390,7 @@ class IndexController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $fileName = $form->get('file')->getData();
             try {
                 $data = (new CsvToArray($fileName, true))
@@ -443,7 +443,7 @@ class IndexController extends AbstractController
 
         $outputStreamResponse = isset($_GET['ajax']);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             try {
                 $fileName = $form->get('file')->getData();
 

--- a/client/src/AppBundle/Controller/Admin/OrganisationController.php
+++ b/client/src/AppBundle/Controller/Admin/OrganisationController.php
@@ -66,7 +66,7 @@ class OrganisationController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $organisation = $form->getData();
 
             try {
@@ -103,7 +103,7 @@ class OrganisationController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $organisation = $form->getData();
 
             try {
@@ -136,7 +136,7 @@ class OrganisationController extends AbstractController
 
         $organisation = $this->getRestClient()->get('v2/organisation/' . $id, 'Organisation');
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             try {
                 $this->getRestClient()->delete('v2/organisation/' . $organisation->getId());
                 $request->getSession()->getFlashBag()->add('notice', 'The organisation has been removed');
@@ -229,7 +229,7 @@ class OrganisationController extends AbstractController
         $organisation = $this->getRestClient()->get('v2/organisation/' . $id, 'Organisation');
         $user = $this->getRestClient()->get('user/' . $userId, 'User');
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             try {
                 $this->getRestClient()->delete('v2/organisation/' . $organisation->getId() . '/user/' . $user->getId());
                 $request->getSession()->getFlashBag()->add('notice', 'User has been removed from ' . $organisation->getName());

--- a/client/src/AppBundle/Controller/Admin/SettingController.php
+++ b/client/src/AppBundle/Controller/Admin/SettingController.php
@@ -30,7 +30,7 @@ class SettingController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $setting = $form->getData();
 
             $this->getRestClient()->put($endpoint, $setting, ['setting']);

--- a/client/src/AppBundle/Controller/Admin/StatsController.php
+++ b/client/src/AppBundle/Controller/Admin/StatsController.php
@@ -32,7 +32,7 @@ class StatsController extends AbstractController
         $form = $this->createForm(ReportSubmissionDownloadFilterType::class , new ReportSubmissionSummaryQuery());
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             try {
                 $reportSubmissionSummaries = $mapper->getBy($form->getData());
                 $downloadableData = $transformer->transform($reportSubmissionSummaries);
@@ -80,7 +80,7 @@ class StatsController extends AbstractController
 
         $append = '';
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $startDate = $form->get('startDate')->getData();
             $endDate = $form->get('endDate')->getData();
             $append = "&startDate={$startDate->format('Y-m-d')}&endDate={$endDate->format('Y-m-d')}";

--- a/client/src/AppBundle/Controller/ClientController.php
+++ b/client/src/AppBundle/Controller/ClientController.php
@@ -62,7 +62,7 @@ class ClientController extends AbstractController
         $form->handleRequest($request);
 
         // edit client form
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $clientUpdated = $form->getData();
             $clientUpdated->setId($client->getId());
             $this->getRestClient()->put('client/upsert', $clientUpdated, ['edit']);
@@ -121,7 +121,7 @@ class ClientController extends AbstractController
         $form = $this->createForm(ClientType::class, $client);
 
         $form->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             try {
                 // validate against casRec
                 $this->getRestClient()->apiCall('post', 'casrec/verify', $client, 'array', []);

--- a/client/src/AppBundle/Controller/CoDeputyController.php
+++ b/client/src/AppBundle/Controller/CoDeputyController.php
@@ -41,7 +41,7 @@ class CoDeputyController extends AbstractController
                 $form->get('client' . ucfirst($clientProperty))->addError(new FormError($error->getMessage()));
             }
 
-            if ($form->isValid()) {
+            if ($form->isSubmitted() && $form->isValid()) {
                 $selfRegisterData = new SelfRegisterData();
                 $selfRegisterData->setFirstname($form['firstname']->getData());
                 $selfRegisterData->setLastname($form['lastname']->getData());
@@ -117,7 +117,7 @@ class CoDeputyController extends AbstractController
             :$this->generateUrl('lay_home');
 
         $form->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             try {
                 /** @var EntityDir\User $invitedUser */
                 $invitedUser = $this->getRestClient()->post('codeputy/add', $form->getData(), ['codeputy'], 'User');
@@ -167,7 +167,7 @@ class CoDeputyController extends AbstractController
             :$this->generateUrl('lay_home');
 
         $form->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             try {
                 //email was updated on the fly
                 if ($form->getData()->getEmail() != $email) {

--- a/client/src/AppBundle/Controller/FeedbackController.php
+++ b/client/src/AppBundle/Controller/FeedbackController.php
@@ -20,7 +20,7 @@ class FeedbackController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             // Store in database
             $score = $form->get('satisfactionLevel')->getData();
             if ($score) {

--- a/client/src/AppBundle/Controller/IndexController.php
+++ b/client/src/AppBundle/Controller/IndexController.php
@@ -76,7 +76,7 @@ class IndexController extends AbstractController
             'isAdmin' => $this->container->getParameter('env') === 'admin',
         ];
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             try {
                 $this->logUserIn($form->getData(), $request, [
                     '_adId' => null,
@@ -273,7 +273,7 @@ class IndexController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid() || $request->query->get('accept') === 'all') {
+        if ($form->isSubmitted() && $form->isValid() || $request->query->get('accept') === 'all') {
             $settings = [
                 'essential' => true,
                 'usage' => $form->get('usage')->getData()

--- a/client/src/AppBundle/Controller/Ndr/ActionController.php
+++ b/client/src/AppBundle/Controller/Ndr/ActionController.php
@@ -56,7 +56,7 @@ class ActionController extends AbstractController
         $form = $this->createForm(FormDir\Ndr\ActionType::class, $ndr, ['step' => $step]);
         $form->handleRequest($request);
 
-        if ($form->get('save')->isClicked() && $form->isValid()) {
+        if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $this->getRestClient()->put('ndr/' . $ndrId, $data, ['action']);
 

--- a/client/src/AppBundle/Controller/Ndr/AssetController.php
+++ b/client/src/AppBundle/Controller/Ndr/AssetController.php
@@ -53,7 +53,7 @@ class AssetController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($ndr->getNoAssetToAdd()) {
                 case 0: // yes
                     return $this->redirectToRoute('ndr_assets_type', ['ndrId' => $ndrId,]);
@@ -86,7 +86,7 @@ class AssetController extends AbstractController
         ]);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $title = $form->getData()->getTitle();
             switch ($title) {
                 case 'Property':
@@ -118,7 +118,7 @@ class AssetController extends AbstractController
         $form = $this->createForm(FormDir\Ndr\Asset\AssetTypeOther::class, $asset);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $asset = $form->getData();
             $this->getRestClient()->post("ndr/{$ndrId}/asset", $asset);
 
@@ -153,7 +153,7 @@ class AssetController extends AbstractController
         $form = $this->createForm(FormDir\Ndr\Asset\AssetTypeOther::class, $asset);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $asset = $form->getData();
             $this->getRestClient()->put("ndr/{$ndrId}/asset/{$assetId}", $asset);
             $request->getSession()->getFlashBag()->add('notice', 'Asset edited');
@@ -180,7 +180,7 @@ class AssetController extends AbstractController
         $form = $this->createForm(FormDir\AddAnotherRecordType::class, $ndr, ['translation_domain' => 'ndr-assets']);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($form['addAnother']->getData()) {
                 case 'yes':
                     return $this->redirectToRoute('ndr_assets_type', ['ndrId' => $ndrId, 'from' => 'another']);
@@ -347,7 +347,7 @@ class AssetController extends AbstractController
         $form = $this->createForm(FormDir\ConfirmDeleteType::class);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $ndr = $this->getNdrIfNotSubmitted($ndrId, self::$jmsGroups);
 
             if ($ndr->hasAssetWithId($assetId)) {

--- a/client/src/AppBundle/Controller/Ndr/AssetController.php
+++ b/client/src/AppBundle/Controller/Ndr/AssetController.php
@@ -249,7 +249,7 @@ class AssetController extends AbstractController
         $form = $this->createForm(FormDir\Ndr\Asset\AssetTypeProperty::class, $asset, ['step' => $step]);
         $form->handleRequest($request);
 
-        if ($form->get('save')->isClicked() && $form->isValid()) {
+        if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {
             $asset = $form->getData();
             /* @var $asset EntityDir\Ndr\AssetProperty */
 

--- a/client/src/AppBundle/Controller/Ndr/BankAccountController.php
+++ b/client/src/AppBundle/Controller/Ndr/BankAccountController.php
@@ -135,7 +135,7 @@ class BankAccountController extends AbstractController
         $form = $this->createForm(FormDir\AddAnotherRecordType::class, $ndr, ['translation_domain' => 'ndr-bank-accounts']);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($form['addAnother']->getData()) {
                 case 'yes':
                     return $this->redirectToRoute('ndr_bank_accounts_step', ['ndrId' => $ndrId, 'step' => 1]);
@@ -184,7 +184,7 @@ class BankAccountController extends AbstractController
         $form = $this->createForm(FormDir\ConfirmDeleteType::class);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $ndr = $this->getNdrIfNotSubmitted($ndrId, self::$jmsGroups);
 
             $request->getSession()->getFlashBag()->add(

--- a/client/src/AppBundle/Controller/Ndr/BankAccountController.php
+++ b/client/src/AppBundle/Controller/Ndr/BankAccountController.php
@@ -76,7 +76,7 @@ class BankAccountController extends AbstractController
         $form = $this->createForm(FormDir\Ndr\BankAccountType::class, $account, ['step' => $step]);
         $form->handleRequest($request);
 
-        if ($form->get('save')->isClicked() && $form->isValid()) {
+        if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {
             // decide what data in the partial form needs to be passed to next step
             if ($step == 1) {
                 $stepUrlData['type'] = $account->getAccountType();

--- a/client/src/AppBundle/Controller/Ndr/DebtController.php
+++ b/client/src/AppBundle/Controller/Ndr/DebtController.php
@@ -41,7 +41,7 @@ class DebtController extends AbstractController
                                  );
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->put('ndr/' . $ndrId, $ndr, ['debt']);
 
             if ($ndr->getHasDebts() == 'yes') {
@@ -76,7 +76,7 @@ class DebtController extends AbstractController
         $form->handleRequest($request);
         $fromPage = $request->get('from');
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->put('ndr/' . $ndr->getId(), $form->getData(), ['debt']);
 
             if ($fromPage == 'summary') {
@@ -114,7 +114,7 @@ class DebtController extends AbstractController
         $fromPage = $request->get('from');
         $fromSummaryPage = $request->get('from') == 'summary';
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->put('ndr/' . $ndr->getId(), $form->getData(), ['ndr-debt-management']);
 
             if ($fromPage == 'summary') {

--- a/client/src/AppBundle/Controller/Ndr/DeputyExpenseController.php
+++ b/client/src/AppBundle/Controller/Ndr/DeputyExpenseController.php
@@ -48,7 +48,7 @@ class DeputyExpenseController extends AbstractController
                                  );
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             /* @var $data EntityDir\Ndr\Ndr */
             switch ($data->getPaidForAnything()) {
@@ -84,7 +84,7 @@ class DeputyExpenseController extends AbstractController
         $form = $this->createForm(FormDir\Ndr\DeputyExpenseType::class, $expense);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $data->setNdr($ndr);
 
@@ -115,7 +115,7 @@ class DeputyExpenseController extends AbstractController
         $form = $this->createForm(FormDir\AddAnotherRecordType::class, $ndr, ['translation_domain' => 'ndr-deputy-expenses']);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($form['addAnother']->getData()) {
                 case 'yes':
                     return $this->redirectToRoute('ndr_deputy_expenses_add', ['ndrId' => $ndrId, 'from' => 'add_another']);
@@ -142,7 +142,7 @@ class DeputyExpenseController extends AbstractController
         $form = $this->createForm(FormDir\Ndr\DeputyExpenseType::class, $expense);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $request->getSession()->getFlashBag()->add('notice', 'Expense edited');
 
@@ -191,7 +191,7 @@ class DeputyExpenseController extends AbstractController
         $form = $this->createForm(FormDir\ConfirmDeleteType::class);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $ndr = $this->getNdrIfNotSubmitted($ndrId, self::$jmsGroups);
 
             $this->getRestClient()->delete('ndr/' . $ndr->getId() . '/expense/' . $expenseId);

--- a/client/src/AppBundle/Controller/Ndr/IncomeBenefitController.php
+++ b/client/src/AppBundle/Controller/Ndr/IncomeBenefitController.php
@@ -61,7 +61,7 @@ class IncomeBenefitController extends AbstractController
                                  );
         $form->handleRequest($request);
 
-        if ($form->get('save')->isClicked() && $form->isValid()) {
+        if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             /* @var $data Ndr */
             $stepToJmsGroup = [

--- a/client/src/AppBundle/Controller/Ndr/NdrController.php
+++ b/client/src/AppBundle/Controller/Ndr/NdrController.php
@@ -215,7 +215,7 @@ class NdrController extends AbstractController
 
         $form = $this->createForm(FormDir\Ndr\ReportDeclarationType::class, $ndr);
         $form->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             // set report submitted with date
 
             $ndr->setSubmitted(true)->setSubmitDate(new \DateTime());
@@ -279,7 +279,7 @@ class NdrController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             // Store in database
             $this->getRestClient()->post('satisfaction', [
                 'score' => $form->get('satisfactionLevel')->getData(),

--- a/client/src/AppBundle/Controller/Ndr/OtherInfoController.php
+++ b/client/src/AppBundle/Controller/Ndr/OtherInfoController.php
@@ -55,7 +55,7 @@ class OtherInfoController extends AbstractController
         $form = $this->createForm(FormDir\Ndr\OtherInfoType::class, $ndr);
         $form->handleRequest($request);
 
-        if ($form->get('save')->isClicked() && $form->isSubmitted && $form->isValid()) {
+        if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $this->getRestClient()->put('ndr/' . $ndrId, $data, ['more-info']);
 

--- a/client/src/AppBundle/Controller/Ndr/OtherInfoController.php
+++ b/client/src/AppBundle/Controller/Ndr/OtherInfoController.php
@@ -55,7 +55,7 @@ class OtherInfoController extends AbstractController
         $form = $this->createForm(FormDir\Ndr\OtherInfoType::class, $ndr);
         $form->handleRequest($request);
 
-        if ($form->get('save')->isClicked() && $form->isValid()) {
+        if ($form->get('save')->isClicked() && $form->isSubmitted && $form->isValid()) {
             $data = $form->getData();
             $this->getRestClient()->put('ndr/' . $ndrId, $data, ['more-info']);
 

--- a/client/src/AppBundle/Controller/Ndr/VisitsCareController.php
+++ b/client/src/AppBundle/Controller/Ndr/VisitsCareController.php
@@ -58,7 +58,7 @@ class VisitsCareController extends AbstractController
                                  );
         $form->handleRequest($request);
 
-        if ($form->get('save')->isClicked() && $form->isValid()) {
+        if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             /* @var $data EntityDir\Ndr\VisitsCare */
             $data

--- a/client/src/AppBundle/Controller/Org/ClientContactController.php
+++ b/client/src/AppBundle/Controller/Org/ClientContactController.php
@@ -40,7 +40,7 @@ class ClientContactController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->post('clients/' . $client->getId() . '/clientcontacts', $form->getData(), ['add_clientcontact']
             );
             $request->getSession()->getFlashBag()->add('notice', 'The contact has been added');
@@ -71,7 +71,7 @@ class ClientContactController extends AbstractController
         $form = $this->createForm(FormDir\Org\ClientContactType::class, $clientContact);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->put('/clientcontacts/' . $id, $form->getData(), ['edit_clientcontact']
             );
             $request->getSession()->getFlashBag()->add('notice', 'The contact has been updated');
@@ -99,7 +99,7 @@ class ClientContactController extends AbstractController
         $client = $clientContact->getClient();
         $this->denyAccessUnlessGranted('delete-client-contact', $client, 'Access denied');
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             try {
                 $this->getRestClient()->delete('clientcontacts/' . $id);
                 $request->getSession()->getFlashBag()->add('notice', 'Contact has been removed');

--- a/client/src/AppBundle/Controller/Org/IndexController.php
+++ b/client/src/AppBundle/Controller/Org/IndexController.php
@@ -87,7 +87,7 @@ class IndexController extends AbstractController
         $form->handleRequest($request);
 
         // edit client form
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $clientUpdated = $form->getData();
             $clientUpdated->setId($client->getId());
             $this->getRestClient()->put('client/upsert', $clientUpdated, ['pa-edit']);

--- a/client/src/AppBundle/Controller/Org/IndexController.php
+++ b/client/src/AppBundle/Controller/Org/IndexController.php
@@ -122,7 +122,7 @@ class IndexController extends AbstractController
 
         /** @var SubmitButton $submitBtn */
         $submitBtn = $form->get('save');
-        if ($submitBtn->isClicked() && $form->isValid()) {
+        if ($submitBtn->isClicked() && $form->isSubmitted() && $form->isValid()) {
             if (true === $form->get('confirmArchive')->getData()) {
                 $this->getRestClient()->apiCall('put', 'client/' . $client->getId() . '/archive', null, 'array');
                 $this->addFlash('notice', 'The client has been archived');

--- a/client/src/AppBundle/Controller/Org/NoteController.php
+++ b/client/src/AppBundle/Controller/Org/NoteController.php
@@ -43,7 +43,7 @@ class NoteController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $note = $form->getData();
 
             $this->getRestClient()->post('note/' . $client->getId(), $note, ['add_note']);
@@ -78,7 +78,7 @@ class NoteController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $note = $form->getData();
 
             $this->getRestClient()->put('note/' . $noteId, $note, ['add_note']);
@@ -114,7 +114,7 @@ class NoteController extends AbstractController
         $form = $this->createForm(FormDir\ConfirmDeleteType::class);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             try {
                 /** @var EntityDir\Note $note */
                 $note = $this->getNote($noteId);

--- a/client/src/AppBundle/Controller/Org/OrganisationController.php
+++ b/client/src/AppBundle/Controller/Org/OrganisationController.php
@@ -88,7 +88,7 @@ class OrganisationController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
 
             try {
                 $email = $form->getData()->getEmail();
@@ -173,7 +173,7 @@ class OrganisationController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $user = $form->getData();
 
             try {
@@ -224,7 +224,7 @@ class OrganisationController extends AbstractController
         $form = $this->createForm(FormDir\ConfirmDeleteType::class);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             try {
                 $this->getRestClient()->delete('v2/organisation/' . $organisation->getId() . '/user/' . $user->getId());
 

--- a/client/src/AppBundle/Controller/Org/TeamController.php
+++ b/client/src/AppBundle/Controller/Org/TeamController.php
@@ -74,7 +74,7 @@ class TeamController extends AbstractController
         }
 
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             /** @var $user EntityDir\User */
             $user = $form->getData();
 
@@ -145,7 +145,7 @@ class TeamController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $user = $form->getData();
 
             try {
@@ -225,7 +225,7 @@ class TeamController extends AbstractController
         $form = $this->createForm(FormDir\ConfirmDeleteType::class);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             try {
                 $userToRemove = $this->getRestClient()->get('team/member/' . $id, 'User');
 

--- a/client/src/AppBundle/Controller/Report/ActionController.php
+++ b/client/src/AppBundle/Controller/Report/ActionController.php
@@ -59,7 +59,7 @@ class ActionController extends AbstractController
                                  );
         $form->handleRequest($request);
 
-        if ($form->get('save')->isClicked() && $form->isValid()) {
+        if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             /* @var $data EntityDir\Report\Action */
             $data->setReport($report);

--- a/client/src/AppBundle/Controller/Report/AssetController.php
+++ b/client/src/AppBundle/Controller/Report/AssetController.php
@@ -58,7 +58,7 @@ class AssetController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($report->getNoAssetToAdd()) {
                 case 0: // yes
                     return $this->redirectToRoute('assets_type', ['reportId' => $reportId,]);
@@ -91,7 +91,7 @@ class AssetController extends AbstractController
         ]);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $title = $form->getData()->getTitle();
             switch ($title) {
                 case 'Property':
@@ -123,7 +123,7 @@ class AssetController extends AbstractController
         $form = $this->createForm(FormDir\Report\Asset\AssetTypeOther::class, $asset);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $asset = $form->getData();
             $this->getRestClient()->post("report/{$reportId}/asset", $asset);
 
@@ -158,7 +158,7 @@ class AssetController extends AbstractController
         $form = $this->createForm(FormDir\Report\Asset\AssetTypeOther::class, $asset);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $asset = $form->getData();
             $this->getRestClient()->put("report/{$reportId}/asset/{$assetId}", $asset);
             $request->getSession()->getFlashBag()->add('notice', 'Asset edited');
@@ -185,7 +185,7 @@ class AssetController extends AbstractController
         $form = $this->createForm(FormDir\AddAnotherRecordType::class, $report, ['translation_domain' => 'report-assets']);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($form['addAnother']->getData()) {
                 case 'yes':
                     return $this->redirectToRoute('assets_type', ['reportId' => $reportId, 'from' => 'another']);
@@ -355,7 +355,7 @@ class AssetController extends AbstractController
         $form->handleRequest($request);
         $report = $this->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             if ($report->hasAssetWithId($assetId)) {
                 $this->getRestClient()->delete("/report/{$reportId}/asset/{$assetId}");
                 $request->getSession()->getFlashBag()->add('notice', 'Asset removed');

--- a/client/src/AppBundle/Controller/Report/AssetController.php
+++ b/client/src/AppBundle/Controller/Report/AssetController.php
@@ -256,7 +256,7 @@ class AssetController extends AbstractController
         $form = $this->createForm(FormDir\Report\Asset\AssetTypeProperty::class, $asset, ['step' => $step]);
         $form->handleRequest($request);
 
-        if ($form->get('save')->isClicked() && $form->isValid()) {
+        if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {
             $asset = $form->getData();
             /* @var $asset Report\AssetProperty */
 

--- a/client/src/AppBundle/Controller/Report/BalanceController.php
+++ b/client/src/AppBundle/Controller/Report/BalanceController.php
@@ -45,7 +45,7 @@ class BalanceController extends AbstractController
         $form = $this->createForm(FormDir\Report\ReasonForBalanceType::class, $report);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $this->getRestClient()->put('report/' . $reportId, $data, ['balance_mismatch_explanation']);
 

--- a/client/src/AppBundle/Controller/Report/BankAccountController.php
+++ b/client/src/AppBundle/Controller/Report/BankAccountController.php
@@ -154,7 +154,7 @@ class BankAccountController extends AbstractController
         $form = $this->createForm(FormDir\AddAnotherRecordType::class, $report, ['translation_domain' => 'report-bank-accounts']);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($form['addAnother']->getData()) {
                 case 'yes':
                     return $this->redirectToRoute('bank_accounts_step', ['reportId' => $reportId, 'step' => 1]);
@@ -217,7 +217,7 @@ class BankAccountController extends AbstractController
         $form->handleRequest($request);
 
         // delete the bank acount if the confirm button is pushed, or there are no payments. Then go back to summary page
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             if ($report->getBankAccountById($accountId)) {
                 $this->getRestClient()->delete("/account/{$accountId}");
             }

--- a/client/src/AppBundle/Controller/Report/BankAccountController.php
+++ b/client/src/AppBundle/Controller/Report/BankAccountController.php
@@ -81,7 +81,7 @@ class BankAccountController extends AbstractController
         $form = $this->createForm(FormDir\Report\BankAccountType::class, $account, ['step' => $step]);
         $form->handleRequest($request);
 
-        if ($form->get('save')->isClicked() && $form->isValid()) {
+        if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {
             // if closing balance is set to non-zero values, un-close the account
             /*if (!$data->isClosingBalanceZero()) {
                 $data->setIsClosed(false);

--- a/client/src/AppBundle/Controller/Report/ContactController.php
+++ b/client/src/AppBundle/Controller/Report/ContactController.php
@@ -49,7 +49,7 @@ class ContactController extends AbstractController
         $form = $this->createForm(FormDir\Report\ContactExistType::class, $report);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($form['hasContacts']->getData()) {
                 case 'yes':
                     return $this->redirectToRoute('contacts_add', ['reportId' => $reportId, 'from'=>'exist']);
@@ -86,7 +86,7 @@ class ContactController extends AbstractController
         $form = $this->createForm(FormDir\Report\ContactType::class, $contact);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $data->setReport($report);
 
@@ -117,7 +117,7 @@ class ContactController extends AbstractController
         $form = $this->createForm(FormDir\AddAnotherRecordType::class, $report, ['translation_domain' => 'report-contacts']);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($form['addAnother']->getData()) {
                 case 'yes':
                     return $this->redirectToRoute('contacts_add', ['reportId' => $reportId, 'from'=>'add_another']);
@@ -145,7 +145,7 @@ class ContactController extends AbstractController
         $form = $this->createForm(FormDir\Report\ContactType::class, $contact);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $data->setReport($report);
 
@@ -196,7 +196,7 @@ class ContactController extends AbstractController
         $form = $this->createForm(FormDir\ConfirmDeleteType::class);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->delete("/report/contact/{$contactId}");
 
             $request->getSession()->getFlashBag()->add(

--- a/client/src/AppBundle/Controller/Report/DebtController.php
+++ b/client/src/AppBundle/Controller/Report/DebtController.php
@@ -45,7 +45,7 @@ class DebtController extends AbstractController
                                  );
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->put('report/' . $reportId, $report, ['debt']);
 
             if ($report->getHasDebts() == 'yes') {
@@ -80,7 +80,7 @@ class DebtController extends AbstractController
         $form->handleRequest($request);
         $fromPage = $request->get('from');
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->put('report/' . $report->getId(), $form->getData(), ['debt']);
 
             if ($fromPage == 'summary') {
@@ -120,7 +120,7 @@ class DebtController extends AbstractController
         $fromPage = $request->get('from');
         $fromSummaryPage = $request->get('from') == 'summary';
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->put('report/' . $report->getId(), $form->getData(), ['debt-management']);
 
             if ($fromPage == 'summary') {

--- a/client/src/AppBundle/Controller/Report/DecisionController.php
+++ b/client/src/AppBundle/Controller/Report/DecisionController.php
@@ -125,7 +125,7 @@ class DecisionController extends AbstractController
         $form = $this->createForm(FormDir\Report\DecisionExistType::class, $report);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($form['hasDecisions']->getData()) {
                 case 'yes':
                     return $this->redirectToRoute('decisions_add', ['reportId' => $reportId, 'from'=>'decisions_exist']);
@@ -163,7 +163,7 @@ class DecisionController extends AbstractController
         $form = $this->createForm(FormDir\Report\DecisionType::class, $decision);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $data->setReport($report);
 
@@ -193,7 +193,7 @@ class DecisionController extends AbstractController
         $form = $this->createForm(FormDir\AddAnotherRecordType::class, $report, ['translation_domain' => 'report-decisions']);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($form['addAnother']->getData()) {
                 case 'yes':
                     return $this->redirectToRoute('decisions_add', ['reportId' => $reportId, 'from'=>'decisions_add_another']);
@@ -221,7 +221,7 @@ class DecisionController extends AbstractController
         $form = $this->createForm(FormDir\Report\DecisionType::class, $decision);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $data->setReport($report);
 
@@ -276,7 +276,7 @@ class DecisionController extends AbstractController
         $form = $this->createForm(FormDir\ConfirmDeleteType::class);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->delete("/report/decision/{$decisionId}");
 
             $request->getSession()->getFlashBag()->add(

--- a/client/src/AppBundle/Controller/Report/DecisionController.php
+++ b/client/src/AppBundle/Controller/Report/DecisionController.php
@@ -57,7 +57,7 @@ class DecisionController extends AbstractController
         $form = $this->createForm(FormDir\Report\MentalCapacityType::class, $mc);
         $form->handleRequest($request);
 
-        if ($form->get('save')->isClicked() && $form->isValid()) {
+        if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $data->setReport($report);
 
@@ -94,7 +94,7 @@ class DecisionController extends AbstractController
         $form = $this->createForm(FormDir\Report\MentalAssessment::class, $mc);
         $form->handleRequest($request);
 
-        if ($form->get('save')->isClicked() && $form->isValid()) {
+        if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
 
             $data->setReport($report);

--- a/client/src/AppBundle/Controller/Report/DeputyExpenseController.php
+++ b/client/src/AppBundle/Controller/Report/DeputyExpenseController.php
@@ -49,7 +49,7 @@ class DeputyExpenseController extends AbstractController
                                  );
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             /* @var $data EntityDir\Report\Report */
             switch ($data->getPaidForAnything()) {
@@ -92,7 +92,7 @@ class DeputyExpenseController extends AbstractController
         );
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $data->setReport($report);
 
@@ -122,7 +122,7 @@ class DeputyExpenseController extends AbstractController
         $form = $this->createForm(FormDir\AddAnotherRecordType::class, $report, ['translation_domain' => 'report-deputy-expenses']);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($form['addAnother']->getData()) {
                 case 'yes':
                     return $this->redirectToRoute('deputy_expenses_add', ['reportId' => $reportId, 'from' => 'add_another']);
@@ -168,7 +168,7 @@ class DeputyExpenseController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $request->getSession()->getFlashBag()->add('notice', 'Expense edited');
 
@@ -226,7 +226,7 @@ class DeputyExpenseController extends AbstractController
         $form = $this->createForm(FormDir\ConfirmDeleteType::class);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->delete('report/' . $report->getId() . '/expense/' . $expenseId);
 
             $request->getSession()->getFlashBag()->add(

--- a/client/src/AppBundle/Controller/Report/DocumentController.php
+++ b/client/src/AppBundle/Controller/Report/DocumentController.php
@@ -89,7 +89,7 @@ class DocumentController extends AbstractController
         /** @var SubmitButton $submitBtn */
         $submitBtn = $form->get('save');
 
-        if ($submitBtn->isClicked() && $form->isValid()) {
+        if ($submitBtn->isClicked() && $form->isSubmitted() && $form->isValid()) {
             /* @var $data EntityDir\Report\Report */
             $data = $form->getData();
 

--- a/client/src/AppBundle/Controller/Report/DocumentController.php
+++ b/client/src/AppBundle/Controller/Report/DocumentController.php
@@ -141,7 +141,7 @@ class DocumentController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $files = $request->files->get('report_document_upload')['files'];
 
             if (is_array($files)) {
@@ -260,7 +260,7 @@ class DocumentController extends AbstractController
         $form = $this->createForm(FormDir\ConfirmDeleteType::class);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             return $this->deleteDocument($request, $documentId);
         }
 

--- a/client/src/AppBundle/Controller/Report/GiftController.php
+++ b/client/src/AppBundle/Controller/Report/GiftController.php
@@ -50,7 +50,7 @@ class GiftController extends AbstractController
                                  );
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             /* @var $data EntityDir\Report\Report */
             switch ($data->getGiftsExist()) {
@@ -93,7 +93,7 @@ class GiftController extends AbstractController
         );
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $data->setReport($report);
 
@@ -146,7 +146,7 @@ class GiftController extends AbstractController
         );
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $request->getSession()->getFlashBag()->add('notice', 'Gift edited');
 
@@ -201,7 +201,7 @@ class GiftController extends AbstractController
 
         $report = $this->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->delete('report/' . $report->getId() . '/gift/' . $giftId);
 
             $request->getSession()->getFlashBag()->add(

--- a/client/src/AppBundle/Controller/Report/LifestyleController.php
+++ b/client/src/AppBundle/Controller/Report/LifestyleController.php
@@ -58,7 +58,7 @@ class LifestyleController extends AbstractController
         $form = $this->createForm(FormDir\Report\LifestyleType::class, $lifestyle, ['step' => $step]);
         $form->handleRequest($request);
 
-        if ($form->get('save')->isClicked() && $form->isValid()) {
+        if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             /* @var $data EntityDir\Report\Lifestyle */
             $data

--- a/client/src/AppBundle/Controller/Report/MoneyInController.php
+++ b/client/src/AppBundle/Controller/Report/MoneyInController.php
@@ -102,7 +102,7 @@ class MoneyInController extends AbstractController
 
         /** @var SubmitButton $saveButton */
         $saveButton = $form->get('save');
-        if ($saveButton->isClicked() && $form->isValid()) {
+        if ($saveButton->isClicked() && $form->isSubmitted() && $form->isValid()) {
             // decide what data in the partial form needs to be passed to next step
             if ($step == 1) {
                 // unset from page to prevent step redirector skipping step 2

--- a/client/src/AppBundle/Controller/Report/MoneyInController.php
+++ b/client/src/AppBundle/Controller/Report/MoneyInController.php
@@ -153,7 +153,7 @@ class MoneyInController extends AbstractController
         $form = $this->createForm(FormDir\AddAnotherRecordType::class, $report, ['translation_domain' => 'report-money-transaction']);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($form['addAnother']->getData()) {
                 case 'yes':
                     return $this->redirectToRoute('money_in_step', ['reportId' => $reportId, 'step' => 1, 'from' => 'money_in_add_another']);
@@ -215,7 +215,7 @@ class MoneyInController extends AbstractController
         $form = $this->createForm(FormDir\ConfirmDeleteType::class);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->delete('/report/' . $reportId . '/money-transaction/' . $transactionId);
 
             $this->addFlash(

--- a/client/src/AppBundle/Controller/Report/MoneyInShortController.php
+++ b/client/src/AppBundle/Controller/Report/MoneyInShortController.php
@@ -47,7 +47,7 @@ class MoneyInShortController extends AbstractController
         $form = $this->createForm(FormDir\Report\MoneyShortType::class, $report, ['field' => 'moneyShortCategoriesIn']);
         $form->handleRequest($request);
 
-        if ($form->get('save')->isClicked() && $form->isValid()) {
+        if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
 
             $this->getRestClient()->put('report/' . $reportId, $data, ['moneyShortCategoriesIn']);

--- a/client/src/AppBundle/Controller/Report/MoneyInShortController.php
+++ b/client/src/AppBundle/Controller/Report/MoneyInShortController.php
@@ -84,7 +84,7 @@ class MoneyInShortController extends AbstractController
         $form->handleRequest($request);
         $fromSummaryPage = $request->get('from') == 'summary';
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             /* @var $data EntityDir\Report\Report */
             $this->getRestClient()->put('report/' . $reportId, $data, ['money-transactions-short-in-exist']);
@@ -116,7 +116,7 @@ class MoneyInShortController extends AbstractController
         $form = $this->createForm(FormDir\Report\MoneyShortTransactionType::class, $record);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $this->getRestClient()->post('report/' . $report->getId() . '/money-transaction-short', $data, ['moneyTransactionShort']);
 
@@ -145,7 +145,7 @@ class MoneyInShortController extends AbstractController
         $form = $this->createForm(FormDir\AddAnotherRecordType::class, $report, ['translation_domain' => 'report-money-short']);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($form['addAnother']->getData()) {
                 case 'yes':
                     return $this->redirectToRoute('money_in_short_add', ['reportId' => $reportId, 'from' => 'add_another']);
@@ -172,7 +172,7 @@ class MoneyInShortController extends AbstractController
         $form = $this->createForm(FormDir\Report\MoneyShortTransactionType::class, $transaction);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $request->getSession()->getFlashBag()->add('notice', 'Entry edited');
 
@@ -203,7 +203,7 @@ class MoneyInShortController extends AbstractController
 
         $report = $this->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->delete('report/' . $report->getId() . '/money-transaction-short/' . $transactionId);
 
             $request->getSession()->getFlashBag()->add(

--- a/client/src/AppBundle/Controller/Report/MoneyOutController.php
+++ b/client/src/AppBundle/Controller/Report/MoneyOutController.php
@@ -97,7 +97,7 @@ class MoneyOutController extends AbstractController
 
         /** @var SubmitButton $saveBtn */
         $saveBtn = $form->get('save');
-        if ($saveBtn->isClicked() && $form->isValid()) {
+        if ($saveBtn->isClicked() && $form->isSubmitted() && $form->isValid()) {
             // decide what data in the partial form needs to be passed to next step
             if ($step == 1) {
                 // unset from page to prevent step redirector skipping step 2

--- a/client/src/AppBundle/Controller/Report/MoneyOutController.php
+++ b/client/src/AppBundle/Controller/Report/MoneyOutController.php
@@ -148,7 +148,7 @@ class MoneyOutController extends AbstractController
         $form = $this->createForm(FormDir\AddAnotherRecordType::class, $report, ['translation_domain' => 'report-money-transaction']);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($form['addAnother']->getData()) {
                 case 'yes':
                     return $this->redirectToRoute('money_out_step', ['reportId' => $reportId, 'step' => 1]);
@@ -210,7 +210,7 @@ class MoneyOutController extends AbstractController
         $form = $this->createForm(FormDir\ConfirmDeleteType::class);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->delete('/report/' . $reportId . '/money-transaction/' . $transactionId);
 
             $this->addFlash(

--- a/client/src/AppBundle/Controller/Report/MoneyOutShortController.php
+++ b/client/src/AppBundle/Controller/Report/MoneyOutShortController.php
@@ -84,7 +84,7 @@ class MoneyOutShortController extends AbstractController
         $form->handleRequest($request);
         $fromSummaryPage = $request->get('from') == 'summary';
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             /* @var $data EntityDir\Report\Report */
             $this->getRestClient()->put('report/' . $reportId, $data, ['money-transactions-short-out-exist']);
@@ -117,7 +117,7 @@ class MoneyOutShortController extends AbstractController
         $form = $this->createForm(FormDir\Report\MoneyShortTransactionType::class, $record);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $this->getRestClient()->post('report/' . $report->getId() . '/money-transaction-short', $data, ['moneyTransactionShort']);
 
@@ -146,7 +146,7 @@ class MoneyOutShortController extends AbstractController
         $form = $this->createForm(FormDir\AddAnotherRecordType::class, $report, ['translation_domain' => 'report-money-short']);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($form['addAnother']->getData()) {
                 case 'yes':
                     return $this->redirectToRoute('money_out_short_add', ['reportId' => $reportId, 'from' => 'add_another']);
@@ -173,7 +173,7 @@ class MoneyOutShortController extends AbstractController
         $form = $this->createForm(FormDir\Report\MoneyShortTransactionType::class, $transaction);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $request->getSession()->getFlashBag()->add('notice', 'Entry edited');
 
@@ -204,7 +204,7 @@ class MoneyOutShortController extends AbstractController
 
         $report = $this->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $report = $this->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
             $this->getRestClient()->delete('report/' . $report->getId() . '/money-transaction-short/' . $transactionId);

--- a/client/src/AppBundle/Controller/Report/MoneyOutShortController.php
+++ b/client/src/AppBundle/Controller/Report/MoneyOutShortController.php
@@ -48,7 +48,7 @@ class MoneyOutShortController extends AbstractController
         $form = $this->createForm(FormDir\Report\MoneyShortType::class, $report, ['field' => 'moneyShortCategoriesOut']);
         $form->handleRequest($request);
 
-        if ($form->get('save')->isClicked() && $form->isValid()) {
+        if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
 
             $this->getRestClient()->put('report/' . $reportId, $data, ['moneyShortCategoriesOut']);

--- a/client/src/AppBundle/Controller/Report/MoneyTransferController.php
+++ b/client/src/AppBundle/Controller/Report/MoneyTransferController.php
@@ -139,7 +139,7 @@ class MoneyTransferController extends AbstractController
 
         /** @var SubmitButton $submitBtn */
         $submitBtn = $form->get('save');
-        if ($submitBtn->isClicked() && $form->isValid()) {
+        if ($submitBtn->isClicked() && $form->isSubmitted() && $form->isValid()) {
             // decide what data in the partial form needs to be passed to next step
             if ($step == 1) {
                 $stepUrlData['from-id'] = $transfer->getAccountFromId();

--- a/client/src/AppBundle/Controller/Report/MoneyTransferController.php
+++ b/client/src/AppBundle/Controller/Report/MoneyTransferController.php
@@ -61,7 +61,7 @@ class MoneyTransferController extends AbstractController
         ]);
 
         $form->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
 
             switch ($report->getNoTransfersToAdd()) {
                 case 0:
@@ -188,7 +188,7 @@ class MoneyTransferController extends AbstractController
         $form = $this->createForm(FormDir\AddAnotherRecordType::class, $report, ['translation_domain' => 'report-money-transfer']);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($form['addAnother']->getData()) {
                 case 'yes':
                     return $this->redirectToRoute('money_transfers_step', ['reportId' => $reportId, 'from' => 'another', 'step' => 1]);
@@ -239,7 +239,7 @@ class MoneyTransferController extends AbstractController
         $form = $this->createForm(FormDir\ConfirmDeleteType::class);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->delete("/report/{$reportId}/money-transfers/{$transferId}");
 
             $this->addFlash(

--- a/client/src/AppBundle/Controller/Report/OtherInfoController.php
+++ b/client/src/AppBundle/Controller/Report/OtherInfoController.php
@@ -57,7 +57,7 @@ class OtherInfoController extends AbstractController
         $form = $this->createForm(FormDir\Report\OtherInfoType::class, $report);
         $form->handleRequest($request);
 
-        if ($form->get('save')->isClicked() && $form->isValid()) {
+        if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $this->getRestClient()->put('report/' . $reportId, $data, ['more-info']);
 

--- a/client/src/AppBundle/Controller/Report/PaFeeExpenseController.php
+++ b/client/src/AppBundle/Controller/Report/PaFeeExpenseController.php
@@ -53,7 +53,7 @@ class PaFeeExpenseController extends AbstractController
         $form = $this->createForm(FormDir\Report\PaFeeExistType::class, $report);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($form['hasFees']->getData()) {
                 case 'yes':
                     $report->setReasonForNoFees(null);
@@ -88,7 +88,7 @@ class PaFeeExpenseController extends AbstractController
         $form->handleRequest($request);
         $fromPage = $request->get('from');
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->put('report/' . $report->getId(), $form->getData(), ['fee']);
             if ($fromPage == 'summary') {
                 $request->getSession()->getFlashBag()->add('notice', 'Fee edited');
@@ -120,7 +120,7 @@ class PaFeeExpenseController extends AbstractController
                                  );
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             /* @var $data EntityDir\Report\Report */
             switch ($data->getPaidForAnything()) {
@@ -168,7 +168,7 @@ class PaFeeExpenseController extends AbstractController
         );
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $data->setReport($report);
 
@@ -203,7 +203,7 @@ class PaFeeExpenseController extends AbstractController
         $form = $this->createForm(FormDir\AddAnotherRecordType::class, $report, ['translation_domain' => 'report-pa-fee-expense']);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($form['addAnother']->getData()) {
                 case 'yes':
                     return $this->redirectToRoute('pa_fee_expense_other_add', ['reportId' => $reportId, 'from' => 'add_another']);
@@ -243,7 +243,7 @@ class PaFeeExpenseController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             $request->getSession()->getFlashBag()->add('notice', 'Expense edited');
 
@@ -275,7 +275,7 @@ class PaFeeExpenseController extends AbstractController
 
         $report = $this->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $report = $this->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
             $this->getRestClient()->delete('report/' . $report->getId() . '/expense/' . $expenseId);

--- a/client/src/AppBundle/Controller/Report/ProfCurrentFeesController.php
+++ b/client/src/AppBundle/Controller/Report/ProfCurrentFeesController.php
@@ -57,7 +57,7 @@ class ProfCurrentFeesController extends AbstractController
         $form->handleRequest($request);
         $fromPage = $request->get('from');
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             switch ($report->getCurrentProfPaymentsReceived()) {
                 case 'yes':
                     return $this->redirectToRoute('current_service_fee_step', ['reportId' => $reportId, 'step' => 1, 'from'=>'exist']);
@@ -213,7 +213,7 @@ class ProfCurrentFeesController extends AbstractController
         $form = $this->createForm(FormDir\Report\ProfServicePreviousFeesEstimateType::class, $report);
 
         $form->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             /* @var $report EntityDir\Report\Report */
             $report = $form->getData();
 

--- a/client/src/AppBundle/Controller/Report/ProfCurrentFeesController.php
+++ b/client/src/AppBundle/Controller/Report/ProfCurrentFeesController.php
@@ -114,7 +114,7 @@ class ProfCurrentFeesController extends AbstractController
         $form->handleRequest($request);
         $buttonClicked = $form->getClickedButton();
 
-        if ($buttonClicked && $form->isValid()) {
+        if ($buttonClicked && $form->isSubmitted() && $form->isValid()) {
             /* @var $profServiceFee EntityDir\Report\ProfServiceFee */
             $profServiceFee = $form->getData();
             $profServiceFee->setReport($report);

--- a/client/src/AppBundle/Controller/Report/ProfDeputyCostsController.php
+++ b/client/src/AppBundle/Controller/Report/ProfDeputyCostsController.php
@@ -62,7 +62,7 @@ class ProfDeputyCostsController extends AbstractController
         $form = $this->createForm(FormDir\Report\ProfDeputyCostHowType::class, $report);
         $form->handleRequest($request);
 
-        if ($form->get('save')->isClicked() && $form->isValid()) {
+        if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
 
             $this->getRestClient()->put('report/' . $reportId, $data, ['deputyCostsHowCharged']);

--- a/client/src/AppBundle/Controller/Report/ProfDeputyCostsController.php
+++ b/client/src/AppBundle/Controller/Report/ProfDeputyCostsController.php
@@ -100,7 +100,7 @@ class ProfDeputyCostsController extends AbstractController
         );
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             /* @var $data EntityDir\Report\Report */
             switch ($data->getProfDeputyCostsHasPrevious()) {
@@ -153,7 +153,7 @@ class ProfDeputyCostsController extends AbstractController
         ]);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
 
             if ($previousReceivedId) { // edit
                 $this->getRestClient()->put('/prof-deputy-previous-cost/' . $previousReceivedId, $pr, ['profDeputyPrevCosts']);
@@ -199,7 +199,7 @@ class ProfDeputyCostsController extends AbstractController
 
         $report = $this->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->delete('report/' . $report->getId() . '/prof-deputy-previous-cost/' . $previousReceivedId);
 
             $request->getSession()->getFlashBag()->add(
@@ -241,7 +241,7 @@ class ProfDeputyCostsController extends AbstractController
         );
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             /* @var $data EntityDir\Report\Report */
 
@@ -289,7 +289,7 @@ class ProfDeputyCostsController extends AbstractController
         $form = $this->createForm(FormDir\Report\ProfDeputyCostInterimType::class, $report);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
 
             $this->getRestClient()->put('/report/' . $reportId, $report, ['profDeputyInterimCosts']);
 
@@ -323,7 +323,7 @@ class ProfDeputyCostsController extends AbstractController
         $form = $this->createForm(FormDir\Report\ProfDeputyFixedCostType::class, $report);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
 
             $this->getRestClient()->put('/report/' . $reportId, $report, ['profDeputyFixedCost']);
 
@@ -360,7 +360,7 @@ class ProfDeputyCostsController extends AbstractController
         $form = $this->createForm(FormDir\Report\ProfDeputyCostSccoType::class, $report);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
 
             $this->getRestClient()->put('/report/' . $reportId, $report, ['profDeputyCostsScco']);
 
@@ -401,7 +401,7 @@ class ProfDeputyCostsController extends AbstractController
         $form = $this->createForm(FormDir\Report\ProfDeputyOtherCostsType::class, $report, []);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->put('report/' . $report->getId(), $form->getData(), ['prof-deputy-other-costs']);
 
             if ($from === 'summary') {

--- a/client/src/AppBundle/Controller/Report/ReportController.php
+++ b/client/src/AppBundle/Controller/Report/ReportController.php
@@ -142,7 +142,7 @@ class ReportController extends AbstractController
             : $this->generateUrl('lay_home');
 
         $editReportDatesForm->handleRequest($request);
-        if ($editReportDatesForm->isValid()) {
+        if ($editReportDatesForm->isSubmitted() && $editReportDatesForm->isValid()) {
             $this->getRestClient()->put('report/' . $reportId, $report, ['startEndDates']);
 
             return $this->redirect($returnLink);
@@ -194,7 +194,7 @@ class ReportController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->post('report', $form->getData());
             $this->getRestClient()->post('v2/court-order', $client, ['client-id']);
             return $this->redirect($this->generateUrl('homepage'));
@@ -334,7 +334,7 @@ class ReportController extends AbstractController
 
         $form = $this->createForm(ReportDeclarationType::class, $report);
         $form->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             /** @var User $currentUser */
             $currentUser = $this->getUser();
 
@@ -379,7 +379,7 @@ class ReportController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             // Store in database
             $this->getRestClient()->post('satisfaction', [
                 'score' => $form->get('satisfactionLevel')->getData(),

--- a/client/src/AppBundle/Controller/Report/VisitsCareController.php
+++ b/client/src/AppBundle/Controller/Report/VisitsCareController.php
@@ -59,7 +59,7 @@ class VisitsCareController extends AbstractController
                                  );
         $form->handleRequest($request);
 
-        if ($form->get('save')->isClicked() && $form->isValid()) {
+        if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
             /* @var $data EntityDir\Report\VisitsCare */
             $data

--- a/client/src/AppBundle/Controller/SettingsController.php
+++ b/client/src/AppBundle/Controller/SettingsController.php
@@ -57,7 +57,7 @@ class SettingsController extends AbstractController
         ]);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $plainPassword = $request->request->get('change_password')['plain_password']['first'];
             $this->getRestClient()->put('user/' . $user->getId() . '/set-password', json_encode([
                 'password_plain' => $plainPassword,
@@ -114,7 +114,7 @@ class SettingsController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $deputy = $form->getData();
 
             if ($form->has('removeAdmin') && !empty($form->get('removeAdmin')->getData())) {

--- a/client/src/AppBundle/Controller/UserController.php
+++ b/client/src/AppBundle/Controller/UserController.php
@@ -83,7 +83,7 @@ class UserController extends AbstractController
         }
 
         $form->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             // login user into API
             try {
                 $deputyProvider->login(['token' => $token]);
@@ -184,7 +184,7 @@ class UserController extends AbstractController
         $form = $this->createForm($formType, $user);
 
         $form->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->put('user/' . $user->getId(), $form->getData(), $jmsPutGroups);
 
             // lay deputies are redirected to adding a client (Step.3)
@@ -218,7 +218,7 @@ class UserController extends AbstractController
         $form = $this->createForm(FormDir\PasswordForgottenType::class, $user);
 
         $form->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $emailAddress = $user->getEmail();
             $disguisedEmail = '***' . substr($emailAddress, 3);
             $logger->warning('Reset password request for : ' . $emailAddress);
@@ -271,7 +271,7 @@ class UserController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
 
             try {
@@ -343,7 +343,7 @@ class UserController extends AbstractController
 
         $form = $this->createForm(FormDir\User\AgreeTermsType::class, $user);
         $form->handleRequest($request);
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $this->getRestClient()->agreeTermsUse($token);
 
             return $this->redirectToRoute('user_activate', ['token' => $token, 'action' => 'activate']);


### PR DESCRIPTION
## Purpose
In Symfony 4, you must call `$form->isSubmitted()` before `$form->isValid()`. This PR fixes instances where we are not, to allow easier upgrading to Symfony 4.

Fixes DDPB-3292

## Approach
I did a find-replace for instances of `if ($form->isValid()` and replaced it with `if ($form->isSubmitted() && $form->isValid`.

I then searched through all instances of `$form->isValid()` and added the `isSubmitted()` check where not identified by the find-replace.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work
  - N/A
- [ ] The product team have approved these changes
