### PR TITLE
DDPB-3373 - Symfony 4 deprecation fixes

### DIFF
--- a/client/app/config/services.yml
+++ b/client/app/config/services.yml
@@ -10,10 +10,12 @@ imports:
 
 services:
     AppBundle\Service\Redirector:
+        public: true
         class: AppBundle\Service\Redirector
         arguments: [ "@security.token_storage", "@security.authorization_checker", "@router", "@session", "%env%" ]
 
     AppBundle\Service\WkHtmlToPdfGenerator:
+        public: true
         arguments: [ "%wkhtmltopdf_address%", 30]
 
     wkhtmltopdf:
@@ -32,6 +34,7 @@ services:
                 allow_redirects: false
 
     AppBundle\Service\Client\Sirius\SiriusApiGatewayClient:
+        public: true
         class: AppBundle\Service\Client\Sirius\SiriusApiGatewayClient
         arguments:
             $httpClient: '@guzzle_api_gateway_client'
@@ -55,6 +58,7 @@ services:
         arguments: ["%ssm_client_params%"]
 
     AppBundle\Service\FeatureFlagService:
+        public: true
         arguments: ['@Aws\Ssm\SsmClient', '%env(FEATURE_FLAG_PREFIX)%']
 
     AppBundle\Serializer\SiriusDocumentUploadSerializer:
@@ -74,3 +78,15 @@ services:
     AppBundle\Service\Availability\WkHtmlToPdfAvailability:
         arguments: ['@AppBundle\Service\WkHtmlToPdfGenerator']
         public: true
+
+    AppBundle\Service\Availability\NotifyAvailability:
+         public: true
+         arguments:
+             $notifyClient: '@Alphagov\Notifications\Client'
+
+    AppBundle\Service\DocumentSyncService:
+        public: true
+        arguments:
+            $storage: '@AppBundle\Service\File\Storage\S3Storage'
+            $siriusApiGatewayClient: '@AppBundle\Service\Client\Sirius\SiriusApiGatewayClient'
+            $restClient: '@AppBundle\Service\Client\RestClient'

--- a/client/app/config/services_api.yml
+++ b/client/app/config/services_api.yml
@@ -10,6 +10,7 @@ services:
             allow_redirects: false
 
     AppBundle\Service\Client\RestClient:
+        public: true
         arguments:
             - '@service_container'
             - '@GuzzleHttp\Client'

--- a/client/composer.json
+++ b/client/composer.json
@@ -4,7 +4,10 @@
     "type": "project",
     "description": "The \"Symfony Standard Edition\" distribution",
     "autoload": {
-        "psr-0": { "": "src/" },
+        "psr-0": {
+            "": "src/",
+            "AppKernel": "",
+        },
         "psr-4": { "DigidepsTests\\": "tests/phpunit" }
     },
     "require": {
@@ -26,7 +29,8 @@
         "alphagov/notifications-php-client": "^2.1",
         "php-http/guzzle6-adapter": "^2.0",
         "sensio/framework-extra-bundle": "5.4.1",
-        "symfony/serializer": "3.4.38"
+        "symfony/serializer": "3.4.38",
+        "symfony/phpunit-bridge": "^5.0"
     },
     "scripts": {
         "post-install-cmd": [

--- a/client/composer.json
+++ b/client/composer.json
@@ -6,7 +6,7 @@
     "autoload": {
         "psr-0": {
             "": "src/",
-            "AppKernel": "",
+            "AppKernel": ""
         },
         "psr-4": { "DigidepsTests\\": "tests/phpunit" }
     },
@@ -30,7 +30,7 @@
         "php-http/guzzle6-adapter": "^2.0",
         "sensio/framework-extra-bundle": "5.4.1",
         "symfony/serializer": "3.4.38",
-        "symfony/phpunit-bridge": "^5.0"
+        "symfony/phpunit-bridge": "^4.4"
     },
     "scripts": {
         "post-install-cmd": [

--- a/client/composer.lock
+++ b/client/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "695841b88e10721b514aa24146349731",
+    "content-hash": "0299cc026d2988ca779dede9542bd7b0",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -4967,16 +4967,16 @@
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v5.0.7",
+            "version": "v4.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "0258b43a94972abf1ee99ce2221359f8ac2a17fd"
+                "reference": "6937c1a1590da7c314537b4f3f741c9255a7072e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/0258b43a94972abf1ee99ce2221359f8ac2a17fd",
-                "reference": "0258b43a94972abf1ee99ce2221359f8ac2a17fd",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/6937c1a1590da7c314537b4f3f741c9255a7072e",
+                "reference": "6937c1a1590da7c314537b4f3f741c9255a7072e",
                 "shasum": ""
             },
             "require": {
@@ -4994,7 +4994,7 @@
             "type": "symfony-bridge",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "4.4-dev"
                 },
                 "thanks": {
                     "name": "phpunit/phpunit",
@@ -5028,7 +5028,7 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2020-03-27T16:56:45+00:00"
+            "time": "2020-03-27T16:54:36+00:00"
         },
         {
             "name": "symfony/polyfill-apcu",

--- a/client/composer.lock
+++ b/client/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8882f4cd043f87e23999977b539a4ab4",
+    "content-hash": "695841b88e10721b514aa24146349731",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -4964,6 +4964,71 @@
                 "logging"
             ],
             "time": "2019-11-13T13:11:14+00:00"
+        },
+        {
+            "name": "symfony/phpunit-bridge",
+            "version": "v5.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/phpunit-bridge.git",
+                "reference": "0258b43a94972abf1ee99ce2221359f8ac2a17fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/0258b43a94972abf1ee99ce2221359f8ac2a17fd",
+                "reference": "0258b43a94972abf1ee99ce2221359f8ac2a17fd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0|<6.4,>=6.0"
+            },
+            "suggest": {
+                "symfony/error-handler": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
+            },
+            "bin": [
+                "bin/simple-phpunit"
+            ],
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                },
+                "thanks": {
+                    "name": "phpunit/phpunit",
+                    "url": "https://github.com/sebastianbergmann/phpunit"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Bridge\\PhpUnit\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony PHPUnit Bridge",
+            "homepage": "https://symfony.com",
+            "time": "2020-03-27T16:56:45+00:00"
         },
         {
             "name": "symfony/polyfill-apcu",

--- a/client/src/AppBundle/Controller/FeedbackController.php
+++ b/client/src/AppBundle/Controller/FeedbackController.php
@@ -3,7 +3,7 @@
 namespace AppBundle\Controller;
 
 use AppBundle\Form\FeedbackType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;

--- a/client/tests/phpunit/phpunit.xml
+++ b/client/tests/phpunit/phpunit.xml
@@ -42,6 +42,8 @@
         <env name="PACT_MOCK_SERVER_PORT" value="80"/>
         <env name="PACT_CONSUMER_NAME" value="Complete the deputy report"/>
         <env name="PACT_PROVIDER_NAME" value="OPG Data"/>
+
+        <server name="KERNEL_CLASS" value="AppKernel" />
     </php>
 
     <filter>


### PR DESCRIPTION
## Purpose
Chipping away at deprecations that are required for a Symfony 4/5 upgrade.

Fixes DDPB-3373

## Approach
I bought in symfony-phpunit-bridge which gives handy deprecation and warnings for the version you install it as (e.g. install phpunit-bridge 4.4 to get warnings for Symfony 4.4). The warnings are limited to code that is hit by phpunit but its a fairly quick way to start to fix things up.

There are 5 deprecations left that would involve a re-write of a test or changing the way a class works so I'm leaving this PR with the easy stuff for now.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
