### PR TITLE
DDPB-3376: Make Synchronise button only visible to super admins

### DIFF
--- a/api/src/AppBundle/Controller/Report/ReportSubmissionController.php
+++ b/api/src/AppBundle/Controller/Report/ReportSubmissionController.php
@@ -176,7 +176,7 @@ class ReportSubmissionController extends RestController
      * Queue submission documents which have been synced yet
      *
      * @Route("/{id}/queue-documents", requirements={"id":"\d+"}, methods={"PUT"})
-     * @Security("has_role('ROLE_ADMIN')")
+     * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function queueDocuments($id)
     {

--- a/api/tests/AppBundle/ControllerReport/ReportSubmissionControllerTest.php
+++ b/api/tests/AppBundle/ControllerReport/ReportSubmissionControllerTest.php
@@ -16,6 +16,7 @@ class ReportSubmissionControllerTest extends AbstractTestController
     private static $pa1;
     private static $pa2;
     private static $deputy1;
+    private static $tokenSuperAdmin = null;
     private static $tokenAdmin = null;
     private static $tokenDeputy = null;
 
@@ -58,6 +59,7 @@ class ReportSubmissionControllerTest extends AbstractTestController
     public function setUp(): void
     {
         if (null === self::$tokenAdmin) {
+            self::$tokenSuperAdmin = $this->loginAsSuperAdmin();
             self::$tokenAdmin = $this->loginAsAdmin();
             self::$tokenDeputy = $this->loginAsDeputy();
         }
@@ -320,7 +322,8 @@ class ReportSubmissionControllerTest extends AbstractTestController
 
         // assert Auth
         $this->assertEndpointNeedsAuth('PUT', $url);
-        $this->assertEndpointAllowedFor('PUT', $url, self::$tokenAdmin);
+        $this->assertEndpointAllowedFor('PUT', $url, self::$tokenSuperAdmin);
+        $this->assertEndpointNotAllowedFor('PUT', $url, self::$tokenAdmin);
         $this->assertEndpointNotAllowedFor('PUT', $url, self::$tokenDeputy);
     }
 
@@ -355,7 +358,7 @@ class ReportSubmissionControllerTest extends AbstractTestController
 
         $this->assertJsonRequest('PUT', '/report-submission/' . $reportSubmission->getId() . '/queue-documents', [
             'mustSucceed' => true,
-            'AuthToken' => self::$tokenAdmin,
+            'AuthToken' => self::$tokenSuperAdmin,
             'data' => [],
         ]);
 
@@ -364,7 +367,7 @@ class ReportSubmissionControllerTest extends AbstractTestController
 
             if ($document[2]) {
                 self::assertEquals(Document::SYNC_STATUS_QUEUED, $record->getSynchronisationStatus());
-                self::assertEquals('admin@example.org', $record->getSynchronisedBy()->getEmail());
+                self::assertEquals('super_admin@example.org', $record->getSynchronisedBy()->getEmail());
             } else {
                 self::assertEquals($document[1], $record->getSynchronisationStatus());
                 self::assertEquals(null, $record->getSynchronisedBy());
@@ -386,7 +389,7 @@ class ReportSubmissionControllerTest extends AbstractTestController
         $this->assertJsonRequest('PUT', '/report-submission/' . $reportSubmission->getId() . '/queue-documents', [
             'mustFail' => true,
             'assertResponseCode' => Response::HTTP_BAD_REQUEST,
-            'AuthToken' => self::$tokenAdmin,
+            'AuthToken' => self::$tokenSuperAdmin,
             'data' => [],
         ]);
     }

--- a/client/src/AppBundle/Controller/Admin/ReportSubmissionController.php
+++ b/client/src/AppBundle/Controller/Admin/ReportSubmissionController.php
@@ -80,7 +80,10 @@ class ReportSubmissionController extends AbstractController
             $postActions = [self::ACTION_DOWNLOAD, self::ACTION_ARCHIVE];
         }
 
-        if ($featureFlagService->get(FeatureFlagService::FLAG_DOCUMENT_SYNC) === '1') {
+        /** @var EntityDir\User $user */
+        $user = $this->getUser();
+
+        if ($featureFlagService->get(FeatureFlagService::FLAG_DOCUMENT_SYNC) === '1' && $user->getRoleName() === EntityDir\User::ROLE_SUPER_ADMIN) {
             $postActions[] = self::ACTION_SYNCHRONISE;
         }
 

--- a/client/tests/phpunit/Controller/AbstractControllerTestCase.php
+++ b/client/tests/phpunit/Controller/AbstractControllerTestCase.php
@@ -58,6 +58,7 @@ abstract class AbstractControllerTestCase extends WebTestCase
     {
         if (is_null($user)) {
             $user = new User();
+            $user->setRoleName($roleNames[0]);
         }
 
         if (is_null($user->getId())) {

--- a/client/tests/phpunit/Controller/AdminReportSubmissionControllerTest.php
+++ b/client/tests/phpunit/Controller/AdminReportSubmissionControllerTest.php
@@ -127,8 +127,28 @@ class AdminReportSubmissionControllerTest extends AbstractControllerTestCase
         self::assertEquals('Solomon Pinedo', $archivedBy->attr('title'));
     }
 
+    public function testHiddenFromAdmins(): void
+    {
+        $this->restClient
+            ->arrayToEntities(ReportSubmission::class . '[]', ['placeholder'])
+            ->shouldBeCalled()
+            ->willReturn([
+                $this->generateReportSubmission('72549273', 'Dario', 'Lucke')
+                    ->setId(47638)
+                    ->setDownloadable(true)
+            ]);
+
+        $crawler = $this->client->request('GET', '/admin/documents/list');
+
+        $button = $crawler->selectButton('Synchronise');
+
+        self::assertNull($button->getNode(0));
+    }
+
     public function testSynchroniseQueuesDocuments(): void
     {
+        $this->mockLoggedInUser(['ROLE_SUPER_ADMIN']);
+
         $submissionId = 47638;
 
         $this->restClient
@@ -155,6 +175,8 @@ class AdminReportSubmissionControllerTest extends AbstractControllerTestCase
 
     public function testSynchroniseButtonHoldIfFlagOff(): void
     {
+        $this->mockLoggedInUser(['ROLE_SUPER_ADMIN']);
+
         $submissionId = 47638;
 
         $this->restClient


### PR DESCRIPTION
## Purpose
In DDPB-3163, we added a button to the report submissions page of the admin panel. This was made available to all admins, but should be restricted to super admins.

Fixes DDPB-3376

## Approach
I restricted the button to only be shown if the user has the super admin role, and restricted the related endpoint as well.

I made a slight change to `mockLoggedInUser` so that it sets the mocked user's role to the first role in the permissions array. This could previosuly be done in `mockLoggedInUser`'s second parameter, but it seemed expected enough to just make default behaviour.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
  - N/A
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes