### PR TITLE
DDPB-3358- Support clients and deputies not having a country 

### DIFF
--- a/client/src/AppBundle/Service/IntlService.php
+++ b/client/src/AppBundle/Service/IntlService.php
@@ -6,7 +6,11 @@ use Symfony\Component\Intl\Intl;
 
 class IntlService
 {
-    public function getCountryNameByCountryCode(?string $countryCode)
+    /**
+     * @param string|null $countryCode
+     * @return string|null
+     */
+    public function getCountryNameByCountryCode(?string $countryCode) : ?string
     {
         return Intl::getRegionBundle()->getCountryName($countryCode);
     }

--- a/client/src/AppBundle/Service/IntlService.php
+++ b/client/src/AppBundle/Service/IntlService.php
@@ -6,7 +6,7 @@ use Symfony\Component\Intl\Intl;
 
 class IntlService
 {
-    public function getCountryNameByCountryCode(string $countryCode)
+    public function getCountryNameByCountryCode(?string $countryCode)
     {
         return Intl::getRegionBundle()->getCountryName($countryCode);
     }

--- a/client/src/AppBundle/Service/Mailer/MailFactory.php
+++ b/client/src/AppBundle/Service/Mailer/MailFactory.php
@@ -296,6 +296,8 @@ class MailFactory
           ->setToEmail($this->emailParams['update_send_to_address'])
           ->setTemplate(self::CLIENT_DETAILS_CHANGE_TEMPLATE_ID);
 
+        $countryName = $this->intlService->getCountryNameByCountryCode($client->getCountry()) ?? 'Country not provided';
+
         $notifyParams = [
             'caseNumber' => $client->getCaseNumber(),
             'fullName' => $client->getFullName(),
@@ -303,7 +305,7 @@ class MailFactory
             'address2' => $client->getAddress2(),
             'address3' => $client->getCounty(),
             'postcode' =>$client->getPostcode(),
-            'countryName' => $this->intlService->getCountryNameByCountryCode($client->getCountry()),
+            'countryName' => $countryName,
             'phone' => $client->getPhone(),
         ];
 
@@ -321,6 +323,9 @@ class MailFactory
             ->setToEmail($this->emailParams['update_send_to_address'])
             ->setTemplate(self::DEPUTY_DETAILS_CHANGE_TEMPLATE_ID);
 
+        $countryName =
+            $this->intlService->getCountryNameByCountryCode($deputy->getAddressCountry()) ?? 'Country not provided';
+
         $notifyParams = [
             'caseNumber' => $deputy->getFirstClient()->getCaseNumber(),
             'fullName' => $deputy->getFullName(),
@@ -328,7 +333,7 @@ class MailFactory
             'address2' => $deputy->getAddress2() !== null ? $deputy->getAddress2() : 'Not provided',
             'address3' => $deputy->getAddress3() !== null ? $deputy->getAddress3() : 'Not provided',
             'postcode' =>$deputy->getAddressPostcode(),
-            'countryName' => $this->intlService->getCountryNameByCountryCode($deputy->getAddressCountry()),
+            'countryName' => $countryName,
             'phone' => $deputy->getPhoneMain(),
             'altPhoneNumber' => $deputy->getPhoneAlternative() !== null ? $deputy->getPhoneAlternative() : 'Not provided',
             'email' => $deputy->getEmail(),


### PR DESCRIPTION
Due to strict mode checks the application was failing when we were trying to convert a null country code value to the actual country name. This change supports null country values and reduces some mocking from our tests.

Fixes DDPB-3358

## Approach
It felt like a better solution to support null values in `getCountryNameByCountryCode()` rather than handle separately in the MailFactory functions.

## Learning
There was a little too much mocking going on in the affected tests as this masked what would actually happen if we fed in a null value rather than receive a null value from the function. I've used the real service in the test now rather than a mock.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes
