### PR TITLE
DDPB-3403: Memory leak over document-sync cycles

### DIFF
--- a/api/src/AppBundle/Controller/Report/DocumentController.php
+++ b/api/src/AppBundle/Controller/Report/DocumentController.php
@@ -150,9 +150,7 @@ class DocumentController extends RestController
         $reportSubmissionIds = $data['submissionIds'];
         $errorMessage = $data['errorMessage'];
 
-        $documentRepo->updateSupportingDocumentStatusByReportSubmissionIds($reportSubmissionIds, $errorMessage);
-
-        return json_encode();
+        return json_encode($documentRepo->updateSupportingDocumentStatusByReportSubmissionIds($reportSubmissionIds, $errorMessage));
     }
 
     /**

--- a/api/src/AppBundle/Controller/Report/DocumentController.php
+++ b/api/src/AppBundle/Controller/Report/DocumentController.php
@@ -150,9 +150,9 @@ class DocumentController extends RestController
         $reportSubmissionIds = $data['submissionIds'];
         $errorMessage = $data['errorMessage'];
 
-        $count = $documentRepo->updateSupportingDocumentStatusByReportSubmissionIds($reportSubmissionIds, $errorMessage);
+        $documentRepo->updateSupportingDocumentStatusByReportSubmissionIds($reportSubmissionIds, $errorMessage);
 
-        return json_encode($count);
+        return json_encode();
     }
 
     /**

--- a/api/src/AppBundle/Entity/Repository/DocumentRepository.php
+++ b/api/src/AppBundle/Entity/Repository/DocumentRepository.php
@@ -125,7 +125,7 @@ AND is_report_pdf=false";
 
         $conn = $this->getEntityManager()->getConnection();
         $stmt = $conn->prepare($updateStatusQuery);
-        $stmt->execute();
+        return $stmt->execute();
     }
 
 }

--- a/api/src/AppBundle/Entity/Repository/DocumentRepository.php
+++ b/api/src/AppBundle/Entity/Repository/DocumentRepository.php
@@ -46,7 +46,7 @@ ndr_submit_date,
 report_submission_id,
 report_submission_uuid
 FROM (
-SELECT DENSE_RANK() OVER(ORDER BY d.id) AS dn,
+SELECT DENSE_RANK() OVER(ORDER BY d.is_report_pdf) AS dn,
 coalesce(c1.case_number, c2.case_number) AS case_number,
 coalesce(rs1.id, rs2.id) AS report_submission_id,
 coalesce(rs1.opg_uuid, rs2.opg_uuid) AS report_submission_uuid,
@@ -61,8 +61,7 @@ LEFT JOIN report_submission rs2 ON rs2.ndr_id = d.ndr_id
 LEFT JOIN client c1 ON c1.id = r.client_id
 LEFT JOIN client c2 ON c2.id = o.client_id
 WHERE d.synchronisation_status = 'QUEUED') AS sub
-WHERE dn < $limit
-ORDER BY is_report_pdf DESC;";
+WHERE dn < $limit;";
 
         $conn = $this->getEntityManager()->getConnection();
         $stmt = $conn->prepare($queuedDocumentsQuery);

--- a/api/src/AppBundle/Entity/Repository/DocumentRepository.php
+++ b/api/src/AppBundle/Entity/Repository/DocumentRepository.php
@@ -126,14 +126,6 @@ AND is_report_pdf=false";
         $conn = $this->getEntityManager()->getConnection();
         $stmt = $conn->prepare($updateStatusQuery);
         $stmt->execute();
-
-        $docsCountQuery = "
-SELECT COUNT(id)
-FROM document
-WHERE report_submission_id IN ($idsString)";
-
-        $res = $conn->query($docsCountQuery);
-        return $res->fetchColumn();
     }
 
 }

--- a/api/src/AppBundle/Entity/Repository/DocumentRepository.php
+++ b/api/src/AppBundle/Entity/Repository/DocumentRepository.php
@@ -61,7 +61,8 @@ LEFT JOIN report_submission rs2 ON rs2.ndr_id = d.ndr_id
 LEFT JOIN client c1 ON c1.id = r.client_id
 LEFT JOIN client c2 ON c2.id = o.client_id
 WHERE d.synchronisation_status = 'QUEUED') AS sub
-WHERE dn < $limit;";
+WHERE dn < $limit
+ORDER BY is_report_pdf DESC;";
 
         $conn = $this->getEntityManager()->getConnection();
         $stmt = $conn->prepare($queuedDocumentsQuery);

--- a/api/src/AppBundle/Entity/Repository/DocumentRepository.php
+++ b/api/src/AppBundle/Entity/Repository/DocumentRepository.php
@@ -46,7 +46,7 @@ ndr_submit_date,
 report_submission_id,
 report_submission_uuid
 FROM (
-SELECT DENSE_RANK() OVER(ORDER BY d.is_report_pdf) AS dn,
+SELECT DENSE_RANK() OVER(ORDER BY d.is_report_pdf DESC, d.id) AS dn,
 coalesce(c1.case_number, c2.case_number) AS case_number,
 coalesce(rs1.id, rs2.id) AS report_submission_id,
 coalesce(rs1.opg_uuid, rs2.opg_uuid) AS report_submission_uuid,

--- a/api/tests/AppBundle/Controller/DocumentControllerTest.php
+++ b/api/tests/AppBundle/Controller/DocumentControllerTest.php
@@ -244,6 +244,6 @@ class DocumentControllerTest extends AbstractTestController
             'data' => ['submissionIds' => [self::$reportSubmission1->getId(), self::$reportSubmission2->getId()], 'errorMessage' => 'An error message']
         ]);
 
-        self::assertEquals('3', $response['data']);
+        self::assertEquals('true', $response['data']);
     }
 }

--- a/client/scripts/documentsync.sh
+++ b/client/scripts/documentsync.sh
@@ -4,4 +4,18 @@ set -e
 # We need below to create the params file on container start
 confd -onetime -backend env
 
-su-exec www-data php app/console digideps:document-sync $@
+EXITSIGNAL=1
+
+while [ ${EXITSIGNAL} -eq 1 ]; do
+  php app/console digideps:document-sync $@
+  printf 'Return value is %s' $?
+  EXITSIGNAL=$?
+done
+
+
+
+echo 'hi'
+echo "$0"
+echo 'hi'
+echo "$@"
+#su-exec www-data php app/console digideps:document-sync $0 $@

--- a/client/scripts/documentsync.sh
+++ b/client/scripts/documentsync.sh
@@ -4,18 +4,4 @@ set -e
 # We need below to create the params file on container start
 confd -onetime -backend env
 
-EXITSIGNAL=1
-
-while [ ${EXITSIGNAL} -eq 1 ]; do
-  php app/console digideps:document-sync $@
-  printf 'Return value is %s' $?
-  EXITSIGNAL=$?
-done
-
-
-
-echo 'hi'
-echo "$0"
-echo 'hi'
-echo "$@"
-#su-exec www-data php app/console digideps:document-sync $0 $@
+su-exec www-data php app/console digideps:document-sync $@

--- a/client/src/AppBundle/Command/DocumentSyncCommand.php
+++ b/client/src/AppBundle/Command/DocumentSyncCommand.php
@@ -13,7 +13,6 @@ use Symfony\Component\Serializer\Serializer;
 
 class DocumentSyncCommand extends DaemonableCommand
 {
-    const FALLBACK_INTERVAL_MINUTES = '4.5';
     const FALLBACK_ROW_LIMITS = '100';
 
     protected static $defaultName = 'digideps:document-sync';
@@ -61,23 +60,14 @@ class DocumentSyncCommand extends DaemonableCommand
             return 0;
         }
 
-        print_r('Memory usage at start is.........');
-        var_dump(memory_get_usage(true));
-
         /** @var QueuedDocumentData[] $documents */
         $documents = $this->getQueuedDocumentsData();
 
         $output->writeln(sprintf('%d documents to upload', count($documents)));
 
-        print_r('Memory usage after getting docs is.........');
-        var_dump(memory_get_usage(true));
-
         foreach ($documents as &$document) {
             $this->documentSyncService->syncDocument($document);
         }
-
-        print_r('Memory usage after syncing is.........');
-        var_dump(memory_get_usage(true));
 
         if ($this->documentSyncService->getSyncErrorSubmissionIds()) {
             $documentsUpdated = $this->documentSyncService->setSubmissionsDocumentsToPermanentError();
@@ -91,12 +81,6 @@ class DocumentSyncCommand extends DaemonableCommand
     private function isFeatureEnabled(): bool
     {
         return $this->parameterStore->getFeatureFlag(ParameterStoreService::FLAG_DOCUMENT_SYNC) === '1';
-    }
-
-    private function getSyncIntervalMinutes(): string
-    {
-        $minutes = $this->parameterStore->getParameter(ParameterStoreService::PARAMETER_DOCUMENT_SYNC_INTERVAL_MINUTES);
-        return $minutes ? $minutes : self::FALLBACK_INTERVAL_MINUTES;
     }
 
     private function getSyncRowLimit(): string

--- a/client/src/AppBundle/Command/DocumentSyncCommand.php
+++ b/client/src/AppBundle/Command/DocumentSyncCommand.php
@@ -65,7 +65,7 @@ class DocumentSyncCommand extends DaemonableCommand
 
         $output->writeln(sprintf('%d documents to upload', count($documents)));
 
-        foreach ($documents as &$document) {
+        foreach ($documents as $document) {
             $this->documentSyncService->syncDocument($document);
         }
 

--- a/client/src/AppBundle/Command/DocumentSyncCommand.php
+++ b/client/src/AppBundle/Command/DocumentSyncCommand.php
@@ -70,9 +70,11 @@ class DocumentSyncCommand extends DaemonableCommand
         }
 
         if ($this->documentSyncService->getSyncErrorSubmissionIds()) {
-            $documentsUpdated = $this->documentSyncService->setSubmissionsDocumentsToPermanentError();
-            $output->writeln(sprintf('%d documents failed to sync', $documentsUpdated));
+            $this->documentSyncService->setSubmissionsDocumentsToPermanentError();
             $this->documentSyncService->setSyncErrorSubmissionIds([]);
+
+            $output->writeln(sprintf('%d documents failed to sync', $this->documentSyncService->getCountDocsNotSynced()));
+            $this->documentSyncService->setCountDocsNotSynced(0);
         }
 
         return 0;

--- a/client/src/AppBundle/Command/DocumentSyncCommand.php
+++ b/client/src/AppBundle/Command/DocumentSyncCommand.php
@@ -73,8 +73,8 @@ class DocumentSyncCommand extends DaemonableCommand
             $this->documentSyncService->setSubmissionsDocumentsToPermanentError();
             $this->documentSyncService->setSyncErrorSubmissionIds([]);
 
-            $output->writeln(sprintf('%d documents failed to sync', $this->documentSyncService->getCountDocsNotSynced()));
-            $this->documentSyncService->setCountDocsNotSynced(0);
+            $output->writeln(sprintf('%d documents failed to sync', $this->documentSyncService->getDocsNotSyncedCount()));
+            $this->documentSyncService->setDocsNotSyncedCount(0);
         }
 
         return 0;

--- a/client/src/AppBundle/Command/DocumentSyncCommand.php
+++ b/client/src/AppBundle/Command/DocumentSyncCommand.php
@@ -69,7 +69,7 @@ class DocumentSyncCommand extends DaemonableCommand
             $this->documentSyncService->syncDocument($document);
         }
 
-        if ($this->documentSyncService->getSyncErrorSubmissionIds()) {
+        if ($this->documentSyncService->getDocsNotSyncedCount() > 0) {
             $this->documentSyncService->setSubmissionsDocumentsToPermanentError();
             $this->documentSyncService->setSyncErrorSubmissionIds([]);
 

--- a/client/src/AppBundle/Command/DocumentSyncCommand.php
+++ b/client/src/AppBundle/Command/DocumentSyncCommand.php
@@ -52,38 +52,40 @@ class DocumentSyncCommand extends DaemonableCommand
         $this->setDescription('Uploads queued documents to Sirius and reports back the success');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         ini_set('memory_limit', '512M');
 
-            if (!$this->isFeatureEnabled()) {
-                $output->writeln('Feature disabled, sleeping');
-                return;
-            }
+        if (!$this->isFeatureEnabled()) {
+            $output->writeln('Feature disabled, sleeping');
+            return 0;
+        }
 
-            print_r('Memory usage at start is.........');
-            var_dump(memory_get_usage(true));
+        print_r('Memory usage at start is.........');
+        var_dump(memory_get_usage(true));
 
-            /** @var QueuedDocumentData[] $documents */
-            $documents = $this->getQueuedDocumentsData();
+        /** @var QueuedDocumentData[] $documents */
+        $documents = $this->getQueuedDocumentsData();
 
-            $output->writeln(sprintf('%d documents to upload', count($documents)));
+        $output->writeln(sprintf('%d documents to upload', count($documents)));
 
-            print_r('Memory usage after getting docs is.........');
-            var_dump(memory_get_usage(true));
+        print_r('Memory usage after getting docs is.........');
+        var_dump(memory_get_usage(true));
 
-            foreach ($documents as &$document) {
-                $this->documentSyncService->syncDocument($document);
-            }
+        foreach ($documents as &$document) {
+            $this->documentSyncService->syncDocument($document);
+        }
 
-            print_r('Memory usage after syncing is.........');
-            var_dump(memory_get_usage(true));
+        print_r('Memory usage after syncing is.........');
+        var_dump(memory_get_usage(true));
 
-            if ($this->documentSyncService->getSyncErrorSubmissionIds()) {
-                $documentsUpdated = $this->documentSyncService->setSubmissionsDocumentsToPermanentError();
-                $output->writeln(sprintf('%d documents failed to sync', $documentsUpdated));
-                $this->documentSyncService->setSyncErrorSubmissionIds([]);
-            }
+        if ($this->documentSyncService->getSyncErrorSubmissionIds()) {
+            $documentsUpdated = $this->documentSyncService->setSubmissionsDocumentsToPermanentError();
+            $output->writeln(sprintf('%d documents failed to sync', $documentsUpdated));
+            $this->documentSyncService->setSyncErrorSubmissionIds([]);
+        }
+
+        return 0;
     }
 
     private function isFeatureEnabled(): bool

--- a/client/src/AppBundle/Command/DocumentSyncCommand.php
+++ b/client/src/AppBundle/Command/DocumentSyncCommand.php
@@ -69,10 +69,12 @@ class DocumentSyncCommand extends DaemonableCommand
             $this->documentSyncService->syncDocument($document);
         }
 
-        if ($this->documentSyncService->getDocsNotSyncedCount() > 0) {
+        if (count($this->documentSyncService->getSyncErrorSubmissionIds()) > 0) {
             $this->documentSyncService->setSubmissionsDocumentsToPermanentError();
             $this->documentSyncService->setSyncErrorSubmissionIds([]);
+        }
 
+        if ($this->documentSyncService->getDocsNotSyncedCount() > 0) {
             $output->writeln(sprintf('%d documents failed to sync', $this->documentSyncService->getDocsNotSyncedCount()));
             $this->documentSyncService->setDocsNotSyncedCount(0);
         }

--- a/client/src/AppBundle/Service/DocumentSyncService.php
+++ b/client/src/AppBundle/Service/DocumentSyncService.php
@@ -294,7 +294,10 @@ class DocumentSyncService
         }
 
         if ($syncStatus === Document::SYNC_STATUS_PERMANENT_ERROR) {
-            $this->addToSyncErrorSubmissionIds($documentData->getReportSubmissionId());
+            if ($documentData->isReportPdf()) {
+                $this->addToSyncErrorSubmissionIds($documentData->getReportSubmissionId());
+            }
+
             $this->docsNotSyncedCount++;
         }
 

--- a/client/src/AppBundle/Service/DocumentSyncService.php
+++ b/client/src/AppBundle/Service/DocumentSyncService.php
@@ -60,6 +60,14 @@ class DocumentSyncService
     }
 
     /**
+     * @param int[] $syncErrorSubmissionIds
+     */
+    public function setSyncErrorSubmissionIds(array $syncErrorSubmissionIds): void
+    {
+        $this->syncErrorSubmissionIds = $syncErrorSubmissionIds;
+    }
+
+    /**
      * @param int $submissionId
      */
     public function addToSyncErrorSubmissionIds(int $submissionId)

--- a/client/src/AppBundle/Service/DocumentSyncService.php
+++ b/client/src/AppBundle/Service/DocumentSyncService.php
@@ -40,7 +40,7 @@ class DocumentSyncService
     private $syncErrorSubmissionIds;
 
     /** @var int */
-    private $countDocsNotSynced;
+    private $docsNotSyncedCount;
 
     public function __construct(
         S3Storage $storage,
@@ -52,7 +52,7 @@ class DocumentSyncService
         $this->siriusApiGatewayClient = $siriusApiGatewayClient;
         $this->restClient = $restClient;
         $this->syncErrorSubmissionIds = [];
-        $this->countDocsNotSynced = 0;
+        $this->docsNotSyncedCount = 0;
     }
 
     /**
@@ -79,14 +79,14 @@ class DocumentSyncService
         $this->syncErrorSubmissionIds[] = $submissionId;
     }
 
-    public function getCountDocsNotSynced()
+    public function getDocsNotSyncedCount()
     {
-        return $this->countDocsNotSynced;
+        return $this->docsNotSyncedCount;
     }
 
-    public function setCountDocsNotSynced(int $count)
+    public function setDocsNotSyncedCount(int $count)
     {
-        return $this->countDocsNotSynced = $count;
+        return $this->docsNotSyncedCount = $count;
     }
 
     /**
@@ -99,6 +99,7 @@ class DocumentSyncService
             return $this->syncReportDocument($documentData);
         } else {
             if (!$documentData->supportingDocumentCanBeSynced()) {
+                $this->docsNotSyncedCount++;
                 return $this->handleDocumentStatusUpdate($documentData, Document::SYNC_STATUS_QUEUED);
             }
 
@@ -294,7 +295,7 @@ class DocumentSyncService
 
         if ($syncStatus === Document::SYNC_STATUS_PERMANENT_ERROR) {
             $this->addToSyncErrorSubmissionIds($documentData->getReportSubmissionId());
-            $this->countDocsNotSynced++;
+            $this->docsNotSyncedCount++;
         }
 
         $this->handleDocumentStatusUpdate($documentData, $syncStatus, $errorMessage);

--- a/client/src/AppBundle/Service/DocumentSyncService.php
+++ b/client/src/AppBundle/Service/DocumentSyncService.php
@@ -81,6 +81,8 @@ class DocumentSyncService
      */
     public function syncDocument(QueuedDocumentData $documentData)
     {
+        print_r('DocumentData is.........');
+        var_dump($documentData);
         if ($documentData->isReportPdf() && mimetype_from_filename($documentData->getFileName()) == 'application/pdf') {
             return $this->syncReportDocument($documentData);
         } else {

--- a/client/src/AppBundle/Service/DocumentSyncService.php
+++ b/client/src/AppBundle/Service/DocumentSyncService.php
@@ -81,8 +81,6 @@ class DocumentSyncService
      */
     public function syncDocument(QueuedDocumentData $documentData)
     {
-        print_r('DocumentData is.........');
-        var_dump($documentData);
         if ($documentData->isReportPdf() && mimetype_from_filename($documentData->getFileName()) == 'application/pdf') {
             return $this->syncReportDocument($documentData);
         } else {

--- a/client/tests/phpunit/Command/DocumentSyncCommandTest.php
+++ b/client/tests/phpunit/Command/DocumentSyncCommandTest.php
@@ -77,6 +77,11 @@ class DocumentSyncCommandTest extends KernelTestCase
             ->shouldBeCalled()
             ->willReturn(0);
 
+        $documentSyncService
+            ->getSyncErrorSubmissionIds()
+            ->shouldBeCalled()
+            ->willReturn([]);
+
         $kernel = static::bootKernel([ 'debug' => false ]);
         $application = new Application($kernel);
 
@@ -155,6 +160,11 @@ class DocumentSyncCommandTest extends KernelTestCase
 
        /** @var DocumentSyncService|ObjectProphecy $documentSyncService */
        $documentSyncService = self::prophesize(DocumentSyncService::class);
+       $documentSyncService
+           ->getSyncErrorSubmissionIds()
+           ->shouldBeCalled()
+           ->willReturn([1]);
+
        $documentSyncService
            ->setSubmissionsDocumentsToPermanentError()
            ->shouldBeCalled();

--- a/client/tests/phpunit/Command/DocumentSyncCommandTest.php
+++ b/client/tests/phpunit/Command/DocumentSyncCommandTest.php
@@ -162,8 +162,20 @@ class DocumentSyncCommandTest extends KernelTestCase
 
        $documentSyncService
            ->setSubmissionsDocumentsToPermanentError()
+           ->shouldBeCalled();
+
+       $documentSyncService
+           ->getDocsNotSyncedCount()
            ->shouldBeCalled()
            ->willReturn(6);
+
+       $documentSyncService
+           ->setSyncErrorSubmissionIds([])
+           ->shouldBeCalled();
+
+       $documentSyncService
+           ->setDocsNotSyncedCount(0)
+           ->shouldBeCalled();
 
        $kernel = static::bootKernel([ 'debug' => false ]);
        $application = new Application($kernel);

--- a/client/tests/phpunit/Command/DocumentSyncCommandTest.php
+++ b/client/tests/phpunit/Command/DocumentSyncCommandTest.php
@@ -142,11 +142,6 @@ class DocumentSyncCommandTest extends KernelTestCase
            ->willReturn('1');
 
        $parameterStore
-           ->getParameter(ParameterStoreService::PARAMETER_DOCUMENT_SYNC_INTERVAL_MINUTES)
-           ->shouldBeCalled()
-           ->willReturn('4.5');
-
-       $parameterStore
            ->getParameter(ParameterStoreService::PARAMETER_DOCUMENT_SYNC_ROW_LIMIT)
            ->shouldBeCalled()
            ->willReturn('100');

--- a/client/tests/phpunit/Command/DocumentSyncCommandTest.php
+++ b/client/tests/phpunit/Command/DocumentSyncCommandTest.php
@@ -73,9 +73,9 @@ class DocumentSyncCommandTest extends KernelTestCase
             ->shouldBeCalled();
 
         $documentSyncService
-            ->getSyncErrorSubmissionIds()
+            ->getDocsNotSyncedCount()
             ->shouldBeCalled()
-            ->willReturn([]);
+            ->willReturn(0);
 
         $kernel = static::bootKernel([ 'debug' => false ]);
         $application = new Application($kernel);
@@ -155,11 +155,6 @@ class DocumentSyncCommandTest extends KernelTestCase
 
        /** @var DocumentSyncService|ObjectProphecy $documentSyncService */
        $documentSyncService = self::prophesize(DocumentSyncService::class);
-       $documentSyncService
-           ->getSyncErrorSubmissionIds()
-           ->shouldBeCalled()
-           ->willReturn([1, 2, 3]);
-
        $documentSyncService
            ->setSubmissionsDocumentsToPermanentError()
            ->shouldBeCalled();

--- a/client/tests/phpunit/Command/DocumentSyncCommandTest.php
+++ b/client/tests/phpunit/Command/DocumentSyncCommandTest.php
@@ -55,11 +55,6 @@ class DocumentSyncCommandTest extends KernelTestCase
             ->willReturn('1');
 
         $parameterStoreService
-            ->getParameter(ParameterStoreService::PARAMETER_DOCUMENT_SYNC_INTERVAL_MINUTES)
-            ->shouldBeCalled()
-            ->willReturn('4.5');
-
-        $parameterStoreService
             ->getParameter(ParameterStoreService::PARAMETER_DOCUMENT_SYNC_ROW_LIMIT)
             ->shouldBeCalled()
             ->willReturn('100');
@@ -107,11 +102,6 @@ class DocumentSyncCommandTest extends KernelTestCase
             ->getFeatureFlag(ParameterStoreService::FLAG_DOCUMENT_SYNC)
             ->shouldBeCalled()
             ->willReturn('0');
-
-        $parameterStore
-            ->getParameter(ParameterStoreService::PARAMETER_DOCUMENT_SYNC_INTERVAL_MINUTES)
-            ->shouldBeCalled()
-            ->willReturn('4.5');
 
         /** @var RestClient|ObjectProphecy $restClient */
         $restClient = self::prophesize(RestClient::class);

--- a/client/tests/phpunit/Service/DocumentSyncServiceTest.php
+++ b/client/tests/phpunit/Service/DocumentSyncServiceTest.php
@@ -19,6 +19,7 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use JMS\Serializer\Serializer;
+use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
@@ -221,7 +222,7 @@ class DocumentSyncServiceTest extends KernelTestCase
     }
 
     /** @test */
-    public function sendDocument_sync_failure_sirius()
+    public function sendDocument_sync_failure_sirius_report_pdf()
     {
         $reportPdfReportSubmission =
             (new ReportSubmission())
@@ -447,5 +448,58 @@ class DocumentSyncServiceTest extends KernelTestCase
 
         $sut = new DocumentSyncService($this->s3Storage->reveal(), $this->siriusApiGatewayClient->reveal(), $this->restClient->reveal());
         $sut->syncDocument($queuedDocumentData);
+    }
+
+    /** @test */
+    public function sendSupportingDocument_sync_failure()
+    {
+        $reportPdfReportSubmission =
+            (new ReportSubmission())
+                ->setId($this->reportSubmissionId)
+                ->setUuid($this->reportPdfSubmissionUuid);
+
+        $queuedDocumentData = (new QueuedDocumentData())
+            ->setReportType(Report::TYPE_PROPERTY_AND_AFFAIRS_HIGH_ASSETS)
+            ->setDocumentId(6789)
+            ->setReportSubmissionId($this->reportSubmissionId)
+            ->setReportSubmissions([$reportPdfReportSubmission])
+            ->setReportStartDate($this->reportStartDate)
+            ->setReportEndDate($this->reportEndDate)
+            ->setReportSubmitDate($this->reportSubmittedDate)
+            ->setStorageReference('storage-ref-here')
+            ->setFilename('bank-statement.pdf')
+            ->setIsReportPdf(false)
+            ->setCaseNumber('1234567T')
+            ->setNdrId(null);
+
+        $this->s3Storage->retrieve('storage-ref-here')->willReturn($this->fileContents);
+
+        $failureResponseBody = ['errors' => [0 => ['id' => 'ABC123', 'code' => 'OPGDATA-API-FORBIDDEN']]];
+        $failureResponse = new Response('403', [], json_encode($failureResponseBody));
+
+        $requestException = new RequestException('An error occurred', new Request('POST', '/report-submission/9876/update-uuid'), $failureResponse);
+
+        $this->siriusApiGatewayClient->sendSupportingDocument(Argument::cetera())
+            ->shouldBeCalled()
+            ->willThrow($requestException);
+
+        $this->restClient
+            ->apiCall('put',
+                'document/6789',
+                json_encode(
+                    ['syncStatus' => Document::SYNC_STATUS_PERMANENT_ERROR,
+                        'syncError' => $failureResponseBody
+                    ]),
+                'Report\\Document',
+                [],
+                false
+            )
+            ->shouldBeCalled()
+            ->willReturn($this->serializer->serialize(new Document(), 'json'));
+
+        $sut = new DocumentSyncService($this->s3Storage->reveal(), $this->siriusApiGatewayClient->reveal(), $this->restClient->reveal());
+        $sut->syncDocument($queuedDocumentData);
+
+        self::assertNotContains($queuedDocumentData->getReportSubmissionId(), $sut->getSyncErrorSubmissionIds());
     }
 }

--- a/client/tests/phpunit/Service/DocumentSyncServiceTest.php
+++ b/client/tests/phpunit/Service/DocumentSyncServiceTest.php
@@ -448,31 +448,4 @@ class DocumentSyncServiceTest extends KernelTestCase
         $sut = new DocumentSyncService($this->s3Storage->reveal(), $this->siriusApiGatewayClient->reveal(), $this->restClient->reveal());
         $sut->syncDocument($queuedDocumentData);
     }
-
-    /**
-     * @test
-     */
-    public function setSubmissionsDocumentsToPermanentError()
-    {
-        $expectedResponse = new Response(200, [], json_encode(['success' => true, 'data' => 3, 'message' => '']));
-
-        $this->restClient
-            ->apiCall('put',
-                'document/update-related-statuses',
-                json_encode(['submissionIds' => [1,2], 'errorMessage' => 'Report PDF failed to sync']),
-                'raw',
-                [],
-                false
-            )
-            ->shouldBeCalled()
-            ->willReturn($expectedResponse->getBody());
-
-        $sut = new DocumentSyncService($this->s3Storage->reveal(), $this->siriusApiGatewayClient->reveal(), $this->restClient->reveal());
-
-        $sut->addToSyncErrorSubmissionIds(1);
-        $sut->addToSyncErrorSubmissionIds(2);
-
-        $updatedDocumentsCount = $sut->setSubmissionsDocumentsToPermanentError();
-        self::assertEquals(3, $updatedDocumentsCount);
-    }
 }

--- a/environment/document_sync.tf
+++ b/environment/document_sync.tf
@@ -45,7 +45,6 @@ resource "aws_ecs_service" "document_sync" {
   name                    = aws_ecs_task_definition.document_sync.family
   cluster                 = aws_ecs_cluster.main.id
   task_definition         = aws_ecs_task_definition.document_sync.arn
-  desired_count           = 1
   launch_type             = "FARGATE"
   enable_ecs_managed_tags = true
   propagate_tags          = "SERVICE"

--- a/environment/document_sync.tf
+++ b/environment/document_sync.tf
@@ -59,7 +59,7 @@ resource "aws_ecs_service" "document_sync" {
 }
 
 resource "aws_cloudwatch_event_rule" "document_sync_cron_rule" {
-  name                = "scheduled-ecs-event-rule"
+  name                = "${aws_ecs_task_definition.document_sync.family}-schedule"
   schedule_expression = "rate(5 minutes)"
 }
 

--- a/environment/document_sync.tf
+++ b/environment/document_sync.tf
@@ -66,7 +66,7 @@ resource "aws_cloudwatch_event_target" "document_sync_scheduled_task" {
   target_id = "ScheduledDocumentSync"
   rule      = aws_cloudwatch_event_rule.document_sync_cron_rule.name
   arn       = aws_ecs_cluster.main.arn
-  role_arn  = aws_iam_role.front.arn
+  role_arn  = data.aws_iam_role.events_task_runner.arn
 
   ecs_target {
     task_count          = 1

--- a/environment/front.tf
+++ b/environment/front.tf
@@ -64,7 +64,6 @@ data "aws_iam_policy_document" "query_ssm" {
     ]
     resources = [
       aws_ssm_parameter.flag_document_sync.arn,
-      aws_ssm_parameter.document_sync_interval_minutes.arn,
       aws_ssm_parameter.document_sync_row_limit.arn
     ]
   }

--- a/environment/front.tf
+++ b/environment/front.tf
@@ -69,3 +69,24 @@ data "aws_iam_policy_document" "query_ssm" {
     ]
   }
 }
+
+resource "aws_iam_role_policy" "ecs_scheduled_tasks" {
+  name   = "front-query-ssm.${local.environment}"
+  policy = data.aws_iam_policy_document.ecs_scheduled_tasks.json
+  role   = aws_iam_role.front.id
+}
+
+data "aws_iam_policy_document" "ecs_scheduled_tasks" {
+  statement {
+    sid    = "AllowCloudwatchPassIAMRolesToECSTasks"
+    effect = "Allow"
+    actions = [
+      "iam:ListInstanceProfiles",
+      "iam:ListRoles",
+      "iam:PassRole"
+    ]
+    resources = [
+      aws_cloudwatch_event_target.document_sync_scheduled_task.arn,
+    ]
+  }
+}

--- a/environment/front.tf
+++ b/environment/front.tf
@@ -71,7 +71,7 @@ data "aws_iam_policy_document" "query_ssm" {
 }
 
 resource "aws_iam_role_policy" "ecs_scheduled_tasks" {
-  name   = "front-query-ssm.${local.environment}"
+  name   = "front-ecs-scheduled-task.${local.environment}"
   policy = data.aws_iam_policy_document.ecs_scheduled_tasks.json
   role   = aws_iam_role.front.id
 }

--- a/environment/front.tf
+++ b/environment/front.tf
@@ -85,8 +85,6 @@ data "aws_iam_policy_document" "ecs_scheduled_tasks" {
       "iam:ListRoles",
       "iam:PassRole"
     ]
-    resources = [
-      aws_cloudwatch_event_target.document_sync_scheduled_task.arn,
-    ]
+    resources = ["*"]
   }
 }

--- a/environment/parameters.tf
+++ b/environment/parameters.tf
@@ -7,18 +7,6 @@ data "aws_ssm_parameter" "sirius_api_base_uri" {
   name = format("/%s", join("/", compact([local.account.secrets_prefix, "sirius-api-base-uri"])))
 }
 
-resource "aws_ssm_parameter" "document_sync_interval_minutes" {
-  name  = "${local.parameter_prefix}document-sync-interval-minutes"
-  type  = "String"
-  value = "4.5"
-
-  tags = local.default_tags
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-}
-
 resource "aws_ssm_parameter" "document_sync_row_limit" {
   name  = "${local.parameter_prefix}document-sync-row-limit"
   type  = "String"


### PR DESCRIPTION
## Purpose
This change moves away from having a daemonable long-running command and instead creates a scheduled cloudwatch event that runs the document sync task once every five minutes. We lose the ability to control the frequency of the task due to the value being baked into the schedule terraform but from my testing today we're not seeing any out of memory errors.

Some other points this PR fixes:
- Now seeing the true number of failed documents per sync in output. Previously this was polluted when performing a batch update on supporting documents.
- Sorting the queued documents by is_report_pdf and then id. I witnessed cases, where the 100 documents returned, were all supporting documents which meant they would always be set to queued and no new documents would be picked up as a supporting document required the report pdf document to be synced.

Fixes DDPB-3403

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
