### PR TITLE
DDPB-3390 - Digideps creates CSV files for HW reports and 103 reports

### DIFF
--- a/api/tests/AppBundle/ControllerReport/ReportSubmissionControllerTest.php
+++ b/api/tests/AppBundle/ControllerReport/ReportSubmissionControllerTest.php
@@ -2,14 +2,11 @@
 
 namespace Tests\AppBundle\ControllerReport;
 
-use AppBundle\Entity\Client;
 use AppBundle\Entity\Report\Document;
 use AppBundle\Entity\Report\ReportSubmission;
-use AppBundle\Entity\User;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\AbstractTestController;
 use AppBundle\TestHelpers\ReportSubmissionHelper;
-use AppBundle\TestHelpers\ReportTestHelper;
 
 class ReportSubmissionControllerTest extends AbstractTestController
 {

--- a/client/src/AppBundle/Entity/Report/Report.php
+++ b/client/src/AppBundle/Entity/Report/Report.php
@@ -53,6 +53,11 @@ class Report implements ReportInterface, StartEndDateComparableInterface
     const TYPE_COMBINED_HIGH_ASSETS = '102-4';
     const TYPE_COMBINED_LOW_ASSETS = '103-4';
 
+    const HIGH_ASSETS_REPORT_TYPES = [
+        self::TYPE_PROPERTY_AND_AFFAIRS_HIGH_ASSETS,
+        self::TYPE_COMBINED_HIGH_ASSETS,
+    ];
+
     /**
      * @JMS\Type("integer")
      * @JMS\Groups({"visits-care", "report-id"})

--- a/client/src/AppBundle/Service/ReportSubmissionService.php
+++ b/client/src/AppBundle/Service/ReportSubmissionService.php
@@ -91,14 +91,17 @@ class ReportSubmissionService
     public function generateReportDocuments(ReportInterface $report)
     {
         $this->generateReportPdf($report);
-        $csvContent = $this->csvGenerator->generateTransactionsCsv($report);
 
-        $this->fileUploader->uploadFile(
-            $report,
-            $csvContent,
-            $report->createAttachmentName('DigiRepTransactions-%s_%s_%s.csv'),
-            false
-        );
+        if (in_array($report->getType(), Report::HIGH_ASSETS_REPORT_TYPES)) {
+            $csvContent = $this->csvGenerator->generateTransactionsCsv($report);
+
+            $this->fileUploader->uploadFile(
+                $report,
+                $csvContent,
+                $report->createAttachmentName('DigiRepTransactions-%s_%s_%s.csv'),
+                false
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
## Purpose
Transaction CSVs are only useful for reports that have high assets but up until now we've been generating them for all report types. This change restricts the CSV generation to just high asset report types.

Fixes DDPB-3390

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [x] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
