### PR TITLE
DDPB-3379: Fix to allow org deputies to delete documents from reports

### DIFF
--- a/api/src/AppBundle/Entity/Organisation.php
+++ b/api/src/AppBundle/Entity/Organisation.php
@@ -50,6 +50,7 @@ class Organisation implements OrganisationInterface
      * @JMS\Groups({"user-organisations"})
      *
      * @ORM\Column(name="is_activated", type="boolean", options={ "default": false}, nullable=false)
+     * @JMS\Groups({"organisation", "client-organisations"})
      */
     private $isActivated;
 

--- a/api/src/AppBundle/Entity/Organisation.php
+++ b/api/src/AppBundle/Entity/Organisation.php
@@ -47,10 +47,9 @@ class Organisation implements OrganisationInterface
     /**
      * @var bool
      *
-     * @JMS\Groups({"user-organisations"})
+     * @JMS\Groups({"organisation", "user-organisations", "client-organisations"})
      *
      * @ORM\Column(name="is_activated", type="boolean", options={ "default": false}, nullable=false)
-     * @JMS\Groups({"organisation", "client-organisations"})
      */
     private $isActivated;
 

--- a/client/src/AppBundle/Controller/Report/DocumentController.php
+++ b/client/src/AppBundle/Controller/Report/DocumentController.php
@@ -391,7 +391,7 @@ class DocumentController extends AbstractController
         return $this->getRestClient()->get(
             'document/' . $documentId,
             'Report\Document',
-            ['documents', 'status', 'document-storage-reference', 'document-report-submission', 'document-report', 'report', 'report-client', 'client', 'client-users', 'user-id']
+            ['documents', 'status', 'document-storage-reference', 'document-report-submission', 'document-report', 'report', 'report-client', 'client', 'client-users', 'user-id', 'client-organisations']
         );
     }
 

--- a/client/src/AppBundle/Entity/Client.php
+++ b/client/src/AppBundle/Entity/Client.php
@@ -8,6 +8,7 @@ use AppBundle\Entity\Traits\IsSoftDeleteableEntity;
 use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use JMS\Serializer\Annotation as JMS;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class Client
@@ -945,5 +946,17 @@ class Client
     public function setOrganisation(Organisation $organisation): void
     {
         $this->organisation = $organisation;
+    }
+
+    public function userBelongsToClientsOrganisation(User $user)
+    {
+        if ($this->getOrganisation() instanceof Organisation && $this->getOrganisation()->isActivated()) {
+            foreach ($user->getOrganisations() as $organisation) {
+                if ($organisation->getId() === $this->getOrganisation()->getId()) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/client/tests/phpunit/Security/DocumentVoterTest.php
+++ b/client/tests/phpunit/Security/DocumentVoterTest.php
@@ -1,0 +1,232 @@
+<?php declare(strict_types=1);
+
+namespace AppBundle\Security;
+
+use AppBundle\Entity\Client;
+use AppBundle\Entity\Organisation;
+use AppBundle\Entity\Report\Document;
+use AppBundle\Entity\Report\Report;
+use AppBundle\Entity\User;
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+class DocumentVoterTest extends TestCase
+{
+    private $sut;
+    private $token;
+    private $deputy;
+    private $organisation;
+    private $client;
+    private $report;
+    private $document;
+
+    public function setUp(): void
+    {
+        $this->sut = new DocumentVoter();
+        $this->token = $this->createMock(TokenInterface::class);
+
+        $this->deputy = (new User())->setId(87);
+        $this->organisation =  (new Organisation())->setId(31)->setIsActivated(true);
+        $this->report = new Report();
+        $this->client = new Client();
+        $this->document = new Document();
+    }
+
+    /**
+     * @dataProvider getSupportedAttributes
+     * @param string $attribute
+     * @param bool $expected
+     */
+    public function testSupports(string $attribute, int $expected): void
+    {
+        $this->token->method('getUser')->willReturn(null);
+        $this->assertEquals($expected, $this->sut->vote($this->token, new Report(), [$attribute]));
+    }
+
+    /**
+     * @return array
+     */
+    public function getSupportedAttributes(): array
+    {
+        return [
+            [DocumentVoter::ADD_DOCUMENT, Voter::ACCESS_DENIED],
+            [DocumentVoter::DELETE_DOCUMENT, Voter::ACCESS_DENIED],
+            ['UNKNOWN', Voter::ACCESS_ABSTAIN],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function voteOnAttributeAllowsLayDeputiesToAddDocumentsToTheirOwnReport(): void
+    {
+        $this->token->method('getUser')->willReturn($this->deputy);
+
+        $this
+            ->ensureReportBelongsToClient()
+            ->ensureClientBelongsToDeputy()
+            ->assertDeputyCanAddDocument();
+    }
+
+    /**
+     * @test
+     */
+    public function voteOnAttributeDeniesLayDeputiesFromAddingDocumentsToAnotherDeputiesReport(): void
+    {
+        $this->token->method('getUser')->willReturn($this->deputy);
+
+        $this
+            ->ensureReportBelongsToClient()
+            ->ensureClientBelongsToDifferentDeputy()
+            ->assertDeputyCannotAddDocument();
+    }
+
+    /**
+     * @test
+     */
+    public function voteOnAttributeAllowsOrgDeputiesToAddDocumentsToReportBelongingToTheirOrg(): void
+    {
+        $this->token->method('getUser')->willReturn($this->deputy);
+
+        $this
+            ->ensureReportBelongsToClient()
+            ->ensureClientAndDeputyBelongToSameOrganisation()
+            ->assertDeputyCanAddDocument();
+    }
+
+    /**
+     * @test
+     */
+    public function voteOnAttributeDeniesOrgDeputiesToAddDocumentsToReportNotBelongingToTheirOrg(): void
+    {
+        $this->token->method('getUser')->willReturn($this->deputy);
+
+        $this
+            ->ensureReportBelongsToClient()
+            ->ensureClientAndDeputyBelongToDifferentOrganisation()
+            ->assertDeputyCannotAddDocument();
+    }
+
+    /**
+     * @test
+     */
+    public function voteOnAttributeAllowsLayDeputiesToDeleteDocumentsFromTheirOwnReport(): void
+    {
+        $this->token->method('getUser')->willReturn($this->deputy);
+
+        $this
+            ->ensureDocumentBelongsToReport()
+            ->ensureReportBelongsToClient()
+            ->ensureClientBelongsToDeputy()
+            ->assertDeputyCanDeleteDocument();
+    }
+
+    /**
+     * @test
+     */
+    public function voteOnAttributeDeniesLayDeputiesFromDeletingDocumentsFromAnotherDeputiesReport(): void
+    {
+        $this->token->method('getUser')->willReturn($this->deputy);
+
+        $this
+            ->ensureDocumentBelongsToReport()
+            ->ensureReportBelongsToClient()
+            ->ensureClientBelongsToDifferentDeputy()
+            ->assertDeputyCannotDeleteDocument();
+    }
+
+    /**
+     * @test
+     */
+    public function voteOnAttributeAllowsOrgDeputiesToDeleteDocumentsFromReportBelongingToTheirOrg(): void
+    {
+        $this->token->method('getUser')->willReturn($this->deputy);
+
+        $this
+            ->ensureDocumentBelongsToReport()
+            ->ensureReportBelongsToClient()
+            ->ensureClientAndDeputyBelongToSameOrganisation()
+            ->assertDeputyCanAddDocument();
+    }
+
+    /**
+     * @test
+     */
+    public function voteOnAttributeDeniesOrgDeputiesFromDeletingDocumentsFromReportNotBelongingToTheirOrg(): void
+    {
+        $this->token->method('getUser')->willReturn($this->deputy);
+
+        $this
+            ->ensureDocumentBelongsToReport()
+            ->ensureReportBelongsToClient()
+            ->ensureClientAndDeputyBelongToDifferentOrganisation()
+            ->assertDeputyCannotAddDocument();
+    }
+
+    private function ensureReportBelongsToClient()
+    {
+        $this->report->setClient($this->client);
+
+        return $this;
+    }
+
+    private function ensureDocumentBelongsToReport()
+    {
+        $this->document->setReport($this->report);
+
+        return $this;
+    }
+
+    private function ensureClientBelongsToDeputy()
+    {
+        $this->client->addUser($this->deputy);
+
+        return $this;
+    }
+
+    private function ensureClientAndDeputyBelongToSameOrganisation()
+    {
+        $this->deputy->setOrganisations(new ArrayCollection([$this->organisation]));
+        $this->client->setOrganisation($this->organisation);
+
+        return $this;
+    }
+
+    private function ensureClientAndDeputyBelongToDifferentOrganisation()
+    {
+        $deputyOrg = (new Organisation())->setId(72)->setIsActivated(true);
+        $this->deputy->setOrganisations(new ArrayCollection([$deputyOrg]));
+        $this->client->setOrganisation($this->organisation);
+
+        return $this;
+    }
+
+    private function ensureClientBelongsToDifferentDeputy()
+    {
+        $this->client->addUser(new User());
+
+        return $this;
+    }
+
+    private function assertDeputyCanAddDocument()
+    {
+        $this->assertEquals(Voter::ACCESS_GRANTED, $this->sut->vote($this->token, $this->report, [DocumentVoter::ADD_DOCUMENT]));
+    }
+
+    private function assertDeputyCannotAddDocument()
+    {
+        $this->assertEquals(Voter::ACCESS_DENIED, $this->sut->vote($this->token, $this->report, [DocumentVoter::ADD_DOCUMENT]));
+    }
+
+    private function assertDeputyCanDeleteDocument()
+    {
+        $this->assertEquals(Voter::ACCESS_GRANTED, $this->sut->vote($this->token, $this->document, [DocumentVoter::DELETE_DOCUMENT]));
+    }
+
+    private function assertDeputyCannotDeleteDocument()
+    {
+        $this->assertEquals(Voter::ACCESS_DENIED, $this->sut->vote($this->token, $this->document, [DocumentVoter::DELETE_DOCUMENT]));
+    }
+}


### PR DESCRIPTION
## Purpose
Fix to allow org deputies to delete documents from reports

Fixes DDPB-3379

## Approach
The current `DocumentVoter` in the client was only granting permissions on its actions if the Report belongs to a Client that is attached to the Deputy. In the case of an Org deputy whose court order never existed pre the organisation migration, the Client will never be associated to the Deputy, but instead they are associated by belonging to the same Organisation. 

I have updated the Voter to run a further a check on whether the Client belongs to the same Organisation as the Deputy.

I added unit tests for the entire Voter, and also tidied up the Voter code.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
