### PR TITLE
DDPB-3330 add audit log group

### DIFF
--- a/environment/admin.tf
+++ b/environment/admin.tf
@@ -29,3 +29,9 @@ resource "aws_iam_role_policy" "admin_query_ssm" {
   policy = data.aws_iam_policy_document.query_ssm.json
   role   = aws_iam_role.admin.id
 }
+
+resource "aws_iam_role_policy" "admin_task_logs" {
+  name   = "admin-task-logs.${local.environment}"
+  policy = data.aws_iam_policy_document.ecs_task_logs.json
+  role   = aws_iam_role.admin.id
+}

--- a/environment/api.tf
+++ b/environment/api.tf
@@ -2,3 +2,9 @@ resource "aws_iam_role" "api" {
   assume_role_policy = data.aws_iam_policy_document.task_role_assume_policy.json
   name               = "api.${local.environment}"
 }
+
+resource "aws_iam_role_policy" "api_task_logs" {
+  name   = "api-task-logs.${local.environment}"
+  policy = data.aws_iam_policy_document.ecs_task_logs.json
+  role   = aws_iam_role.api.id
+}

--- a/environment/ecs.tf
+++ b/environment/ecs.tf
@@ -78,3 +78,33 @@ resource "aws_service_discovery_private_dns_namespace" "private" {
   name = "${local.environment}.private"
   vpc  = data.aws_vpc.vpc.id
 }
+
+data "aws_iam_policy_document" "ecs_task_logs" {
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    resources = [
+      "${aws_cloudwatch_log_group.audit.arn}:log-stream:*",
+      aws_cloudwatch_log_group.audit.arn
+    ]
+
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+  }
+}
+
+resource "aws_cloudwatch_log_group" "audit" {
+  name = "audit-${local.environment}"
+  tags = local.default_tags
+}

--- a/environment/front.tf
+++ b/environment/front.tf
@@ -87,3 +87,9 @@ data "aws_iam_policy_document" "ecs_scheduled_tasks" {
     resources = ["*"]
   }
 }
+
+resource "aws_iam_role_policy" "front_task_logs" {
+  name   = "front-task-logs.${local.environment}"
+  policy = data.aws_iam_policy_document.ecs_task_logs.json
+  role   = aws_iam_role.front.id
+}


### PR DESCRIPTION
## Purpose
A separate audit log group that will hold any application audit information such as when a client is deleted. This is locked down from org infra so that viewers and operators (of which all console viewers will be a member of) can't view the contents. They can still see it exists.

Fixes DDPB-3330

## Approach
A few issues with this. Talked to Matt about whether we needed breakglass for this group, he suggested we should. You can only attach one log group to an ECS container so we needed a better way of splitting out the logs. 
Using Monolog, we can split out the logs and give the task user access to only create streams and post logs, the set of permissions the task has is the minimum it needs to work with the new log groups.

Although you can create log groups with monolog, we want them managed by terraform.

## Learning
My initial attempt at this was to use firelens and fluentd to split the logs and send them to different log groups. This added extra containers and wasn't very simple to implement.

The better approach seemed to be to use monolog to split them at the application level and send log messages through to the relevant log group.

Another bit I didn't realise was that log groups cant have their own role based policies. As such we've had to put deny operations on viewer and operator so that they can't view that log.

This uses aws client to make connections from the task user (using monolog and php aws sdk).

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
