### PR TITLE
DDPB-3406 - Expand fixtures endpoints

### DIFF
--- a/api/src/AppBundle/DataFixtures/UserFixtures.php
+++ b/api/src/AppBundle/DataFixtures/UserFixtures.php
@@ -198,7 +198,7 @@ class UserFixtures extends AbstractDataFixture
 
         // Create CasRec record for lay deputies
         if ($data['deputyType'] === 'LAY') {
-            $casRec = new CasRec([
+            $casRec = ([
                 'Case' => $data['id'],
                 'Surname' => $data['id'],
                 'Deputy No' => str_replace('-', '', $data['id']),

--- a/api/src/AppBundle/DataFixtures/UserFixtures.php
+++ b/api/src/AppBundle/DataFixtures/UserFixtures.php
@@ -198,7 +198,7 @@ class UserFixtures extends AbstractDataFixture
 
         // Create CasRec record for lay deputies
         if ($data['deputyType'] === 'LAY') {
-            $casRec = ([
+            $casRec = new CasRec([
                 'Case' => $data['id'],
                 'Surname' => $data['id'],
                 'Deputy No' => str_replace('-', '', $data['id']),

--- a/api/src/AppBundle/Entity/Repository/UserRepository.php
+++ b/api/src/AppBundle/Entity/Repository/UserRepository.php
@@ -53,6 +53,10 @@ class UserRepository extends AbstractEntityRepository
             ->orderBy('u.' . $order_by, $sort_order)
             ->groupBy('u.id');
 
+        if ($request->get('filter_by_ids')) {
+            $this->qb->where(sprintf('u.id IN (%s)', $request->get('filter_by_ids')));
+        }
+
         return $this->qb->getQuery()->getResult();
     }
 

--- a/api/src/AppBundle/FixtureFactory/CasRecFactory.php
+++ b/api/src/AppBundle/FixtureFactory/CasRecFactory.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace AppBundle\FixtureFactory;
+
+use AppBundle\Entity\CasRec;
+use AppBundle\v2\Registration\DTO\LayDeputyshipDto;
+use AppBundle\v2\Registration\SelfRegistration\Factory\CasRecFactory as CasRecDTOFactory;
+
+class CasRecFactory
+{
+
+    /**
+     * @var CasRecDTOFactory
+     */
+    private $casRecFactory;
+
+    public function __construct(CasRecDTOFactory $casRecFactory)
+    {
+        $this->casRecFactory = $casRecFactory;
+    }
+
+    /**
+     * @param array $data
+     * @return Client
+     */
+    public function create(array $data): CasRec
+    {
+        $caseNumber = str_pad((string) rand(1,99999999), 8, "0", STR_PAD_LEFT);
+        $deputyNumber = str_pad((string) rand(1,999999), 6, "0", STR_PAD_LEFT);
+
+        $dto = (new LayDeputyshipDto())
+            ->setCaseNumber($caseNumber)
+            ->setSource('casrec')
+            ->setClientSurname('Smith')
+            ->setCorref('L2')
+            ->setDeputyNumber($deputyNumber)
+            ->setDeputyPostcode('SW1')
+            ->setDeputySurname('Jones')
+            ->setIsNdrEnabled(false)
+            ->setOrderDate(new \DateTime())
+            ->setTypeOfReport($data['reportType']);
+
+        $casRecEntity = $this->casRecFactory->createFromDto($dto);
+
+        return $casRecEntity;
+    }
+
+    public function createCoDeputy(string $caseNumber, array $data): CasRec
+    {
+        $deputyNumber = str_pad((string) rand(1,999999), 6, "0", STR_PAD_LEFT);
+
+        $dto = (new LayDeputyshipDto())
+            ->setCaseNumber($caseNumber)
+            ->setSource('casrec')
+            ->setClientSurname('Smith')
+            ->setCorref('L2')
+            ->setDeputyNumber($deputyNumber)
+            ->setDeputyPostcode('SW1')
+            ->setDeputySurname('Bloggs')
+            ->setIsNdrEnabled(false)
+            ->setOrderDate(new \DateTime())
+            ->setTypeOfReport($data['reportType']);
+
+        $casRecEntity = $this->casRecFactory->createFromDto($dto);
+
+        return $casRecEntity;
+    }
+}

--- a/api/src/AppBundle/FixtureFactory/UserFactory.php
+++ b/api/src/AppBundle/FixtureFactory/UserFactory.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\FixtureFactory;
 
+use AppBundle\Entity\Client;
 use AppBundle\Entity\User;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
@@ -83,6 +84,28 @@ class UserFactory
             default:
                 return 'ROLE_' . $roleName . '_NAMED';
         }
+    }
 
+    public function createCoDeputy(User $originalDeputy, Client $client, array $data)
+    {
+        $user2 = clone $originalDeputy;
+        $user2->setLastname($user2->getLastname() . '-2')
+            ->setEmail(
+                sprintf(
+                    '%s-deputy-%d@fixture.com',
+                    strtolower($data['deputyType']),
+                    mt_rand(1000, 99999)
+                )
+            )
+            ->addClient($client)
+            ->setActive($data['deputyType']);
+
+        if ($data['activated'] !== 'true') {
+            $user2->setActive(false);
+        } else {
+            $user2->setPassword($this->encoder->encodePassword($user2, 'Abcd1234'));
+        }
+
+        return $user2;
     }
 }

--- a/api/src/AppBundle/FixtureFactory/UserFactory.php
+++ b/api/src/AppBundle/FixtureFactory/UserFactory.php
@@ -42,10 +42,10 @@ class UserFactory
             ->setAddressCountry('GB')
             ->setRoleName($roleName);
 
-        if ($data['activated'] !== 'true') {
-            $user->setActive(false);
-        } else {
+        if ($data['activated'] === 'true' || $data['activated'] === true) {
             $user->setPassword($this->encoder->encodePassword($user, 'Abcd1234'));
+        } else {
+            $user->setActive(false);
         }
 
         return $user;
@@ -92,18 +92,18 @@ class UserFactory
         $user2->setLastname($user2->getLastname() . '-2')
             ->setEmail(
                 sprintf(
-                    '%s-deputy-%d@fixture.com',
+                    'co-%s-deputy-%d@fixture.com',
                     strtolower($data['deputyType']),
-                    mt_rand(1000, 99999)
+                    mt_rand(1000, 9999)
                 )
             )
             ->addClient($client)
             ->setActive($data['deputyType']);
 
-        if ($data['activated'] !== 'true') {
-            $user2->setActive(false);
-        } else {
+        if ($data['activated'] === 'true' || $data['activated'] === true) {
             $user2->setPassword($this->encoder->encodePassword($user2, 'Abcd1234'));
+        } else {
+            $user2->setActive(false);
         }
 
         return $user2;

--- a/api/src/AppBundle/v2/Fixture/Controller/FixtureController.php
+++ b/api/src/AppBundle/v2/Fixture/Controller/FixtureController.php
@@ -102,7 +102,7 @@ class FixtureController
 
         $this->em->flush();
 
-        return $this->buildSuccessResponse(['deputyEmail' => $deputy->getEmail()], 'Court order created', Response::HTTP_CREATED);
+        return $this->buildSuccessResponse(['deputyEmail' => $deputy->getEmail(), 'deputies' => $client->getUsers()], 'Court order created', Response::HTTP_CREATED);
     }
 
     /**
@@ -131,6 +131,7 @@ class FixtureController
             'deputyType' => $fromRequest['deputyType'],
             'email' => $fromRequest['deputyEmail'],
             'activated'=> 'true',
+            'coDeputyEnabled' => $fromRequest['coDeputyEnabled']
         ]);
 
         $this->em->persist($deputy);

--- a/api/src/AppBundle/v2/Fixture/Controller/FixtureController.php
+++ b/api/src/AppBundle/v2/Fixture/Controller/FixtureController.php
@@ -100,9 +100,21 @@ class FixtureController
             $this->createOrgAndAttachParticipants($fromRequest, $deputy, $client);
         }
 
+        // If codeputy was enabled, add a secondary account
+        if ($fromRequest['coDeputyEnabled']) {
+            $coDeputy = $this->userFactory->createCoDeputy($deputy, $client, $fromRequest);
+            $this->em->persist($coDeputy);
+        }
+
         $this->em->flush();
 
-        return $this->buildSuccessResponse(['deputyEmail' => $deputy->getEmail(), 'deputies' => $client->getUsers()], 'Court order created', Response::HTTP_CREATED);
+        $deputyIds = [$deputy->getId()];
+
+        if (isset($coDeputy)) {
+            $deputyIds[] = $coDeputy->getId();
+        }
+
+        return $this->buildSuccessResponse(['deputyEmail' => $deputy->getEmail(), 'deputyIds' => $deputyIds], 'Court order created', Response::HTTP_CREATED);
     }
 
     /**
@@ -130,7 +142,7 @@ class FixtureController
             'id' => $fromRequest['deputyEmail'],
             'deputyType' => $fromRequest['deputyType'],
             'email' => $fromRequest['deputyEmail'],
-            'activated'=> 'true',
+            'activated'=> $fromRequest['activated'],
             'coDeputyEnabled' => $fromRequest['coDeputyEnabled']
         ]);
 

--- a/client/src/AppBundle/Controller/Admin/FixtureController.php
+++ b/client/src/AppBundle/Controller/Admin/FixtureController.php
@@ -290,9 +290,19 @@ class FixtureController extends AbstractController
                 'createCoDeputy' => $submitted['createCoDeputy'],
             ]), [], 'array');
 
-            $this->addFlash('notice', 'Created casrec case');
+            $this->addFlash('notice', $this->createCasRecFlashMessage($response));
         }
 
         return ['form' => $form->createView()];
+    }
+
+    /**
+     * @param array $deputies
+     * @param string $caseNumber
+     * @return string
+     */
+    public function createCasRecFlashMessage(array $data)
+    {
+        return $this->twig->render('AppBundle:FlashMessages:fixture-casrec-created.html.twig', $data);
     }
 }

--- a/client/src/AppBundle/Form/Admin/Fixture/CasrecFixtureType.php
+++ b/client/src/AppBundle/Form/Admin/Fixture/CasrecFixtureType.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace AppBundle\Form\Admin\Fixture;
+
+
+use AppBundle\Entity\User;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CasrecFixtureType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('deputyType', ChoiceType::class, [
+                'choices' => ['Lay' => User::TYPE_LAY],
+                'data' => $options['deputyType']
+            ])
+            ->add('reportType', ChoiceType::class, [
+                'choices' => ['Property and financial affairs high assets' => 'OPG102'],
+                'data' => $options['reportType']
+            ])
+            ->add('createCoDeputy', ChoiceType::class, [
+                'choices' => ['Yes' => true, 'No' => false],
+                'data' => $options['createCoDeputy']
+            ])
+            ->add('submit', SubmitType::class);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'translation_domain' => 'admin-fixtures'
+        ])->setRequired(['deputyType', 'reportType', 'createCoDeputy']);
+    }
+}

--- a/client/src/AppBundle/Form/Admin/Fixture/CourtOrderFixtureType.php
+++ b/client/src/AppBundle/Form/Admin/Fixture/CourtOrderFixtureType.php
@@ -34,6 +34,10 @@ class CourtOrderFixtureType extends AbstractType
                 'choices' => ['Not started' => Report::STATUS_NOT_STARTED, 'Submittable' => Report::STATUS_READY_TO_SUBMIT],
                 'data' => $options['reportStatus']
             ])
+            ->add('coDeputyEnabled', ChoiceType::class, [
+                'choices' => ['Enabled' => true, 'Disabled' => false],
+                'data' => $options['coDeputyEnabled']
+            ])
             ->add('submit', SubmitType::class);
     }
 
@@ -41,6 +45,6 @@ class CourtOrderFixtureType extends AbstractType
     {
         $resolver->setDefaults([
             'translation_domain' => 'admin-fixtures'
-        ])->setRequired(['deputyType', 'reportType', 'reportStatus']);
+        ])->setRequired(['deputyType', 'reportType', 'reportStatus', 'coDeputyEnabled']);
     }
 }

--- a/client/src/AppBundle/Form/Admin/Fixture/CourtOrderFixtureType.php
+++ b/client/src/AppBundle/Form/Admin/Fixture/CourtOrderFixtureType.php
@@ -38,6 +38,10 @@ class CourtOrderFixtureType extends AbstractType
                 'choices' => ['Enabled' => true, 'Disabled' => false],
                 'data' => $options['coDeputyEnabled']
             ])
+            ->add('activated', ChoiceType::class, [
+                'choices' => ['Activated' => true, 'Not Activated' => false],
+                'data' => $options['activated']
+            ])
             ->add('submit', SubmitType::class);
     }
 
@@ -45,6 +49,6 @@ class CourtOrderFixtureType extends AbstractType
     {
         $resolver->setDefaults([
             'translation_domain' => 'admin-fixtures'
-        ])->setRequired(['deputyType', 'reportType', 'reportStatus', 'coDeputyEnabled']);
+        ])->setRequired(['deputyType', 'reportType', 'reportStatus', 'coDeputyEnabled', 'activated']);
     }
 }

--- a/client/src/AppBundle/Resources/translations/admin-fixtures.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin-fixtures.en.yml
@@ -1,11 +1,13 @@
 courtOrders:
   deputyType:
-    label: Deputy role
+    label: Deputy Role
   reportType:
-    label: Report type
+    label: Report Type
   reportStatus:
-    label: Report status
+    label: Report Status
   coDeputyEnabled:
       label: Co-Deputy Enabled
+  activated:
+      label: Account Activated
   submit:
     label: Create

--- a/client/src/AppBundle/Resources/translations/admin-fixtures.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin-fixtures.en.yml
@@ -1,13 +1,24 @@
 courtOrders:
-  deputyType:
-    label: Deputy Role
-  reportType:
-    label: Report Type
-  reportStatus:
-    label: Report Status
-  coDeputyEnabled:
-      label: Co-Deputy Enabled
-  activated:
-      label: Account Activated
-  submit:
-    label: Create
+    deputyType:
+        label: Deputy Role
+    reportType:
+        label: Report Type
+    reportStatus:
+        label: Report Status
+    coDeputyEnabled:
+        label: Co-Deputy Enabled
+    createCoDeputy:
+        label: Create Co-Deputy
+    activated:
+        label: Account Activated
+    submit:
+        label: Create
+casRec:
+    deputyType:
+        label: Deputy Role
+    reportType:
+        label: Report Type
+    createCoDeputy:
+        label: Create a Co-Deputy entry
+    submit:
+        label: Create

--- a/client/src/AppBundle/Resources/translations/admin-fixtures.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin-fixtures.en.yml
@@ -5,5 +5,7 @@ courtOrders:
     label: Report type
   reportStatus:
     label: Report status
+  coDeputyEnabled:
+      label: Co-Deputy Enabled
   submit:
     label: Create

--- a/client/src/AppBundle/Resources/views/Admin/Fixtures/casRec.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Fixtures/casRec.html.twig
@@ -1,0 +1,16 @@
+{% extends 'AppBundle:Layouts:application.html.twig' %}
+
+{% trans_default_domain "admin-fixtures" %}
+
+{% block htmlTitle %}Data Fixtures - CasRec{% endblock %}
+{% block pageTitle %}CasRec{% endblock %}
+{% block supportTitleTop %}Data Fixtures{% endblock %}
+
+{% block pageContent %}
+    {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
+    {{ form_select(form.deputyType, 'casRec.deputyType') }}
+    {{ form_select(form.reportType, 'casRec.reportType') }}
+    {{ form_select(form.createCoDeputy, 'casRec.createCoDeputy') }}
+    {{ form_submit(form.submit, 'casRec.submit') }}
+    {{ form_end(form) }}
+{% endblock %}

--- a/client/src/AppBundle/Resources/views/Admin/Fixtures/courtOrders.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Fixtures/courtOrders.html.twig
@@ -11,6 +11,7 @@
     {{ form_select(form.deputyType, 'courtOrders.deputyType') }}
     {{ form_select(form.reportType, 'courtOrders.reportType') }}
     {{ form_select(form.reportStatus, 'courtOrders.reportStatus') }}
+    {{ form_select(form.reportStatus, 'courtOrders.coDeputyEnabled') }}
     {{ form_submit(form.submit, 'courtOrders.submit') }}
     {{ form_end(form) }}
 {% endblock %}

--- a/client/src/AppBundle/Resources/views/Admin/Fixtures/courtOrders.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Fixtures/courtOrders.html.twig
@@ -4,14 +4,15 @@
 
 {% block htmlTitle %}Data Fixtures - Court Orders{% endblock %}
 {% block pageTitle %}Court Orders{% endblock %}
-{% block supportTitleTop %}Date Fixtures{% endblock %}
+{% block supportTitleTop %}Data Fixtures{% endblock %}
 
 {% block pageContent %}
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
     {{ form_select(form.deputyType, 'courtOrders.deputyType') }}
     {{ form_select(form.reportType, 'courtOrders.reportType') }}
     {{ form_select(form.reportStatus, 'courtOrders.reportStatus') }}
-    {{ form_select(form.reportStatus, 'courtOrders.coDeputyEnabled') }}
+    {{ form_select(form.coDeputyEnabled, 'courtOrders.coDeputyEnabled') }}
+    {{ form_select(form.activated, 'courtOrders.activated') }}
     {{ form_submit(form.submit, 'courtOrders.submit') }}
     {{ form_end(form) }}
 {% endblock %}

--- a/client/src/AppBundle/Resources/views/FlashMessages/fixture-casrec-created.html.twig
+++ b/client/src/AppBundle/Resources/views/FlashMessages/fixture-casrec-created.html.twig
@@ -1,5 +1,6 @@
 <p>Created CasRec {% if coDeputyLastName is defined %} entries {% else %} entry {% endif %}</p>
 
+<p>Use the details below during the registration process to create accounts.</p>
 
 <ul>
     <li>Case number: <strong>{{ caseNumber }}</strong></li>

--- a/client/src/AppBundle/Resources/views/FlashMessages/fixture-casrec-created.html.twig
+++ b/client/src/AppBundle/Resources/views/FlashMessages/fixture-casrec-created.html.twig
@@ -1,0 +1,14 @@
+<p>Created CasRec {% if coDeputyLastName is defined %} entries {% else %} entry {% endif %}</p>
+
+
+<ul>
+    <li>Case number: <strong>{{ caseNumber }}</strong></li>
+    <li>Client last name: <strong>{{ clientLastName }}</strong></li>
+    <br/>
+    <li>Deputy Last Name: <strong>{{ deputyLastName }}</strong></li>
+    <li>Deputy Postal Code: <strong>{{ deputyPostCode }}</strong></li>
+    {% if coDeputyLastName is defined %}
+        <li>Co-Deputy Last Name: <strong>{{ coDeputyLastName }}</strong></li>
+        <li>Co-Deputy Postal Code: <strong>{{ coDeputyPostCode }}</strong></li>
+    {% endif %}
+</ul>

--- a/client/src/AppBundle/Resources/views/FlashMessages/fixture-user-created.html.twig
+++ b/client/src/AppBundle/Resources/views/FlashMessages/fixture-user-created.html.twig
@@ -1,0 +1,8 @@
+<p>Created deputies</p>
+
+<ul>
+    <li>Case number: {{ caseNumber }}</li>
+    {% for deputy in deputies %}
+        <li>{{ deputy.email }}</li>
+    {% endfor %}
+</ul>

--- a/client/src/AppBundle/Resources/views/FlashMessages/fixture-user-created.html.twig
+++ b/client/src/AppBundle/Resources/views/FlashMessages/fixture-user-created.html.twig
@@ -1,8 +1,8 @@
-<p>Created deputies</p>
+<p>Created fixture {{ deputies|length > 1 ? 'deputies' : 'deputy' }}:</p>
+<p>Case number: <strong>{{ caseNumber }}</strong></p>
 
 <ul>
-    <li>Case number: {{ caseNumber }}</li>
     {% for deputy in deputies %}
-        <li>{{ deputy.email }}</li>
+        <li>Email: <strong>{{ deputy.email }}</strong></li>
     {% endfor %}
 </ul>


### PR DESCRIPTION
## Purpose
During the investigation for DDPB-3406 I realised other than manipulating the CSV there was no way to easily create Casrec entries or registered co-deputies. I've expanded the court order fixture creation page to have the option of creating a co-deputy and if the user should be activated or not. I also added a new endpoint /fixtures/create-casrec that lets you add sole or co-deputy entries there ready to be used int he registration flow.

Fixes DDPB-3406.

I had some issues with returning entities when POSTing to the user creation endpoint which is why I've had to make the extra callout to get the created deputies. If there's a trick to this let me know @aiesoftware!

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
