### PR TITLE
DDPB-3082: Add view page for deputy in admin

### DIFF
--- a/behat/tests/bootstrap/UserTrait.php
+++ b/behat/tests/bootstrap/UserTrait.php
@@ -387,6 +387,7 @@ trait UserTrait
     public function iEnableNdrForUser($action, $email)
     {
         $this->clickOnBehatLink('user-' . $email);
+        $this->clickLink('Edit user');
 
         strtolower($action) === 'enable' ?
             $this->checkOption('admin_ndrEnabled') :

--- a/behat/tests/features/pa/01-registration-steps/01-admin-add-pa-users-and-activate.feature
+++ b/behat/tests/features/pa/01-registration-steps/01-admin-add-pa-users-and-activate.feature
@@ -130,6 +130,7 @@ Feature: Add PA users and activate PA user (journey)
     Given I save the application status into "pa-users-uploaded"
     When I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "user-behat-pa2publicguardiangovuk" in the "user-behat-pa2publicguardiangovuk" region
+    And I press "Edit user"
     Then the following fields should have the corresponding values:
       | admin_firstname      | Pa User                         |
       | admin_lastname       | Two                             |

--- a/behat/tests/features/prof/01-registration-steps/01-admin-add-pa-users-and-activate.feature
+++ b/behat/tests/features/prof/01-registration-steps/01-admin-add-pa-users-and-activate.feature
@@ -177,6 +177,7 @@ Feature: Add PROF users and activate PROF user (journey)
     Given I save the application status into "prof-users-uploaded"
     When I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "user-behat-prof2publicguardiangovuk" in the "user-behat-prof2publicguardiangovuk" region
+    And I press "Edit user"
     Then the following fields should have the corresponding values:
       | admin_firstname      | Pa User                           |
       | admin_lastname       | Two                               |

--- a/client/src/AppBundle/Resources/translations/admin.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin.en.yml
@@ -78,6 +78,27 @@ deleteConfirm:
   supportTitle: Users
   question: Are you sure that you want to delete <strong class="bold">%fullName%</strong>? This action cannot be undone.
 
+viewUser:
+  htmlTitle: Administration - Users
+  supportTitle: Users
+  summary:
+    email: Email
+    postcode: Postcode
+    role: Role
+    editUser: Edit user
+  clientTable:
+    heading: Clients and reports
+    header:
+      client: Client
+      caseNumber: Case number
+      reports: Number of reports
+  organisationsTable:
+    heading: Organisations
+    header:
+      organisation: Name
+      identifier: Email domain
+    noOrganisations: This user is not a member of any active organisations.
+
 editUser:
   htmlTitle: Administration - Users
   pageTitle: Edit user

--- a/client/src/AppBundle/Resources/views/Admin/Index/editUser.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Index/editUser.html.twig
@@ -51,44 +51,6 @@
     {% endif %}
     {{ form_end(form) }}
 
-    {% if 'ROLE_LAY_DEPUTY' == user.roleName and numberOfClients > 0 %}
-        <h2 class="govuk-heading-m">{{ (page ~ '.clientTable.heading') | trans }}</h2>
-        <table class="width-two-thirds">
-            <thead>
-                <tr>
-                    <th>{{ (page ~ '.clientTable.header.client') | trans }}</th>
-                    <th class="numeric-small text--right">{{ (page ~ '.clientTable.header.caseNumber') | trans }}</th>
-                    <th class="numeric-small text--right">{{ (page ~ '.clientTable.header.reports') | trans }}</th>
-                </tr>
-
-            </thead>
-
-            {% for client in user.clients %}
-                <tr>
-                    <td>{{ client.firstname|title }} {{ client.lastname|title }}</td>
-                    <td class="numeric-small">{{ client.caseNumber|upper }}</td>
-                    <td class="numeric-small">{{ client.reports | length }}</td>
-                </tr>
-            {% endfor %}
-        </table>
-    {% elseif user.organisations is not empty %}
-        <table class="push--bottom">
-            <thead>
-                <tr>
-                    <th scope="col">{{ 'organisations' | trans({}, 'common') }}</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for organisation in user.organisations %}
-                    <tr>
-                        <td>
-                            <a class="govuk-link" href="{{ path('admin_organisation_view', { id: organisation.id }) }}">{{ organisation.name }}</a>
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    {% endif %}
     {% if action is defined %}
         {% if action == 'edit' %}
             {% if is_granted('delete-user', user) %}

--- a/client/src/AppBundle/Resources/views/Admin/Index/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Index/index.html.twig
@@ -89,7 +89,7 @@
                 <tr class="behat-region-user-{{ user.email | behat_namify }}">
                     <td>
                         {% if user.roleName != 'ROLE_ADMIN' or is_granted('ROLE_ADMIN') %}
-                            <a href='{{ path('admin_editUser', { filter: user.id }) }}'
+                            <a href='{{ path('admin_user_view', { id: user.id }) }}'
                                class="behat-link-user-{{ user.email | behat_namify }} govuk-!-font-weight-bold">{{ fullName }}</a><br>
                         {% endif %}
                         <div class="govuk-caption-m">

--- a/client/src/AppBundle/Resources/views/Admin/Index/viewUser.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Index/viewUser.html.twig
@@ -1,0 +1,111 @@
+{% extends 'AppBundle:Layouts:application.html.twig' %}
+{% import 'AppBundle:Macros:macros.html.twig' as macros %}
+
+{% trans_default_domain "admin" %}
+{% set page = 'viewUser' %}
+
+{% set navSection = 'users' %}
+
+{% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
+{% block pageTitle %}{{ user.fullName }}{% endblock %}
+
+{% block actions %}
+    <a href="{{ path('admin_editUser', {'filter': user.id}) }}" role="button" data-module="govuk-button" class="govuk-button govuk-button--secondary">
+        {{ (page ~ '.summary.editUser') | trans }}
+    </a>
+{% endblock %}
+
+{% block supportTitleTop %}
+    <span class="govuk-caption-xl">{{ (page ~ '.supportTitle') | trans }}</span>
+{% endblock %}
+
+{% block breadcrumbs %}
+    {{ macros.breadcrumbsArray([
+        { href: url('admin_homepage'), text: 'Admin' },
+        { href: url('admin_homepage'), text: 'Users' },
+        { text: user.fullName }
+    ]) }}
+{% endblock %}
+
+{% block pageContent %}
+
+    {% if 'ROLE_LAY_DEPUTY' == user.roleName %}
+        {% set numberOfClients = user.clients | length %}
+        {% set firstClient = numberOfClients > 0 ? (user.clients | first) : null %}
+        {% set reports = firstClient ? firstClient.reports : [] %}
+        {% set reportsCount = reports | length %}
+    {% endif %}
+
+    <dl class="govuk-summary-list govuk-summary-list--no-border">
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+                {{ (page ~ '.summary.email') | trans }}
+            </dt>
+            <dd class="govuk-summary-list__value">
+                {{ user.email }}
+            </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+                {{ (page ~ '.summary.postcode') | trans }}
+            </dt>
+            <dd class="govuk-summary-list__value">
+                {{ user.addressPostcode }}
+            </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+                {{ (page ~ '.summary.role') | trans }}
+            </dt>
+            <dd class="govuk-summary-list__value">
+                {{ user.roleFullName }}
+            </dd>
+        </div>
+    </dl>
+
+    {% if 'ROLE_LAY_DEPUTY' == user.roleName and numberOfClients > 0 %}
+        <h2 class="govuk-heading-m">{{ (page ~ '.clientTable.heading') | trans }}</h2>
+        <table class="width-two-thirds">
+            <thead>
+            <tr>
+                <th>{{ (page ~ '.clientTable.header.client') | trans }}</th>
+                <th class="numeric-small text--right">{{ (page ~ '.clientTable.header.caseNumber') | trans }}</th>
+                <th class="numeric-small text--right">{{ (page ~ '.clientTable.header.reports') | trans }}</th>
+            </tr>
+
+            </thead>
+
+            {% for client in user.clients %}
+                <tr>
+                    <td>{{ client.firstname|title }} {{ client.lastname|title }}</td>
+                    <td class="numeric-small">{{ client.caseNumber|upper }}</td>
+                    <td class="numeric-small">{{ client.reports | length }}</td>
+                </tr>
+            {% endfor %}
+        </table>
+    {% else %}
+        <h2 class="govuk-heading-m">{{ (page ~ '.organisationsTable.heading') | trans }}</h2>
+        {% if user.organisations is not empty %}
+            <table class="width-two-thirds">
+                <thead>
+                <tr>
+                    <th>{{ (page ~ '.organisationsTable.header.organisation') | trans }}</th>
+                    <th class="numeric-small text--right">{{ (page ~ '.organisationsTable.header.identifier') | trans }}</th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for organisation in user.organisations %}
+                    <tr>
+                        <td>
+                            <a class="govuk-link" href="{{ path('admin_organisation_view', { id: organisation.id }) }}">{{ organisation.name }}</a>
+                        </td>
+                        <td class="numeric-small">{{ organisation.emailIdentifier }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            {{ (page ~ '.organisationsTable.noOrganisations') | trans }}
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/client/src/AppBundle/Resources/views/Admin/Organisation/view.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Organisation/view.html.twig
@@ -137,7 +137,7 @@
             {% for user in organisation.users %}
                 <tr class="govuk-table__row behat-region-org-{{ user.fullName | behat_namify }}">
                     <td class="govuk-table__cell">
-                        <a class="govuk-link" href="{{ url('admin_editUser', { filter: user.id }) }}">
+                        <a class="govuk-link" href="{{ url('admin_user_view', { id: user.id }) }}">
                             {{ user.fullName }}
                         </a>
                     </td>


### PR DESCRIPTION
## Purpose
Currently clicking on a user in admin directs straight to the edit page of that user. This task creates a view page, which will be the landing page for all links linking to the deputy page, and will contain an "Edit user" button that will direct to the edit page. The flow is identical to the Organisation pages in admin.

Fixes DDPB-3082

## Approach
Added a new route/controller/view for the view page
Update existing links to land on the view page instead of edit page
Move the table data from the edit page view into the view page view
Updated behat tests to account for the extra page in the journey


## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
