### PR TITLE
DDPB-3384: Improve readability of DocumentSync errors

### DIFF
--- a/client/app/config/services.yml
+++ b/client/app/config/services.yml
@@ -96,7 +96,10 @@ services:
 
     AppBundle\Service\DocumentSyncService:
         public: true
+        autowire: true
+        autoconfigure: true
         arguments:
             $storage: '@AppBundle\Service\File\Storage\S3Storage'
             $siriusApiGatewayClient: '@AppBundle\Service\Client\Sirius\SiriusApiGatewayClient'
             $restClient: '@AppBundle\Service\Client\RestClient'
+            $serializer: '@serializer'

--- a/client/app/config/services.yml
+++ b/client/app/config/services.yml
@@ -102,4 +102,3 @@ services:
             $storage: '@AppBundle\Service\File\Storage\S3Storage'
             $siriusApiGatewayClient: '@AppBundle\Service\Client\Sirius\SiriusApiGatewayClient'
             $restClient: '@AppBundle\Service\Client\RestClient'
-            $serializer: '@serializer'

--- a/client/src/AppBundle/Model/Sirius/SiriusApiError.php
+++ b/client/src/AppBundle/Model/Sirius/SiriusApiError.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+
+namespace AppBundle\Model\Sirius;
+
+class SiriusApiError
+{
+    /** @var string */
+    private $title, $code, $description;
+
+    /**
+     * @return string|null
+     */
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string|null $title
+     * @return SiriusApiError
+     */
+    public function setTitle(?string $title): self
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCode(): ?string
+    {
+        return $this->code;
+    }
+
+    /**
+     * @param string|null $code
+     * @return SiriusApiError
+     */
+    public function setCode(?string $code): self
+    {
+        $this->code = $code;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param string|null $description
+     * @return SiriusApiError
+     */
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+        return $this;
+    }
+}

--- a/client/src/AppBundle/Service/DocumentSyncService.php
+++ b/client/src/AppBundle/Service/DocumentSyncService.php
@@ -295,7 +295,7 @@ class DocumentSyncService
             $errorMessage = sprintf('S3 error while syncing document: %s', $e->getMessage());
         } else {
             if (method_exists($e, 'getResponse') && method_exists($e->getResponse(), 'getBody')) {
-                $errorMessage = $this->errorTranslator->translateApiError($e->getResponse()->getBody());
+                $errorMessage = $this->errorTranslator->translateApiError((string) $e->getResponse()->getBody());
             } else {
                 $errorMessage = (string) $e->getMessage();
             }

--- a/client/src/AppBundle/Service/DocumentSyncService.php
+++ b/client/src/AppBundle/Service/DocumentSyncService.php
@@ -303,4 +303,37 @@ class DocumentSyncService
 
         $this->handleDocumentStatusUpdate($documentData, $syncStatus, $errorMessage);
     }
+
+    public function translateApiError(?string $apiErrorCode)
+    {
+        $translations = [
+            'OPGDATA-API-FORBIDDEN' => 'Credentials used for integration lack correct permissions',
+            'OPGDATA-API-API_CONFIGURATION_ERROR' => 'Integration API internal error',
+            'OPGDATA-API-AUTHORIZER_CONFIGURATION_ERROR' => 'Integration API internal error',
+            'OPGDATA-API-AUTHORIZER_FAILURE' => 'Integration API internal error',
+            'OPGDATA-API-INVALIDREQUEST' => 'The body of the request is not valid',
+            'OPGDATA-API-BAD_REQUEST_PARAMETERS' => 'The parameters of the request are not valid',
+            'OPGDATA-API-SERVERERROR' => 'Integration API server error',
+            'OPGDATA-API-EXPIRED_TOKEN' => 'Auth token has expired',
+            'OPGDATA-API-INTEGRATION_FAILURE' => 'There was a problem syncing from the integration to Sirius',
+            'OPGDATA-API-INTEGRATION_TIMEOUT' => 'The sync process timed out while communicating with Sirius',
+            'OPGDATA-API-INVALID_API_KEY' => 'The API key used in the request is not valid',
+            'OPGDATA-API-INVALID_SIGNATURE' => 'The signature of the request is not valid',
+            'OPGDATA-API-MISSING_AUTHENTICATION_TOKEN' => 'Authentication token is missing from the request',
+            'OPGDATA-API-QUOTA_EXCEEDED' => 'API quota has been exceeded',
+            'OPGDATA-API-FILESIZELIMIT' => 'The size of the file exceeded the file size limit (6MB)',
+            'OPGDATA-API-NOTFOUND' => 'Invalid URL used during integration or the resource no longer exists',
+            'OPGDATA-API-THROTTLED' => 'Too many requests made - throttling in action',
+            'OPGDATA-API-UNAUTHORISED' => 'No user/auth provided during requests',
+            'OPGDATA-API-MEDIA' => 'Media type of the file is not supported',
+            'OPGDATA-API-WAF_FILTERED' => 'AWS WAF filtered this request and it was not sent to Sirius'
+        ];
+
+        if (is_null($apiErrorCode) || is_null($translations[$apiErrorCode])) {
+            return 'UNEXPECTED ERROR CODE: An unknown error occurred during document sync';
+        } else {
+            return sprintf('%s: %s', $apiErrorCode, $translations[$apiErrorCode]);
+        }
+
+    }
 }

--- a/client/src/AppBundle/Service/SiriusApiErrorTranslator.php
+++ b/client/src/AppBundle/Service/SiriusApiErrorTranslator.php
@@ -21,7 +21,7 @@ class SiriusApiErrorTranslator
 
     public function translateApiError(string $errorJson)
     {
-        $apiError = $this->serializeError($errorJson);
+        $apiError = $this->deserializeError($errorJson);
 
         $translations = [
             'OPGDATA-API-FORBIDDEN' => 'Credentials used for integration lack correct permissions',
@@ -57,7 +57,7 @@ class SiriusApiErrorTranslator
      * @param string $errorJson
      * @return SiriusApiError
      */
-    private function serializeError(string $errorJson): SiriusApiError
+    private function deserializeError(string $errorJson): SiriusApiError
     {
         $decodedJson = json_decode($errorJson, true)['errors'];
         return $this->serializer->deserialize(json_encode($decodedJson), 'AppBundle\Model\Sirius\SiriusApiError', 'json');

--- a/client/src/AppBundle/Service/SiriusApiErrorTranslator.php
+++ b/client/src/AppBundle/Service/SiriusApiErrorTranslator.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+
+namespace AppBundle\Service;
+
+
+use AppBundle\Model\Sirius\SiriusApiError;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class SiriusApiErrorTranslator
+{
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    public function __construct(SerializerInterface $serializer)
+    {
+        $this->serializer = $serializer;
+    }
+
+    public function translateApiError(string $errorJson)
+    {
+        $apiError = $this->serializeError($errorJson);
+
+        $translations = [
+            'OPGDATA-API-FORBIDDEN' => 'Credentials used for integration lack correct permissions',
+            'OPGDATA-API-API_CONFIGURATION_ERROR' => 'Integration API internal error',
+            'OPGDATA-API-AUTHORIZER_CONFIGURATION_ERROR' => 'Integration API internal error',
+            'OPGDATA-API-AUTHORIZER_FAILURE' => 'Integration API internal error',
+            'OPGDATA-API-INVALIDREQUEST' => 'The body of the request is not valid',
+            'OPGDATA-API-BAD_REQUEST_PARAMETERS' => 'The parameters of the request are not valid',
+            'OPGDATA-API-SERVERERROR' => 'Integration API server error',
+            'OPGDATA-API-EXPIRED_TOKEN' => 'Auth token has expired',
+            'OPGDATA-API-INTEGRATION_FAILURE' => 'There was a problem syncing from the integration to Sirius',
+            'OPGDATA-API-INTEGRATION_TIMEOUT' => 'The sync process timed out while communicating with Sirius',
+            'OPGDATA-API-INVALID_API_KEY' => 'The API key used in the request is not valid',
+            'OPGDATA-API-INVALID_SIGNATURE' => 'The signature of the request is not valid',
+            'OPGDATA-API-MISSING_AUTHENTICATION_TOKEN' => 'Authentication token is missing from the request',
+            'OPGDATA-API-QUOTA_EXCEEDED' => 'API quota has been exceeded',
+            'OPGDATA-API-FILESIZELIMIT' => 'The size of the file exceeded the file size limit (6MB)',
+            'OPGDATA-API-NOTFOUND' => 'Invalid URL used during integration or the resource no longer exists',
+            'OPGDATA-API-THROTTLED' => 'Too many requests made - throttling in action',
+            'OPGDATA-API-UNAUTHORISED' => 'No user/auth provided during requests',
+            'OPGDATA-API-MEDIA' => 'Media type of the file is not supported',
+            'OPGDATA-API-WAF_FILTERED' => 'AWS WAF filtered this request and it was not sent to Sirius'
+        ];
+
+        if (is_null($apiError->getCode()) || is_null($translations[$apiError->getCode()])) {
+            return 'UNEXPECTED ERROR CODE: An unknown error occurred during document sync';
+        } else {
+            return sprintf('%s: %s', $apiError->getCode(), $translations[$apiError->getCode()]);
+        }
+    }
+
+    /**
+     * @param string $errorJson
+     * @return SiriusApiError
+     */
+    private function serializeError(string $errorJson): SiriusApiError
+    {
+        $decodedJson = json_decode($errorJson, true)['errors'];
+        return $this->serializer->deserialize(json_encode($decodedJson), 'AppBundle\Model\Sirius\SiriusApiError', 'json');
+    }
+}

--- a/client/tests/phpunit/Service/DocumentSyncServiceTest.php
+++ b/client/tests/phpunit/Service/DocumentSyncServiceTest.php
@@ -7,6 +7,7 @@ use AppBundle\Entity\Report\Document;
 use AppBundle\Entity\Report\Report;
 use AppBundle\Entity\Report\ReportSubmission;
 use AppBundle\Model\Sirius\QueuedDocumentData;
+use AppBundle\Model\Sirius\SiriusApiError;
 use AppBundle\Service\Client\RestClient;
 use AppBundle\Service\Client\Sirius\SiriusApiGatewayClient;
 use AppBundle\Service\File\Storage\S3Storage;
@@ -23,6 +24,8 @@ use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 
 class DocumentSyncServiceTest extends KernelTestCase
 {
@@ -501,58 +504,5 @@ class DocumentSyncServiceTest extends KernelTestCase
         $sut->syncDocument($queuedDocumentData);
 
         self::assertNotContains($queuedDocumentData->getReportSubmissionId(), $sut->getSyncErrorSubmissionIds());
-    }
-
-    /**
-     * @test
-     * @dataProvider errorProvider
-     */
-    public function translateApiErrors(?string $apiErrorCode, string $expectedTranslation)
-    {
-        $sut = new DocumentSyncService($this->s3Storage->reveal(), $this->siriusApiGatewayClient->reveal(), $this->restClient->reveal());
-
-        $translation = $sut->translateApiError($apiErrorCode);
-        $expectedError = sprintf('%s: %s', $apiErrorCode, $expectedTranslation);
-
-        self::assertEquals($expectedError, $translation);
-    }
-
-    public function errorProvider()
-    {
-        return [
-            'ACCESS_DENIED' => ['OPGDATA-API-FORBIDDEN', 'Credentials used for integration lack correct permissions'],
-            'API_CONFIGURATION_ERROR' => ['OPGDATA-API-API_CONFIGURATION_ERROR', 'Integration API internal error'],
-            'AUTHORIZER_CONFIGURATION_ERROR' => ['OPGDATA-API-AUTHORIZER_CONFIGURATION_ERROR', 'Integration API internal error'],
-            'AUTHORIZER_FAILURE' => ['OPGDATA-API-AUTHORIZER_FAILURE', 'Integration API internal error'],
-            'BAD_REQUEST_BODY' => ['OPGDATA-API-INVALIDREQUEST', 'The body of the request is not valid'],
-            'BAD_REQUEST_PARAMETERS' => ['OPGDATA-API-BAD_REQUEST_PARAMETERS', 'The parameters of the request are not valid'],
-            'DEFAULT_5XX' => ['OPGDATA-API-SERVERERROR', 'Integration API server error'],
-            'EXPIRED_TOKEN' => ['OPGDATA-API-EXPIRED_TOKEN', 'Auth token has expired'],
-            'INTEGRATION_FAILURE' => ['OPGDATA-API-INTEGRATION_FAILURE', 'There was a problem syncing from the integration to Sirius'],
-            'INTEGRATION_TIMEOUT' => ['OPGDATA-API-INTEGRATION_TIMEOUT', 'The sync process timed out while communicating with Sirius'],
-            'INVALID_API_KEY' => ['OPGDATA-API-INVALID_API_KEY', 'The API key used in the request is not valid'],
-            'INVALID_SIGNATURE' => ['OPGDATA-API-INVALID_SIGNATURE', 'The signature of the request is not valid'],
-            'MISSING_AUTHENTICATION_TOKEN' => ['OPGDATA-API-MISSING_AUTHENTICATION_TOKEN', 'Authentication token is missing from the request'],
-            'QUOTA_EXCEEDED' => ['OPGDATA-API-QUOTA_EXCEEDED', 'API quota has been exceeded'],
-            'REQUEST_TOO_LARGE' => ['OPGDATA-API-FILESIZELIMIT', 'The size of the file exceeded the file size limit (6MB)'],
-            'RESOURCE_NOT_FOUND' => ['OPGDATA-API-NOTFOUND', 'Invalid URL used during integration or the resource no longer exists'],
-            'THROTTLED' => ['OPGDATA-API-THROTTLED', 'Too many requests made - throttling in action'],
-            'UNAUTHORIZED' => ['OPGDATA-API-UNAUTHORISED', 'No user/auth provided during requests'],
-            'UNSUPPORTED_MEDIA_TYPE' => ['OPGDATA-API-MEDIA', 'Media type of the file is not supported'],
-            'WAF_FILTERED' => ['OPGDATA-API-WAF_FILTERED', 'AWS WAF filtered this request and it was not sent to Sirius'],
-        ];
-    }
-
-    /**
-     * @test
-     */
-    public function translateApiErrors_unexpected_error_code()
-    {
-        $sut = new DocumentSyncService($this->s3Storage->reveal(), $this->siriusApiGatewayClient->reveal(), $this->restClient->reveal());
-
-        $translation = $sut->translateApiError("SOME ERROR CODE WE HAVEN'T SEEN BEFORE");
-        $expectedError = 'UNEXPECTED ERROR CODE: An unknown error occurred during document sync';
-
-        self::assertEquals($expectedError, $translation);
     }
 }

--- a/client/tests/phpunit/Service/DocumentSyncServiceTest.php
+++ b/client/tests/phpunit/Service/DocumentSyncServiceTest.php
@@ -502,4 +502,57 @@ class DocumentSyncServiceTest extends KernelTestCase
 
         self::assertNotContains($queuedDocumentData->getReportSubmissionId(), $sut->getSyncErrorSubmissionIds());
     }
+
+    /**
+     * @test
+     * @dataProvider errorProvider
+     */
+    public function translateApiErrors(?string $apiErrorCode, string $expectedTranslation)
+    {
+        $sut = new DocumentSyncService($this->s3Storage->reveal(), $this->siriusApiGatewayClient->reveal(), $this->restClient->reveal());
+
+        $translation = $sut->translateApiError($apiErrorCode);
+        $expectedError = sprintf('%s: %s', $apiErrorCode, $expectedTranslation);
+
+        self::assertEquals($expectedError, $translation);
+    }
+
+    public function errorProvider()
+    {
+        return [
+            'ACCESS_DENIED' => ['OPGDATA-API-FORBIDDEN', 'Credentials used for integration lack correct permissions'],
+            'API_CONFIGURATION_ERROR' => ['OPGDATA-API-API_CONFIGURATION_ERROR', 'Integration API internal error'],
+            'AUTHORIZER_CONFIGURATION_ERROR' => ['OPGDATA-API-AUTHORIZER_CONFIGURATION_ERROR', 'Integration API internal error'],
+            'AUTHORIZER_FAILURE' => ['OPGDATA-API-AUTHORIZER_FAILURE', 'Integration API internal error'],
+            'BAD_REQUEST_BODY' => ['OPGDATA-API-INVALIDREQUEST', 'The body of the request is not valid'],
+            'BAD_REQUEST_PARAMETERS' => ['OPGDATA-API-BAD_REQUEST_PARAMETERS', 'The parameters of the request are not valid'],
+            'DEFAULT_5XX' => ['OPGDATA-API-SERVERERROR', 'Integration API server error'],
+            'EXPIRED_TOKEN' => ['OPGDATA-API-EXPIRED_TOKEN', 'Auth token has expired'],
+            'INTEGRATION_FAILURE' => ['OPGDATA-API-INTEGRATION_FAILURE', 'There was a problem syncing from the integration to Sirius'],
+            'INTEGRATION_TIMEOUT' => ['OPGDATA-API-INTEGRATION_TIMEOUT', 'The sync process timed out while communicating with Sirius'],
+            'INVALID_API_KEY' => ['OPGDATA-API-INVALID_API_KEY', 'The API key used in the request is not valid'],
+            'INVALID_SIGNATURE' => ['OPGDATA-API-INVALID_SIGNATURE', 'The signature of the request is not valid'],
+            'MISSING_AUTHENTICATION_TOKEN' => ['OPGDATA-API-MISSING_AUTHENTICATION_TOKEN', 'Authentication token is missing from the request'],
+            'QUOTA_EXCEEDED' => ['OPGDATA-API-QUOTA_EXCEEDED', 'API quota has been exceeded'],
+            'REQUEST_TOO_LARGE' => ['OPGDATA-API-FILESIZELIMIT', 'The size of the file exceeded the file size limit (6MB)'],
+            'RESOURCE_NOT_FOUND' => ['OPGDATA-API-NOTFOUND', 'Invalid URL used during integration or the resource no longer exists'],
+            'THROTTLED' => ['OPGDATA-API-THROTTLED', 'Too many requests made - throttling in action'],
+            'UNAUTHORIZED' => ['OPGDATA-API-UNAUTHORISED', 'No user/auth provided during requests'],
+            'UNSUPPORTED_MEDIA_TYPE' => ['OPGDATA-API-MEDIA', 'Media type of the file is not supported'],
+            'WAF_FILTERED' => ['OPGDATA-API-WAF_FILTERED', 'AWS WAF filtered this request and it was not sent to Sirius'],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function translateApiErrors_unexpected_error_code()
+    {
+        $sut = new DocumentSyncService($this->s3Storage->reveal(), $this->siriusApiGatewayClient->reveal(), $this->restClient->reveal());
+
+        $translation = $sut->translateApiError("SOME ERROR CODE WE HAVEN'T SEEN BEFORE");
+        $expectedError = 'UNEXPECTED ERROR CODE: An unknown error occurred during document sync';
+
+        self::assertEquals($expectedError, $translation);
+    }
 }

--- a/client/tests/phpunit/Service/SiriusApiErrorTranslatorTest.php
+++ b/client/tests/phpunit/Service/SiriusApiErrorTranslatorTest.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+
+use AppBundle\Service\SiriusApiErrorTranslator;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+class SiriusApiErrorTranslatorTest extends KernelTestCase
+{
+    /**
+     * @var Serializer
+     */
+    private $serializer;
+
+    public function setUp(): void
+    {
+        $this->serializer = new Serializer([new ObjectNormalizer()], [new JsonEncoder()]);
+    }
+
+    /**
+     * @test
+     * @dataProvider errorProvider
+     */
+    public function translateApiErrors(?string $apiErrorCode, string $expectedTranslation)
+    {
+        $sut = new SiriusApiErrorTranslator($this->serializer);
+
+        $errorJson = sprintf('{"errors":{"id":"7d0bb9c2-76c5-4cd1-b7a4-6cc28acc197f","code":"%s","title":"Request Too Long","detail":"","meta":{"x-ray":""}}}', $apiErrorCode);
+        $translation = $sut->translateApiError($errorJson);
+        $expectedError = sprintf('%s: %s', $apiErrorCode, $expectedTranslation);
+
+        self::assertEquals($expectedError, $translation);
+    }
+
+    public function errorProvider()
+    {
+        return [
+            'ACCESS_DENIED' => ['OPGDATA-API-FORBIDDEN', 'Credentials used for integration lack correct permissions'],
+            'API_CONFIGURATION_ERROR' => ['OPGDATA-API-API_CONFIGURATION_ERROR', 'Integration API internal error'],
+            'AUTHORIZER_CONFIGURATION_ERROR' => ['OPGDATA-API-AUTHORIZER_CONFIGURATION_ERROR', 'Integration API internal error'],
+            'AUTHORIZER_FAILURE' => ['OPGDATA-API-AUTHORIZER_FAILURE', 'Integration API internal error'],
+            'BAD_REQUEST_BODY' => ['OPGDATA-API-INVALIDREQUEST', 'The body of the request is not valid'],
+            'BAD_REQUEST_PARAMETERS' => ['OPGDATA-API-BAD_REQUEST_PARAMETERS', 'The parameters of the request are not valid'],
+            'DEFAULT_5XX' => ['OPGDATA-API-SERVERERROR', 'Integration API server error'],
+            'EXPIRED_TOKEN' => ['OPGDATA-API-EXPIRED_TOKEN', 'Auth token has expired'],
+            'INTEGRATION_FAILURE' => ['OPGDATA-API-INTEGRATION_FAILURE', 'There was a problem syncing from the integration to Sirius'],
+            'INTEGRATION_TIMEOUT' => ['OPGDATA-API-INTEGRATION_TIMEOUT', 'The sync process timed out while communicating with Sirius'],
+            'INVALID_API_KEY' => ['OPGDATA-API-INVALID_API_KEY', 'The API key used in the request is not valid'],
+            'INVALID_SIGNATURE' => ['OPGDATA-API-INVALID_SIGNATURE', 'The signature of the request is not valid'],
+            'MISSING_AUTHENTICATION_TOKEN' => ['OPGDATA-API-MISSING_AUTHENTICATION_TOKEN', 'Authentication token is missing from the request'],
+            'QUOTA_EXCEEDED' => ['OPGDATA-API-QUOTA_EXCEEDED', 'API quota has been exceeded'],
+            'REQUEST_TOO_LARGE' => ['OPGDATA-API-FILESIZELIMIT', 'The size of the file exceeded the file size limit (6MB)'],
+            'RESOURCE_NOT_FOUND' => ['OPGDATA-API-NOTFOUND', 'Invalid URL used during integration or the resource no longer exists'],
+            'THROTTLED' => ['OPGDATA-API-THROTTLED', 'Too many requests made - throttling in action'],
+            'UNAUTHORIZED' => ['OPGDATA-API-UNAUTHORISED', 'No user/auth provided during requests'],
+            'UNSUPPORTED_MEDIA_TYPE' => ['OPGDATA-API-MEDIA', 'Media type of the file is not supported'],
+            'WAF_FILTERED' => ['OPGDATA-API-WAF_FILTERED', 'AWS WAF filtered this request and it was not sent to Sirius'],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function translateApiErrors_unexpected_error_code()
+    {
+        $sut = new SiriusApiErrorTranslator($this->serializer);
+
+        $errorJson = '{"errors":{"id":"7d0bb9c2-76c5-4cd1-b7a4-6cc28acc197f","code":"AN UNEXPECTED CODE","title":"Request Too Long","detail":"","meta":{"x-ray":""}}}';
+        $translation = $sut->translateApiError($errorJson);
+        $expectedError = 'UNEXPECTED ERROR CODE: An unknown error occurred during document sync';
+
+        self::assertEquals($expectedError, $translation);
+    }
+}


### PR DESCRIPTION
## Purpose
We are currently storing the full json blob error responses from the integration API and displaying this to users in the submission admin panel. While there is some detail in the blob its not always easy to see what has gone wrong. This change translates the error types into easier to read versions.

Fixes DDPB-3384

## Approach
I've used the Open API spec as the source of truth for all the error types (https://github.com/ministryofjustice/opg-data/blob/master/docs/deputy-reporting-openapi-v1.yml). I've raised the scenario where a caseref doesn't exist within Sirius with the integrations team (https://mojdt.slack.com/archives/CBKSZGH0C/p1590577117014100?thread_ts=1590484609.003800&cid=CBKSZGH0C) as it doesn't look like we have a way to identify this right now, but this shouldn't stop us from moving ahead with this as we can update the translations at a later date.

## Learning
Mocking the Symfony serializer in tests is a pain and requires lots of set up calls. Instead I've used a real instance of the translator with two of the built in encoders/normalizers.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
