### PR TITLE
DDPB-3248: Updates tag colours

### DIFF
--- a/client/src/AppBundle/Resources/views/Report/Balance/balance.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Balance/balance.html.twig
@@ -37,7 +37,7 @@
                     </div>
                 </div>
             {% endset %}
-            {{ macros.notification(report.isDue ? 'error' : 'notice', alertMessage) }}
+            {{ macros.notification(report.isDue and report.balanceMismatchExplanation is null ? 'error' : 'info', alertMessage) }}
         {% endif %}
     {% endif %}
 

--- a/client/src/AppBundle/Twig/ComponentsExtension.php
+++ b/client/src/AppBundle/Twig/ComponentsExtension.php
@@ -102,6 +102,7 @@ class ComponentsExtension extends AbstractExtension
 
                     case 'needs-attention':
                     case 'unsubmitted':
+                    case 'not-matching':
                         return 'govuk-tag--red';
 
                     case 'done':

--- a/client/src/AppBundle/Twig/ComponentsExtension.php
+++ b/client/src/AppBundle/Twig/ComponentsExtension.php
@@ -93,21 +93,21 @@ class ComponentsExtension extends AbstractExtension
                 switch ($status) {
                     case 'notStarted':
                     case 'not-started':
-                        return 'opg-tag--not-started';
+                        return 'govuk-tag--grey';
 
                     case 'notFinished':
                     case 'active':
                     case 'incomplete':
-                        return 'opg-tag--notice';
+                        return 'govuk-tag--yellow';
 
                     case 'needs-attention':
                     case 'unsubmitted':
-                        return 'opg-tag--warning';
+                        return 'govuk-tag--red';
 
                     case 'done':
                     case 'submitted':
                     case 'readyToSubmit':
-                        return 'opg-tag--success';
+                        return 'govuk-tag--green';
 
                     default:
                         return '';


### PR DESCRIPTION
## Purpose
Update tag to use gov-uk classes, using colours based on prototype discussed in the ticket.

Fixes DDPB-3248

## Approach
The tag code is shared throughout the app so just a case of updating that central code.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
