### PR TITLE
DDPB-3456: Fix to include discharged clients in report submission fil…

### DIFF
--- a/api/src/AppBundle/Entity/Repository/ReportSubmissionRepository.php
+++ b/api/src/AppBundle/Entity/Repository/ReportSubmissionRepository.php
@@ -7,6 +7,7 @@ use AppBundle\Entity\Report\Document;
 use AppBundle\Entity\Report\ReportSubmission;
 use AppBundle\Entity\User;
 use Doctrine\ORM\EntityRepository;
+use Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter;
 
 class ReportSubmissionRepository extends EntityRepository
 {
@@ -138,6 +139,10 @@ class ReportSubmissionRepository extends EntityRepository
         $order = 'ASC'
     ) {
 
+        /** @var SoftDeleteableFilter $filter */
+        $filter = $this->_em->getFilters()->getFilter('softdeleteable');
+        $filter->disableForEntity(Client::class);
+
         $qb = $this->createQueryBuilder('rs');
         $qb
             ->leftJoin('rs.createdBy', 'cb')
@@ -159,6 +164,8 @@ class ReportSubmissionRepository extends EntityRepository
             ->setParameter(':fromDate', $this->determineCreatedFromDate($fromDate))
             ->setParameter(':toDate', $this->determineCreatedToDate($toDate))
             ->orderBy('rs.' . $orderBy, $order);
+
+        $this->_em->getFilters()->enable('softdeleteable');
 
         return $qbSelect->getQuery()->getResult();
     }


### PR DESCRIPTION
## Purpose
Fix the error that occurs when a dat file is attempting to download for a period that contains a report submission for a discharged client.

Fixes DDPB-3456

## Approach
The current query does not join on clients that are soft deleted, so the transformer produces a fatal error when attempting to call `->getCaseNumber()` on a null object instead of a `Client`.

To include soft deleted clients in our queries we temporarily disable the `softdeletable` filter.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
