### PR TITLE
DDPB-3454: Adds synchronisation fields to checklist by moving existin…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ workflows:
           requires: [ reset environment ]
           filters: { branches: { ignore: [ master ] } }
           task_name: integration_test
-          timeout: 2100
+          timeout: 2400
 
       - client-unit-test:
           name: client unit test

--- a/api/app/DoctrineMigrations/Version242.php
+++ b/api/app/DoctrineMigrations/Version242.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version242 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE checklist ADD synchronised_by INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE checklist ADD opg_uuid VARCHAR(36) DEFAULT NULL');
+        $this->addSql('ALTER TABLE checklist ADD synchronisation_status VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE checklist ADD synchronisation_time TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL');
+        $this->addSql('ALTER TABLE checklist ADD synchronisation_error VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE checklist ADD CONSTRAINT FK_5C696D2F1EFE0E05 FOREIGN KEY (synchronised_by) REFERENCES dd_user (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_5C696D2F1EFE0E05 ON checklist (synchronised_by)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE checklist DROP CONSTRAINT FK_5C696D2F1EFE0E05');
+        $this->addSql('DROP INDEX IDX_5C696D2F1EFE0E05');
+        $this->addSql('ALTER TABLE checklist DROP synchronised_by');
+        $this->addSql('ALTER TABLE checklist DROP opg_uuid');
+        $this->addSql('ALTER TABLE checklist DROP synchronisation_status');
+        $this->addSql('ALTER TABLE checklist DROP synchronisation_time');
+        $this->addSql('ALTER TABLE checklist DROP synchronisation_error');
+    }
+}

--- a/api/src/AppBundle/Controller/Report/DocumentController.php
+++ b/api/src/AppBundle/Controller/Report/DocumentController.php
@@ -171,7 +171,7 @@ class DocumentController extends RestController
         $document = $em->getRepository(Document::class)->find($id);
 
         $serialisedGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['document-synchronisation', 'document-id'];
+            ? (array) $request->query->get('groups') : ['synchronisation', 'document-id'];
 
         $this->setJmsSerialiserGroups($serialisedGroups);
 

--- a/api/src/AppBundle/Controller/Report/ReportSubmissionController.php
+++ b/api/src/AppBundle/Controller/Report/ReportSubmissionController.php
@@ -38,7 +38,7 @@ class ReportSubmissionController extends RestController
         'user-rolename',
         'user-teamname',
         'documents',
-        'document-synchronisation',
+        'synchronisation',
     ];
 
     /**

--- a/api/src/AppBundle/Entity/Report/Checklist.php
+++ b/api/src/AppBundle/Entity/Report/Checklist.php
@@ -3,6 +3,8 @@
 namespace AppBundle\Entity\Report;
 
 use AppBundle\Entity\ReportInterface;
+use AppBundle\Entity\SynchronisableInterface;
+use AppBundle\Entity\SynchronisableTrait;
 use AppBundle\Entity\Traits\ModifyAudit;
 use AppBundle\Entity\User;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -15,9 +17,10 @@ use JMS\Serializer\Annotation as JMS;
  * @ORM\Table(name="checklist")
  * @ORM\Entity()
  */
-class Checklist
+class Checklist implements SynchronisableInterface
 {
     use ModifyAudit;
+    use SynchronisableTrait;
 
     /**
      * @var int
@@ -311,6 +314,14 @@ class Checklist
      * @JMS\Groups({"report-checklist"})
      */
     private $buttonClicked;
+
+    /**
+     * @var string|null
+     * @JMS\Type("string")
+     * @JMS\Groups({"report-submission"})
+     * @ORM\Column(name="opg_uuid", type="string", length=36, nullable=true)
+     */
+    private $uuid;
 
     /**
      * @param Report $report
@@ -911,6 +922,26 @@ class Checklist
     public function setButtonClicked($buttonClicked)
     {
         $this->buttonClicked = $buttonClicked;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUuid(): ?string
+    {
+        return $this->uuid;
+    }
+
+    /**
+     * @param string|null $uuid
+     *
+     * @return $this
+     */
+    public function setUuid(?string $uuid)
+    {
+        $this->uuid = $uuid;
+
         return $this;
     }
 }

--- a/api/src/AppBundle/Entity/Report/Document.php
+++ b/api/src/AppBundle/Entity/Report/Document.php
@@ -3,6 +3,8 @@
 namespace AppBundle\Entity\Report;
 
 use AppBundle\Entity\Ndr\Ndr;
+use AppBundle\Entity\SynchronisableInterface;
+use AppBundle\Entity\SynchronisableTrait;
 use AppBundle\Entity\Traits\CreationAudit;
 use AppBundle\Entity\User;
 use DateTime;
@@ -19,15 +21,10 @@ use JMS\Serializer\Annotation as JMS;
  *     })
  * @ORM\Entity(repositoryClass="AppBundle\Entity\Repository\DocumentRepository")
  */
-class Document
+class Document implements SynchronisableInterface
 {
     use CreationAudit;
-
-    const SYNC_STATUS_QUEUED = 'QUEUED';
-    const SYNC_STATUS_IN_PROGRESS = 'IN_PROGRESS';
-    const SYNC_STATUS_SUCCESS = 'SUCCESS';
-    const SYNC_STATUS_TEMPORARY_ERROR = 'TEMPORARY_ERROR';
-    const SYNC_STATUS_PERMANENT_ERROR = 'PERMANENT_ERROR';
+    use SynchronisableTrait;
 
     /**
      * @var int
@@ -103,39 +100,6 @@ class Document
      * @ORM\JoinColumn(name="report_submission_id", referencedColumnName="id", onDelete="SET NULL")
      */
     private $reportSubmission;
-
-    /**
-     * @var string|null
-     * @JMS\Type("string")
-     * @JMS\Groups({"document-synchronisation"})
-     * @ORM\Column(name="synchronisation_status", type="string", options={"default": null}, nullable=true)
-     */
-    private $synchronisationStatus;
-
-    /**
-     * @var DateTime|null
-     * @JMS\Type("DateTime")
-     * @JMS\Groups({"document-synchronisation"})
-     * @ORM\Column(name="synchronisation_time", type="datetime", options={"default": null}, nullable=true)
-     */
-    private $synchronisationTime;
-
-    /**
-     * @var string|null
-     * @JMS\Type("string")
-     * @JMS\Groups({"document-synchronisation"})
-     * @ORM\Column(name="synchronisation_error", type="string", options={"default": null}, nullable=true)
-     */
-    private $synchronisationError;
-
-    /**
-     * @var User|null
-     * @JMS\Type("AppBundle\Entity\User")
-     * @JMS\Groups({"document-synchronisation"})
-     * @ORM\ManyToOne(targetEntity="AppBundle\Entity\User")
-     * @ORM\JoinColumn(name="synchronised_by", referencedColumnName="id", onDelete="SET NULL")
-     */
-    private $synchronisedBy;
 
     /**
      * Document constructor.
@@ -299,87 +263,5 @@ class Document
     private function isTransactionDocument()
     {
         return strpos($this->getFileName(), 'DigiRepTransactions') !== false;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getSynchronisationStatus(): ?string
-    {
-        return $this->synchronisationStatus;
-    }
-
-    /**
-     * @param string $status
-     * @return $this
-     */
-    public function setSynchronisationStatus(?string $status)
-    {
-        if (!in_array($status, array(
-            self::SYNC_STATUS_QUEUED,
-            self::SYNC_STATUS_IN_PROGRESS,
-            self::SYNC_STATUS_SUCCESS,
-            self::SYNC_STATUS_TEMPORARY_ERROR,
-            self::SYNC_STATUS_PERMANENT_ERROR,
-        ))) {
-            throw new \InvalidArgumentException('Invalid synchronisation status');
-        }
-
-        $this->synchronisationStatus = $status;
-        return $this;
-    }
-
-    /**
-     * @return DateTime|null
-     */
-    public function getSynchronisationTime(): ?DateTime
-    {
-        return $this->synchronisationTime;
-    }
-
-    /**
-     * @param DateTime $time
-     * @return $this
-     */
-    public function setSynchronisationTime(?DateTime $time)
-    {
-        $this->synchronisationTime = $time;
-        return $this;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getSynchronisationError(): ?string
-    {
-        return $this->synchronisationError;
-    }
-
-    /**
-     * @param string $error
-     * @return $this
-     */
-    public function setSynchronisationError(?string $error)
-    {
-        $this->synchronisationError = $error;
-        return $this;
-    }
-
-    /**
-     * @return User|null
-     */
-    public function getSynchronisedBy(): ?User
-    {
-        return $this->synchronisedBy;
-    }
-
-    /**
-     * @param User $user
-     * @return $this
-     */
-    public function setSynchronisedBy(?User $user)
-    {
-        $this->synchronisedBy = $user;
-        return $this;
     }
 }

--- a/api/src/AppBundle/Entity/SynchronisableInterface.php
+++ b/api/src/AppBundle/Entity/SynchronisableInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AppBundle\Entity;
+
+interface SynchronisableInterface
+{
+    const SYNC_STATUS_QUEUED = 'QUEUED';
+    const SYNC_STATUS_IN_PROGRESS = 'IN_PROGRESS';
+    const SYNC_STATUS_SUCCESS = 'SUCCESS';
+    const SYNC_STATUS_TEMPORARY_ERROR = 'TEMPORARY_ERROR';
+    const SYNC_STATUS_PERMANENT_ERROR = 'PERMANENT_ERROR';
+}

--- a/api/src/AppBundle/Entity/SynchronisableTrait.php
+++ b/api/src/AppBundle/Entity/SynchronisableTrait.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace AppBundle\Entity;
+
+use DateTime;
+
+trait SynchronisableTrait
+{
+    /**
+     * @var string|null
+     * @JMS\Type("string")
+     * @JMS\Groups({"synchronisation"})
+     * @ORM\Column(name="synchronisation_status", type="string", options={"default": null}, nullable=true)
+     */
+    protected $synchronisationStatus;
+
+    /**
+     * @var DateTime|null
+     * @JMS\Type("DateTime")
+     * @JMS\Groups({"synchronisation"})
+     * @ORM\Column(name="synchronisation_time", type="datetime", options={"default": null}, nullable=true)
+     */
+    protected $synchronisationTime;
+
+    /**
+     * @var string|null
+     * @JMS\Type("string")
+     * @JMS\Groups({"synchronisation"})
+     * @ORM\Column(name="synchronisation_error", type="string", options={"default": null}, nullable=true)
+     */
+    protected $synchronisationError;
+
+    /**
+     * @var User|null
+     * @JMS\Type("AppBundle\Entity\User")
+     * @JMS\Groups({"synchronisation"})
+     * @ORM\ManyToOne(targetEntity="AppBundle\Entity\User")
+     * @ORM\JoinColumn(name="synchronised_by", referencedColumnName="id", onDelete="SET NULL")
+     */
+    protected $synchronisedBy;
+
+    /**
+     * @return string|null
+     */
+    public function getSynchronisationStatus(): ?string
+    {
+        return $this->synchronisationStatus;
+    }
+
+    /**
+     * @param string $status
+     * @return $this
+     */
+    public function setSynchronisationStatus(?string $status)
+    {
+        if (!in_array($status, array(
+            self::SYNC_STATUS_QUEUED,
+            self::SYNC_STATUS_IN_PROGRESS,
+            self::SYNC_STATUS_SUCCESS,
+            self::SYNC_STATUS_TEMPORARY_ERROR,
+            self::SYNC_STATUS_PERMANENT_ERROR,
+        ))) {
+            throw new \InvalidArgumentException('Invalid synchronisation status');
+        }
+
+        $this->synchronisationStatus = $status;
+        return $this;
+    }
+
+    /**
+     * @return DateTime|null
+     */
+    public function getSynchronisationTime(): ?DateTime
+    {
+        return $this->synchronisationTime;
+    }
+
+    /**
+     * @param DateTime $time
+     * @return $this
+     */
+    public function setSynchronisationTime(?DateTime $time)
+    {
+        $this->synchronisationTime = $time;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSynchronisationError(): ?string
+    {
+        return $this->synchronisationError;
+    }
+
+    /**
+     * @param string $error
+     * @return $this
+     */
+    public function setSynchronisationError(?string $error)
+    {
+        $this->synchronisationError = $error;
+        return $this;
+    }
+
+    /**
+     * @return User|null
+     */
+    public function getSynchronisedBy(): ?User
+    {
+        return $this->synchronisedBy;
+    }
+
+    /**
+     * @param User $user
+     * @return $this
+     */
+    public function setSynchronisedBy(?User $user)
+    {
+        $this->synchronisedBy = $user;
+        return $this;
+    }
+}

--- a/client/src/AppBundle/Entity/Report/Checklist.php
+++ b/client/src/AppBundle/Entity/Report/Checklist.php
@@ -4,6 +4,8 @@ namespace AppBundle\Entity\Report;
 
 use AppBundle\Entity\Report\Traits\HasReportTrait;
 use AppBundle\Entity\ReportInterface;
+use AppBundle\Entity\SynchronisableInterface;
+use AppBundle\Entity\SynchronisableTrait;
 use AppBundle\Entity\Traits\ModifyAudit;
 use AppBundle\Validator\Constraints as AppAssert;
 use JMS\Serializer\Annotation as JMS;
@@ -13,10 +15,11 @@ use Symfony\Component\Validator\Constraints as Assert;
  * Checklist.
  *
  */
-class Checklist
+class Checklist implements SynchronisableInterface
 {
     use HasReportTrait;
     use ModifyAudit;
+    use SynchronisableTrait;
 
     /**
      * @var int
@@ -294,6 +297,12 @@ class Checklist
      * @JMS\Groups({"report-checklist"})
      */
     protected $buttonClicked;
+
+    /**
+     * @var string|null
+     * @JMS\Type("string")
+     */
+    private $uuid;
 
     /**
      * Checklist constructor.
@@ -907,6 +916,26 @@ class Checklist
     public function setButtonClicked($buttonClicked)
     {
         $this->buttonClicked = $buttonClicked;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUuid(): ?string
+    {
+        return $this->uuid;
+    }
+
+    /**
+     * @param string|null $uuid
+     *
+     * @return $this
+     */
+    public function setUuid(?string $uuid)
+    {
+        $this->uuid = $uuid;
+
         return $this;
     }
 }

--- a/client/src/AppBundle/Entity/Report/Document.php
+++ b/client/src/AppBundle/Entity/Report/Document.php
@@ -4,6 +4,8 @@ namespace AppBundle\Entity\Report;
 
 use AppBundle\Entity\DocumentInterface;
 use AppBundle\Entity\Report\Traits\HasReportTrait;
+use AppBundle\Entity\SynchronisableInterface;
+use AppBundle\Entity\SynchronisableTrait;
 use AppBundle\Entity\Traits\CreationAudit;
 use AppBundle\Entity\User;
 use DateTime;
@@ -15,18 +17,14 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 /**
  * @Assert\Callback(callback="isValidForReport", groups={"document"})
  */
-class Document implements DocumentInterface
+class Document implements DocumentInterface, SynchronisableInterface
 {
     const FILE_NAME_MAX_LENGTH = 255;
     const MAX_UPLOAD_PER_REPORT = 100;
-    const SYNC_STATUS_QUEUED = 'QUEUED';
-    const SYNC_STATUS_IN_PROGRESS = 'IN_PROGRESS';
-    const SYNC_STATUS_SUCCESS = 'SUCCESS';
-    const SYNC_STATUS_TEMPORARY_ERROR = 'TEMPORARY_ERROR';
-    const SYNC_STATUS_PERMANENT_ERROR = 'PERMANENT_ERROR';
 
     use CreationAudit;
     use HasReportTrait;
+    use SynchronisableTrait;
 
     /**
      * @param ExecutionContextInterface $context
@@ -121,34 +119,6 @@ class Document implements DocumentInterface
      * @JMS\Groups({"document-report-subnmission"})
      */
     private $reportSubmission;
-
-    /**
-     * @var string|null
-     * @JMS\Type("string")
-     * @JMS\Groups({"document-synchronisation"})
-     */
-    private $synchronisationStatus;
-
-    /**
-     * @var DateTime|null
-     * @JMS\Type("DateTime")
-     * @JMS\Groups({"document-synchronisation"})
-     */
-    private $synchronisationTime;
-
-    /**
-     * @var string|null
-     * @JMS\Type("string")
-     * @JMS\Groups({"document-synchronisation"})
-     */
-    private $synchronisationError;
-
-    /**
-     * @var User|null
-     * @JMS\Type("AppBundle\Entity\User")
-     * @JMS\Groups({"document-synchronisation"})
-     */
-    private $synchronisedBy;
 
     /**
      * @return int
@@ -258,88 +228,6 @@ class Document implements DocumentInterface
     {
         $this->reportSubmission = $repostSubmission;
 
-        return $this;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getSynchronisationStatus(): ?string
-    {
-        return $this->synchronisationStatus;
-    }
-
-    /**
-     * @param string $status
-     * @return $this
-     */
-    public function setSynchronisationStatus(?string $status)
-    {
-        if (!in_array($status, array(
-            self::SYNC_STATUS_QUEUED,
-            self::SYNC_STATUS_IN_PROGRESS,
-            self::SYNC_STATUS_SUCCESS,
-            self::SYNC_STATUS_TEMPORARY_ERROR,
-            self::SYNC_STATUS_PERMANENT_ERROR,
-        ))) {
-            throw new \InvalidArgumentException('Invalid synchronisation status');
-        }
-
-        $this->synchronisationStatus = $status;
-        return $this;
-    }
-
-    /**
-     * @return DateTime|null
-     */
-    public function getSynchronisationTime(): ?DateTime
-    {
-        return $this->synchronisationTime;
-    }
-
-    /**
-     * @param DateTime $time
-     * @return $this
-     */
-    public function setSynchronisationTime(?DateTime $time)
-    {
-        $this->synchronisationTime = $time;
-        return $this;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getSynchronisationError(): ?string
-    {
-        return $this->synchronisationError;
-    }
-
-    /**
-     * @param string $error
-     * @return $this
-     */
-    public function setSynchronisationError(?string $error)
-    {
-        $this->synchronisationError = $error;
-        return $this;
-    }
-
-    /**
-     * @return User|null
-     */
-    public function getSynchronisedBy(): ?User
-    {
-        return $this->synchronisedBy;
-    }
-
-    /**
-     * @param User $user
-     * @return $this
-     */
-    public function setSynchronisedBy(?User $user)
-    {
-        $this->synchronisedBy = $user;
         return $this;
     }
 

--- a/client/src/AppBundle/Entity/SynchronisableInterface.php
+++ b/client/src/AppBundle/Entity/SynchronisableInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AppBundle\Entity;
+
+interface SynchronisableInterface
+{
+    const SYNC_STATUS_QUEUED = 'QUEUED';
+    const SYNC_STATUS_IN_PROGRESS = 'IN_PROGRESS';
+    const SYNC_STATUS_SUCCESS = 'SUCCESS';
+    const SYNC_STATUS_TEMPORARY_ERROR = 'TEMPORARY_ERROR';
+    const SYNC_STATUS_PERMANENT_ERROR = 'PERMANENT_ERROR';
+}

--- a/client/src/AppBundle/Entity/SynchronisableTrait.php
+++ b/client/src/AppBundle/Entity/SynchronisableTrait.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace AppBundle\Entity;
+
+use DateTime;
+
+trait SynchronisableTrait
+{
+    /**
+     * @var string|null
+     * @JMS\Type("string")
+     * @JMS\Groups({"synchronisation"})
+     */
+    protected $synchronisationStatus;
+
+    /**
+     * @var DateTime|null
+     * @JMS\Type("DateTime")
+     * @JMS\Groups({"synchronisation"})
+     */
+    protected $synchronisationTime;
+
+    /**
+     * @var string|null
+     * @JMS\Type("string")
+     * @JMS\Groups({"synchronisation"})
+     */
+    protected $synchronisationError;
+
+    /**
+     * @var User|null
+     * @JMS\Type("AppBundle\Entity\User")
+     * @JMS\Groups({"synchronisation"})
+     */
+    protected $synchronisedBy;
+
+    /**
+     * @return string|null
+     */
+    public function getSynchronisationStatus(): ?string
+    {
+        return $this->synchronisationStatus;
+    }
+
+    /**
+     * @param string $status
+     * @return $this
+     */
+    public function setSynchronisationStatus(?string $status)
+    {
+        if (!in_array($status, array(
+            self::SYNC_STATUS_QUEUED,
+            self::SYNC_STATUS_IN_PROGRESS,
+            self::SYNC_STATUS_SUCCESS,
+            self::SYNC_STATUS_TEMPORARY_ERROR,
+            self::SYNC_STATUS_PERMANENT_ERROR,
+        ))) {
+            throw new \InvalidArgumentException('Invalid synchronisation status');
+        }
+
+        $this->synchronisationStatus = $status;
+        return $this;
+    }
+
+    /**
+     * @return DateTime|null
+     */
+    public function getSynchronisationTime(): ?DateTime
+    {
+        return $this->synchronisationTime;
+    }
+
+    /**
+     * @param DateTime $time
+     * @return $this
+     */
+    public function setSynchronisationTime(?DateTime $time)
+    {
+        $this->synchronisationTime = $time;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSynchronisationError(): ?string
+    {
+        return $this->synchronisationError;
+    }
+
+    /**
+     * @param string $error
+     * @return $this
+     */
+    public function setSynchronisationError(?string $error)
+    {
+        $this->synchronisationError = $error;
+        return $this;
+    }
+
+    /**
+     * @return User|null
+     */
+    public function getSynchronisedBy(): ?User
+    {
+        return $this->synchronisedBy;
+    }
+
+    /**
+     * @param User $user
+     * @return $this
+     */
+    public function setSynchronisedBy(?User $user)
+    {
+        $this->synchronisedBy = $user;
+        return $this;
+    }
+}


### PR DESCRIPTION
## Purpose
Add sync fields to `checklist` database records to enable sync functionality.

Fixes DDPB-3454

## Approach
The equivalent fields already exist on the `Document` entity, so I created a trait for them both to use. Unfortunately traits do not support `const`s, but interfaces do, so to prevent re writing those, I put them in an interface which both entities now implement.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
