### PR TITLE
DDPB-3415: Resolve made date issue preventing access to checklist

### DIFF
--- a/api/src/AppBundle/Entity/Client.php
+++ b/api/src/AppBundle/Entity/Client.php
@@ -919,6 +919,10 @@ class Client implements ClientInterface
      */
     public function getExpectedReportStartDate($year = NULL)
     {
+        if (is_null($this->getCourtDate())) {
+            return null;
+        }
+
         // Default year to current
         if (!isset($year)) {
             $year = date('Y');

--- a/api/tests/AppBundle/Entity/ClientTest.php
+++ b/api/tests/AppBundle/Entity/ClientTest.php
@@ -56,7 +56,7 @@ class ClientTest extends TestCase
             [new \DateTime('2016-02-29'), 2020, new \DateTime('2019-03-01')],
             [new \DateTime('2020-02-29'), 2020, new \DateTime('2020-02-29')],
             [new \DateTime('2020-02-29'), 2021, new \DateTime('2020-02-29')],
-            [new \DateTime('2020-02-29'), 2022, new \DateTime('2021-03-01')],
+            [new \DateTime('2020-02-29'), 2022, new \DateTime('2021-03-01')]
         ];
     }
 
@@ -91,6 +91,12 @@ class ClientTest extends TestCase
         );
     }
 
+    public function testGetExpectedStartDate_null_court_date()
+    {
+        $this->object->setCourtDate(null);
+        $this->assertEquals(null, $this->object->getExpectedReportStartDate(2020));
+    }
+
     /**
      * @dataProvider courtDateExpectedEndDateProvider
      */
@@ -101,5 +107,11 @@ class ClientTest extends TestCase
             $expected->format('d/m/Y'),
             $this->object->getExpectedReportEndDate($year)->format('d/m/Y')
         );
+    }
+
+    public function testGetExpectedEndDate_null_court_date()
+    {
+        $this->object->setCourtDate(null);
+        $this->assertEquals(null, $this->object->getExpectedReportEndDate(2020));
     }
 }

--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/partials/_deputy-and-client-info.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/partials/_deputy-and-client-info.html.twig
@@ -12,7 +12,7 @@
 <div class="govuk-inset-text govuk-!-margin-top-2">
     <div class="behat-region-court-date">
         <strong>{{ 'courtOrderDate' | trans({}, 'common') }}:</strong>
-        {% if report.client.courtDate is not null %}
+        {% if report.client.courtDate is defined and report.client.courtDate is not null %}
             {{ report.client.courtDate | date("j M Y") }}
         {% else %}
             Not known


### PR DESCRIPTION
## Purpose
Case managers had reported an application error when accessing report checklists for reports that had a made date set to null. This change ensures users can access a report checklist despite a missing made date.

Fixes DDPB-3415

## Approach
The issue actually turned out to be linked to the calculated report start and end date as this relies on there being a court date set on a report. I've returned null for the calculated start date (and by proxy, end date) which seems to have solved the issue. I've tested submitting reports and NDRs without a client court date and all seems well locally and the checklist is accessible.

**Can anyone think of any other unintended implications of returning null for an expected start and end date?** I've followed through the usages in the code and they seem minimal but I'm not sure where we are requesting this virtual property as part of an API call.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
