### PR TITLE
Add Pa11y accessibility test tool to CircleCI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ workflows:
 
       - pa11y-ci:
           name: accessibility test
-          filters: { branches: { ignore: [ master ] } }s
+          filters: { branches: { ignore: [ master ] } }
 
       - terraform-command:
           name: apply environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -508,8 +508,7 @@ jobs:
             docker-compose --project-name pa11y-ci exec frontend touch /var/www/.enableProd
             docker-compose --project-name pa11y-ci exec admin touch /var/www/.enableProd
             docker-compose --project-name pa11y-ci exec api touch /var/www/.enableProd
-            docker-compose -f docker-compose.yml --project-name pa11y-ci run pa11y || echo "Pa11y found some errors"
-
+            docker-compose -f docker-compose.yml --project-name pa11y-ci run pa11y
 
   run-task:
     executor: terraform/terraform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -508,7 +508,7 @@ jobs:
             docker-compose --project-name pa11y-ci exec frontend touch /var/www/.enableProd
             docker-compose --project-name pa11y-ci exec admin touch /var/www/.enableProd
             docker-compose --project-name pa11y-ci exec api touch /var/www/.enableProd
-            docker-compose -f docker-compose.yml --project-name pa11y-ci run pa11y try{pa11y-ci}catch(error){console.log("error")}
+            docker-compose -f docker-compose.yml --project-name pa11y-ci run pa11y || echo "Pa11y found some errors"
 
 
   run-task:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -503,7 +503,7 @@ jobs:
       - run:
           name: Run pa11y
           command: |
-            docker-compose -f docker-compose.yml up -d pa11y
+            docker-compose -f docker-compose.yml --project-name pa11y-ci up -d pa11y
             docker-compose -f docker-compose.yml --project-name pa11y-ci run pa11y pa11y-ci
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -511,6 +511,9 @@ jobs:
             sleep 10
             docker-compose -f docker-compose.yml run pa11y pa11y-ci || echo "Pa11y found some errors"
 
+            # The || operator ensures that if pa11y exits with an error code, we echo an informative message
+            # instead of failing the job and the pipeline too.
+
   run-task:
     executor: terraform/terraform
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,7 @@ workflows:
 
       - pa11y-ci:
           name: accessibility test
-          filters: { branches: { ignore: [ master ] } }
-          timeout: 300
+          filters: { branches: { ignore: [ master ] } }s
 
       - terraform-command:
           name: apply environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -504,7 +504,7 @@ jobs:
       - run:
           name: Run pa11y
           command: |
-            docker-compose -f docker-compose.yml --project-name pa11y-ci up -d frontend
+            docker-compose -f docker-compose.yml up --no-deps frontend api redisfront router localstack postgres admin redisadmin pa11y
             docker-compose -f docker-compose.yml --project-name pa11y-ci run pa11y pa11y-ci
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -503,7 +503,7 @@ jobs:
       - run:
           name: Run pa11y
           command: |
-            docker-compose -f docker-compose.yml up --no-deps frontend api redisfront router localstack postgres admin redisadmin pa11y
+            docker-compose -f docker-compose.yml up -d pa11y
             docker-compose -f docker-compose.yml --project-name pa11y-ci run pa11y pa11y-ci
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -491,8 +491,8 @@ jobs:
           flags: phpunit
 
   pa11y-ci:
-    docker:
-      - image: circleci/php
+    machine:
+      - image: circleci/classic:latest
     steps:
       - setup_remote_docker
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -508,6 +508,7 @@ jobs:
             docker-compose --project-name pa11y-ci exec frontend touch /var/www/.enableProd
             docker-compose --project-name pa11y-ci exec admin touch /var/www/.enableProd
             docker-compose --project-name pa11y-ci exec api touch /var/www/.enableProd
+            sleep 5
             docker-compose -f docker-compose.yml --project-name pa11y-ci run pa11y pa11y-ci || echo "Pa11y found some errors"
 
   run-task:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,18 @@ workflows:
           task_name: reset_database
           timeout: 180
 
+      - pa11yci/a11y-audit:
+          name: accessibility test
+          requires: [ apply environment ]
+          filters: { branches: { ignore: [ master ] } }
+          custom_url_command: |
+            if [[ -f /tmp/workspace/preview-url ]]; then
+              sed -i -e "s#https://digideps.local/#`cat https://BRANCHNAME.digideps.local/`#g" .pa11yci
+            fi
+            if [[ -f /tmp/workspace/preview-url ]]; then
+              sed -i -e "s#https://admin.digideps.local/#`cat https://admin.BRANCHNAME.digideps.local/`#g" .pa11yci
+            fi
+
       - run-task:
           name: integration test
           requires: [ reset environment ]
@@ -43,7 +55,7 @@ workflows:
 
       - run-task:
           name: backup environment
-          requires: [ api unit test, client unit test, integration test ]
+          requires: [ api unit test, client unit test, integration test, accessibility test ]
           filters: { branches: { ignore: [ master ] } }
           task_name: backup
 
@@ -211,6 +223,7 @@ workflows:
 orbs:
   aws-cli: circleci/aws-cli@0.1.13
   slack: circleci/slack@3.3.0
+  pa11yci: nebulab/pa11yci@1.0.0
   ecs_helper:
     commands:
       install:
@@ -413,7 +426,7 @@ jobs:
           root: .
           paths:
             - ./docker-images.tar
-            - ./lambda_functions/layer.tar
+            - ./lambda_functions/layer.targi
 
   client-unit-test:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,11 @@ workflows:
           name: build pr
           filters: { branches: { ignore: [ master ] } }
 
+      - pa11y-ci:
+          name: accessibility test
+          filters: { branches: { ignore: [ master ] } }
+          timeout: 300
+
       - terraform-command:
           name: apply environment
           requires: [ build pr, lint terraform ]
@@ -40,12 +45,6 @@ workflows:
           name: api unit test
           requires: [ apply environment ]
           filters: { branches: { ignore: [ master ] } }
-
-      - pa11y-ci:
-          name: accessibility test
-          requires: [ integration test ]
-          filters: { branches: { ignore: [ master ] } }
-          timeout: 300
 
       - run-task:
           name: backup environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -504,11 +504,12 @@ jobs:
       - run:
           name: Run pa11y
           command: |
-            docker-compose -f docker-compose.yml --project-name pa11y-ci up -d pa11y
-            docker-compose --project-name pa11y-ci exec frontend touch /var/www/.enableProdMode
-            docker-compose --project-name pa11y-ci exec admin touch /var/www/.enableProdMode
-            docker-compose --project-name pa11y-ci exec api touch /var/www/.enableProdMode
-            docker-compose -f docker-compose.yml --project-name pa11y-ci run pa11y pa11y-ci || echo "Pa11y found some errors"
+            docker-compose -f docker-compose.yml up -d pa11y
+            docker-compose exec frontend touch /var/www/.enableProdMode
+            docker-compose exec admin touch /var/www/.enableProdMode
+            docker-compose exec api touch /var/www/.enableProdMode
+            sleep 10
+            docker-compose -f docker-compose.yml run pa11y pa11y-ci || echo "Pa11y found some errors"
 
   run-task:
     executor: terraform/terraform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,6 @@ workflows:
           name: build pr
           filters: { branches: { ignore: [ master ] } }
 
-      - pa11y-ci:
-          name: accessibility test
-          filters: { branches: { ignore: [ master ] } }
-
       - terraform-command:
           name: apply environment
           requires: [ build pr, lint terraform ]
@@ -42,6 +38,11 @@ workflows:
 
       - api-unit-tests:
           name: api unit test
+          requires: [ apply environment ]
+          filters: { branches: { ignore: [ master ] } }
+
+      - pa11y-ci:
+          name: accessibility test
           requires: [ apply environment ]
           filters: { branches: { ignore: [ master ] } }
 
@@ -504,7 +505,10 @@ jobs:
           name: Run pa11y
           command: |
             docker-compose -f docker-compose.yml --project-name pa11y-ci up -d pa11y
-            docker-compose -f docker-compose.yml --project-name pa11y-ci run pa11y pa11y-ci
+            docker-compose --project-name pa11y-ci exec frontend touch /var/www/.enableProd
+            docker-compose --project-name pa11y-ci exec admin touch /var/www/.enableProd
+            docker-compose --project-name pa11y-ci exec api touch /var/www/.enableProd
+            docker-compose -f docker-compose.yml --project-name pa11y-ci run pa11y try{pa11y-ci}catch(error){console.log("error")}
 
 
   run-task:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -508,7 +508,7 @@ jobs:
             docker-compose --project-name pa11y-ci exec frontend touch /var/www/.enableProd
             docker-compose --project-name pa11y-ci exec admin touch /var/www/.enableProd
             docker-compose --project-name pa11y-ci exec api touch /var/www/.enableProd
-            docker-compose -f docker-compose.yml --project-name pa11y-ci run pa11y
+            docker-compose -f docker-compose.yml --project-name pa11y-ci run pa11y pa11y-ci || echo "Pa11y found some errors"
 
   run-task:
     executor: terraform/terraform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,13 +24,6 @@ workflows:
           task_name: reset_database
           timeout: 180
 
-      - pa11yci/a11y-audit:
-          name: accessibility test
-          requires: [ apply environment ]
-          filters: { branches: { ignore: [ master ] } }
-          custom_url_command: |
-              sed -i -e "s#ddpbXXXX#`cat `${CIRCLE_BRANCH//-}#g" .pa11yci
-
       - run-task:
           name: integration test
           requires: [ reset environment ]
@@ -48,9 +41,15 @@ workflows:
           requires: [ apply environment ]
           filters: { branches: { ignore: [ master ] } }
 
+      - pa11y-ci:
+          name: accessibility test
+          requires: [ integration test ]
+          filters: { branches: { ignore: [ master ] } }
+          timeout: 300
+
       - run-task:
           name: backup environment
-          requires: [ api unit test, client unit test, integration test, accessibility test ]
+          requires: [ api unit test, client unit test, integration test ]
           filters: { branches: { ignore: [ master ] } }
           task_name: backup
 
@@ -218,7 +217,6 @@ workflows:
 orbs:
   aws-cli: circleci/aws-cli@0.1.13
   slack: circleci/slack@3.3.0
-  pa11yci: nebulab/pa11yci@1.0.0
   ecs_helper:
     commands:
       install:
@@ -493,6 +491,24 @@ jobs:
       - codecov/upload:
           file: ./merged.xml
           flags: phpunit
+
+  pa11y-ci:
+    docker:
+      - image: circleci/php
+    steps:
+      - setup_remote_docker
+      - checkout
+      - attach_workspace: { at: ~/project }
+      - run:
+          name: Set environment
+          command: |
+            ~/project/.circleci/set_env.sh >> $BASH_ENV
+      - run:
+          name: Run pa11y
+          command: |
+            docker-compose -f docker-compose.yml --project-name pa11y-ci up -d frontend
+            docker-compose -f docker-compose.yml --project-name pa11y-ci run pa11y pa11y-ci
+
 
   run-task:
     executor: terraform/terraform

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,10 +505,9 @@ jobs:
           name: Run pa11y
           command: |
             docker-compose -f docker-compose.yml --project-name pa11y-ci up -d pa11y
-            docker-compose --project-name pa11y-ci exec frontend touch /var/www/.enableProd
-            docker-compose --project-name pa11y-ci exec admin touch /var/www/.enableProd
-            docker-compose --project-name pa11y-ci exec api touch /var/www/.enableProd
-            sleep 5
+            docker-compose --project-name pa11y-ci exec frontend touch /var/www/.enableProdMode
+            docker-compose --project-name pa11y-ci exec admin touch /var/www/.enableProdMode
+            docker-compose --project-name pa11y-ci exec api touch /var/www/.enableProdMode
             docker-compose -f docker-compose.yml --project-name pa11y-ci run pa11y pa11y-ci || echo "Pa11y found some errors"
 
   run-task:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,7 +492,7 @@ jobs:
 
   pa11y-ci:
     machine:
-      - image: circleci/classic:latest
+      image: circleci/classic:latest
     steps:
       - setup_remote_docker
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,7 +426,7 @@ jobs:
           root: .
           paths:
             - ./docker-images.tar
-            - ./lambda_functions/layer.targi
+            - ./lambda_functions/layer.tar
 
   client-unit-test:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,7 @@ workflows:
           requires: [ apply environment ]
           filters: { branches: { ignore: [ master ] } }
           custom_url_command: |
-            if [[ -f /tmp/workspace/preview-url ]]; then
               sed -i -e "s#ddpbXXXX#`cat `${CIRCLE_BRANCH//-}#g" .pa11yci
-            fi
 
       - run-task:
           name: integration test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,7 @@ workflows:
           filters: { branches: { ignore: [ master ] } }
           custom_url_command: |
             if [[ -f /tmp/workspace/preview-url ]]; then
-              sed -i -e "s#https://digideps.local/#`cat https://BRANCHNAME.digideps.local/`#g" .pa11yci
-            fi
-            if [[ -f /tmp/workspace/preview-url ]]; then
-              sed -i -e "s#https://admin.digideps.local/#`cat https://admin.BRANCHNAME.digideps.local/`#g" .pa11yci
+              sed -i -e "s#ddpbXXXX#`cat `${CIRCLE_BRANCH//-}#g" .pa11yci
             fi
 
       - run-task:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -494,7 +494,6 @@ jobs:
     machine:
       image: circleci/classic:latest
     steps:
-      - setup_remote_docker
       - checkout
       - attach_workspace: { at: ~/project }
       - run:

--- a/.pa11yci
+++ b/.pa11yci
@@ -12,7 +12,7 @@
    },
    "urls":[
       {
-         "url":"https://digideps.local/login",
+         "url":"ddpbXXXX.complete-deputy-report.service.gov.uk",
          "actions":[
             "set field #login_email to bobby.blue@example.com",
             "set field #login_password to Abcd1234",
@@ -20,7 +20,7 @@
          ]
       },
       {
-         "url":"https://digideps.local/report/58/overview"
+         "url":"ddpbXXXX.complete-deputy-report.service.gov.uk"
       }
    ]
 }

--- a/.pa11yci
+++ b/.pa11yci
@@ -8,7 +8,8 @@
       },
       "hideElements":"svg",
       "timeout":100000,
-      "wait":5000
+      "wait":5000,
+      "level": "none"
    },
    "urls":[
       {

--- a/.pa11yci
+++ b/.pa11yci
@@ -1,0 +1,26 @@
+{
+   "defaults":{
+      "chromeLaunchConfig":{
+         "ignoreHTTPSErrors":false,
+         "args":[
+            "--ignore-certificate-errors"
+         ]
+      },
+      "hideElements":"svg",
+      "timeout":100000,
+      "wait":5000
+   },
+   "urls":[
+      {
+         "url":"https://digideps.local/login",
+         "actions":[
+            "set field #login_email to bobby.blue@example.com",
+            "set field #login_password to Abcd1234",
+            "click element #login_login"
+         ]
+      },
+      {
+         "url":"https://digideps.local/report/58/overview"
+      }
+   ]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,12 @@ services:
             - php
             - scripts/localstack-init.php
 
+    pa11y:
+        build:
+            context: ./pa11y
+        depends_on:
+            - frontend
+
     frontend:
         build:
             context: ./client

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,11 +54,6 @@ services:
             context: ./pa11y
         depends_on:
             - frontend
-        networks:
-            default:
-                aliases:
-                    - www.digideps.local
-                    - digideps.local
 
     frontend:
         build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,11 @@ services:
             context: ./pa11y
         depends_on:
             - frontend
+        networks:
+            default:
+                aliases:
+                    - www.digideps.local
+                    - digideps.local
 
     frontend:
         build:

--- a/pa11y/.pa11yci
+++ b/pa11y/.pa11yci
@@ -8,7 +8,7 @@
          ]
       },
       "hideElements":"svg",
-      "timeout":30000,
+      "timeout":60000,
       "wait":5000
    },
    "urls":[

--- a/pa11y/.pa11yci
+++ b/pa11y/.pa11yci
@@ -18,10 +18,12 @@
             "set field #login_email to bobby.blue@example.com",
             "set field #login_password to Abcd1234",
             "click element #login_login"
-         ]
+         ],
+         "screenCapture": "screenshots/login.png"
       },
       {
-         "url": "https://digideps.local"
+         "url": "https://digideps.local",
+         "screenCapture": "screenshots/index.png"
       }
    ]
 }

--- a/pa11y/.pa11yci
+++ b/pa11y/.pa11yci
@@ -13,7 +13,7 @@
    },
    "urls":[
       {
-         "url": "https://digideps.local/login",
+         "url": "https://frontend:8070/login",
          "actions": [
             "set field #login_email to bobby.blue@example.com",
             "set field #login_password to Abcd1234",
@@ -21,7 +21,7 @@
          ]
       },
       {
-         "url": "https://digideps.local"
+         "url": "https://frontend:8070"
       }
    ]
 }

--- a/pa11y/.pa11yci
+++ b/pa11y/.pa11yci
@@ -10,11 +10,12 @@
       "hideElements":"svg",
       "timeout":100000,
       "wait":5000,
-      "level": "none"
+      "level": "none",
+      "threshold": 1000
    },
    "urls":[
       {
-         "url": "https://digideps.local/login",
+         "url": "https://frontend/login",
          "actions": [
             "set field #login_email to bobby.blue@example.com",
             "set field #login_password to Abcd1234",
@@ -22,7 +23,7 @@
          ]
       },
       {
-         "url": "https://digideps.local"
+         "url": "https://frontend"
       }
    ]
 }

--- a/pa11y/.pa11yci
+++ b/pa11y/.pa11yci
@@ -8,10 +8,8 @@
          ]
       },
       "hideElements":"svg",
-      "timeout":100000,
-      "wait":5000,
-      "level": "none",
-      "threshold": 1000
+      "timeout":30000,
+      "wait":5000
    },
    "urls":[
       {

--- a/pa11y/.pa11yci
+++ b/pa11y/.pa11yci
@@ -3,7 +3,8 @@
       "chromeLaunchConfig":{
          "ignoreHTTPSErrors":false,
          "args":[
-            "--ignore-certificate-errors"
+            "--ignore-certificate-errors",
+            "--no-sandbox"
          ]
       },
       "hideElements":"svg",
@@ -13,15 +14,15 @@
    },
    "urls":[
       {
-         "url":"ddpbXXXX.complete-deputy-report.service.gov.uk",
-         "actions":[
+         "url": "https://digideps.local/login",
+         "actions": [
             "set field #login_email to bobby.blue@example.com",
             "set field #login_password to Abcd1234",
             "click element #login_login"
          ]
       },
       {
-         "url":"ddpbXXXX.complete-deputy-report.service.gov.uk"
+         "url": "https://digideps.local"
       }
    ]
 }

--- a/pa11y/.pa11yci
+++ b/pa11y/.pa11yci
@@ -13,7 +13,7 @@
    },
    "urls":[
       {
-         "url": "https://frontend:8070/login",
+         "url": "https://frontend/login",
          "actions": [
             "set field #login_email to bobby.blue@example.com",
             "set field #login_password to Abcd1234",
@@ -21,7 +21,7 @@
          ]
       },
       {
-         "url": "https://frontend:8070"
+         "url": "https://frontend"
       }
    ]
 }

--- a/pa11y/.pa11yci
+++ b/pa11y/.pa11yci
@@ -13,7 +13,7 @@
    },
    "urls":[
       {
-         "url": "https://frontend/login",
+         "url": "https://digideps.local/login",
          "actions": [
             "set field #login_email to bobby.blue@example.com",
             "set field #login_password to Abcd1234",
@@ -21,7 +21,7 @@
          ]
       },
       {
-         "url": "https://frontend"
+         "url": "https://digideps.local"
       }
    ]
 }

--- a/pa11y/Dockerfile
+++ b/pa11y/Dockerfile
@@ -8,8 +8,7 @@ RUN apk add --no-cache \
       freetype-dev \
       harfbuzz \
       ca-certificates \
-      ttf-freefont \
-
+      ttf-freefont
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \

--- a/pa11y/Dockerfile
+++ b/pa11y/Dockerfile
@@ -20,34 +20,12 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
 # Puppeteer v1.19.0 works with Chromium 77.
 RUN yarn add puppeteer@1.19.0
 
-# Add user so we don't need --no-sandbox.
-#RUN addgroup -S pptruser && adduser -S -g pptruser pptruser \
-#    && mkdir -p /home/pptruser/Downloads /app \
-#    && chown -R pptruser:pptruser /home/pptruser \
-#    && chown -R pptruser:pptruser /app
-
-# Run everything after as non-privileged user.
-#USER pptruser
-
-#FROM node:14.5.0 AS node
 WORKDIR /home/node/app
-
 
 RUN npm -g config set user root
 
-#RUN mkdir global
-#RUN chmod 777 /home/node/app/global
-#RUN npm install puppeteer --unsafe-perm=true
-
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD = false
-#RUN npm config set prefix /home/node/app/global
 
 RUN npm install -g pa11y-ci
 
-#RUN ldd /usr/local/lib/node_modules/pa11y-ci/node_modules/puppeteer/.local-chromium/linux-686378/chrome-linux/chrome | grep not
-
 COPY .pa11yci .
-
-#RUN pa11y-ci > output.txt
-
-#RUN cat output.txt

--- a/pa11y/Dockerfile
+++ b/pa11y/Dockerfile
@@ -1,0 +1,53 @@
+FROM node:14.5.0-alpine3.10
+
+# Installs latest Chromium (77) package.
+RUN apk add --no-cache \
+      chromium \
+      nss \
+      freetype \
+      freetype-dev \
+      harfbuzz \
+      ca-certificates \
+      ttf-freefont \
+      nodejs \
+      yarn
+
+
+# Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+# Puppeteer v1.19.0 works with Chromium 77.
+RUN yarn add puppeteer@1.19.0
+
+# Add user so we don't need --no-sandbox.
+#RUN addgroup -S pptruser && adduser -S -g pptruser pptruser \
+#    && mkdir -p /home/pptruser/Downloads /app \
+#    && chown -R pptruser:pptruser /home/pptruser \
+#    && chown -R pptruser:pptruser /app
+
+# Run everything after as non-privileged user.
+#USER pptruser
+
+#FROM node:14.5.0 AS node
+WORKDIR /home/node/app
+
+
+RUN npm -g config set user root
+
+#RUN mkdir global
+#RUN chmod 777 /home/node/app/global
+#RUN npm install puppeteer --unsafe-perm=true
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD = false
+#RUN npm config set prefix /home/node/app/global
+
+RUN npm install -g pa11y-ci
+
+#RUN ldd /usr/local/lib/node_modules/pa11y-ci/node_modules/puppeteer/.local-chromium/linux-686378/chrome-linux/chrome | grep not
+
+COPY .pa11yci .
+
+#RUN pa11y-ci > output.txt
+
+#RUN cat output.txt

--- a/pa11y/Dockerfile
+++ b/pa11y/Dockerfile
@@ -9,8 +9,6 @@ RUN apk add --no-cache \
       harfbuzz \
       ca-certificates \
       ttf-freefont \
-      nodejs \
-      yarn
 
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
@@ -18,7 +16,7 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
     PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 # Puppeteer v1.19.0 works with Chromium 77.
-RUN yarn add puppeteer@1.19.0
+RUN npm i puppeteer@1.19.0
 
 WORKDIR /home/node/app
 


### PR DESCRIPTION
## Purpose
Add Pa11y Accessibility testing tool to pipeline to alert developers to any areas of the service that may cause issues to users who are using other tools to view webpages.

Fixes DDPB-3325

## Approach
Added a pa11y job into the config for CircleCI. This jobs runs the pa11y container/service. The container grabs all the dependencies needed to run the pa11y tool and brings in the config file pa11y needs. 

After the pa11y container is finished being brought up, prod mode is enabled is remove the symfony profiler from display. The job waits for a small amount of time before running the pa11y test.

During the test, pa11y will report any errors it detects. The command to run the pa11y test ensures that the job, and therefore the pipeline, does not fail when an error is detected.

## Learning
Learnt how to create and configure jobs in CircleCI through the config.yml file. 
Learnt how to create a Docker service and configure dependencies and networks.
Learnt how to install packages in a Docker container through the Dockerfile.
Learnt how to configure pa11y tool to run on multiple URLs.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
