### PR TITLE
DDPB-3437: Increase file upload limit from 20 to 100

### DIFF
--- a/client/docker/confd/templates/pool.conf.tmpl
+++ b/client/docker/confd/templates/pool.conf.tmpl
@@ -528,7 +528,7 @@ catch_workers_output = yes
 ;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
 access.log = /dev/null
 
-; Support uploading 50 files at once
+; Support uploading 100 files at once
 php_value[max_file_uploads] = 100
 
 php_flag[display_errors] = off

--- a/client/docker/confd/templates/pool.conf.tmpl
+++ b/client/docker/confd/templates/pool.conf.tmpl
@@ -528,6 +528,7 @@ catch_workers_output = yes
 ;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
 access.log = /dev/null
 
+; Support uploading 50 files at once
 php_value[max_file_uploads] = 100
 
 php_flag[display_errors] = off

--- a/client/docker/confd/templates/pool.conf.tmpl
+++ b/client/docker/confd/templates/pool.conf.tmpl
@@ -528,6 +528,8 @@ catch_workers_output = yes
 ;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
 access.log = /dev/null
 
+php_value[max_file_uploads] = 100
+
 php_flag[display_errors] = off
 
 php_admin_value[memory_limit] = 256M


### PR DESCRIPTION
## Purpose
We noticed during testing some of the document bugs tickets that you could select more than 20 images to upload but only 20 would be attached with no errors displayed to users. This isn't a great user experience and makes testing the document sync feature slower.

Fixes DDPB-3437

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
