### PR TITLE
DDPB-3336: Audit for account information - user role

### DIFF
--- a/api/src/AppBundle/Controller/UserController.php
+++ b/api/src/AppBundle/Controller/UserController.php
@@ -126,6 +126,8 @@ class UserController extends RestController
 
         $data = $this->deserializeBodyContent($request);
         $this->populateUser($requestedUser, $data);
+
+        // check if rolename in data - if so add audit log
         $this->userService->editUser($originalUser, $requestedUser);
 
         return ['id' => $requestedUser->getId()];

--- a/client/app/config/services.yml
+++ b/client/app/config/services.yml
@@ -103,3 +103,7 @@ services:
             $storage: '@AppBundle\Service\File\Storage\S3Storage'
             $siriusApiGatewayClient: '@AppBundle\Service\Client\Sirius\SiriusApiGatewayClient'
             $restClient: '@AppBundle\Service\Client\RestClient'
+
+    AppBundle\Controller\SettingsController:
+        autowire: true
+        autoconfigure: true

--- a/client/app/config/services.yml
+++ b/client/app/config/services.yml
@@ -107,3 +107,7 @@ services:
     AppBundle\Controller\SettingsController:
         autowire: true
         autoconfigure: true
+
+    AppBundle\Controller\Org\OrganisationController:
+        autowire: true
+        autoconfigure: true

--- a/client/src/AppBundle/Controller/Admin/AdController.php
+++ b/client/src/AppBundle/Controller/Admin/AdController.php
@@ -56,7 +56,7 @@ class AdController extends AbstractController
 
                     return $this->redirectToRoute('ad_homepage', [
                         'userAdded'=>$response->getId(),
-                        //'order_by'=>'id',
+                        //'order_by'=>'id's,
                         //'sort_order'=>'DESC',
                     ]);
                 } catch (RestClientException $e) {

--- a/client/src/AppBundle/Controller/Admin/Client/ClientController.php
+++ b/client/src/AppBundle/Controller/Admin/Client/ClientController.php
@@ -87,7 +87,7 @@ class ClientController extends AbstractController
         $this->getRestClient()->delete('client/' . $id . '/delete');
 
         $logger->notice('', $auditEvents->clientDischarged(
-            AuditEvents::CLIENT_DISCHARGED_ADMIN_TRIGGER,
+            AuditEvents::TRIGGER_ADMIN_BUTTON,
             $client->getCaseNumber(),
             $this->getUser()->getEmail(),
             $deputy->getFullName(),

--- a/client/src/AppBundle/Controller/SettingsController.php
+++ b/client/src/AppBundle/Controller/SettingsController.php
@@ -161,6 +161,7 @@ class SettingsController extends AbstractController
                         AuditEvents::TRIGGER_DEPUTY_USER,
                         $oldRole,
                         $newRole,
+                        $user->getEmail(),
                         $user->getEmail()
                     );
 

--- a/client/src/AppBundle/Controller/SettingsController.php
+++ b/client/src/AppBundle/Controller/SettingsController.php
@@ -4,16 +4,51 @@ namespace AppBundle\Controller;
 
 use AppBundle\Entity as EntityDir;
 use AppBundle\Form as FormDir;
+use AppBundle\Service\Audit\AuditEvents;
+use AppBundle\Service\Logger;
+use AppBundle\Service\Mailer\MailFactory;
+use AppBundle\Service\Mailer\MailSender;
 use AppBundle\Service\Redirector;
+use AppBundle\Service\Time\DateTimeProvider;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\File\Exception\AccessDeniedException;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class SettingsController extends AbstractController
 {
+    /** @var MailFactory */
+    private $mailFactory;
+
+    /** @var MailSender */
+    private $mailSender;
+
+    /** @var TranslatorInterface */
+    private $translator;
+
+    /** @var Logger */
+    private $logger;
+
+    /** @var DateTimeProvider */
+    private $dateTimeProvider;
+
+    public function __construct(
+        MailFactory $mailFactory,
+        MailSender $mailSender,
+        TranslatorInterface $translator,
+        Logger $logger,
+        DateTimeProvider $dateTimeProvider
+    ) {
+        $this->mailFactory = $mailFactory;
+        $this->mailSender = $mailSender;
+        $this->translator = $translator;
+        $this->logger = $logger;
+        $this->dateTimeProvider = $dateTimeProvider;
+    }
+
     /**
      * @Route("/deputyship-details", name="account_settings")
      * @Route("/org/settings", name="org_settings")
@@ -118,7 +153,17 @@ class SettingsController extends AbstractController
             $deputy = $form->getData();
 
             if ($form->has('removeAdmin') && !empty($form->get('removeAdmin')->getData())) {
+                $oldRole = $user->getRoleName();
                 $newRole = $this->determineNoAdminRole();
+
+                $event = (new AuditEvents($this->dateTimeProvider))
+                    ->roleChanged(
+                        AuditEvents::TRIGGER_DEPUTY_USER,
+                        $oldRole,
+                        $newRole,
+                        $user->getEmail()
+                    );
+
                 $user->setRoleName($newRole);
 
                 $this->addFlash('notice', 'For security reasons you have been logged out because you have changed your admin rights. Please log in again below');
@@ -139,18 +184,21 @@ class SettingsController extends AbstractController
             try {
                 $this->getRestClient()->put('user/' . $user->getId(), $deputy, $jmsPutGroups);
 
+                if (isset($event, $oldRole, $newRole) && $oldRole !== $newRole) {
+                    $this->logger->notice('', $event);
+                }
+
                 if ($user->isLayDeputy()) {
                     $hydratedDeputy = $this->getUserWithData(['user-clients', 'client']);
 
-                    $updateDeputyDetailsEmail = $this->getMailFactory()->createUpdateDeputyDetailsEmail($hydratedDeputy);
-                    $this->getMailSender()->send($updateDeputyDetailsEmail, ['html']);
+                    $updateDeputyDetailsEmail = $this->mailFactory->createUpdateDeputyDetailsEmail($hydratedDeputy);
+                    $this->mailSender->send($updateDeputyDetailsEmail);
                 }
 
                 return $this->redirect($redirectRoute);
             } catch (\Throwable $e) {
-                $translator = $this->get('translator');
                 if ($e->getCode() == 422 && $form->get('email')) {
-                    $form->get('email')->addError(new FormError($translator->trans('user.email.alreadyUsed', [], 'validators')));
+                    $form->get('email')->addError(new FormError($this->translator->trans('user.email.alreadyUsed', [], 'validators')));
                 }
             }
         }

--- a/client/src/AppBundle/Entity/User.php
+++ b/client/src/AppBundle/Entity/User.php
@@ -1201,10 +1201,13 @@ class User implements AdvancedUserInterface, DeputyInterface
 
     /**
      * @param ArrayCollection $organisations
+     * @return User
      */
-    public function setOrganisations($organisations)
+    public function setOrganisations($organisations): self
     {
         $this->organisations = $organisations;
+
+        return $this;
     }
 
     /**

--- a/client/src/AppBundle/Service/Audit/AuditEvents.php
+++ b/client/src/AppBundle/Service/Audit/AuditEvents.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace AppBundle\Service\Audit;
 
@@ -10,6 +10,8 @@ final class AuditEvents
     const CLIENT_DISCHARGED = 'CLIENT_DISCHARGED';
     const CLIENT_DISCHARGED_ADMIN_TRIGGER = 'ADMIN_BUTTON';
     const CLIENT_DISCHARGED_CSV_TRIGGER = 'CSV_UPLOAD';
+    const ROLE_CHANGED = 'ROLE_CHANGED';
+    const TRIGGER_ADMIN_BUTTON = null;
 
     /**
      * @var DateTimeProvider
@@ -60,5 +62,26 @@ final class AuditEvents
             'event' => $eventName,
             'type' => 'audit'
         ];
+    }
+
+    /**
+     * @param string $trigger
+     * @param string $changedFrom
+     * @param string $changedTo
+     * @param string $changedBy
+     * @return array
+     * @throws \Exception
+     */
+    public function roleChanged(string $trigger, string $changedFrom, string $changedTo, string $changedBy): array
+    {
+        $event = [
+            'trigger' => $trigger,
+            'role_changed_from' => $changedFrom,
+            'role_changed_to' => $changedTo,
+            'changed_by' => $changedBy,
+            'changed_on' => $this->dateTimeProvider->getDateTime()->format(DateTime::ATOM),
+        ];
+
+        return $event + $this->baseEvent(AuditEvents::ROLE_CHANGED);
     }
 }

--- a/client/src/AppBundle/Service/Audit/AuditEvents.php
+++ b/client/src/AppBundle/Service/Audit/AuditEvents.php
@@ -73,7 +73,7 @@ final class AuditEvents
      * @return array
      * @throws \Exception
      */
-    public function roleChanged(string $trigger, string $changedFrom, string $changedTo, string $changedBy): array
+    public function roleChanged(string $trigger, string $changedFrom, string $changedTo, string $changedBy, string $userChanged): array
     {
         $event = [
             'trigger' => $trigger,
@@ -81,6 +81,7 @@ final class AuditEvents
             'role_changed_to' => $changedTo,
             'changed_by' => $changedBy,
             'changed_on' => $this->dateTimeProvider->getDateTime()->format(DateTime::ATOM),
+            'user_changed' => $userChanged,
         ];
 
         return $event + $this->baseEvent(AuditEvents::EVENT_ROLE_CHANGED);

--- a/client/src/AppBundle/Service/Audit/AuditEvents.php
+++ b/client/src/AppBundle/Service/Audit/AuditEvents.php
@@ -7,11 +7,12 @@ use DateTime;
 
 final class AuditEvents
 {
-    const CLIENT_DISCHARGED = 'CLIENT_DISCHARGED';
-    const CLIENT_DISCHARGED_ADMIN_TRIGGER = 'ADMIN_BUTTON';
-    const CLIENT_DISCHARGED_CSV_TRIGGER = 'CSV_UPLOAD';
-    const ROLE_CHANGED = 'ROLE_CHANGED';
-    const TRIGGER_ADMIN_BUTTON = null;
+    const EVENT_CLIENT_DISCHARGED = 'CLIENT_DISCHARGED';
+    const EVENT_ROLE_CHANGED = 'ROLE_CHANGED';
+
+    const TRIGGER_ADMIN_BUTTON = 'ADMIN_BUTTON';
+    const TRIGGER_CSV_UPLOAD = 'CSV_UPLOAD';
+    const TRIGGER_DEPUTY_USER = 'DEPUTY_USER';
 
     /**
      * @var DateTimeProvider
@@ -49,7 +50,7 @@ final class AuditEvents
             'deputyship_start_date' => $deputyshipStartDate ? $deputyshipStartDate->format(DateTime::ATOM) : null,
         ];
 
-        return $event + $this->baseEvent(AuditEvents::CLIENT_DISCHARGED);
+        return $event + $this->baseEvent(AuditEvents::EVENT_CLIENT_DISCHARGED);
     }
 
     /**
@@ -82,6 +83,6 @@ final class AuditEvents
             'changed_on' => $this->dateTimeProvider->getDateTime()->format(DateTime::ATOM),
         ];
 
-        return $event + $this->baseEvent(AuditEvents::ROLE_CHANGED);
+        return $event + $this->baseEvent(AuditEvents::EVENT_ROLE_CHANGED);
     }
 }

--- a/client/tests/phpunit/Controller/AbstractControllerTestCase.php
+++ b/client/tests/phpunit/Controller/AbstractControllerTestCase.php
@@ -58,8 +58,11 @@ abstract class AbstractControllerTestCase extends WebTestCase
     {
         if (is_null($user)) {
             $user = (new User())
+                ->setFirstname('Test')
+                ->setLastname('User')
                 ->setRoleName($roleNames[0])
-                ->setEmail('logged-in-user@email.com');
+                ->setEmail('logged-in-user@email.com')
+                ->setPhoneMain('01213214321');
         }
 
         if (is_null($user->getId())) {

--- a/client/tests/phpunit/Controller/ClientControllerTest.php
+++ b/client/tests/phpunit/Controller/ClientControllerTest.php
@@ -57,7 +57,7 @@ class ClientControllerTest extends AbstractControllerTestCase
                 'deputy_name' => 'Bjork Gudmundsdottir',
                 'discharged_on' => $this->now->format(DateTime::ATOM),
                 'deputyship_start_date' => $this->orderStartDate->format(DateTime::ATOM),
-                'event' => AuditEvents::CLIENT_DISCHARGED,
+                'event' => AuditEvents::EVENT_CLIENT_DISCHARGED,
                 'type' => 'audit'
             ];
 

--- a/client/tests/phpunit/Controller/SettingsControllerTest.php
+++ b/client/tests/phpunit/Controller/SettingsControllerTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace AppBundle\Controller;
+
+
+use AppBundle\Entity\Client;
+use AppBundle\Entity\User;
+use AppBundle\Service\Audit\AuditEvents;
+use AppBundle\Service\Logger;
+use AppBundle\Service\Mailer\MailFactory;
+use AppBundle\Service\Mailer\MailSender;
+use AppBundle\Service\Time\ClockInterface;
+use AppBundle\Service\Time\DateTimeProvider;
+use DateTime;
+use Prophecy\Argument;
+
+class SettingsControllerTest extends AbstractControllerTestCase
+{
+    /** @var DateTime */
+    private $now, $orderStartDate;
+
+    /** @var User */
+    private $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = $this->mockLoggedInUser(['ROLE_PROF_ADMIN']);
+        $this->now = new DateTime();
+        $this->orderStartDate = new DateTime('-1 Day');
+    }
+    public function testDischargeConfirmAction(): void
+    {
+        $this->restClient->put('user/1', $this->user, Argument::type('array'))->shouldBeCalled();
+        $this->restClient->get('user/1', Argument::cetera())->shouldBeCalled()->willReturn($this->user);
+
+        $this->injectProphecyService(DateTimeProvider::class, function($dateTimeProvider) {
+            $dateTimeProvider->getDateTime()->willReturn($this->now);
+        });
+
+        $this->injectProphecyService(Logger::class, function($logger) {
+            $expectedEvent = [
+                'trigger' => 'DEPUTY_USER',
+                'role_changed_from' => 'ROLE_PROF_ADMIN',
+                'role_changed_to' => 'ROLE_PROF_TEAM_MEMBER',
+                'changed_by' => $this->user->getEmail(),
+                'changed_on' => $this->now->format(DateTime::ATOM),
+                'event' => AuditEvents::EVENT_ROLE_CHANGED,
+                'type' => 'audit'
+            ];
+
+            $logger->notice('', $expectedEvent)->shouldBeCalled();
+        });
+
+        $crawler = $this->client->request('GET', "/org/settings/your-details/edit");
+        $button = $crawler->selectButton('Save');
+
+        $this->client->submit($button->form(), [
+            'profile[firstname]' => $this->user->getFirstname(),
+            'profile[lastname]' => $this->user->getLastname(),
+            'profile[phoneMain]' => $this->user->getPhoneMain(),
+            'profile[removeAdmin]' => 1,
+        ]);
+    }
+}

--- a/client/tests/phpunit/Controller/SettingsControllerTest.php
+++ b/client/tests/phpunit/Controller/SettingsControllerTest.php
@@ -30,7 +30,11 @@ class SettingsControllerTest extends AbstractControllerTestCase
         $this->now = new DateTime();
         $this->orderStartDate = new DateTime('-1 Day');
     }
-    public function testDischargeConfirmAction(): void
+
+    /**
+     * @test
+     */
+    public function profileEditAction(): void
     {
         $this->restClient->put('user/1', $this->user, Argument::type('array'))->shouldBeCalled();
         $this->restClient->get('user/1', Argument::cetera())->shouldBeCalled()->willReturn($this->user);
@@ -46,6 +50,7 @@ class SettingsControllerTest extends AbstractControllerTestCase
                 'role_changed_to' => 'ROLE_PROF_TEAM_MEMBER',
                 'changed_by' => $this->user->getEmail(),
                 'changed_on' => $this->now->format(DateTime::ATOM),
+                'user_changed' => $this->user->getEmail(),
                 'event' => AuditEvents::EVENT_ROLE_CHANGED,
                 'type' => 'audit'
             ];

--- a/client/tests/phpunit/Service/Audit/AuditEventsTest.php
+++ b/client/tests/phpunit/Service/Audit/AuditEventsTest.php
@@ -59,7 +59,7 @@ class AuditEventsTest extends TestCase
      * @test
      * @dataProvider roleChangedProvider
      */
-    public function roleChanged(string $trigger, $changedFrom, $changedTo, $changedBy): void
+    public function roleChanged(string $trigger, $changedFrom, $changedTo, $changedBy, $userChanged): void
     {
         $now = new DateTime();
         /** @var ObjectProphecy|DateTimeProvider $dateTimeProvider */
@@ -71,6 +71,7 @@ class AuditEventsTest extends TestCase
             'role_changed_from' => $changedFrom,
             'role_changed_to' => $changedTo,
             'changed_by' => $changedBy,
+            'user_changed' => $userChanged,
             'changed_on' => $now->format(DateTime::ATOM),
             'event' => AuditEvents::EVENT_ROLE_CHANGED,
             'type' => 'audit'
@@ -80,7 +81,8 @@ class AuditEventsTest extends TestCase
             $trigger,
             $changedFrom,
             $changedTo,
-            $changedBy
+            $changedBy,
+            $userChanged
         );
 
         $this->assertEquals($expected, $actual);
@@ -89,8 +91,8 @@ class AuditEventsTest extends TestCase
     public function roleChangedProvider()
     {
         return [
-            'PA to LAY' => ['ADMIN_BUTTON', 'ROLE_PA', 'ROLE_LAY_DEPUTY', 'polly.jean.harvey@test.com'],
-            'PROF to PA' => ['ADMIN_BUTTON', 'ROLE_PROF', 'ROLE_PA', 't.amos@test.com'],
+            'PA to LAY' => ['ADMIN_BUTTON', 'ROLE_PA', 'ROLE_LAY_DEPUTY', 'polly.jean.harvey@test.com', 't.amos@test.com'],
+            'PROF to PA' => ['ADMIN_BUTTON', 'ROLE_PROF', 'ROLE_PA', 't.amos@test.com', 'polly.jean.harvey@test.com'],
         ];
     }
 }

--- a/client/tests/phpunit/Service/Audit/AuditEventsTest.php
+++ b/client/tests/phpunit/Service/Audit/AuditEventsTest.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Service\Audit;
 
+use AppBundle\Entity\User;
 use AppBundle\Service\Time\DateTimeProvider;
 use AppBundle\Service\Time\FakeClock;
 use DateTime;
@@ -52,5 +53,44 @@ class AuditEventsTest extends TestCase
              ],
              'Null start date' => [null, null]
          ];
+    }
+
+    /**
+     * @test
+     * @dataProvider roleChangedProvider
+     */
+    public function roleChanged(string $trigger, $changedFrom, $changedTo, $changedBy): void
+    {
+        $now = new DateTime();
+        /** @var ObjectProphecy|DateTimeProvider $dateTimeProvider */
+        $dateTimeProvider = self::prophesize(DateTimeProvider::class);
+        $dateTimeProvider->getDateTime()->shouldBeCalled()->willReturn($now);
+
+        $expected = [
+            'trigger' => $trigger,
+            'role_changed_from' => $changedFrom,
+            'role_changed_to' => $changedTo,
+            'changed_by' => $changedBy,
+            'changed_on' => $now->format(DateTime::ATOM),
+            'event' => AuditEvents::ROLE_CHANGED,
+            'type' => 'audit'
+        ];
+
+        $actual = (new AuditEvents($dateTimeProvider->reveal()))->roleChanged(
+            $trigger,
+            $changedFrom,
+            $changedTo,
+            $changedBy
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function roleChangedProvider()
+    {
+        return [
+            'PA to LAY' => ['ADMIN_BUTTON', 'ROLE_PA', 'ROLE_LAY_DEPUTY', 'polly.jean.harvey@test.com'],
+            'PROF to PA' => ['ADMIN_BUTTON', 'ROLE_PROF', 'ROLE_PA', 't.amos@test.com'],
+        ];
     }
 }

--- a/client/tests/phpunit/Service/Audit/AuditEventsTest.php
+++ b/client/tests/phpunit/Service/Audit/AuditEventsTest.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Service\Audit;
 
-use AppBundle\Entity\User;
+
 use AppBundle\Service\Time\DateTimeProvider;
 use AppBundle\Service\Time\FakeClock;
 use DateTime;
@@ -29,7 +29,7 @@ class AuditEventsTest extends TestCase
             'deputy_name' => 'Bjork Gudmundsdottir',
             'discharged_on' => $now->format(DateTime::ATOM),
             'deputyship_start_date' => $expectedStartDate,
-            'event' => AuditEvents::CLIENT_DISCHARGED,
+            'event' => AuditEvents::EVENT_CLIENT_DISCHARGED,
             'type' => 'audit'
         ];
 
@@ -72,7 +72,7 @@ class AuditEventsTest extends TestCase
             'role_changed_to' => $changedTo,
             'changed_by' => $changedBy,
             'changed_on' => $now->format(DateTime::ATOM),
-            'event' => AuditEvents::ROLE_CHANGED,
+            'event' => AuditEvents::EVENT_ROLE_CHANGED,
             'type' => 'audit'
         ];
 


### PR DESCRIPTION
## Purpose
Continuing with the audit logging risk identified - this change emits audit logs when a users role is changed.

Fixes DDPB-3336

## Approach
I've been over the CSV upload process and couldn't see anywhere obvious where a User's role is changed. The only other two places I could see this happening was:

- A user removing admin privileges from themselves in the frontend
- A PA/Prof admin adding or removing admin roles to other members of their org

I purposefully left out team role updates as we'll soon be removing all team code.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
