### PR TITLE
DDPB-3310: Invalid ARIA attributes in organisation report overview accordion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -551,7 +551,7 @@ jobs:
             docker-compose exec frontend touch /var/www/.enableProdMode
             docker-compose exec admin touch /var/www/.enableProdMode
             docker-compose -f docker-compose.yml run --rm api sh scripts/reset_db_structure.sh
-            docker-compose -f docker-compose.yml run --rm api sh scripts/reset_db_fixtures.shdocker-compose
+            docker-compose -f docker-compose.yml run --rm api sh scripts/reset_db_fixtures.sh
             sleep 10
             docker-compose -f docker-compose.yml run pa11y pa11y-ci || echo "Pa11y found some errors"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -550,7 +550,7 @@ jobs:
             docker-compose -f docker-compose.yml up -d pa11y
             docker-compose exec frontend touch /var/www/.enableProdMode
             docker-compose exec admin touch /var/www/.enableProdMode
-            docker-compose docker-compose -f docker-compose.yml run --rm api sh scripts/reset_db_structure.sh
+            docker-compose -f docker-compose.yml run --rm api sh scripts/reset_db_structure.sh
             docker-compose -f docker-compose.yml run --rm api sh scripts/reset_db_fixtures.shdocker-compose
             sleep 10
             docker-compose -f docker-compose.yml run pa11y pa11y-ci || echo "Pa11y found some errors"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -550,6 +550,7 @@ jobs:
             docker-compose -f docker-compose.yml up -d pa11y
             docker-compose exec frontend touch /var/www/.enableProdMode
             docker-compose exec admin touch /var/www/.enableProdMode
+            docker-compose exec api touch /var/www/.enableProdMode
             docker-compose -f docker-compose.yml run --rm api sh scripts/reset_db_structure.sh
             docker-compose -f docker-compose.yml run --rm api sh scripts/reset_db_fixtures.sh
             sleep 10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -550,7 +550,8 @@ jobs:
             docker-compose -f docker-compose.yml up -d pa11y
             docker-compose exec frontend touch /var/www/.enableProdMode
             docker-compose exec admin touch /var/www/.enableProdMode
-            docker-compose exec api touch /var/www/.enableProdMode
+            docker-compose docker-compose -f docker-compose.yml run --rm api sh scripts/reset_db_structure.sh
+            docker-compose -f docker-compose.yml run --rm api sh scripts/reset_db_fixtures.shdocker-compose
             sleep 10
             docker-compose -f docker-compose.yml run pa11y pa11y-ci || echo "Pa11y found some errors"
 

--- a/client/src/AppBundle/Resources/views/Org/ClientProfile/overview.html.twig
+++ b/client/src/AppBundle/Resources/views/Org/ClientProfile/overview.html.twig
@@ -21,7 +21,7 @@
 {% block pageContent %}
 
     {# Use a random ID to ensure that changes to open sections don't persist #}
-    <div class="govuk-accordion" data-module="govuk-accordion" id="overview-accordion-{{ "now" | date("U") }}">
+    <div class="govuk-accordion" data-module="govuk-accordion" id="overview-accordion">
         {% include 'AppBundle:Org/ClientProfile:_client.html.twig' with {
         '   client': client
         } %}

--- a/pa11y/.pa11yci
+++ b/pa11y/.pa11yci
@@ -8,7 +8,7 @@
          ]
       },
       "hideElements":"svg",
-      "timeout":60000,
+      "timeout":40000,
       "wait":5000
    },
    "urls":[
@@ -24,6 +24,19 @@
       {
          "url": "https://digideps.local",
          "screenCapture": "screenshots/index.png"
+      },
+      {
+         "url": "https://digideps.local/report/{id}/overview",
+         "actions": [
+            "navigate to https://digideps.local/login",
+            "set field #login_email to behat-prof1@publicguardian.gov.uk",
+            "set field #login_password to Abcd1234",
+            "click element #login_login",
+            "wait for path to be /org/",
+            "wait for element .behat-link-pa-report-open to be visible",
+            "click element .behat-link-pa-report-open"
+         ],
+         "screenCapture": "screenshots/report-overview.png"
       }
    ]
 }

--- a/pa11y/screenshots/.gitignore
+++ b/pa11y/screenshots/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
## Purpose
Fix an issue with invalid aria values in an accordion that was identified as part of the DAC report.

Fixes DDPB-3310

## Approach
I had a search around the codebase and couldn't find anywhere else we were appending an EPOCH time string to an accordion ID. From looking at the git history I think this may have come about when we were using a custom solution rather than the GDS version. The date string was originally added there to ensure the IDs were unique but the GDS component automatically appends a number based on how many sections of the accordion there are. The date string was probably left in after we moved to the GDS version.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [x] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
