### PR TITLE
DDPB-3311: Move Details element within dd element

### DIFF
--- a/client/src/AppBundle/Resources/views/Org/ClientProfile/_reportDetail-PA.html.twig
+++ b/client/src/AppBundle/Resources/views/Org/ClientProfile/_reportDetail-PA.html.twig
@@ -49,17 +49,17 @@
             <dd class="push--bottom">
                 <span class="push--right">{{ report.startDate | date(" j F Y") }} to {{ report.endDate | date(" j F Y") }}</span>
                 <a href="{{ path('report_edit', {'reportId': report.id}) }}" class="right behat-link-edit-report-period">{{ 'edit' | trans }}</a>
-            </dd>
 
-            <details class="govuk-details" data-module="govuk-details">
-                <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">{{ 'overdueHelpTextHeader' | trans }}</span>
-                </summary>
-                <div class="govuk-details__text">
-                    <p>{{ 'overdueHelpTextParagraph1' | trans }}</p>
-                    <p>{{ 'overdueHelpTextParagraph2' | trans }}</p>
-                </div>
-            </details>
+                <details class="govuk-details" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                        <span class="govuk-details__summary-text">{{ 'overdueHelpTextHeader' | trans }}</span>
+                    </summary>
+                    <div class="govuk-details__text">
+                        <p>{{ 'overdueHelpTextParagraph1' | trans }}</p>
+                        <p>{{ 'overdueHelpTextParagraph2' | trans }}</p>
+                    </div>
+                </details>
+            </dd>
 
             <dt>
                 <strong class="govuk-!-font-weight-bold">{{ 'reportDueDate' | trans() }}</strong>

--- a/client/src/AppBundle/Resources/views/Org/ClientProfile/_reportDetail-PA.html.twig
+++ b/client/src/AppBundle/Resources/views/Org/ClientProfile/_reportDetail-PA.html.twig
@@ -50,7 +50,7 @@
                 <span class="push--right">{{ report.startDate | date(" j F Y") }} to {{ report.endDate | date(" j F Y") }}</span>
                 <a href="{{ path('report_edit', {'reportId': report.id}) }}" class="right behat-link-edit-report-period">{{ 'edit' | trans }}</a>
 
-                <details class="govuk-details" data-module="govuk-details">
+                <details class="govuk-details govuk-!-padding-top-5" data-module="govuk-details">
                     <summary class="govuk-details__summary">
                         <span class="govuk-details__summary-text">{{ 'overdueHelpTextHeader' | trans }}</span>
                     </summary>

--- a/client/src/AppBundle/Resources/views/Org/ClientProfile/_reportDetail-Prof.html.twig
+++ b/client/src/AppBundle/Resources/views/Org/ClientProfile/_reportDetail-Prof.html.twig
@@ -48,7 +48,7 @@
                 <span class="push--right">{{ report.startDate | date(" j F Y") }} to {{ report.endDate | date(" j F Y") }}</span>
                 <a href="{{ path('report_edit', {'reportId': report.id}) }}" class="right behat-link-edit-report-period">{{ 'edit' | trans }}</a>
 
-                <details class="govuk-details" data-module="govuk-details">
+                <details class="govuk-details govuk-!-padding-top-5" data-module="govuk-details">
                     <summary class="govuk-details__summary">
                         <span class="govuk-details__summary-text">{{ 'overdueHelpTextHeader' | trans }}</span>
                     </summary>

--- a/client/src/AppBundle/Resources/views/Org/ClientProfile/_reportDetail-Prof.html.twig
+++ b/client/src/AppBundle/Resources/views/Org/ClientProfile/_reportDetail-Prof.html.twig
@@ -47,18 +47,17 @@
             <dd class="push--bottom">
                 <span class="push--right">{{ report.startDate | date(" j F Y") }} to {{ report.endDate | date(" j F Y") }}</span>
                 <a href="{{ path('report_edit', {'reportId': report.id}) }}" class="right behat-link-edit-report-period">{{ 'edit' | trans }}</a>
+
+                <details class="govuk-details" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                        <span class="govuk-details__summary-text">{{ 'overdueHelpTextHeader' | trans }}</span>
+                    </summary>
+                    <div class="govuk-details__text">
+                        <p>{{ 'overdueHelpTextParagraph1' | trans }}</p>
+                        <p>{{ 'overdueHelpTextParagraph2' | trans }}</p>
+                    </div>
+                </details>
             </dd>
-
-            <details class="govuk-details" data-module="govuk-details">
-                <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">{{ 'overdueHelpTextHeader' | trans }}</span>
-                </summary>
-                <div class="govuk-details__text">
-                    <p>{{ 'overdueHelpTextParagraph1' | trans }}</p>
-                    <p>{{ 'overdueHelpTextParagraph2' | trans }}</p>
-                </div>
-            </details>
-
             <dt>
                 <strong class="govuk-!-font-weight-bold">{{ 'reportDueDate' | trans() }}</strong>
             </dt>


### PR DESCRIPTION
## Purpose
Semantically incorrect markup in the prof and PA report overview template was picked up in the DAC report that would cause screen readers to announce definition lists incorrectly. This change ensures both views are now semantically correct.

Fixes DDPB-3311

## Approach
It seemed the easiest fix was to just move the `details` element into the `dd` element it was sitting next to as a sibling.  I've added a pa11y test for this view in #393 so haven't duplicated here.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [x] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
