### PR TITLE
DDPB-3530: Support audit logging when removing and adding client email address

### DIFF
--- a/client/src/AppBundle/Controller/Org/IndexController.php
+++ b/client/src/AppBundle/Controller/Org/IndexController.php
@@ -120,7 +120,8 @@ class IndexController extends AbstractController
                     $clientUpdated->getFullName()
                 );
 
-                $this->logger->notice('', $event);
+                $message = is_null($newEmail) ? 'Client email address removed' : '';
+                $this->logger->notice($message, $event);
 
             }
 

--- a/client/src/AppBundle/Service/Audit/AuditEvents.php
+++ b/client/src/AppBundle/Service/Audit/AuditEvents.php
@@ -81,7 +81,7 @@ final class AuditEvents
 
     public function clientEmailChanged(
         string $trigger,
-        string $emailChangedFrom,
+        ?string $emailChangedFrom,
         ?string $emailChangedTo,
         string $changedBy,
         string $subjectFullName

--- a/client/src/AppBundle/Service/Audit/AuditEvents.php
+++ b/client/src/AppBundle/Service/Audit/AuditEvents.php
@@ -66,34 +66,7 @@ final class AuditEvents
          string $subjectRole
     )
     {
-        $event = $this->emailChangedBaseEvent($trigger, $emailChangedFrom, $emailChangedTo, $changedBy, $subjectFullName, $subjectRole);
-
-        return $event + $this->baseEvent(AuditEvents::EVENT_USER_EMAIL_CHANGED);
-    }
-
-    public function clientEmailChanged(
-        string $trigger,
-        string $emailChangedFrom,
-        string $emailChangedTo,
-        string $changedBy,
-        string $subjectFullName
-    )
-    {
-        $event = $this->emailChangedBaseEvent($trigger, $emailChangedFrom, $emailChangedTo, $changedBy, $subjectFullName, 'CLIENT');
-
-        return $event + $this->baseEvent(AuditEvents::EVENT_CLIENT_EMAIL_CHANGED);
-    }
-
-    private function emailChangedBaseEvent(
-        string $trigger,
-        string $emailChangedFrom,
-        string $emailChangedTo,
-        string $changedBy,
-        string $subjectFullName,
-        string $subjectRole
-    )
-    {
-        return [
+        $event = [
             'trigger' => $trigger,
             'email_changed_from' => $emailChangedFrom,
             'email_changed_to' => $emailChangedTo,
@@ -102,6 +75,29 @@ final class AuditEvents
             'subject_full_name' => $subjectFullName,
             'subject_role' => $subjectRole,
         ];
+
+        return $event + $this->baseEvent(AuditEvents::EVENT_USER_EMAIL_CHANGED);
+    }
+
+    public function clientEmailChanged(
+        string $trigger,
+        string $emailChangedFrom,
+        ?string $emailChangedTo,
+        string $changedBy,
+        string $subjectFullName
+    )
+    {
+        $event = [
+            'trigger' => $trigger,
+            'email_changed_from' => $emailChangedFrom,
+            'email_changed_to' => $emailChangedTo,
+            'changed_on' => $this->dateTimeProvider->getDateTime()->format(DateTime::ATOM),
+            'changed_by' => $changedBy,
+            'subject_full_name' => $subjectFullName,
+            'subject_role' => 'CLIENT',
+        ];
+
+        return $event + $this->baseEvent(AuditEvents::EVENT_CLIENT_EMAIL_CHANGED);
     }
 
     /**

--- a/client/tests/phpunit/Controller/Org/IndexControllerTest.php
+++ b/client/tests/phpunit/Controller/Org/IndexControllerTest.php
@@ -40,8 +40,9 @@ class IndexControllerTest extends AbstractControllerTestCase
 
     /**
      * @test
+     * @dataProvider emailAddressProvider
      */
-    public function clientEditAction_client_email_changed_audit_log_created(): void
+    public function clientEditAction_client_email_changed_audit_log_created(?string $oldEmail, ?string $newEmail, string $message): void
     {
         $report = (new Report())
             ->setId(4);
@@ -52,7 +53,7 @@ class IndexControllerTest extends AbstractControllerTestCase
             ->setId(5)
             ->setDateOfBirth(new DateTime('6 January 1978'))
             ->setPhone('01213541234')
-            ->setEmail('d.dibb@email.com')
+            ->setEmail($oldEmail)
             ->setAddress('Strawberry Jam Lane')
             ->setAddress2('California')
             ->setCounty('West Midlands')
@@ -60,7 +61,7 @@ class IndexControllerTest extends AbstractControllerTestCase
             ->setCurrentReport($report);
 
         $updatedClient = (clone $client)
-            ->setEmail('deakin.dibb@email.com');
+            ->setEmail($newEmail);
 
         $this->restClient->get(sprintf('client/%s', $client->getId()), Argument::cetera())->shouldBeCalled()->willReturn($client);
         $this->restClient->put('client/upsert', $updatedClient, ['pa-edit'])->shouldBeCalled();
@@ -69,11 +70,11 @@ class IndexControllerTest extends AbstractControllerTestCase
             $dateTimeProvider->getDateTime()->willReturn($this->now);
         });
 
-        $this->injectProphecyService(Logger::class, function($logger) use($client, $updatedClient) {
+        $this->injectProphecyService(Logger::class, function($logger) use($oldEmail, $newEmail, $message, $updatedClient) {
             $expectedEvent = [
                 'trigger' => 'DEPUTY_USER_EDIT',
-                'email_changed_from' => $client->getEmail(),
-                'email_changed_to' => $updatedClient->getEmail(),
+                'email_changed_from' => $oldEmail,
+                'email_changed_to' => $newEmail,
                 'changed_on' => $this->now->format(DateTime::ATOM),
                 'changed_by' => $this->loggedInProfAdminUser->getEmail(),
                 'subject_full_name' => $updatedClient->getFullName(),
@@ -82,7 +83,7 @@ class IndexControllerTest extends AbstractControllerTestCase
                 'type' => 'audit'
             ];
 
-            $logger->notice('', $expectedEvent)->shouldBeCalled();
+            $logger->notice($message, $expectedEvent)->shouldBeCalled();
         });
 
         $crawler = $this->client->request('GET', sprintf("/org/client/%s/edit", $client->getId()));
@@ -95,12 +96,21 @@ class IndexControllerTest extends AbstractControllerTestCase
             'org_client_edit[dateOfBirth][month]' => '1',
             'org_client_edit[dateOfBirth][year]' => '1978',
             'org_client_edit[phone]' => '01213541234',
-            'org_client_edit[email]' => 'deakin.dibb@email.com',
+            'org_client_edit[email]' => $newEmail,
             'org_client_edit[address]' => 'Strawberry Jam Lane',
             'org_client_edit[address2]' => 'California',
             'org_client_edit[county]' => 'West Midlands',
             'org_client_edit[postcode]' => 'B31 1AB',
         ]);
+    }
+
+    public function emailAddressProvider()
+    {
+        return [
+            'Email changed' => ['d.dibb@email.com', 'deakin.dibb@email.com', ''],
+            'Email added' => [null, 'deakin.dibb@email.com', ''],
+            'Email removed' => ['d.dibb@email.com', null, 'Client email address removed'],
+        ];
     }
 
     /**
@@ -148,71 +158,6 @@ class IndexControllerTest extends AbstractControllerTestCase
             'org_client_edit[dateOfBirth][year]' => '1978',
             'org_client_edit[phone]' => '01213541234',
             'org_client_edit[email]' => 'd.dibb@email.com',
-            'org_client_edit[address]' => 'Strawberry Jam Lane',
-            'org_client_edit[address2]' => 'New York',
-            'org_client_edit[county]' => 'West Midlands',
-            'org_client_edit[postcode]' => 'B31 1AB',
-        ]);
-    }
-
-    /**
-     * @test
-     */
-    public function clientEditAction_removing_email_address_is_logged(): void
-    {
-        $report = (new Report())
-            ->setId(4);
-
-        $client = (new Client())
-            ->setFirstname('Deakin')
-            ->setLastname('Dibb')
-            ->setId(5)
-            ->setDateOfBirth(new DateTime('6 January 1978'))
-            ->setPhone('01213541234')
-            ->setEmail('a@b.com')
-            ->setAddress('Strawberry Jam Lane')
-            ->setAddress2('California')
-            ->setCounty('West Midlands')
-            ->setPostcode('B31 1AB')
-            ->setCurrentReport($report);
-
-        $updatedClient = (clone $client)
-            ->setAddress2('New York')
-            ->setEmail(null);
-
-        // Super strange bug requires calling this here to ensure its populated on the entity during put assertion
-        $updatedClient->getFullName();
-
-        $this->restClient->get(sprintf('client/%s', $client->getId()), Argument::cetera())->shouldBeCalled()->willReturn($client);
-        $this->restClient->put('client/upsert', $updatedClient, ['pa-edit'])->shouldBeCalled();
-
-        $this->injectProphecyService(Logger::class, function($logger) use($client, $updatedClient) {
-            $expectedEvent = [
-                'trigger' => 'DEPUTY_USER_EDIT',
-                'email_changed_from' => $client->getEmail(),
-                'email_changed_to' => null,
-                'changed_on' => $this->now->format(DateTime::ATOM),
-                'changed_by' => $this->loggedInProfAdminUser->getEmail(),
-                'subject_full_name' => $updatedClient->getFullName(),
-                'subject_role' => 'CLIENT',
-                'event' => 'CLIENT_EMAIL_CHANGED',
-                'type' => 'audit'
-            ];
-
-            $logger->notice('Client email address removed', $expectedEvent)->shouldBeCalled();
-        });
-
-        $crawler = $this->client->request('GET', sprintf("/org/client/%s/edit", $client->getId()));
-        $button = $crawler->selectButton('Save client details');
-
-        $this->client->submit($button->form(), [
-            'org_client_edit[firstname]' => 'Deakin',
-            'org_client_edit[lastname]' => 'Dibb',
-            'org_client_edit[dateOfBirth][day]' => '6',
-            'org_client_edit[dateOfBirth][month]' => '1',
-            'org_client_edit[dateOfBirth][year]' => '1978',
-            'org_client_edit[phone]' => '01213541234',
-            'org_client_edit[email]' => '',
             'org_client_edit[address]' => 'Strawberry Jam Lane',
             'org_client_edit[address2]' => 'New York',
             'org_client_edit[county]' => 'West Midlands',

--- a/client/tests/phpunit/Service/Audit/AuditEventsTest.php
+++ b/client/tests/phpunit/Service/Audit/AuditEventsTest.php
@@ -94,7 +94,7 @@ class AuditEventsTest extends TestCase
      * @test
      * @dataProvider emailChangeProvider
      */
-    public function clientEmailChanged(string $name)
+    public function clientEmailChanged(string $oldEmail, ?string $newEmail)
     {
         $now = new DateTime();
         /** @var ObjectProphecy|DateTimeProvider $dateTimeProvider */
@@ -103,11 +103,11 @@ class AuditEventsTest extends TestCase
 
         $expected = [
             'trigger' => 'DEPUTY_USER_EDIT',
-            'email_changed_from' => 'me@test.com',
-            'email_changed_to' => 'you@test.com',
+            'email_changed_from' => $oldEmail,
+            'email_changed_to' => $newEmail,
             'changed_on' => $now->format(DateTime::ATOM),
             'changed_by' => 'super-admin@email.com',
-            'subject_full_name' => $name,
+            'subject_full_name' => 'Panda Bear',
             'subject_role' => 'CLIENT',
             'event' => 'CLIENT_EMAIL_CHANGED',
             'type' => 'audit'
@@ -115,10 +115,10 @@ class AuditEventsTest extends TestCase
 
         $actual = (new AuditEvents($dateTimeProvider->reveal()))->clientEmailChanged(
             'DEPUTY_USER_EDIT',
-            'me@test.com',
-            'you@test.com',
+            $oldEmail,
+            $newEmail,
             'super-admin@email.com',
-            $name
+            'Panda Bear'
         );
 
         $this->assertEquals($expected, $actual);
@@ -127,8 +127,8 @@ class AuditEventsTest extends TestCase
     public function emailChangeProvider()
     {
         return [
-            'Panda Bear' => ['Panda Bear'],
-            'Geologist' =>  ['Geologist']
+            'Email changed' => ['me@test.com', 'you@test.com'],
+            'Email removed' =>  ['me@test.com', null]
         ];
     }
 

--- a/client/tests/phpunit/Service/Audit/AuditEventsTest.php
+++ b/client/tests/phpunit/Service/Audit/AuditEventsTest.php
@@ -59,7 +59,7 @@ class AuditEventsTest extends TestCase
      * @test
      * @dataProvider emailChangeProvider
      */
-    public function userEmailChanged(string $name)
+    public function userEmailChanged()
     {
         $now = new DateTime();
         /** @var ObjectProphecy|DateTimeProvider $dateTimeProvider */
@@ -72,7 +72,7 @@ class AuditEventsTest extends TestCase
             'email_changed_to' => 'you@test.com',
             'changed_on' => $now->format(DateTime::ATOM),
             'changed_by' => 'super-admin@email.com',
-            'subject_full_name' => $name,
+            'subject_full_name' => 'Panda Bear',
             'subject_role' => 'ROLE_LAY_DEPUTY',
             'event' => 'USER_EMAIL_CHANGED',
             'type' => 'audit'
@@ -83,7 +83,7 @@ class AuditEventsTest extends TestCase
             'me@test.com',
             'you@test.com',
             'super-admin@email.com',
-            $name,
+            'Panda Bear',
             'ROLE_LAY_DEPUTY'
         );
 
@@ -94,7 +94,7 @@ class AuditEventsTest extends TestCase
      * @test
      * @dataProvider emailChangeProvider
      */
-    public function clientEmailChanged(string $oldEmail, ?string $newEmail)
+    public function clientEmailChanged(?string $oldEmail, ?string $newEmail)
     {
         $now = new DateTime();
         /** @var ObjectProphecy|DateTimeProvider $dateTimeProvider */
@@ -128,7 +128,8 @@ class AuditEventsTest extends TestCase
     {
         return [
             'Email changed' => ['me@test.com', 'you@test.com'],
-            'Email removed' =>  ['me@test.com', null]
+            'Email removed' =>  ['me@test.com', null],
+            'Email added' => [null, 'you@test.com']
         ];
     }
 


### PR DESCRIPTION
## Purpose
The system currently supports adding and removing Client email addresses alongside changing them but our audit logging does not. This change allows the old and new email address to be null to support this.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
