### PR TITLE
DDPB-3463: Rename base branch from master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,81 +5,81 @@ workflows:
     jobs:
       - lint:
           name: lint terraform
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
 
       - build:
           name: build pr
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
 
       - terraform-command:
           name: apply environment
           requires: [ build pr, lint terraform ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
           tf_command: apply
 
       - run-task:
           name: reset environment
           requires: [ apply environment ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
           task_name: reset_database
           timeout: 180
 
       - run-task:
           name: integration test
           requires: [ reset environment ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
           task_name: integration_test
           timeout: 2400
 
       - client-unit-test:
           name: client unit test
           requires: [ apply environment ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
 
       - api-unit-tests:
           name: api unit test
           requires: [ apply environment ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
 
       - pa11y-ci:
           name: accessibility test
           requires: [ apply environment ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
 
       - run-task:
           name: backup environment
           requires: [ api unit test, client unit test, integration test ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
           task_name: backup
 
       - run-task:
           name: restore environment
           requires: [ backup environment ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
           task_name: restore
 
       - cleanup:
           name: approve destroy environment
           type: approval
           requires: [ restore environment ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
 
       - terraform-command:
           name: destroy environment
           requires: [ approve destroy environment ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
           tf_command: destroy
 
-  master:
+  main:
     jobs:
       - build:
-          name: build master
-          filters: { branches: { only: [ master ] } }
+          name: build main
+          filters: { branches: { only: [ main ] } }
 
       - terraform-command:
           name: apply shared-development
-          requires: [ build master ]
-          filters: { branches: { only: [ master ] } }
+          requires: [ build main ]
+          filters: { branches: { only: [ main ] } }
           tf_tier: shared
           tf_workspace: development
           tf_command: apply
@@ -87,7 +87,7 @@ workflows:
       - terraform-command:
           name: plan shared-preproduction
           requires: [ apply shared-development ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           tf_tier: shared
           tf_workspace: preproduction
           tf_command: plan
@@ -95,76 +95,76 @@ workflows:
       - terraform-command:
           name: plan preproduction
           requires: [ apply shared-development ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           tf_workspace: preproduction
           tf_command: plan
 
       - terraform-command:
           name: apply shared-preproduction
           requires: [ plan shared-preproduction, plan preproduction ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           tf_tier: shared
           tf_workspace: preproduction
           tf_command: apply
 
       - terraform-command:
-          name: apply master
+          name: apply main
           requires: [ apply shared-preproduction ]
-          filters: { branches: { only: [ master ] } }
-          tf_workspace: master
+          filters: { branches: { only: [ main ] } }
+          tf_workspace: main
           tf_command: apply
 
       - run-task:
-          name: reset master
-          requires: [ apply master ]
-          filters: { branches: { only: [ master ] } }
+          name: reset main
+          requires: [ apply main ]
+          filters: { branches: { only: [ main ] } }
           task_name: reset_database
-          tf_workspace: master
+          tf_workspace: main
           timeout: 180
 
       - run-task:
           name: integration test
-          requires: [ reset master ]
-          filters: { branches: { only: [ master ] } }
+          requires: [ reset main ]
+          filters: { branches: { only: [ main ] } }
           task_name: integration_test
-          tf_workspace: master
+          tf_workspace: main
           timeout: 1800
 
       - client-unit-test:
           name: client unit test
-          requires: [ apply master ]
-          filters: { branches: { only: [ master ] } }
+          requires: [ apply main ]
+          filters: { branches: { only: [ main ] } }
 
       - api-unit-tests:
           name: api unit test
-          requires: [ apply master ]
-          filters: { branches: { only: [ master ] } }
+          requires: [ apply main ]
+          filters: { branches: { only: [ main ] } }
 
       - terraform-command:
           name: apply training
           requires: [ apply shared-production ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           tf_workspace: training
           tf_command: apply
 
       - terraform-command:
           name: apply preproduction
           requires: [ api unit test, client unit test, integration test ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           tf_workspace: preproduction
           tf_command: apply
 
       - terraform-command:
           name: plan production
           requires: [ apply preproduction ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           tf_workspace: production02
           tf_command: plan
 
       - terraform-command:
           name: plan shared-production
           requires: [ apply preproduction ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           tf_tier: shared
           tf_workspace: production
           tf_command: plan
@@ -173,18 +173,18 @@ workflows:
           name: approve release to production notification
           message: "Production is ready for release and pending approval"
           requires: [ plan shared-production, plan production ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
 
       - approve:
           name: approve release to production
           type: approval
           requires: [ plan shared-production, plan production ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
 
       - terraform-command:
           name: apply shared-production
           requires: [ approve release to production ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           tf_tier: shared
           tf_workspace: production
           tf_command: apply
@@ -192,7 +192,7 @@ workflows:
       - terraform-command:
           name: apply production
           requires: [ apply shared-production ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           pact_tag: true
           tf_workspace: production02
           tf_command: apply
@@ -200,7 +200,7 @@ workflows:
       - run-task:
           name: backup production
           requires: [ apply production ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           task_name: backup
           tf_workspace: production02
           timeout: 600
@@ -208,50 +208,50 @@ workflows:
       - run-task:
           name: restore production to preproduction
           requires: [ backup production ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           task_name: restore_from_production
           tf_workspace: preproduction
           timeout: 600
 
-  weekly_master_run:
+  weekly_main_run:
     triggers:
       - schedule:
           cron: "00 05 * * 0"
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - build:
-          name: build master
-          filters: { branches: { only: [ master ] } }
+          name: build main
+          filters: { branches: { only: [ main ] } }
       - terraform-command:
-          name: apply master
-          requires: [ build master ]
-          filters: { branches: { only: [ master ] } }
-          tf_workspace: master
+          name: apply main
+          requires: [ build main ]
+          filters: { branches: { only: [ main ] } }
+          tf_workspace: main
           tf_command: apply
       - run-task:
-          name: reset master
-          requires: [ apply master ]
-          filters: { branches: { only: [ master ] } }
+          name: reset main
+          requires: [ apply main ]
+          filters: { branches: { only: [ main ] } }
           task_name: reset_database
-          tf_workspace: master
+          tf_workspace: main
           timeout: 180
       - client-unit-test:
           name: client unit test
-          requires: [ apply master ]
-          filters: { branches: { only: [ master ] } }
+          requires: [ apply main ]
+          filters: { branches: { only: [ main ] } }
       - api-unit-tests:
           name: api unit test
-          requires: [ apply master ]
-          filters: { branches: { only: [ master ] } }
+          requires: [ apply main ]
+          filters: { branches: { only: [ main ] } }
       - run-task:
           name: integration test
-          requires: [ reset master ]
-          filters: { branches: { only: [ master ] } }
+          requires: [ reset main ]
+          filters: { branches: { only: [ main ] } }
           task_name: integration_test
-          tf_workspace: master
+          tf_workspace: main
           notify_slack: true
           timeout: 1800
 
@@ -421,7 +421,7 @@ jobs:
       - run:
           name: Check updated PHP files for errors
           command: |
-            MERGE_BASE_COMMIT=( $(git merge-base master HEAD) )
+            MERGE_BASE_COMMIT=( $(git merge-base main HEAD) )
             API_CHANGED_FILES=( $(git diff --relative=api --name-only --diff-filter=d $MERGE_BASE_COMMIT | grep .php) ) || [[ $? == 1 ]]
             CLIENT_CHANGED_FILES=( $(git diff --relative=client --name-only --diff-filter=d $MERGE_BASE_COMMIT | grep .php) ) || [[ $? == 1 ]]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,6 +421,9 @@ jobs:
       - run:
           name: Check updated PHP files for errors
           command: |
+            CURRENT_BRANCH=( git rev-parse --abbrev-ref HEAD )
+            git checkout main
+            git checkout $CURRENT_BRANCH
             MERGE_BASE_COMMIT=( $(git merge-base main HEAD) )
             API_CHANGED_FILES=( $(git diff --relative=api --name-only --diff-filter=d $MERGE_BASE_COMMIT | grep .php) ) || [[ $? == 1 ]]
             CLIENT_CHANGED_FILES=( $(git diff --relative=client --name-only --diff-filter=d $MERGE_BASE_COMMIT | grep .php) ) || [[ $? == 1 ]]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,15 +70,15 @@ workflows:
           filters: { branches: { ignore: [ main ] } }
           tf_command: destroy
 
-  main:
+  master:
     jobs:
       - build:
-          name: build main
+          name: build master
           filters: { branches: { only: [ main ] } }
 
       - terraform-command:
           name: apply shared-development
-          requires: [ build main ]
+          requires: [ build master ]
           filters: { branches: { only: [ main ] } }
           tf_tier: shared
           tf_workspace: development
@@ -108,15 +108,15 @@ workflows:
           tf_command: apply
 
       - terraform-command:
-          name: apply main
+          name: apply master
           requires: [ apply shared-preproduction ]
           filters: { branches: { only: [ main ] } }
           tf_workspace: master
           tf_command: apply
 
       - run-task:
-          name: reset main
-          requires: [ apply main ]
+          name: reset master
+          requires: [ apply master ]
           filters: { branches: { only: [ main ] } }
           task_name: reset_database
           tf_workspace: master
@@ -124,7 +124,7 @@ workflows:
 
       - run-task:
           name: integration test
-          requires: [ reset main ]
+          requires: [ reset master ]
           filters: { branches: { only: [ main ] } }
           task_name: integration_test
           tf_workspace: master
@@ -132,12 +132,12 @@ workflows:
 
       - client-unit-test:
           name: client unit test
-          requires: [ apply main ]
+          requires: [ apply master ]
           filters: { branches: { only: [ main ] } }
 
       - api-unit-tests:
           name: api unit test
-          requires: [ apply main ]
+          requires: [ apply master ]
           filters: { branches: { only: [ main ] } }
 
       - terraform-command:
@@ -213,42 +213,42 @@ workflows:
           tf_workspace: preproduction
           timeout: 600
 
-  weekly_main_run:
+  weekly_master_run:
     triggers:
       - schedule:
           cron: "00 05 * * 0"
           filters:
             branches:
               only:
-                - main
+                - master
     jobs:
       - build:
-          name: build main
+          name: build master
           filters: { branches: { only: [ main ] } }
       - terraform-command:
-          name: apply main
-          requires: [ build main ]
+          name: apply master
+          requires: [ build master ]
           filters: { branches: { only: [ main ] } }
           tf_workspace: master
           tf_command: apply
       - run-task:
-          name: reset main
-          requires: [ apply main ]
+          name: reset master
+          requires: [ apply master ]
           filters: { branches: { only: [ main ] } }
           task_name: reset_database
           tf_workspace: master
           timeout: 180
       - client-unit-test:
           name: client unit test
-          requires: [ apply main ]
+          requires: [ apply master ]
           filters: { branches: { only: [ main ] } }
       - api-unit-tests:
           name: api unit test
-          requires: [ apply main ]
+          requires: [ apply master ]
           filters: { branches: { only: [ main ] } }
       - run-task:
           name: integration test
-          requires: [ reset main ]
+          requires: [ reset master ]
           filters: { branches: { only: [ main ] } }
           task_name: integration_test
           tf_workspace: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,81 +5,81 @@ workflows:
     jobs:
       - lint:
           name: lint terraform
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
 
       - build:
           name: build pr
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
 
       - terraform-command:
           name: apply environment
           requires: [ build pr, lint terraform ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
           tf_command: apply
 
       - run-task:
           name: reset environment
           requires: [ apply environment ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
           task_name: reset_database
           timeout: 180
 
       - run-task:
           name: integration test
           requires: [ reset environment ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
           task_name: integration_test
           timeout: 2400
 
       - client-unit-test:
           name: client unit test
           requires: [ apply environment ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
 
       - api-unit-tests:
           name: api unit test
           requires: [ apply environment ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
 
       - pa11y-ci:
           name: accessibility test
           requires: [ apply environment ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
 
       - run-task:
           name: backup environment
           requires: [ api unit test, client unit test, integration test ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
           task_name: backup
 
       - run-task:
           name: restore environment
           requires: [ backup environment ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
           task_name: restore
 
       - cleanup:
           name: approve destroy environment
           type: approval
           requires: [ restore environment ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
 
       - terraform-command:
           name: destroy environment
           requires: [ approve destroy environment ]
-          filters: { branches: { ignore: [ master ] } }
+          filters: { branches: { ignore: [ main ] } }
           tf_command: destroy
 
-  master:
+  main:
     jobs:
       - build:
-          name: build master
-          filters: { branches: { only: [ master ] } }
+          name: build main
+          filters: { branches: { only: [ main ] } }
 
       - terraform-command:
           name: apply shared-development
-          requires: [ build master ]
-          filters: { branches: { only: [ master ] } }
+          requires: [ build main ]
+          filters: { branches: { only: [ main ] } }
           tf_tier: shared
           tf_workspace: development
           tf_command: apply
@@ -87,7 +87,7 @@ workflows:
       - terraform-command:
           name: plan shared-preproduction
           requires: [ apply shared-development ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           tf_tier: shared
           tf_workspace: preproduction
           tf_command: plan
@@ -95,76 +95,76 @@ workflows:
       - terraform-command:
           name: plan preproduction
           requires: [ apply shared-development ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           tf_workspace: preproduction
           tf_command: plan
 
       - terraform-command:
           name: apply shared-preproduction
           requires: [ plan shared-preproduction, plan preproduction ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           tf_tier: shared
           tf_workspace: preproduction
           tf_command: apply
 
       - terraform-command:
-          name: apply master
+          name: apply main
           requires: [ apply shared-preproduction ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           tf_workspace: master
           tf_command: apply
 
       - run-task:
-          name: reset master
-          requires: [ apply master ]
-          filters: { branches: { only: [ master ] } }
+          name: reset main
+          requires: [ apply main ]
+          filters: { branches: { only: [ main ] } }
           task_name: reset_database
           tf_workspace: master
           timeout: 180
 
       - run-task:
           name: integration test
-          requires: [ reset master ]
-          filters: { branches: { only: [ master ] } }
+          requires: [ reset main ]
+          filters: { branches: { only: [ main ] } }
           task_name: integration_test
           tf_workspace: master
           timeout: 1800
 
       - client-unit-test:
           name: client unit test
-          requires: [ apply master ]
-          filters: { branches: { only: [ master ] } }
+          requires: [ apply main ]
+          filters: { branches: { only: [ main ] } }
 
       - api-unit-tests:
           name: api unit test
-          requires: [ apply master ]
-          filters: { branches: { only: [ master ] } }
+          requires: [ apply main ]
+          filters: { branches: { only: [ main ] } }
 
       - terraform-command:
           name: apply training
           requires: [ apply shared-production ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           tf_workspace: training
           tf_command: apply
 
       - terraform-command:
           name: apply preproduction
           requires: [ api unit test, client unit test, integration test ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           tf_workspace: preproduction
           tf_command: apply
 
       - terraform-command:
           name: plan production
           requires: [ apply preproduction ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           tf_workspace: production02
           tf_command: plan
 
       - terraform-command:
           name: plan shared-production
           requires: [ apply preproduction ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           tf_tier: shared
           tf_workspace: production
           tf_command: plan
@@ -173,18 +173,18 @@ workflows:
           name: approve release to production notification
           message: "Production is ready for release and pending approval"
           requires: [ plan shared-production, plan production ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
 
       - approve:
           name: approve release to production
           type: approval
           requires: [ plan shared-production, plan production ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
 
       - terraform-command:
           name: apply shared-production
           requires: [ approve release to production ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           tf_tier: shared
           tf_workspace: production
           tf_command: apply
@@ -192,7 +192,7 @@ workflows:
       - terraform-command:
           name: apply production
           requires: [ apply shared-production ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           pact_tag: true
           tf_workspace: production02
           tf_command: apply
@@ -200,7 +200,7 @@ workflows:
       - run-task:
           name: backup production
           requires: [ apply production ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           task_name: backup
           tf_workspace: production02
           timeout: 600
@@ -208,48 +208,48 @@ workflows:
       - run-task:
           name: restore production to preproduction
           requires: [ backup production ]
-          filters: { branches: { only: [ master ] } }
+          filters: { branches: { only: [ main ] } }
           task_name: restore_from_production
           tf_workspace: preproduction
           timeout: 600
 
-  weekly_master_run:
+  weekly_main_run:
     triggers:
       - schedule:
           cron: "00 05 * * 0"
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - build:
-          name: build master
-          filters: { branches: { only: [ master ] } }
+          name: build main
+          filters: { branches: { only: [ main ] } }
       - terraform-command:
-          name: apply master
-          requires: [ build master ]
-          filters: { branches: { only: [ master ] } }
+          name: apply main
+          requires: [ build main ]
+          filters: { branches: { only: [ main ] } }
           tf_workspace: master
           tf_command: apply
       - run-task:
-          name: reset master
-          requires: [ apply master ]
-          filters: { branches: { only: [ master ] } }
+          name: reset main
+          requires: [ apply main ]
+          filters: { branches: { only: [ main ] } }
           task_name: reset_database
           tf_workspace: master
           timeout: 180
       - client-unit-test:
           name: client unit test
-          requires: [ apply master ]
-          filters: { branches: { only: [ master ] } }
+          requires: [ apply main ]
+          filters: { branches: { only: [ main ] } }
       - api-unit-tests:
           name: api unit test
-          requires: [ apply master ]
-          filters: { branches: { only: [ master ] } }
+          requires: [ apply main ]
+          filters: { branches: { only: [ main ] } }
       - run-task:
           name: integration test
-          requires: [ reset master ]
-          filters: { branches: { only: [ master ] } }
+          requires: [ reset main ]
+          filters: { branches: { only: [ main ] } }
           task_name: integration_test
           tf_workspace: master
           notify_slack: true
@@ -421,7 +421,10 @@ jobs:
       - run:
           name: Check updated PHP files for errors
           command: |
-            MERGE_BASE_COMMIT=( $(git merge-base master HEAD) )
+            CURRENT_BRANCH=( git rev-parse --abbrev-ref HEAD )
+            git checkout main
+            git checkout $CURRENT_BRANCH
+            MERGE_BASE_COMMIT=( $(git merge-base main HEAD) )
             API_CHANGED_FILES=( $(git diff --relative=api --name-only --diff-filter=d $MERGE_BASE_COMMIT | grep .php) ) || [[ $? == 1 ]]
             CLIENT_CHANGED_FILES=( $(git diff --relative=client --name-only --diff-filter=d $MERGE_BASE_COMMIT | grep .php) ) || [[ $? == 1 ]]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,81 +5,81 @@ workflows:
     jobs:
       - lint:
           name: lint terraform
-          filters: { branches: { ignore: [ main ] } }
+          filters: { branches: { ignore: [ master ] } }
 
       - build:
           name: build pr
-          filters: { branches: { ignore: [ main ] } }
+          filters: { branches: { ignore: [ master ] } }
 
       - terraform-command:
           name: apply environment
           requires: [ build pr, lint terraform ]
-          filters: { branches: { ignore: [ main ] } }
+          filters: { branches: { ignore: [ master ] } }
           tf_command: apply
 
       - run-task:
           name: reset environment
           requires: [ apply environment ]
-          filters: { branches: { ignore: [ main ] } }
+          filters: { branches: { ignore: [ master ] } }
           task_name: reset_database
           timeout: 180
 
       - run-task:
           name: integration test
           requires: [ reset environment ]
-          filters: { branches: { ignore: [ main ] } }
+          filters: { branches: { ignore: [ master ] } }
           task_name: integration_test
           timeout: 2400
 
       - client-unit-test:
           name: client unit test
           requires: [ apply environment ]
-          filters: { branches: { ignore: [ main ] } }
+          filters: { branches: { ignore: [ master ] } }
 
       - api-unit-tests:
           name: api unit test
           requires: [ apply environment ]
-          filters: { branches: { ignore: [ main ] } }
+          filters: { branches: { ignore: [ master ] } }
 
       - pa11y-ci:
           name: accessibility test
           requires: [ apply environment ]
-          filters: { branches: { ignore: [ main ] } }
+          filters: { branches: { ignore: [ master ] } }
 
       - run-task:
           name: backup environment
           requires: [ api unit test, client unit test, integration test ]
-          filters: { branches: { ignore: [ main ] } }
+          filters: { branches: { ignore: [ master ] } }
           task_name: backup
 
       - run-task:
           name: restore environment
           requires: [ backup environment ]
-          filters: { branches: { ignore: [ main ] } }
+          filters: { branches: { ignore: [ master ] } }
           task_name: restore
 
       - cleanup:
           name: approve destroy environment
           type: approval
           requires: [ restore environment ]
-          filters: { branches: { ignore: [ main ] } }
+          filters: { branches: { ignore: [ master ] } }
 
       - terraform-command:
           name: destroy environment
           requires: [ approve destroy environment ]
-          filters: { branches: { ignore: [ main ] } }
+          filters: { branches: { ignore: [ master ] } }
           tf_command: destroy
 
-  main:
+  master:
     jobs:
       - build:
-          name: build main
-          filters: { branches: { only: [ main ] } }
+          name: build master
+          filters: { branches: { only: [ master ] } }
 
       - terraform-command:
           name: apply shared-development
-          requires: [ build main ]
-          filters: { branches: { only: [ main ] } }
+          requires: [ build master ]
+          filters: { branches: { only: [ master ] } }
           tf_tier: shared
           tf_workspace: development
           tf_command: apply
@@ -87,7 +87,7 @@ workflows:
       - terraform-command:
           name: plan shared-preproduction
           requires: [ apply shared-development ]
-          filters: { branches: { only: [ main ] } }
+          filters: { branches: { only: [ master ] } }
           tf_tier: shared
           tf_workspace: preproduction
           tf_command: plan
@@ -95,76 +95,76 @@ workflows:
       - terraform-command:
           name: plan preproduction
           requires: [ apply shared-development ]
-          filters: { branches: { only: [ main ] } }
+          filters: { branches: { only: [ master ] } }
           tf_workspace: preproduction
           tf_command: plan
 
       - terraform-command:
           name: apply shared-preproduction
           requires: [ plan shared-preproduction, plan preproduction ]
-          filters: { branches: { only: [ main ] } }
+          filters: { branches: { only: [ master ] } }
           tf_tier: shared
           tf_workspace: preproduction
           tf_command: apply
 
       - terraform-command:
-          name: apply main
+          name: apply master
           requires: [ apply shared-preproduction ]
-          filters: { branches: { only: [ main ] } }
-          tf_workspace: main
+          filters: { branches: { only: [ master ] } }
+          tf_workspace: master
           tf_command: apply
 
       - run-task:
-          name: reset main
-          requires: [ apply main ]
-          filters: { branches: { only: [ main ] } }
+          name: reset master
+          requires: [ apply master ]
+          filters: { branches: { only: [ master ] } }
           task_name: reset_database
-          tf_workspace: main
+          tf_workspace: master
           timeout: 180
 
       - run-task:
           name: integration test
-          requires: [ reset main ]
-          filters: { branches: { only: [ main ] } }
+          requires: [ reset master ]
+          filters: { branches: { only: [ master ] } }
           task_name: integration_test
-          tf_workspace: main
+          tf_workspace: master
           timeout: 1800
 
       - client-unit-test:
           name: client unit test
-          requires: [ apply main ]
-          filters: { branches: { only: [ main ] } }
+          requires: [ apply master ]
+          filters: { branches: { only: [ master ] } }
 
       - api-unit-tests:
           name: api unit test
-          requires: [ apply main ]
-          filters: { branches: { only: [ main ] } }
+          requires: [ apply master ]
+          filters: { branches: { only: [ master ] } }
 
       - terraform-command:
           name: apply training
           requires: [ apply shared-production ]
-          filters: { branches: { only: [ main ] } }
+          filters: { branches: { only: [ master ] } }
           tf_workspace: training
           tf_command: apply
 
       - terraform-command:
           name: apply preproduction
           requires: [ api unit test, client unit test, integration test ]
-          filters: { branches: { only: [ main ] } }
+          filters: { branches: { only: [ master ] } }
           tf_workspace: preproduction
           tf_command: apply
 
       - terraform-command:
           name: plan production
           requires: [ apply preproduction ]
-          filters: { branches: { only: [ main ] } }
+          filters: { branches: { only: [ master ] } }
           tf_workspace: production02
           tf_command: plan
 
       - terraform-command:
           name: plan shared-production
           requires: [ apply preproduction ]
-          filters: { branches: { only: [ main ] } }
+          filters: { branches: { only: [ master ] } }
           tf_tier: shared
           tf_workspace: production
           tf_command: plan
@@ -173,18 +173,18 @@ workflows:
           name: approve release to production notification
           message: "Production is ready for release and pending approval"
           requires: [ plan shared-production, plan production ]
-          filters: { branches: { only: [ main ] } }
+          filters: { branches: { only: [ master ] } }
 
       - approve:
           name: approve release to production
           type: approval
           requires: [ plan shared-production, plan production ]
-          filters: { branches: { only: [ main ] } }
+          filters: { branches: { only: [ master ] } }
 
       - terraform-command:
           name: apply shared-production
           requires: [ approve release to production ]
-          filters: { branches: { only: [ main ] } }
+          filters: { branches: { only: [ master ] } }
           tf_tier: shared
           tf_workspace: production
           tf_command: apply
@@ -192,7 +192,7 @@ workflows:
       - terraform-command:
           name: apply production
           requires: [ apply shared-production ]
-          filters: { branches: { only: [ main ] } }
+          filters: { branches: { only: [ master ] } }
           pact_tag: true
           tf_workspace: production02
           tf_command: apply
@@ -200,7 +200,7 @@ workflows:
       - run-task:
           name: backup production
           requires: [ apply production ]
-          filters: { branches: { only: [ main ] } }
+          filters: { branches: { only: [ master ] } }
           task_name: backup
           tf_workspace: production02
           timeout: 600
@@ -208,50 +208,50 @@ workflows:
       - run-task:
           name: restore production to preproduction
           requires: [ backup production ]
-          filters: { branches: { only: [ main ] } }
+          filters: { branches: { only: [ master ] } }
           task_name: restore_from_production
           tf_workspace: preproduction
           timeout: 600
 
-  weekly_main_run:
+  weekly_master_run:
     triggers:
       - schedule:
           cron: "00 05 * * 0"
           filters:
             branches:
               only:
-                - main
+                - master
     jobs:
       - build:
-          name: build main
-          filters: { branches: { only: [ main ] } }
+          name: build master
+          filters: { branches: { only: [ master ] } }
       - terraform-command:
-          name: apply main
-          requires: [ build main ]
-          filters: { branches: { only: [ main ] } }
-          tf_workspace: main
+          name: apply master
+          requires: [ build master ]
+          filters: { branches: { only: [ master ] } }
+          tf_workspace: master
           tf_command: apply
       - run-task:
-          name: reset main
-          requires: [ apply main ]
-          filters: { branches: { only: [ main ] } }
+          name: reset master
+          requires: [ apply master ]
+          filters: { branches: { only: [ master ] } }
           task_name: reset_database
-          tf_workspace: main
+          tf_workspace: master
           timeout: 180
       - client-unit-test:
           name: client unit test
-          requires: [ apply main ]
-          filters: { branches: { only: [ main ] } }
+          requires: [ apply master ]
+          filters: { branches: { only: [ master ] } }
       - api-unit-tests:
           name: api unit test
-          requires: [ apply main ]
-          filters: { branches: { only: [ main ] } }
+          requires: [ apply master ]
+          filters: { branches: { only: [ master ] } }
       - run-task:
           name: integration test
-          requires: [ reset main ]
-          filters: { branches: { only: [ main ] } }
+          requires: [ reset master ]
+          filters: { branches: { only: [ master ] } }
           task_name: integration_test
-          tf_workspace: main
+          tf_workspace: master
           notify_slack: true
           timeout: 1800
 
@@ -421,10 +421,7 @@ jobs:
       - run:
           name: Check updated PHP files for errors
           command: |
-            CURRENT_BRANCH=( $(git rev-parse --abbrev-ref HEAD) )
-            git checkout main
-            git checkout $CURRENT_BRANCH
-            MERGE_BASE_COMMIT=( $(git merge-base main HEAD) )
+            MERGE_BASE_COMMIT=( $(git merge-base master HEAD) )
             API_CHANGED_FILES=( $(git diff --relative=api --name-only --diff-filter=d $MERGE_BASE_COMMIT | grep .php) ) || [[ $? == 1 ]]
             CLIENT_CHANGED_FILES=( $(git diff --relative=client --name-only --diff-filter=d $MERGE_BASE_COMMIT | grep .php) ) || [[ $? == 1 ]]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,7 +421,7 @@ jobs:
       - run:
           name: Check updated PHP files for errors
           command: |
-            CURRENT_BRANCH=( git rev-parse --abbrev-ref HEAD )
+            CURRENT_BRANCH=( $(git rev-parse --abbrev-ref HEAD) )
             git checkout main
             git checkout $CURRENT_BRANCH
             MERGE_BASE_COMMIT=( $(git merge-base main HEAD) )

--- a/api/scripts/reset_db_structure.sh
+++ b/api/scripts/reset_db_structure.sh
@@ -11,8 +11,8 @@ confd -onetime -backend env
 
 echo "Dropping $PGDATABASE database, user $PGUSER on $PGHOST"
 
-psql -c "DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA IF NOT EXISTS public;"
-
 # Apply migrations to rebuild database
+su-exec www-data php app/console doctrine:database:drop --force
+su-exec www-data php app/console doctrine:database:create
 su-exec www-data php app/console doctrine:migrations:status-check
 su-exec www-data php app/console doctrine:migrations:migrate --no-interaction -vvv

--- a/docker/bash_profile
+++ b/docker/bash_profile
@@ -121,7 +121,7 @@ dd-behat-run()
 
 dd-phpstan() {
   if [ "$1" = "" ]; then
-    MERGE_BASE_COMMIT=( $(git merge-base master HEAD) )
+    MERGE_BASE_COMMIT=( $(git merge-base main HEAD) )
     API_CHANGED_FILES=( $(git diff --relative=api --name-only --diff-filter=d $MERGE_BASE_COMMIT | grep .php) ) || [[ $? == 1 ]]
     CLIENT_CHANGED_FILES=( $(git diff --relative=client --name-only --diff-filter=d $MERGE_BASE_COMMIT | grep .php) ) || [[ $? == 1 ]]
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -46,7 +46,7 @@ JIRA issues should be moved to the "Acceptance" column and have a product manage
 
 ### Ready to merge
 
-If the product manager approves your work, they will move the JIRA issue to the "Ready for Release" column. At this point you should approve the destruction of the feature environment in CircleCI, and merge the branch into `master`.
+If the product manager approves your work, they will move the JIRA issue to the "Ready for Release" column. At this point you should approve the destruction of the feature environment in CircleCI, and merge the branch into `main`.
 
 After the pull request has completed, the changes are automatically tested and, if the tests pass, deployed to pre-production.
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -8,29 +8,29 @@ deletion of the resource. If for any reason they are manually deleted then a fin
 
 To control our upgrade of minor versions we have put in place a staged deployment.
 
-Out of the non Dev environments only master is set to auto increment the minor version. This happens during the maintenance window.
+Out of the non Dev environments only main is set to auto increment the minor version. This happens during the maintenance window.
 
-Pre-production is setup to pull the current version from master which will have been through the full test suites and will set itself to
+Pre-production is setup to pull the current version from main which will have been through the full test suites and will set itself to
 update during it's maintenance window. Production then pulls from pre-production. This is done via the output in the previous jobs state file.
 
 So an upgrade will look something like this:
 
 #### Maintenance window 1
-- Master upgrades from 9.6.12 to 9.6.13
+- Main upgrades from 9.6.12 to 9.6.13
 - The same night as maintenance window, workflow if automatically kicked off to run all the tests and we are alerted of any issues
-- On next apply of pre-production it will pull the new 9.6.13 version from master and apply it to itself. This doesn't update straight away
+- On next apply of pre-production it will pull the new 9.6.13 version from main and apply it to itself. This doesn't update straight away
 but puts in an event in the pre-production maintenance window to upgrade at next maintenance.
 - On apply to Production there is no update as prod still sees Pre-Production set to 9.6.12 the same as what it is set to.
 
 #### Maintenance window 2
 
-- Master is still at 9.6.13
-- Pre-production has now upgraded to 9.6.13, no changes to apply as same as master
+- Main is still at 9.6.13
+- Pre-production has now upgraded to 9.6.13, no changes to apply as same as main
 - Production sees that Pre-production is ahead and adds event to it's maintenance window to upgrade to 9.6.13
 
 #### Maintenance window 3
 
-- Master is still at 9.6.13
+- Main is still at 9.6.13
 - Pre-production at 9.6.13
 - Production has now upgraded to 9.6.13
 

--- a/docs/architecture/decisions/0002-use-amazon-aurora-for-application-database.md
+++ b/docs/architecture/decisions/0002-use-amazon-aurora-for-application-database.md
@@ -10,7 +10,7 @@ Accepted
 
 DigiDeps uses a Postgres database to store persistent information. Since the project was first set up, we have been using an Amazon RDS hosted instance of Postgres for this. However, this hosting option lacks scalability so we have to pay for a full database host 24/7 for each environment.
 
-We have several environments which do not need to be highly available. This includes "ephemeral" development environments, the "master" environment used in CI, and the training environment. We do not need to run a database for these environments outside of working hours, and often inside of them too.
+We have several environments which do not need to be highly available. This includes "ephemeral" development environments, the "main" environment used in CI, and the training environment. We do not need to run a database for these environments outside of working hours, and often inside of them too.
 
 ## Decision
 

--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -40,7 +40,7 @@
       "state_source": "preproduction",
       "elasticache_count": 2,
       "always_on": true,
-      "copy_version_from": "master"
+      "copy_version_from": "main"
     },
     "training": {
       "account_id": "515688267891",
@@ -62,7 +62,7 @@
       "always_on": true,
       "copy_version_from": "preproduction"
     },
-    "master": {
+    "main": {
       "account_id": "454262938596",
       "admin_whitelist": [],
       "force_destroy_bucket": true,

--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -40,7 +40,7 @@
       "state_source": "preproduction",
       "elasticache_count": 2,
       "always_on": true,
-      "copy_version_from": "main"
+      "copy_version_from": "master"
     },
     "training": {
       "account_id": "515688267891",
@@ -61,26 +61,6 @@
       "elasticache_count": 1,
       "always_on": true,
       "copy_version_from": "preproduction"
-    },
-    "main": {
-      "account_id": "454262938596",
-      "admin_whitelist": [],
-      "force_destroy_bucket": true,
-      "front_whitelist": [],
-      "ga_default": "UA-57312200-2",
-      "ga_gds": "",
-      "subdomain_enabled": true,
-      "is_production": 0,
-      "secrets_prefix": "",
-      "task_count": 3,
-      "symfony_env": "test",
-      "db_subnet_group": "private",
-      "ec_subnet_group": "private",
-      "sirius_api_account": "492687888235",
-      "state_source": "preproduction",
-      "elasticache_count": 1,
-      "always_on": true,
-      "copy_version_from": "NonApplicable"
     },
     "master": {
       "account_id": "454262938596",

--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -82,6 +82,26 @@
       "always_on": true,
       "copy_version_from": "NonApplicable"
     },
+    "master": {
+      "account_id": "454262938596",
+      "admin_whitelist": [],
+      "force_destroy_bucket": true,
+      "front_whitelist": [],
+      "ga_default": "UA-57312200-2",
+      "ga_gds": "",
+      "subdomain_enabled": true,
+      "is_production": 0,
+      "secrets_prefix": "",
+      "task_count": 3,
+      "symfony_env": "test",
+      "db_subnet_group": "private",
+      "ec_subnet_group": "private",
+      "sirius_api_account": "492687888235",
+      "state_source": "preproduction",
+      "elasticache_count": 1,
+      "always_on": true,
+      "copy_version_from": "NonApplicable"
+    },
     "default": {
       "account_id": "248804316466",
       "admin_whitelist": [],


### PR DESCRIPTION
## Purpose
As part of removing oppressive language from our codebase this change will rename references from `master` to `main`.

Fixes DDPB-3463

## Approach
A search folder by folder highlighted the following places we needed to make the change:

### Documentation
- Rename all instances of master to main

### Scripts
- Update bash_profile scripts to use main rather than master

### CircleCI
- Rename all instances of master to main in .circleci/config.yml

### Terraform - opg-digideps
Change tfvars.json reference from master to main

### Terraform - opg-org-infra
Change default_branch_name in opg-org-infra to from master to main (PR raised separately)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes