### PR TITLE
Remove temp fix for getting main branch in pipeline now main is default branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,9 +421,6 @@ jobs:
       - run:
           name: Check updated PHP files for errors
           command: |
-            CURRENT_BRANCH=( $(git rev-parse --abbrev-ref HEAD) )
-            git checkout main
-            git checkout $CURRENT_BRANCH
             MERGE_BASE_COMMIT=( $(git merge-base main HEAD) )
             API_CHANGED_FILES=( $(git diff --relative=api --name-only --diff-filter=d $MERGE_BASE_COMMIT | grep .php) ) || [[ $? == 1 ]]
             CLIENT_CHANGED_FILES=( $(git diff --relative=client --name-only --diff-filter=d $MERGE_BASE_COMMIT | grep .php) ) || [[ $? == 1 ]]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ You must have Docker installed.
 ```sh
 docker-compose run --rm api sh scripts/reset_db_structure.sh
 docker-compose run --rm api sh scripts/reset_db_fixtures.sh
-
 ```
 
 ## Traffic Flow Diagram


### PR DESCRIPTION

I'd previously had to add a manual checkout of `main` while we still had `master` as our default branch. Now we've switched over the temporary fix can be removed.