### PR TITLE
DDPB-3534 - Rename master workspace to integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,6 +256,7 @@ workflows:
 orbs:
   aws-cli: circleci/aws-cli@0.1.13
   slack: circleci/slack@3.4.2
+  codecov: codecov/codecov@1.0.2
   ecs_helper:
     commands:
       install:
@@ -303,8 +304,6 @@ orbs:
           - run:
               name: Install Terraform
               command: sudo unzip terraform_${TF_VERSION}_linux_amd64.zip -d /bin
-
-  codecov: codecov/codecov@1.0.2
 
 jobs:
   lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ workflows:
           tf_command: plan
 
       - slack/approval-notification:
-          name: approve release to production notification
+          name: release approval notification
           message: "Production is ready for release and pending approval"
           requires: [ plan shared-production, plan production ]
           filters: { branches: { only: [ main ] } }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,15 +70,15 @@ workflows:
           filters: { branches: { ignore: [ main ] } }
           tf_command: destroy
 
-  master:
+  integration:
     jobs:
       - build:
-          name: build master
+          name: build integration
           filters: { branches: { only: [ main ] } }
 
       - terraform-command:
           name: apply shared-development
-          requires: [ build master ]
+          requires: [ build integration ]
           filters: { branches: { only: [ main ] } }
           tf_tier: shared
           tf_workspace: development
@@ -108,36 +108,36 @@ workflows:
           tf_command: apply
 
       - terraform-command:
-          name: apply master
+          name: apply integration
           requires: [ apply shared-preproduction ]
           filters: { branches: { only: [ main ] } }
-          tf_workspace: master
+          tf_workspace: integration
           tf_command: apply
 
       - run-task:
-          name: reset master
-          requires: [ apply master ]
+          name: reset integration
+          requires: [ apply integration ]
           filters: { branches: { only: [ main ] } }
           task_name: reset_database
-          tf_workspace: master
+          tf_workspace: integration
           timeout: 180
 
       - run-task:
           name: integration test
-          requires: [ reset master ]
+          requires: [ reset integration ]
           filters: { branches: { only: [ main ] } }
           task_name: integration_test
-          tf_workspace: master
+          tf_workspace: integration
           timeout: 1800
 
       - client-unit-test:
           name: client unit test
-          requires: [ apply master ]
+          requires: [ apply integration ]
           filters: { branches: { only: [ main ] } }
 
       - api-unit-tests:
           name: api unit test
-          requires: [ apply master ]
+          requires: [ apply integration ]
           filters: { branches: { only: [ main ] } }
 
       - terraform-command:
@@ -213,45 +213,43 @@ workflows:
           tf_workspace: preproduction
           timeout: 600
 
-  weekly_master_run:
+  weekly_integration_run:
     triggers:
       - schedule:
           cron: "00 05 * * 0"
-          filters:
-            branches:
-              only:
-                - master
+          filters: { branches: { only: [ main ] } }
+
     jobs:
       - build:
-          name: build master
+          name: build integration
           filters: { branches: { only: [ main ] } }
       - terraform-command:
-          name: apply master
-          requires: [ build master ]
+          name: apply integration
+          requires: [ build integration ]
           filters: { branches: { only: [ main ] } }
-          tf_workspace: master
+          tf_workspace: integration
           tf_command: apply
       - run-task:
-          name: reset master
-          requires: [ apply master ]
+          name: reset integration
+          requires: [ apply integration ]
           filters: { branches: { only: [ main ] } }
           task_name: reset_database
-          tf_workspace: master
+          tf_workspace: integration
           timeout: 180
       - client-unit-test:
           name: client unit test
-          requires: [ apply master ]
+          requires: [ apply integration ]
           filters: { branches: { only: [ main ] } }
       - api-unit-tests:
           name: api unit test
-          requires: [ apply master ]
+          requires: [ apply integration ]
           filters: { branches: { only: [ main ] } }
       - run-task:
           name: integration test
-          requires: [ reset master ]
+          requires: [ reset integration ]
           filters: { branches: { only: [ main ] } }
           task_name: integration_test
-          tf_workspace: master
+          tf_workspace: integration
           notify_slack: true
           timeout: 1800
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,9 +421,6 @@ jobs:
       - run:
           name: Check updated PHP files for errors
           command: |
-            CURRENT_BRANCH=( $(git rev-parse --abbrev-ref HEAD) )
-            git checkout main
-            git checkout $CURRENT_BRANCH
             MERGE_BASE_COMMIT=( $(git merge-base main HEAD) )
             API_CHANGED_FILES=( $(git diff --relative=api --name-only --diff-filter=d $MERGE_BASE_COMMIT | grep .php) ) || [[ $? == 1 ]]
             CLIENT_CHANGED_FILES=( $(git diff --relative=client --name-only --diff-filter=d $MERGE_BASE_COMMIT | grep .php) ) || [[ $? == 1 ]]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ You must have Docker installed.
 ```sh
 docker-compose run --rm api sh scripts/reset_db_structure.sh
 docker-compose run --rm api sh scripts/reset_db_fixtures.sh
-
 ```
 
 ## Traffic Flow Diagram

--- a/environment/admin_sg.tf
+++ b/environment/admin_sg.tf
@@ -97,7 +97,7 @@ resource "aws_security_group_rule" "admin_whitelist" {
   from_port         = 443
   to_port           = 443
   security_group_id = module.admin_elb_security_group.id
-  cidr_blocks       = local.admin_whitelist
+  cidr_blocks       = local.admin_allow_list
 }
 
 //No room for rules left in admin_elb_security_group

--- a/environment/front_sg.tf
+++ b/environment/front_sg.tf
@@ -105,7 +105,7 @@ resource "aws_security_group_rule" "front_elb_http_in" {
   from_port         = 80
   to_port           = 80
   security_group_id = module.front_elb_security_group.id
-  cidr_blocks       = local.front_whitelist
+  cidr_blocks       = local.front_allow_list
 }
 
 resource "aws_security_group_rule" "front_elb_https_in" {
@@ -114,7 +114,7 @@ resource "aws_security_group_rule" "front_elb_https_in" {
   from_port         = 443
   to_port           = 443
   security_group_id = module.front_elb_security_group.id
-  cidr_blocks       = local.front_whitelist
+  cidr_blocks       = local.front_allow_list
 }
 
 //No room for rules left in front_elb_security_group

--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -40,7 +40,7 @@
       "state_source": "preproduction",
       "elasticache_count": 2,
       "always_on": true,
-      "copy_version_from": "master"
+      "copy_version_from": "integration"
     },
     "training": {
       "account_id": "515688267891",
@@ -62,7 +62,7 @@
       "always_on": true,
       "copy_version_from": "preproduction"
     },
-    "master": {
+    "integration": {
       "account_id": "454262938596",
       "admin_whitelist": [],
       "force_destroy_bucket": true,

--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -2,9 +2,9 @@
   "accounts": {
     "production02": {
       "account_id": "515688267891",
-      "admin_whitelist": [],
+      "admin_allow_list": [],
       "force_destroy_bucket": false,
-      "front_whitelist": [
+      "front_allow_list": [
         "0.0.0.0/0"
       ],
       "ga_default": "UA-57312200-3",
@@ -24,9 +24,9 @@
     },
     "preproduction": {
       "account_id": "454262938596",
-      "admin_whitelist": [],
+      "admin_allow_list": [],
       "force_destroy_bucket": false,
-      "front_whitelist": [],
+      "front_allow_list": [],
       "ga_default": "UA-57312200-3",
       "ga_gds": "",
       "subdomain_enabled": true,
@@ -44,9 +44,9 @@
     },
     "training": {
       "account_id": "515688267891",
-      "admin_whitelist": [],
+      "admin_allow_list": [],
       "force_destroy_bucket": true,
-      "front_whitelist": [],
+      "front_allow_list": [],
       "ga_default": "UA-57312200-2",
       "ga_gds": "",
       "subdomain_enabled": true,
@@ -64,9 +64,9 @@
     },
     "integration": {
       "account_id": "454262938596",
-      "admin_whitelist": [],
+      "admin_allow_list": [],
       "force_destroy_bucket": true,
-      "front_whitelist": [],
+      "front_allow_list": [],
       "ga_default": "UA-57312200-2",
       "ga_gds": "",
       "subdomain_enabled": true,
@@ -84,10 +84,10 @@
     },
     "default": {
       "account_id": "248804316466",
-      "admin_whitelist": [],
+      "admin_allow_list": [],
       "send_internal_email": false,
       "force_destroy_bucket": true,
-      "front_whitelist": [],
+      "front_allow_list": [],
       "ga_default": "UA-57312200-2",
       "ga_gds": "",
       "subdomain_enabled": true,

--- a/environment/variables.tf
+++ b/environment/variables.tf
@@ -10,9 +10,9 @@ variable "accounts" {
   type = map(
     object({
       account_id           = string
-      admin_whitelist      = list(string)
+      admin_allow_list     = list(string)
       force_destroy_bucket = bool
-      front_whitelist      = list(string)
+      front_allow_list     = list(string)
       ga_default           = string
       ga_gds               = string
       subdomain_enabled    = bool
@@ -35,20 +35,20 @@ data "aws_ip_ranges" "route53_healthchecks_ips" {
   services = ["route53_healthchecks"]
 }
 
-module "whitelist" {
+module "allow_list" {
   source = "git@github.com:ministryofjustice/terraform-aws-moj-ip-whitelist.git"
 }
 
 locals {
-  default_whitelist = concat(module.whitelist.moj_sites, formatlist("%s/32", data.aws_nat_gateway.nat[*].public_ip))
+  default_allow_list = concat(module.allow_list.moj_sites, formatlist("%s/32", data.aws_nat_gateway.nat[*].public_ip))
 
   route53_healthchecker_ips = data.aws_ip_ranges.route53_healthchecks_ips.cidr_blocks
 
-  environment     = lower(terraform.workspace)
-  account         = contains(keys(var.accounts), local.environment) ? var.accounts[local.environment] : var.accounts["default"]
-  subdomain       = local.account["subdomain_enabled"] ? local.environment : ""
-  front_whitelist = length(local.account["front_whitelist"]) > 0 ? local.account["front_whitelist"] : local.default_whitelist
-  admin_whitelist = length(local.account["admin_whitelist"]) > 0 ? local.account["admin_whitelist"] : local.default_whitelist
+  environment      = lower(terraform.workspace)
+  account          = contains(keys(var.accounts), local.environment) ? var.accounts[local.environment] : var.accounts["default"]
+  subdomain        = local.account["subdomain_enabled"] ? local.environment : ""
+  front_allow_list = length(local.account["front_allow_list"]) > 0 ? local.account["front_allow_list"] : local.default_allow_list
+  admin_allow_list = length(local.account["admin_allow_list"]) > 0 ? local.account["admin_allow_list"] : local.default_allow_list
 }
 
 data "terraform_remote_state" "shared" {


### PR DESCRIPTION
## Purpose
After the renaming of our default branch to `main` it seemed like a good opportunity to diverge the name of the workspace to something else. The reason behind this being that sharing a name insinuates that there is a direct link between the branch and the workspace when in reality they are completely separate. We've settled in `integration` as this is the closest name that describes the workspace's purpose (running integration tests in a prod-like environment).

Fixes DDPB-3534.

## Learning
I now know what a workspace is 🙃  

```
A workspace is effectively a state file

So it's the full configuration for whatever you're building. You could have multiple workspaces in a single account or one workspace that puts resources across multiple accounts

In practice it affects what the resources are named

Terraform knows to update resource apple-tree because it's called apple-tree. You could easily (and we've had it in the past), have two workspaces updating the same resource if they both have a reference to apple-tree in them

This is why we prepend terraform.environment to everything cos it is taken from the workspace name
```
(courtesy of sage @jamesrwarren )

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
