### PR TITLE
DDPB-3531: add manual sync fallback when checklist sync feature is di…

### DIFF
--- a/client/src/AppBundle/Resources/translations/admin-checklist.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin-checklist.en.yml
@@ -231,6 +231,7 @@ checklistPage:
 checklistSubmittedPage:
   htmlTitle: Administration - Report checklist
   panelTitle: Checklist submitted
+  downloadText: Your PDF download should start automatically. <a href="%downloadLinkUrl%" class="%downloadLinkClassList%">Click here</a> to download it if it does not download automatically.
   toChecklistButtonText: Return to checklist
   toClientListButtonText: View client list
   manageReportLinkText: Manage this report

--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/checklistSubmitted.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/checklistSubmitted.html.twig
@@ -18,6 +18,15 @@
                 </div>
             </div>
 
+            {% if syncFeatureIsEnabled == false %}
+                <p class="govuk-body govuk-!-padding-top-6 govuk-!-padding-bottom-1">
+                    {{ (page ~ '.downloadText') | trans({
+                        '%downloadLinkUrl%': path('admin_checklist_pdf', {'id': report.id}),
+                        '%downloadLinkClassList%': "behat-link-download-checklist-pdf"
+                    }) | raw }}
+                </p>
+            {% endif %}
+
             <p class="govuk-body govuk-!-padding-top-1 govuk-!-padding-bottom-6">
                 <a href="{{ path('admin_report_manage', {'id': report.id}) }}"
                    class="govkuk-link behat-link-manage">{{ (page ~ '.manageReportLinkText') | trans }}
@@ -32,4 +41,14 @@
             </a>
         </div>
     </div>
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+
+    {% if syncFeatureIsEnabled == false %}
+        <script>
+          window.location.href = "{{ path('admin_checklist_pdf', {'id': report.id}) }}";
+        </script>
+    {% endif %}
 {% endblock %}

--- a/environment/parameters.tf
+++ b/environment/parameters.tf
@@ -46,7 +46,7 @@ resource "aws_ssm_parameter" "checklist_sync_row_limit" {
 resource "aws_ssm_parameter" "flag_checklist_sync" {
   name  = "${local.feature_flag_prefix}checklist-sync"
   type  = "String"
-  value = "1"
+  value = "0"
 
   tags = local.default_tags
 


### PR DESCRIPTION
## Purpose
To disable checklist sync by default so that we can release to prod gradually without invoking the sync.

Fixes DDPB-3531

## Approach
The net effect is that when disabled, we should fall back to the old process of generating and downloading the checklist PDF on submit, instead of queueing it in the database.


## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
