### PR TITLE
pin the was provider to version to avoid breaking ACM change

### DIFF
--- a/environment/provider.tf
+++ b/environment/provider.tf
@@ -16,6 +16,7 @@ provider "aws" {
     role_arn     = "arn:aws:iam::${local.account["account_id"]}:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
+  version = "2.70.0"
 }
 
 provider "aws" {
@@ -26,6 +27,7 @@ provider "aws" {
     role_arn     = "arn:aws:iam::311462405659:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
+  version = "2.70.0"
 }
 
 # DD has it's public DNS in production, not management
@@ -37,6 +39,7 @@ provider "aws" {
     role_arn     = "arn:aws:iam::515688267891:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
+  version = "2.70.0"
 }
 
 provider "aws" {
@@ -67,6 +70,7 @@ provider "aws" {
     role_arn     = "arn:aws:iam::515688267891:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
+  version = "2.70.0"
 }
 
 provider "aws" {
@@ -77,4 +81,5 @@ provider "aws" {
     role_arn     = "arn:aws:iam::${local.account["account_id"]}:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
+  version = "2.70.0"
 }

--- a/shared/provider.tf
+++ b/shared/provider.tf
@@ -16,6 +16,7 @@ provider "aws" {
     role_arn     = "arn:aws:iam::${var.accounts[terraform.workspace].account_id}:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
+  version = "2.70.0"
 }
 
 provider "aws" {
@@ -26,6 +27,7 @@ provider "aws" {
     role_arn     = "arn:aws:iam::311462405659:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
+  version = "2.70.0"
 }
 
 provider "aws" {
@@ -36,4 +38,5 @@ provider "aws" {
     role_arn     = "arn:aws:iam::${local.account["account_id"]}:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
+  version = "2.70.0"
 }


### PR DESCRIPTION
## Purpose
_AWS provider released a v3 with a change causing ACM usage to fail _


## Approach
_Pin provider version_
