### PR TITLE
DDPB-3536: Limit adding Lay deputies from admin frontend to super admins

### DIFF
--- a/behat/tests/features/admin/05-ndr-enablement.feature
+++ b/behat/tests/features/admin/05-ndr-enablement.feature
@@ -1,7 +1,7 @@
 Feature: Enabling and disabling NDR for Lay deputies
 
   Scenario: Enabling and disabling NDR from admin toggles the availability of the NDR and Report accordingly
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "Abcd1234"
     And there is an activated "Lay Deputy" user with NDR "disabled" and email "red-squirrel@publicguardian.gov.uk" and password "Abcd1234"
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
 

--- a/behat/tests/features/deputy/01-registration-steps/01-create-users.feature
+++ b/behat/tests/features/deputy/01-registration-steps/01-create-users.feature
@@ -45,7 +45,7 @@ Feature: deputy / user / add user
 
   @ndr
   Scenario: add deputy user (ndr)
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "Abcd1234"
       # assert form OK
     When I create a new "NDR-enabled" "Lay Deputy" user "John NDR" "Doe NDR" with email "behat-user-ndr@publicguardian.gov.uk" and postcode "AB12CD"
     Then I should see "behat-user-ndr@publicguardian.gov.uk" in the "users" region

--- a/client/src/AppBundle/Form/Admin/AddUserType.php
+++ b/client/src/AppBundle/Form/Admin/AddUserType.php
@@ -26,7 +26,6 @@ class AddUserType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $deputyRoles = [
-            User::ROLE_LAY_DEPUTY,
             User::ROLE_PA_NAMED,
             User::ROLE_PA_ADMIN,
             User::ROLE_PA_TEAM_MEMBER,

--- a/client/src/AppBundle/Form/Admin/AddUserType.php
+++ b/client/src/AppBundle/Form/Admin/AddUserType.php
@@ -38,6 +38,7 @@ class AddUserType extends AbstractType
 
         $loggedInUser = $this->tokenStorage->getToken()->getUser();
         if ($loggedInUser->getRoleName() === User::ROLE_SUPER_ADMIN) {
+            $deputyRoles[] = User::ROLE_LAY_DEPUTY;
             $staffRoles[] = User::ROLE_SUPER_ADMIN;
         }
 


### PR DESCRIPTION
## Purpose
We've tracked down the co-deputy flag bug to instances where a Lay Deputy is created in the admin panel using the Add User form. This flow doesn't carry out a casrec verification step and so the co-deputy flag is never set. We should limit this feature to super admins only to ensure we don't have any further cases pop up.

Fixes DDPB-3536

## Learning
There are a few behat tests that rely on this form to populate data as part of existing older tests. I contemplated using the ensure users exist behat function we have now but it wasn't clear if some of the users created with specific email addresses were used in further tests so this seemed like a good compromise.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [x] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
