### PR TITLE
DDPB-3314: Update non-descriptive links

### DIFF
--- a/client/src/AppBundle/Resources/views/Admin/Client/Client/details.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Client/details.html.twig
@@ -189,8 +189,9 @@
                             <br />
                         {% endif %}
                         {% if enableManageLink %}
-                            <a href="{{ path('admin_report_manage', {'id': report.id}) }}"
-                               class="behat-link-manage">{{ 'manage' | trans({}, 'common') }}</a>
+                            <a href="{{ path('admin_report_manage', {'id': report.id}) }}" class="behat-link-manage">
+                                {{ 'manage' | trans({}, 'common') }} <span class="govuk-visually-hidden">{{ report.period | replace({' to ': '–'}) }} report</span>
+                            </a>
                             <br />
                         {% endif %}
                         {% if enableDownloadLink %}

--- a/client/src/AppBundle/Resources/views/Admin/Index/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Index/index.html.twig
@@ -110,10 +110,11 @@
                             {{ 'yes' | trans({}, 'common') }}
                         {% else %}
                             {{ 'no' | trans({}, 'common') }}
-                            <br/><a class="js-return-html behat-link-send-activation-email"
+                            <br/>
+                            <a class="js-return-html behat-link-send-activation-email"
                                     href="{{ path('admin_send_activation_link', {'email': user.email}) }}">
-                            {{ (page ~ '.userTable.sendEmail') | trans }}
-                        </a>
+                                {{ (page ~ '.userTable.sendEmail') | trans }} <span class="govuk-visually-hidden"> to {{ fullName }}</span>
+                            </a>
                         {% endif %}
 
                     </td>

--- a/client/src/AppBundle/Resources/views/Admin/Organisation/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Organisation/index.html.twig
@@ -52,11 +52,11 @@
                     </td>
                     <td class="govuk-table__cell govuk-table__cell--numeric">
                         <a class="govuk-link behat-link-edit" href="{{ url('admin_organisation_edit', { id: organisation.id }) }}">
-                            {{ 'edit' | trans({}, 'common') }}
+                            {{ 'edit' | trans({}, 'common') }} <span class="govuk-visually-hidden">{{ organisation.name }}</span>
                         </a>
                         {% if is_granted('ROLE_SUPER_ADMIN') %}
                             <a class="govuk-link govuk-!-margin-left-1 behat-link-delete" href="{{ url('admin_organisation_delete', { id: organisation.id }) }}">
-                                {{ 'remove' | trans({}, 'common') }}
+                                {{ 'remove' | trans({}, 'common') }} <span class="govuk-visually-hidden">{{ organisation.name }}</span>
                             </a>
                         {% endif %}
                     </td>

--- a/client/src/AppBundle/Resources/views/Org/ClientProfile/_reportDetail-PA.html.twig
+++ b/client/src/AppBundle/Resources/views/Org/ClientProfile/_reportDetail-PA.html.twig
@@ -48,7 +48,9 @@
             </dt>
             <dd class="push--bottom">
                 <span class="push--right">{{ report.startDate | date(" j F Y") }} to {{ report.endDate | date(" j F Y") }}</span>
-                <a href="{{ path('report_edit', {'reportId': report.id}) }}" class="right behat-link-edit-report-period">{{ 'edit' | trans }}</a>
+                <a href="{{ path('report_edit', {'reportId': report.id}) }}" class="right behat-link-edit-report-period">
+                    {{ 'edit' | trans }} <span class="govuk-visually-hidden">reporting period</span>
+                </a>
 
                 <details class="govuk-details govuk-!-padding-top-5" data-module="govuk-details">
                     <summary class="govuk-details__summary">

--- a/client/src/AppBundle/Resources/views/Org/ClientProfile/_reportDetail-Prof.html.twig
+++ b/client/src/AppBundle/Resources/views/Org/ClientProfile/_reportDetail-Prof.html.twig
@@ -46,7 +46,9 @@
             </dt>
             <dd class="push--bottom">
                 <span class="push--right">{{ report.startDate | date(" j F Y") }} to {{ report.endDate | date(" j F Y") }}</span>
-                <a href="{{ path('report_edit', {'reportId': report.id}) }}" class="right behat-link-edit-report-period">{{ 'edit' | trans }}</a>
+                <a href="{{ path('report_edit', {'reportId': report.id}) }}" class="right behat-link-edit-report-period">
+                    {{ 'edit' | trans }} <span class="govuk-visually-hidden">reporting period</span>
+                </a>
 
                 <details class="govuk-details govuk-!-padding-top-5" data-module="govuk-details">
                     <summary class="govuk-details__summary">

--- a/client/src/AppBundle/Resources/views/Org/Team/list.html.twig
+++ b/client/src/AppBundle/Resources/views/Org/Team/list.html.twig
@@ -88,13 +88,19 @@
                 </td>
                 <td class="govuk-table__header change-answer">
                     {% if user.id != app.user.id and is_granted('edit-user', user) %}
-                        <a class="behat-link-edit" href="{{  path('edit_team_member', {'id': user.id}) }}">{{ 'edit' | trans({}, 'common' ) }}</a><br>
+                        <a class="behat-link-edit" href="{{  path('edit_team_member', {'id': user.id}) }}">
+                            {{ 'edit' | trans({}, 'common' ) }} <span class="govuk-visually-hidden">{{ user.firstname }} {{ user.lastname }}'s account</span>
+                        </a><br>
                     {% endif %}
                     {% if is_granted('delete-user', user) %}
-                        <a class="behat-link-delete" href="{{  path('delete_team_member', {'id': user.id}) }}">{{ 'remove' | trans({}, 'common' ) }}</a><br>
+                        <a class="behat-link-delete" href="{{  path('delete_team_member', {'id': user.id}) }}">
+                            {{ 'remove' | trans({}, 'common' ) }} <span class="govuk-visually-hidden">{{ user.firstname }} {{ user.lastname }} from organisation</span>
+                        </a><br>
                     {% endif %}
                     {% if is_granted('edit-user', user) and not user.active %}
-                        <a class="behat-link-send-activation-email" href="{{ path('team_send_activation_link', {'id': user.id}) }}">{{ 'listPage.resendActivation' | trans }}</a>
+                        <a class="behat-link-send-activation-email" href="{{ path('team_send_activation_link', {'id': user.id}) }}">
+                            {{ 'listPage.resendActivation' | trans }} <span class="govuk-visually-hidden">email to {{ user.firstname }} {{ user.lastname }}</span>
+                        </a>
                     {% endif %}
                 </td>
             </tr>

--- a/client/src/AppBundle/Resources/views/Report/Report/_subsection.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Report/_subsection.html.twig
@@ -50,13 +50,14 @@
 
     <a href="{{ linkToSubSection }}" class="opg-overview-section__link behat-link-edit-{{ subSection }}" id="edit-{{ subSection }}">
         {% if subSection == 'balance' %}
-            {{ 'view' | trans({}, 'common') | capitalize }}
+            {{ 'view' | trans({}, 'common') | capitalize }} <span class="govuk-visually-hidden">{{ (subSection ~ '.subSectionTitle') | trans }}
         {% else %}
             {% if state.state == 'not-started' %}
-                {{ 'start' | trans({}, 'common') | capitalize }}
+                {{ 'start' | trans({}, 'common') | capitalize }} <span class="govuk-visually-hidden">{{ (subSection ~ '.subSectionTitle') | trans }}</span>
             {% else %}
-                {{ 'edit' | trans({}, 'common') | capitalize }}
+                {{ 'edit' | trans({}, 'common') | capitalize }} <span class="govuk-visually-hidden">{{ (subSection ~ '.subSectionTitle') | trans }}</span>
             {% endif %}
         {% endif %}
     </a>
+
 </div>

--- a/client/src/AppBundle/Resources/views/Report/Report/_subsection.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Report/_subsection.html.twig
@@ -50,7 +50,7 @@
 
     <a href="{{ linkToSubSection }}" class="opg-overview-section__link behat-link-edit-{{ subSection }}" id="edit-{{ subSection }}">
         {% if subSection == 'balance' %}
-            {{ 'view' | trans({}, 'common') | capitalize }} <span class="govuk-visually-hidden">{{ (subSection ~ '.subSectionTitle') | trans }}
+            {{ 'view' | trans({}, 'common') | capitalize }} <span class="govuk-visually-hidden">{{ (subSection ~ '.subSectionTitle') | trans }}</span>
         {% else %}
             {% if state.state == 'not-started' %}
                 {{ 'start' | trans({}, 'common') | capitalize }} <span class="govuk-visually-hidden">{{ (subSection ~ '.subSectionTitle') | trans }}</span>

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -19,3 +19,4 @@ _Any tips and tricks, blog posts or tools which helped you. Plus anything notabl
 - [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
 - [ ] There are no deprecated CSS classes noted in the profiler
 - [ ] Translations are used and the profiler doesn't identify any missing
+- [ ] Any links or buttons added are screen reader friendly and contextually complete


### PR DESCRIPTION
## Purpose
We have multiple instances where links are limited to single words (Edit, Remove, Add etc) or contextually incomplete phrases (send email rather than send email to <users name> etc). This makes it more difficult for users of screen readers to navigate and work with our application. This change adds context to as many instances of these links and buttons as possible. 

Fixes DDPB-3314

## Learning
I've added an extra checklist to our frontend checklist as a reminder to ensure we add context to any links or buttons that we add as part of a PR to make sure our app continues to be screen reader-friendly.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [x] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [x] Any links or buttons added are screen reader friendly and contextually complete