### PR TITLE
Use correct workspace name for prod

### DIFF
--- a/environment/document_sync.tf
+++ b/environment/document_sync.tf
@@ -27,7 +27,7 @@ locals {
     }
   }
 
-  document_sync_interval = local.environment == "production" ? "rate(5 minutes)" : "rate(24 hours)"
+  document_sync_interval = local.environment == "production02" ? "rate(5 minutes)" : "rate(24 hours)"
 
 }
 

--- a/environment/parameters.tf
+++ b/environment/parameters.tf
@@ -1,7 +1,7 @@
 locals {
   feature_flag_prefix       = "/${local.environment}/flag/"
   parameter_prefix          = "/${local.environment}/parameter/"
-  sirius_api_base_uri_value = local.environment == "production" ? "https://deputy-reporting.api.opg.service.justice.gov.uk" : "http://${local.mock_sirius_integration_service_fqdn}:8080"
+  sirius_api_base_uri_value = local.environment == "production02" ? "https://deputy-reporting.api.opg.service.justice.gov.uk" : "http://${local.mock_sirius_integration_service_fqdn}:8080"
 }
 
 resource "aws_ssm_parameter" "sirius_api_base_uri" {


### PR DESCRIPTION
## Purpose
The dastardly `02` of `production02` strikes again. This change should stop the Sirius URL from being updated to the mock server on prod.

Fixes DDPB-####

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
