### PR TITLE
DDPB-3313: Update detail and summary elements to use GDS version for IE11 fallback

### DIFF
--- a/client/src/AppBundle/Resources/views/Index/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Index/index.html.twig
@@ -29,11 +29,11 @@
                         <a id="creat-account-button" class="button" href="{{ path('register') }}">{{ 'createaccount' | trans }}</a>
                     </p>
 
-                    <details class="push--bottom">
-                        <summary>
-                            <span class="summary">{{ 'whatyouneed' |trans }}</span>
+                    <details class="govuk-details" data-module="govuk-details">
+                        <summary class="govuk-details__summary">
+                            <span class="govuk-details__summary-text">{{ 'whatyouneed' |trans }}</span>
                         </summary>
-                        <div class="opg-indented-block">
+                        <div class="govuk-details__text">
                             <ul class="govuk-list govuk-list--bullet">
                                 <li>{{ 'whatyouneedListItem1' | trans }}</li>
                                 <li>{{ 'whatyouneedListItem2' | trans }}</li>
@@ -57,20 +57,20 @@
 
             <div class="text push--top">
 
-                <details>
-                    <summary>
-                        <span class="summary">{{ 'whyWeNeed.summary' |trans }}</span>
+                <details class="govuk-details" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                        <span class="govuk-details__summary-text">{{ 'whyWeNeed.summary' |trans }}</span>
                     </summary>
-                    <div class="opg-indented-block">
+                    <div class="govuk-details__text">
                         <p>{{ 'whyWeNeed.para01' |trans }}</p>
                     </div>
                 </details>
 
-                <details>
-                    <summary>
-                        <span class="summary">{{ 'provideDetails.summary' |trans }}</span>
+                <details class="govuk-details" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                        <span class="govuk-details__summary-text">{{ 'provideDetails.summary' |trans }}</span>
                     </summary>
-                    <div class="opg-indented-block">
+                    <div class="govuk-details__text">
                         <p>{{ 'provideDetails.para01' |trans }}</p>
                         <ul class="govuk-list govuk-list--bullet">
                             <li>{{ 'provideDetails.listItem01' |trans }}</li>
@@ -86,20 +86,20 @@
                     </div>
                 </details>
 
-                <details>
-                    <summary>
-                        <span class="summary">{{ 'moreThanOne.summary' |trans }}</span>
+                <details class="govuk-details" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                        <span class="govuk-details__summary-text">{{ 'moreThanOne.summary' |trans }}</span>
                     </summary>
-                    <div class="opg-indented-block">
+                    <div class="govuk-details__text">
                         <p>{{ 'moreThanOne.para01' |trans }}</p>
                     </div>
                 </details>
 
-                <details>
-                    <summary>
-                        <span class="summary">{{ 'afterISubmit.summary' |trans }}</span>
+                <details class="govuk-details" data-module="govuk-details">
+                    <summary class="govuk-details__summary">
+                        <span class="govuk-details__summary-text">{{ 'afterISubmit.summary' |trans }}</span>
                     </summary>
-                    <div class="opg-indented-block">
+                    <div class="govuk-details__text">
                         <p>{{ 'afterISubmit.para01' |trans }}</p>
                     </div>
                 </details>

--- a/client/src/AppBundle/Resources/views/Ndr/Action/start.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Action/start.html.twig
@@ -18,11 +18,11 @@
 	    <p>{{ 'startPage.pageSectionDescription1' | trans(transOptions) }}</p>
 	    <p>{{ 'startPage.pageSectionDescription2' | trans(transOptions) }}</p>
 
-	    <details class="push--bottom">
-            <summary>
-                <span class="summary">{{ 'startPage.hiddenText01.summary' | trans(transOptions) }}</span>
+        <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">{{ 'startPage.hiddenText01.summary' | trans(transOptions) }}</span>
             </summary>
-            <div class="opg-indented-block">
+            <div class="govuk-details__text">
                 <p>{{ 'startPage.hiddenText01.content.para01' |trans(transOptions) }}</p>
                 <p>{{ 'startPage.hiddenText01.content.para02' |trans(transOptions)|raw }}</p>
                 <ul class="govuk-list govuk-list--bullet">

--- a/client/src/AppBundle/Resources/views/Ndr/Action/step.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Action/step.html.twig
@@ -37,11 +37,11 @@
             <p>{{ 'stepPage.gifts.pageSectionDescription1' | trans(transOptions) }}</p>
             <p>{{ 'stepPage.gifts.pageSectionDescription2' | trans(transOptions) }}</p>
 
-            <details class="push--bottom">
-                <summary>
-                    <span class="summary">{{ 'stepPage.gifts.hiddenText01.summary' | trans(transOptions) }}</span>
+            <details class="govuk-details" data-module="govuk-details">
+                <summary class="govuk-details__summary">
+                    <span class="govuk-details__summary-text">{{ 'stepPage.gifts.hiddenText01.summary' | trans(transOptions) }}</span>
                 </summary>
-                <div class="opg-indented-block">
+                <div class="govuk-details__text">
                     <p>{{ 'stepPage.gifts.hiddenText01.content.para01' |trans(transOptions) }}</p>
                     <ul class="govuk-list govuk-list--bullet">
                         <li>{{ 'stepPage.gifts.hiddenText01.content.listItem01' | trans }}</li>
@@ -95,11 +95,11 @@
             'legendText' : 'form.actionPropertySellingRent.label' | trans(transOptions, translationDomain)
         }) }}
 
-        <details class="text push--bottom">
-            <summary>
-                <span class="summary">{{ 'stepPage.property.selling.hiddenText01.summary' | trans(transOptions) }}</span>
+        <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">{{ 'stepPage.property.selling.hiddenText01.summary' | trans(transOptions) }}</span>
             </summary>
-            <div class="opg-indented-block">
+            <div class="govuk-details__text">
                 <p>{{ 'stepPage.property.selling.hiddenText01.content.para01' |trans(transOptions) }}</p>
                 <p>{{ 'stepPage.property.selling.hiddenText01.content.para02' |trans(transOptions)|raw }}</p>
                 <p>{{ 'stepPage.property.selling.hiddenText01.content.para03' |trans(transOptions) }}</p>
@@ -125,4 +125,3 @@
     {{ form_end(form) }}
 
 {% endblock %}
-

--- a/client/src/AppBundle/Resources/views/Ndr/BankAccount/start.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/BankAccount/start.html.twig
@@ -19,11 +19,11 @@
         <p>{{ 'startPage.pageSectionDescription2' | trans(transOptions) }}</p>
         <p>{{ 'startPage.pageSectionDescription3' | trans(transOptions) }}</p>
 
-        <details class="push--bottom">
-            <summary>
-                <span class="summary">{{ 'startPage.hiddenText01.summary' | trans(transOptions) }}</span>
+        <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">{{ 'startPage.hiddenText01.summary' | trans(transOptions) }}</span>
             </summary>
-            <div class="opg-indented-block">
+            <div class="govuk-details__text">
                 <p>{{ 'startPage.hiddenText01.content.para01' |trans(transOptions) }}</p>
                 <ul class="govuk-list govuk-list--bullet">
                     <li>{{ 'startPage.hiddenText01.content.listItem01' | trans(transOptions) }}</li>

--- a/client/src/AppBundle/Resources/views/Ndr/DeputyExpense/start.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/DeputyExpense/start.html.twig
@@ -19,11 +19,11 @@
         <p>{{ 'startPage.pageSectionDescription2' | trans(transOptions) }}</p>
         <p>{{ 'startPage.pageSectionDescription3' | trans(transOptions) }}</p>
 
-        <details class="push--bottom">
-            <summary>
-                <span class="summary">{{ 'startPage.hiddenText01.summary' |trans }}</span>
+        <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">{{ 'startPage.hiddenText01.summary' |trans }}</span>
             </summary>
-            <div class="opg-indented-block">
+            <div class="govuk-details__text">
                 <p>{{ 'startPage.hiddenText01.content.para01' |trans|raw }}</p>
             </div>
         </details>

--- a/client/src/AppBundle/Resources/views/Ndr/IncomeBenefit/start.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/IncomeBenefit/start.html.twig
@@ -19,11 +19,11 @@
 	        {{ 'startPage.pageSectionDescription' | trans(transOptions, translationDomain) }}
 	    </p>
 
-	    <details class="push--bottom">
-            <summary>
-                <span class="summary">{{ 'startPage.hiddenText01.summary' | trans(transOptions, translationDomain) }}</span>
+        <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">{{ 'startPage.hiddenText01.summary' | trans(transOptions, translationDomain) }}</span>
             </summary>
-            <div class="opg-indented-block">
+            <div class="govuk-details__text">
                 <p>{{ 'startPage.hiddenText01.content.para01' |trans(transOptions, translationDomain)|raw }}</p>
             </div>
         </details>

--- a/client/src/AppBundle/Resources/views/Org/ClientProfile/_notes.html.twig
+++ b/client/src/AppBundle/Resources/views/Org/ClientProfile/_notes.html.twig
@@ -35,11 +35,11 @@
                     <tr>
                         <td class="width-half">
                             {% if note.content %}
-                                <details>
-                                    <summary>
-                                        <span class="summary">{{ note.title }}</span>
+                                <details class="govuk-details" data-module="govuk-details">
+                                    <summary class="govuk-details__summary">
+                                        <span class="govuk-details__summary-text">{{ note.title }}</span>
                                     </summary>
-                                    <div class="opg-indented-block dont-break-out">
+                                    <div class="govuk-details__text">
                                         {{ note.content }}
                                     </div>
                                 </details>

--- a/client/src/AppBundle/Resources/views/Report/Action/start.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Action/start.html.twig
@@ -19,11 +19,11 @@
     <div class="text">
 	    <p>{{ (page ~ '.pageSectionDescription1' ~ append104) | trans(transOptions) }}</p>
 
-	    <details class="push--bottom">
-            <summary>
-                <span class="summary">{{ (page ~ '.hiddenText01.summary') | trans(transOptions) }}</span>
+	    <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">{{ (page ~ '.hiddenText01.summary') | trans(transOptions) }}</span>
             </summary>
-            <div class="opg-indented-block">
+            <div class="govuk-details__text">
                 <p>{{ (page ~ '.hiddenText01.content.para01') |trans(transOptions) }}</p>
                 <p>{{ (page ~ '.hiddenText01.content.para02') |trans(transOptions)|raw }}</p>
                 <ul class="govuk-list govuk-list--bullet">

--- a/client/src/AppBundle/Resources/views/Report/Action/step.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Action/step.html.twig
@@ -45,11 +45,11 @@
         </div>
 
         {% if '104' not in report.type %}
-            <details class="text push--bottom">
-                <summary>
-                    <span class="summary">{{ 'form.doYouExpectFinancialDecisions.hiddenText01.summary' | trans(transOptions) }}</span>
+            <details class="govuk-details" data-module="govuk-details">
+                <summary class="govuk-details__summary">
+                    <span class="govuk-details__summary-text">{{ 'form.doYouExpectFinancialDecisions.hiddenText01.summary' | trans(transOptions) }}</span>
                 </summary>
-                <div class="opg-indented-block">
+                <div class="govuk-details__text">
                     <p>{{ 'form.doYouExpectFinancialDecisions.hiddenText01.content.para01' |trans(transOptions) }}</p>
                     <p>{{ 'form.doYouExpectFinancialDecisions.hiddenText01.content.para02' |trans(transOptions)|raw }}</p>
                     <p>{{ 'form.doYouExpectFinancialDecisions.hiddenText01.content.para03' |trans(transOptions) }}</p>

--- a/client/src/AppBundle/Resources/views/Report/Balance/balance.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Balance/balance.html.twig
@@ -70,11 +70,11 @@
 
             <p class="govuk-!-font-weight-bold">{{ 'moreInfo.para4' | trans(transOptions) }}</p>
 
-            <details class="push--bottom">
-                <summary>
-                    <span class="summary">{{ 'moreInfo.whatToDo.title' | trans }}</span>
+            <details class="govuk-details" data-module="govuk-details">
+                <summary class="govuk-details__summary">
+                    <span class="govuk-details__summary-text">{{ 'moreInfo.whatToDo.title' | trans }}</span>
                 </summary>
-                <div class="opg-indented-block">
+                <div class="govuk-details__text">
                     <p>{{ 'moreInfo.whatToDo.para1' | trans }}</p>
                     <ul class="govuk-list govuk-list--bullet">
                         <li>{{ 'moreInfo.whatToDo.listItem1' | trans }}</li>

--- a/client/src/AppBundle/Resources/views/Report/BankAccount/start.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/BankAccount/start.html.twig
@@ -25,11 +25,11 @@
         {% endif %}
 
         {% if not app.user.isDeputyOrg() %}
-            <details class="push--bottom">
-                <summary>
-                    <span class="summary">{{ 'startPage.hiddenText01.summary' | trans(transOptions) }}</span>
+            <details class="govuk-details" data-module="govuk-details">
+                <summary class="govuk-details__summary">
+                    <span class="govuk-details__summary-text">{{ 'startPage.hiddenText01.summary' | trans(transOptions) }}</span>
                 </summary>
-                <div class="opg-indented-block">
+                <div class="govuk-details__text">
                     <p>{{ 'startPage.hiddenText01.content.para01' |trans(transOptions)|raw }}</p>
                 </div>
             </details>

--- a/client/src/AppBundle/Resources/views/Report/Decision/exist.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Decision/exist.html.twig
@@ -45,11 +45,11 @@
         {# Reusing content from the start page #}
         {% set page = 'startPage' %}
 
-        <details class="push--bottom">
-            <summary>
-                <span class="summary">{{ (page ~ '.whatisdecisionSummary') | trans }}</span>
+    <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">{{ (page ~ '.whatisdecisionSummary') | trans }}</span>
             </summary>
-            <div class="text opg-indented-block">
+            <div class="govuk-details__text">
                 <p>{{ (page ~ '.whatisdecisionPara1' ~ append104) | trans(transOptions) }}</p>
                 <p>{{ (page ~ '.whatisdecisionPara2' ~ append104) | trans(transOptions) }}</p>
                 <ul class="govuk-list govuk-list--bullet">

--- a/client/src/AppBundle/Resources/views/Report/Decision/start.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Decision/start.html.twig
@@ -19,21 +19,21 @@
 
     <p class="text">{{ (page ~ '.description1') | trans(transOptions) }}</p>
 
-    <details>
-        <summary>
-            <span class="summary">{{ (page ~ '.whatisMentalCapacitySummary') | trans }}</span>
+    <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">{{ (page ~ '.whatisMentalCapacitySummary') | trans }}</span>
         </summary>
-        <div class="text opg-indented-block">
+        <div class="govuk-details__text">
             <p>{{ (page ~ '.whatisMentalCapacityPara1') | trans(transOptions) }}</p>
             <p>{{ (page ~ '.whatisMentalCapacityPara2') | trans(transOptions)|raw }}</p>
         </div>
     </details>
 
-    <details {% if '104' in report.type %}class="push--bottom"{% endif %}>
-        <summary>
-            <span class="summary">{{ (page ~ '.whatisdecisionSummary') | trans }}</span>
+    <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">{{ (page ~ '.whatisdecisionSummary') | trans }}</span>
         </summary>
-        <div class="text opg-indented-block">
+        <div class="govuk-details__text">
             <p>{{ (page ~ '.whatisdecisionPara1' ~ append104) | trans(transOptions) }}</p>
             <p>{{ (page ~ '.whatisdecisionPara2' ~ append104) | trans(transOptions) }}</p>
             <ul class="govuk-list govuk-list--bullet">

--- a/client/src/AppBundle/Resources/views/Report/DeputyExpense/start.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/DeputyExpense/start.html.twig
@@ -26,11 +26,11 @@
         	},translationDomain) }}
         </p>
 
-        <details class="push--bottom">
-            <summary>
-                <span class="summary">{{ 'startPage.hiddenText01.summary' |trans }}</span>
+        <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">{{ 'startPage.hiddenText01.summary' |trans }}</span>
             </summary>
-            <div class="opg-indented-block">
+            <div class="govuk-details__text">
                 <p>{{ 'startPage.hiddenText01.content.para01' |trans|raw }}</p>
             </div>
         </details>

--- a/client/src/AppBundle/Resources/views/Report/Gift/start.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Gift/start.html.twig
@@ -21,11 +21,11 @@
         <p>{{ 'startPage.pageSectionDescription1' | trans(transOptions) }}</p>
         <p>{{ 'startPage.pageSectionDescription2' | trans(transOptions) }}</p>
 
-        <details class="push--bottom">
-            <summary>
-                <span class="summary">{{ 'startPage.hiddenText01.summary' | trans(transOptions) }}</span>
+        <details class="push--bottom" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">{{ 'startPage.hiddenText01.summary' | trans(transOptions) }}</span>
             </summary>
-            <div class="opg-indented-block">
+            <div class="govuk-details__text">
                 <p>{{ 'startPage.hiddenText01.content.para01' |trans(transOptions) }}</p>
                 <ul class="govuk-list govuk-list--bullet">
                     <li>{{ 'startPage.hiddenText01.content.listItem01' | trans }}</li>

--- a/client/src/AppBundle/Resources/views/Report/MoneyOut/summary.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/MoneyOut/summary.html.twig
@@ -33,11 +33,11 @@
             </div>
 
             {# More details (from the start page) #}
-            <details class="push--bottom">
-                <summary>
-                    <span class="summary">{{ 'summaryPage.moneyOut.moreDetails' |trans }}</span>
+            <details class="govuk-details" data-module="govuk-details">
+                <summary class="govuk-details__summary">
+                    <span class="govuk-details__summary-text">{{ 'summaryPage.moneyOut.moreDetails' |trans }}</span>
                 </summary>
-                <div class="opg-indented-block text">
+                <div class="govuk-details__text">
                     <p>{{ ('startPage.moneyOut.pageSectionDescription2' ~ app.user.getRoleForTrans) | trans(transOptions) | raw }}</p>
                     <p>{{ 'startPage.moneyOut.pageSectionDescription3' | trans }}</p>
                     <h2 class="govuk-heading-s">{{ 'startPage.moneyOut.totalOrIndividualHeading' | trans }}</h2>

--- a/client/src/AppBundle/Resources/views/User/register.html.twig
+++ b/client/src/AppBundle/Resources/views/User/register.html.twig
@@ -12,11 +12,11 @@
         <p>{{ 'ifyoualready' | trans }} <a href="{{ path('login') }}">{{ 'signin' | trans }}</a>.</p>
     </div>
 
-    <details class="push--bottom">
-        <summary>
-            <span class="summary">{{ 'moreThanOne' | trans }}</span>
+    <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">{{ 'moreThanOne' | trans }}</span>
         </summary>
-        <div class="opg-indented-block">
+        <div class="govuk-details__text">
             <p class="text">{{ 'moreThanOneDescription' | trans | raw }}</p>
         </div>
     </details>


### PR DESCRIPTION
## Purpose
Restoring this after @jamesrwarren overwrote the previous work (totally my faulty as I had the wrong branch name 🙈 ).

Switching from custom CSS classes on `details` and `summary` elements to using GDS versions with an added data-module to support IE11 fallback.

Fixes DDPB-3313

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [x] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
