### PR TITLE
DDPB-3332: Add deputy deleted event and add logging to delete deputy action

### DIFF
--- a/client/src/AppBundle/Controller/Admin/IndexController.php
+++ b/client/src/AppBundle/Controller/Admin/IndexController.php
@@ -318,7 +318,7 @@ class IndexController extends AbstractController
      */
     public function deleteAction($id)
     {
-        $deputy = $this->getRestClient()->get("user/{$id}", 'User', ['user', 'client', 'client-reports', 'report']);
+        $user = $this->getRestClient()->get("user/{$id}", 'User', ['user', 'client', 'client-reports', 'report']);
 
         try {
             $this->getRestClient()->delete('user/' . $id);
@@ -326,16 +326,16 @@ class IndexController extends AbstractController
             $event = (new AuditEvents($this->dateTimeProvider))->deputyDeleted(
                 AuditEvents::TRIGGER_ADMIN_BUTTON,
                 $this->getUser()->getEmail(),
-                $deputy->getFullName(),
-                $deputy->getEmail(),
-                $deputy->getRoleName(),
+                $user->getFullName(),
+                $user->getEmail(),
+                $user->getRoleName(),
             );
 
             $this->logger->notice('', $event);
             return $this->redirect($this->generateUrl('admin_homepage'));
         } catch (\Throwable $e) {
             $this->logger->warning(
-                sprintf('Error while deleting deputy: %s', $e->getMessage()), ['deputy_email' => $deputy->getEmail()]
+                sprintf('Error while deleting deputy: %s', $e->getMessage()), ['deputy_email' => $user->getEmail()]
             );
 
             $this->addFlash('error', 'There was a problem deleting the deputy - please try again later');

--- a/client/src/AppBundle/Controller/Admin/IndexController.php
+++ b/client/src/AppBundle/Controller/Admin/IndexController.php
@@ -337,6 +337,9 @@ class IndexController extends AbstractController
             $this->logger->warning(
                 sprintf('Error while deleting deputy: %s', $e->getMessage()), ['deputy_email' => $deputy->getEmail()]
             );
+
+            $this->addFlash('error', 'There was a problem deleting the deputy - please try again later');
+            return $this->redirect($this->generateUrl('admin_homepage'));
         }
     }
 

--- a/client/src/AppBundle/Controller/Admin/IndexController.php
+++ b/client/src/AppBundle/Controller/Admin/IndexController.php
@@ -323,7 +323,7 @@ class IndexController extends AbstractController
         try {
             $this->getRestClient()->delete('user/' . $id);
 
-            $event = (new AuditEvents($this->dateTimeProvider))->deputyDeleted(
+            $event = (new AuditEvents($this->dateTimeProvider))->userDeleted(
                 AuditEvents::TRIGGER_ADMIN_BUTTON,
                 $this->getUser()->getEmail(),
                 $user->getFullName(),

--- a/client/src/AppBundle/Service/Audit/AuditEvents.php
+++ b/client/src/AppBundle/Service/Audit/AuditEvents.php
@@ -11,6 +11,7 @@ final class AuditEvents
     const EVENT_CLIENT_DISCHARGED = 'CLIENT_DISCHARGED';
     const EVENT_ROLE_CHANGED = 'ROLE_CHANGED';
     const EVENT_CLIENT_EMAIL_CHANGED = 'CLIENT_EMAIL_CHANGED';
+    const EVENT_DEPUTY_DELETED = 'DEPUTY_DELETED';
 
     const TRIGGER_ADMIN_USER_EDIT = 'ADMIN_USER_EDIT';
     const TRIGGER_ADMIN_BUTTON = 'ADMIN_BUTTON';
@@ -132,5 +133,28 @@ final class AuditEvents
         ];
 
         return $event + $this->baseEvent(AuditEvents::EVENT_ROLE_CHANGED);
+    }
+
+    /**
+     * @param string $trigger
+     * @param string $deletedBy
+     * @param string $subjectFullname
+     * @param string $subjectEmail
+     * @param string $subjectRole
+     * @return array|string[]
+     * @throws \Exception
+     */
+    public function deputyDeleted(string $trigger, string $deletedBy, string $subjectFullname, string $subjectEmail, string $subjectRole): array
+    {
+        $event = [
+            'trigger' => $trigger,
+            'deleted_on' => $this->dateTimeProvider->getDateTime()->format(DateTime::ATOM),
+            'deleted_by' => $deletedBy,
+            'subject_full_name' => $subjectFullname,
+            'subject_email' => $subjectEmail,
+            'subject_role' => $subjectRole,
+        ];
+
+        return $event + $this->baseEvent(AuditEvents::EVENT_DEPUTY_DELETED);
     }
 }

--- a/client/src/AppBundle/Service/Audit/AuditEvents.php
+++ b/client/src/AppBundle/Service/Audit/AuditEvents.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Service\Audit;
 
+use AppBundle\Entity\User;
 use AppBundle\Service\Time\DateTimeProvider;
 use DateTime;
 
@@ -12,12 +13,14 @@ final class AuditEvents
     const EVENT_ROLE_CHANGED = 'ROLE_CHANGED';
     const EVENT_CLIENT_EMAIL_CHANGED = 'CLIENT_EMAIL_CHANGED';
     const EVENT_DEPUTY_DELETED = 'DEPUTY_DELETED';
+    const EVENT_ADMIN_DELETED = 'ADMIN_DELETED';
 
     const TRIGGER_ADMIN_USER_EDIT = 'ADMIN_USER_EDIT';
     const TRIGGER_ADMIN_BUTTON = 'ADMIN_BUTTON';
     const TRIGGER_CSV_UPLOAD = 'CSV_UPLOAD';
     const TRIGGER_DEPUTY_USER = 'DEPUTY_USER';
     const TRIGGER_DEPUTY_USER_EDIT = 'DEPUTY_USER_EDIT';
+
 
     /**
      * @var DateTimeProvider
@@ -144,7 +147,7 @@ final class AuditEvents
      * @return array|string[]
      * @throws \Exception
      */
-    public function deputyDeleted(string $trigger, string $deletedBy, string $subjectFullname, string $subjectEmail, string $subjectRole): array
+    public function userDeleted(string $trigger, string $deletedBy, string $subjectFullname, string $subjectEmail, string $subjectRole): array
     {
         $event = [
             'trigger' => $trigger,
@@ -155,6 +158,9 @@ final class AuditEvents
             'subject_role' => $subjectRole,
         ];
 
-        return $event + $this->baseEvent(AuditEvents::EVENT_DEPUTY_DELETED);
+        $eventType = in_array($subjectRole, [User::ROLE_ADMIN, User::ROLE_SUPER_ADMIN]) ?
+            AuditEvents::EVENT_ADMIN_DELETED : AuditEvents::EVENT_DEPUTY_DELETED;
+
+        return $event + $this->baseEvent($eventType);
     }
 }

--- a/client/src/AppBundle/Service/Logger.php
+++ b/client/src/AppBundle/Service/Logger.php
@@ -21,4 +21,9 @@ class Logger
     {
         $this->logger->notice($message, $context);
     }
+
+    public function warning(string $message, ?array $context)
+    {
+        $this->logger->warning($message, $context);
+    }
 }

--- a/client/tests/phpunit/Controller/AdminIndexControllerTest.php
+++ b/client/tests/phpunit/Controller/AdminIndexControllerTest.php
@@ -251,5 +251,8 @@ class AdminIndexControllerTest extends AbstractControllerTestCase
         $deleteLink = $crawler->selectLink("Yes, I'm sure")->link();
 
         $this->client->click($deleteLink);
+
+        $session = $this->client->getContainer()->get('session');
+        self::assertContains("There was a problem deleting the deputy - please try again later", $session->getBag('flashes')->peek('error'));
     }
 }

--- a/client/tests/phpunit/Service/Audit/AuditEventsTest.php
+++ b/client/tests/phpunit/Service/Audit/AuditEventsTest.php
@@ -173,4 +173,37 @@ class AuditEventsTest extends TestCase
             'PROF to PA' => ['ADMIN_BUTTON', 'ROLE_PROF', 'ROLE_PA', 't.amos@test.com', 'polly.jean.harvey@test.com'],
         ];
     }
+
+    /**
+     * @test
+     */
+    public function deputyDeleted(): void
+    {
+        $now = new DateTime();
+
+        /** @var ObjectProphecy|DateTimeProvider $dateTimeProvider */
+        $dateTimeProvider = self::prophesize(DateTimeProvider::class);
+        $dateTimeProvider->getDateTime()->shouldBeCalled()->willReturn($now);
+
+        $expected = [
+            'trigger' => 'ADMIN_BUTTON',
+            'deleted_on' => $now->format(DateTime::ATOM),
+            'deleted_by' => 'super-admin@email.com',
+            'subject_full_name' => 'Roisin Murphy',
+            'subject_email' => 'r.murphy@email.com',
+            'subject_role' => 'ROLE_LAY_DEPUTY',
+            'event' => 'DEPUTY_DELETED',
+            'type' => 'audit'
+        ];
+
+        $actual = (new AuditEvents($dateTimeProvider->reveal()))->deputyDeleted(
+            'ADMIN_BUTTON',
+            'super-admin@email.com',
+            'Roisin Murphy',
+            'r.murphy@email.com',
+            'ROLE_LAY_DEPUTY'
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
 }

--- a/client/tests/phpunit/Service/Audit/AuditEventsTest.php
+++ b/client/tests/phpunit/Service/Audit/AuditEventsTest.php
@@ -224,8 +224,8 @@ class AuditEventsTest extends TestCase
             'trigger' => 'ADMIN_BUTTON',
             'deleted_on' => $now->format(DateTime::ATOM),
             'deleted_by' => 'super-admin@email.com',
-            'subject_full_name' => 'Roisin Murphy',
-            'subject_email' => 'r.murphy@email.com',
+            'subject_full_name' => 'Robyn Konichiwa',
+            'subject_email' => 'r.konichiwa@email.com',
             'subject_role' => $role,
             'event' => 'ADMIN_DELETED',
             'type' => 'audit'
@@ -234,8 +234,8 @@ class AuditEventsTest extends TestCase
         $actual = (new AuditEvents($dateTimeProvider->reveal()))->userDeleted(
             'ADMIN_BUTTON',
             'super-admin@email.com',
-            'Roisin Murphy',
-            'r.murphy@email.com',
+            'Robyn Konichiwa',
+            'r.konichiwa@email.com',
             $role
         );
 


### PR DESCRIPTION
## Purpose
Adds audit logging for deleting a deputy.

Fixes DDPB-3332

## Approach
Although very unlikely, I've added some error catching around failures to delete a deputy so we aren't logging events that never happen.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes
