### PR TITLE
DDPB-3457: Capitals not persisted in text boxes

### DIFF
--- a/client/src/AppBundle/Resources/views/Report/Formatted/_prof_deputy_costs_estimate.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Formatted/_prof_deputy_costs_estimate.html.twig
@@ -87,7 +87,7 @@
                 </table>
                 {% if report.profDeputyCostsEstimateHasMoreInfo == 'yes' %}
                     <div class="labelvalue push-half--top">
-                        <div class="value">{{ report.profDeputyCostsEstimateMoreInfoDetails | capitalize | trans }}</div>
+                        <div class="value">{{ report.profDeputyCostsEstimateMoreInfoDetails | trans }}</div>
                     </div>
                 {% endif %}
             </div>

--- a/client/src/AppBundle/Resources/views/Report/ProfDeputyCostsEstimate/_answers.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/ProfDeputyCostsEstimate/_answers.html.twig
@@ -64,7 +64,7 @@
                 </dt>
                 <dd class="govuk-summary-list__value">
                     {% if 'yes' == report.profDeputyCostsEstimateHasMoreInfo %}
-                        {{ report.profDeputyCostsEstimateMoreInfoDetails | capitalize | trans }}
+                        {{ report.profDeputyCostsEstimateMoreInfoDetails | trans }}
                     {% else %}
                         {{ 'summaryPage.noMoreInfo' | trans }}
                     {% endif %}


### PR DESCRIPTION
## Purpose
An issue was identified where the in the “More Information” box in the “Deputy Costs Estimates” section, it only accepts the first capital letter and any capital’s afterwards (e.g. start of a second sentence) are turned into a lower case when the form is produced.

This means on both the summary page for the section and review page for the report, the information entered by the user would only have a capital letter for the first character, and the rest would be lower case. However, returning to page to edit the information would show the information in its original format as entered by the user.

Fixes DDPB-3457

## Approach
We removed `| capitalize` which was the source of the issue. This would load the text and format it as to upper-case the first character and lower-case the rest. Unsure as to why it was being used here and in other places too.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
