### PR TITLE
DDPB-3511: Revert file limit to 15MB

### DIFF
--- a/client/src/AppBundle/Entity/Report/Document.php
+++ b/client/src/AppBundle/Entity/Report/Document.php
@@ -77,7 +77,7 @@ class Document implements DocumentInterface, SynchronisableInterface
      *
      * @Assert\NotBlank(message="Please choose a file", groups={"document"})
      * @Assert\File(
-     *     maxSize = "5M",
+     *     maxSize = "15M",
      *     maxSizeMessage = "document.file.errors.maxSizeMessage",
      *     mimeTypes = {"application/pdf", "application/x-pdf", "image/png", "image/jpeg"},
      *     mimeTypesMessage = "document.file.errors.mimeTypesMessage",

--- a/client/src/AppBundle/Resources/assets/javascripts/modules/uploadFile.js
+++ b/client/src/AppBundle/Resources/assets/javascripts/modules/uploadFile.js
@@ -1,5 +1,5 @@
 /* globals $ */
-var UPLOAD_LIMIT = 5
+var UPLOAD_LIMIT = 15
 
 module.exports = function (containerSelector) {
   // Show in progress message
@@ -10,7 +10,7 @@ module.exports = function (containerSelector) {
     }
   })
 
-  // Show an error if file is over 5mb
+  // Show an error if file is over 15mb
   $('#upload_form').on('submit', function (e) {
     e.preventDefault()
     var fileElement = $('#report_document_upload_files')

--- a/client/src/AppBundle/Resources/translations/report-documents.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-documents.en.yml
@@ -7,7 +7,7 @@ form:
     label: Attach a file
     hint: ""
   errors:
-    fileSize: "Your uploaded file exceeded the maximum size of 5M"
+    fileSize: "Your uploaded file exceeded the maximum size of 15M"
     risky: "Cannot upload file, risky content found inside. Technical details: %techDetails%"
     virusFound:  "Cannot upload file, virus found inside. Technical details: %techDetails%"
     generic: "Cannot upload file, please try again later. Technical details: %techDetails%"
@@ -28,7 +28,7 @@ attachPage:
   selectHeading: 1. Select the files
   selectHelp: Please select 'Choose files' below to find your files.
   selectHint1: You only need to upload documents if we have asked you to.
-  selectHint2: You can only upload PDF, JPG or PNG files, and they must be smaller than 5MB.
+  selectHint2: You can only upload PDF, JPG or PNG files, and they must be smaller than 15MB.
   uploadHeading: 2. Upload the files to your report
   noDocuments: No documents
   documentList: Attached documents

--- a/client/src/AppBundle/Resources/translations/validators.en.yml
+++ b/client/src/AppBundle/Resources/translations/validators.en.yml
@@ -188,12 +188,12 @@ document:
   file:
     errors:
       mimeTypesMessage: "Please upload a valid file type. Supported file types include PDF, JPG and PNG"
-      maxSizeMessage: "The file you selected to upload is too big. Please check your file size is less than 5mb."
+      maxSizeMessage: "The file you selected to upload is too big. Please check your file size is less than 15mb."
       alreadyPresent: "You have already uploaded a file with this name. Please rename your file before uploading again."
       maxDocumentsPerReport: "You have reached the maximum number of attachments for this report"
       invalidName: "Your file has an invalid name"
       maxMessage: "The file name can't be longer than 255 letters"
-      fileSize: "Your uploaded file exceeded the maximum size of 5M"
+      fileSize: "Your uploaded file exceeded the maximum size of 15M"
       risky: "Unfortunately, our antivirus check found a problem with this file and we are unable to upload it. Please choose another file"
       virusFound:  "Unfortunately, our antivirus check found a problem with this file and we are unable to upload it. Please choose another file"
       generic: "Cannot upload file, please try again later"


### PR DESCRIPTION
## Purpose
Now we're sending S3 references rather than document contents we can revert to allowing documents up to 15MB to be uploaded.

Fixes DDPB-3511

## Approach
Just reversed the changes in #315 and kept the behat test.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [x] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
