### PR TITLE
Add php commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 **/secrets.json
 **/.tmp.aws.config
 .phpunit.result.cache
+.php_cs.cache
 
 # Common vendor folders
 .terraform/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,7 @@ repos:
     hooks:
         - id: php-cs-fixer
           files: \.(php)$
+-   repo: https://github.com/acsauk/php-strict-types-pre-commit-hook
+    rev: main
+    hooks:
+        -    id: php-strict-types

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,6 @@ repos:
     rev: master
     hooks:
     -   id: git-secrets
--   repo: https://github.com/acsauk/php-strict-types-pre-commit-hook
-    rev: master
-    hooks:
-    -    id: php-strict-types
 -   repo: https://github.com/digitalpulp/pre-commit-php.git
     rev: 1.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,12 @@ repos:
     rev: master
     hooks:
     -   id: git-secrets
+-   repo: https://github.com/acsauk/php-strict-types-pre-commit-hook
+    rev: master
+    hooks:
+    -    id: php-strict-types
+-   repo: https://github.com/digitalpulp/pre-commit-php.git
+    rev: 1.4.0
+    hooks:
+        - id: php-cs-fixer
+          files: \.(php)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,9 @@ repos:
 -   repo: https://github.com/digitalpulp/pre-commit-php.git
     rev: 1.4.0
     hooks:
-        - id: php-cs-fixer
-          files: \.(php)$
+    - id: php-cs-fixer
+      files: \.(php)$
 -   repo: https://github.com/acsauk/php-strict-types-pre-commit-hook
     rev: main
     hooks:
-        -    id: php-strict-types
+    -    id: php-strict-types

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This app is the [Complete the deputy report][service] service. It provides an on
 
 You must have Docker installed.
 
+If developing the app then ensure you have [pre-commit](https://pre-commit.com/) installed to take advantage of the pre-commit [hooks](.pre-commit-config.yaml) we've added to the project to make PRs a more consistent and enjoyable experience.
+
 ## Installation
 
 - Add `127.0.0.1 digideps.local admin.digideps.local api.digideps.local www.digideps.local` to `/etc/hosts`


### PR DESCRIPTION
## Purpose
I've added in a couple of pre-commit hooks to our repo to try to automatically fix any styling errors as according to PSR2 and to add strict types to newly created PHP files so we don't need to keep remembering to do it.

## Learning
`sed` on mac does not work like `sed` on Linux!