### PR TITLE
DDPB-3532 see if works better as always_on false

### DIFF
--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -102,7 +102,7 @@
       "sirius_api_account": "248804316466",
       "state_source": "development",
       "elasticache_count": 1,
-      "always_on": true,
+      "always_on": false,
       "copy_version_from": "NonApplicable"
     },
     "default": {


### PR DESCRIPTION
## Purpose
It was brought to our attention that the development environment was running slowly. There didn't seem to be much difference in traffic except that the aws availability check was being hit repeatedly. By changing this single option to false we bypass this check. It's also probably better to be on aurora as the env is not used that often.

Fixes DDPB-3532

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
