### PR TITLE
DDPB-3320: changed the page titles to match the top-level heading

### DIFF
--- a/client/src/AppBundle/Resources/translations/client-contacts.en.yml
+++ b/client/src/AppBundle/Resources/translations/client-contacts.en.yml
@@ -1,9 +1,9 @@
 addContact:
-  htmlTitle: Client profile - add contact | GOV.UK
+  htmlTitle: Add contact - Complete the deputy report | GOV.UK
   pageTitle: Add contact
   supportTitle: "Client profile: %fullName%"
 editContact:
-  htmlTitle: Client profile - edit contact | GOV.UK
+  htmlTitle: Edit contact - Complete the deputy report | GOV.UK
   pageTitle: Edit contact
   supportTitle: "Client profile: %fullName%"
 deletePage:
@@ -31,10 +31,10 @@ form:
     label: Organisation address
     context: line 1 of 3
   address2:
-    label: ' '
+    label: " "
     context: Organisation address line 2 of 3
   address3:
-    label: ' '
+    label: " "
     context: Organisation address line 3 of 3
   addressPostcode:
     label: Organisation postcode

--- a/client/src/AppBundle/Resources/translations/client-notes.en.yml
+++ b/client/src/AppBundle/Resources/translations/client-notes.en.yml
@@ -1,9 +1,9 @@
 addNote:
-  htmlTitle: Client profile - add note | GOV.UK
+  htmlTitle: Add note - Complete the deputy report | GOV.UK
   pageTitle: Add note
   supportTitle: "Client profile: %fullName%"
 editNote:
-  htmlTitle: Client profile - edit note | GOV.UK
+  htmlTitle: Edit note - Complete the deputy report | GOV.UK
   pageTitle: Edit note
   supportTitle: "Client profile: %fullName%"
 deletePage:

--- a/client/src/AppBundle/Resources/translations/client-profile.en.yml
+++ b/client/src/AppBundle/Resources/translations/client-profile.en.yml
@@ -1,3 +1,4 @@
+htmlTitle: "Client profile - Complete the deputy report | GOV.UK"
 pageTitle: "Client profile"
 clientName: "Client name:"
 courtOrderNo: "Court order no:"

--- a/client/src/AppBundle/Resources/translations/client.en.yml
+++ b/client/src/AppBundle/Resources/translations/client.en.yml
@@ -1,5 +1,5 @@
 editClient:
-  htmlTitle: "Deputy report - Client's details | GOV.UK"
+  htmlTitle: "%client%'s details - Complete the deputy report | GOV.UK"
   pageTitle: "%client%'s details"
   pageSectionDescription: "You can update %client%'s details and your court order date below."
   lastLoggedIn: "Last signed in:"
@@ -7,7 +7,7 @@ editClient:
     label: Address
     context: line 1 of 2
   address2:
-    label: ' '
+    label: " "
     context: Address line 2 of 2
     hint: ""
   county:
@@ -22,7 +22,7 @@ editClient:
     defaultOption: Please select ...
 
 showClient:
-  htmlTitle: "Deputy report - Client's details | GOV.UK"
+  htmlTitle: "%client%'s details - Complete the deputy report | GOV.UK"
   pageTitle: "%client%'s details"
   clientTable:
     header:

--- a/client/src/AppBundle/Resources/translations/co-deputy.en.yml
+++ b/client/src/AppBundle/Resources/translations/co-deputy.en.yml
@@ -1,5 +1,5 @@
 addCoDeputy:
-  htmlTitle: Deputy report - Invite deputy | GOV.UK
+  htmlTitle: Invite deputy - Complete the deputy report | GOV.UK
   pageTitle: Invite deputy
   intro: |
     You can invite additional deputies to %clientFirstName%'s reports, all we need is their
@@ -7,7 +7,7 @@ addCoDeputy:
   submitButton: Send invitation
 
 reinviteDeputy:
-  htmlTitle: Deputy report - Reinvite deputy | GOV.UK
+  htmlTitle: Reinvite deputy - Complete the deputy report | GOV.UK
   pageTitle: Reinvite deputy
   intro: |
     Use the box below to resend an invitation to the original or alternative email address.
@@ -56,9 +56,9 @@ form:
         hint: You are currently an administrator on the Deputy Report Service.
 
 clientLastname:
-    label: Last name
+  label: Last name
 clientCaseNumber:
-    label: Case number
-    hint: You will find the case number on the first page of the court order (top right-hand corner)
+  label: Case number
+  hint: You will find the case number on the first page of the court order (top right-hand corner)
 saveAndContinue:
-    label: Save and continue
+  label: Save and continue

--- a/client/src/AppBundle/Resources/translations/cookies.en.yml
+++ b/client/src/AppBundle/Resources/translations/cookies.en.yml
@@ -1,5 +1,5 @@
+htmlTitle: Cookies - Complete the deputy report | GOV.UK
 pageTitle: Cookies
-htmlTitle: Cookies
 
 intro:
     para01: Cookies are files saved on your phone, tablet or computer when you visit a website.

--- a/client/src/AppBundle/Resources/translations/delete-page.en.yml
+++ b/client/src/AppBundle/Resources/translations/delete-page.en.yml
@@ -1,5 +1,5 @@
 page:
-    htmlTitle: Deputy report - remove %subject% | GOV.UK
+    htmlTitle: Remove %subject% - Complete the deputy report | GOV.UK
     question: Are you sure you want to remove this %subject%?
     title: Remove %subject%
     linkButtonLabel: Yes, remove %subject%

--- a/client/src/AppBundle/Resources/translations/home.en.yml
+++ b/client/src/AppBundle/Resources/translations/home.en.yml
@@ -1,4 +1,4 @@
-htmlTitle: "Deputy report | GOV.UK"
+htmlTitle: "Complete the deputy report | GOV.UK"
 pageTitle: "Complete the deputy report"
 intro:
   lede: |

--- a/client/src/AppBundle/Resources/translations/ndr-actions.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-actions.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "New deputy report - actions you plan to take | GOV.UK"
+  htmlTitle: "Actions you plan to take - Complete the deputy report | GOV.UK"
   pageTitle: Actions you plan to take
   pageSectionDescription1: |
     Use this section to tell us about any significant financial decisions you plan to
@@ -24,7 +24,7 @@ startPage:
   startButton: Start actions
 
 stepPage:
-  htmlTitle: "New deputy report - actions you plan to take | GOV.UK"
+  htmlTitle: "Actions you plan to take - Complete the deputy report | GOV.UK"
   supportTitle: Actions you plan to take
   gifts:
     pageTitle: Gifts
@@ -65,9 +65,8 @@ stepPage:
           para04: <a href="https://www.gov.uk/joint-property-ownership" target="_blank">Find out more</a>
   backLink: Back
 
-
 summaryPage:
-  htmlTitle: "New deputy report - actions you plan to take | GOV.UK"
+  htmlTitle: "Actions you plan to take - Complete the deputy report | GOV.UK"
   pageTitle: Actions you plan to take
   weAskAbout: |
     In this section, we ask you about significant financial decisions you're planning to make on

--- a/client/src/AppBundle/Resources/translations/ndr-assets.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-assets.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - assets | GOV.UK"
+  htmlTitle: "Assets - Complete the deputy report | GOV.UK"
   pageTitle: Assets
   pageSectionDescription: |
     Use this section to tell us about %client%'s assets.
@@ -8,7 +8,7 @@ startPage:
   startButton: Start assets
 
 existPage:
-  htmlTitle: "New deputy report - assets | GOV.UK"
+  htmlTitle: "Assets - Complete the deputy report | GOV.UK"
   supportTitle: Assets
   form:
     noAssetToAdd:
@@ -18,9 +18,9 @@ existPage:
       label: Save and continue
 
 typePage:
-  htmlTitle: "New deputy report - assets | GOV.UK"
-  supportTitle: Assets
+  htmlTitle: "Add an asset - Complete the deputy report | GOV.UK"
   pageTitle: Add an asset
+  supportTitle: Assets
   pageSectionDescription: |
     Please tell us a bit more about %client%'s assets.
     Start by adding a type of asset; we'll then ask you for
@@ -29,32 +29,32 @@ typePage:
   formstartButton: Save and continue
 
 addPage:
-  htmlTitle: "New deputy report - Assets | GOV.UK"
-  supportTitle: Assets
+  htmlTitle: "Add an asset: %assetTitle% - Complete the deputy report | GOV.UK"
   pageTitle: "Add an asset: %assetTitle%"
+  supportTitle: Assets
 
 editPage:
-  htmlTitle: "New deputy report - Assets | GOV.UK"
-  supportTitle: Assets
+  htmlTitle: "Edit %assetTitle% - Complete the deputy report | GOV.UK"
   pageTitle: Edit %assetTitle%
+  supportTitle: Assets
 
 addAnotherPage:
-  htmlTitle: "New deputy report - assets | GOV.UK"
+  htmlTitle: "Assets - Complete the deputy report | GOV.UK"
   pageTitle: Assets
   form:
     addAnother:
       label: The asset has been saved. Would you like to add another now?
       hint: If you prefer, you can come back to this section later to add more assets
     save:
-       label: Continue
+      label: Continue
 
 stepPageProperty:
-  htmlTitle: "New deputy report - Property | GOV.UK"
-  supportTitle: Assets
+  htmlTitle: "Add an asset: property - Complete the deputy report | GOV.UK"
   pageTitle: "Add an asset: property"
+  supportTitle: Assets
 
 summaryPage:
-  htmlTitle: "New deputy report - assets | GOV.UK"
+  htmlTitle: "Assets - Complete the deputy report | GOV.UK"
   pageTitle: Assets
   supportTitle: ""
   weAskAbout: In this section, we ask you about %client%'s assets, including property.
@@ -139,4 +139,4 @@ form:
     rentIncomeMonth:
       label: What is the rental income each month?
   save:
-      label: Save and continue
+    label: Save and continue

--- a/client/src/AppBundle/Resources/translations/ndr-assets.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-assets.en.yml
@@ -64,7 +64,7 @@ summaryPage:
   totalValue: "Total value of assets: £%value%"
 
 deletePage:
-  htmlTitle: "New deputy report - remove asset | GOV.UK"
+  htmlTitle: "Remove asset - Complete the deputy report | GOV.UK"
   subject: asset
   summary:
     type: Type

--- a/client/src/AppBundle/Resources/translations/ndr-bank-accounts.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-bank-accounts.en.yml
@@ -26,7 +26,7 @@ startPage:
   startButton: Start accounts
 
 stepPage:
-  htmlTitle: "Deputy report - Accounts | GOV.UK"
+  htmlTitle: "Accounts - Complete the deputy report | GOV.UK"
   pageTitle:
     add: Add an account
     edit: Edit an account
@@ -36,7 +36,7 @@ stepPage:
   backLink: Back
 
 addAnotherPage:
-  htmlTitle: "Deputy report - add another account | GOV.UK"
+  htmlTitle: "Add another account - Complete the deputy report | GOV.UK"
   pageTitle: Accounts
   form:
     addAnother:
@@ -46,14 +46,14 @@ addAnotherPage:
       label: Continue
 
 summaryPage:
-  htmlTitle: "Deputy report - Accounts | GOV.UK"
+  htmlTitle: "Accounts - Complete the deputy report | GOV.UK"
   pageTitle: Accounts
   weAskAbout: |
     In this section, we ask you about %client%'s bank accounts, building society
     accounts, savings accounts and ISAs.
 
 deletePage:
-  htmlTitle: "Deputy report - remove account | GOV.UK"
+  htmlTitle: "Remove account - Complete the deputy report | GOV.UK"
   subject: account
   summary:
     accountType: Account type

--- a/client/src/AppBundle/Resources/translations/ndr-bank-accounts.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-bank-accounts.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - Accounts | GOV.UK"
+  htmlTitle: "Accounts - Complete the deputy report | GOV.UK"
   pageTitle: Accounts
   pageSectionDescription1: |
     An important part of your role as a deputy is to keep a record of
@@ -43,7 +43,7 @@ addAnotherPage:
       label: The account has been saved. Would you like to add another now?
       hint: If you prefer, you can come back to this section later to add more accounts
     save:
-       label: Continue
+      label: Continue
 
 summaryPage:
   htmlTitle: "Deputy report - Accounts | GOV.UK"
@@ -62,15 +62,15 @@ deletePage:
 
 form:
   accountType:
-      label: What type of account is it?
-      choices:
-          current: Current account
-          savings: Savings account
-          isa: ISA
-          postoffice: Post Office account
-          cfo: Court Funds Office account
-          other: Other type of account
-          other_no_sortcode: Other type of account without sort code
+    label: What type of account is it?
+    choices:
+      current: Current account
+      savings: Savings account
+      isa: ISA
+      postoffice: Post Office account
+      cfo: Court Funds Office account
+      other: Other type of account
+      other_no_sortcode: Other type of account without sort code
   bank:
     label: Bank or building society name
   meta:
@@ -81,12 +81,12 @@ form:
   sortCode:
     legend: Sort code
   balanceOnCourtOrderDate:
-      label: How much was in the account on %cotDate%?
+    label: How much was in the account on %cotDate%?
   isJointAccount:
-      label: Is this a joint account?
-      hint: |
-        Joint accounts are often used by married couples or couples who live together. The money in
-        a joint account is owned by both account holders.
+    label: Is this a joint account?
+    hint: |
+      Joint accounts are often used by married couples or couples who live together. The money in
+      a joint account is owned by both account holders.
   save:
     label: Save and continue
   cancel:

--- a/client/src/AppBundle/Resources/translations/ndr-debts.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-debts.en.yml
@@ -24,7 +24,7 @@ managementPage:
       hint: For example, give details of any regular payments to creditors or payment plans
 
 editPage:
-  htmlTitle: "New deputy report - debts | GOV.UK"
+  htmlTitle: "Tell us more about %client%'s debts - Complete the deputy report | GOV.UK"
   pageTitle: Tell us more about %client%'s debts.
   supportTitle: Debts
   pageHint: If %client% has a mortgage on a property, use the Assets section to tell us about it

--- a/client/src/AppBundle/Resources/translations/ndr-debts.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-debts.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "New deputy report - debts | GOV.UK"
+  htmlTitle: "Debts - Complete the deputy report | GOV.UK"
   pageTitle: "Debts"
   pageSectionDescription: |
     Use this section to tell us about %client%'s debts, for example, overdue
@@ -7,7 +7,7 @@ startPage:
   startButton: Start debts
 
 existPage:
-  htmlTitle: "New deputy report - debts | GOV.UK"
+  htmlTitle: "Debts - Complete the deputy report | GOV.UK"
   supportTitle: Debts
   form:
     exist:
@@ -16,7 +16,7 @@ existPage:
       label: Save and continue
 
 managementPage:
-  htmlTitle: "Deputy report - debts | GOV.UK"
+  htmlTitle: "Debts - Complete the deputy report | GOV.UK"
   supportTitle: Debts
   form:
     debtManagement:

--- a/client/src/AppBundle/Resources/translations/ndr-declaration.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-declaration.en.yml
@@ -1,5 +1,5 @@
 page:
-  htmlTitle: "Deputy report - deputy's declaration | GOV.UK"
+  htmlTitle: "Deputy's declaration - Complete the deputy report | GOV.UK"
   pageTitle: "Deputy's declaration"
   descriptionPara01: "I confirm the information I have given in this report is true and correct to the best of my knowledge and belief."
   descriptionPara02: "I understand I have obligations to the Court of Protection and the Office of the Public Guardian, and that if I knowingly provide false or misleading information there may be legal consequences."

--- a/client/src/AppBundle/Resources/translations/ndr-deputy-expenses.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-deputy-expenses.en.yml
@@ -56,7 +56,7 @@ summaryPage:
   addButton: Add a deputy expense
 
 deletePage:
-  htmlTitle: "Deputy report - remove deputy expense | GOV.UK"
+  htmlTitle: "Remove deputy expense - Complete the deputy report | GOV.UK"
   subject: expense
   summary:
     explanation: Description

--- a/client/src/AppBundle/Resources/translations/ndr-deputy-expenses.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-deputy-expenses.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - deputy expenses | GOV.UK"
+  htmlTitle: "Deputy expenses - Complete the deputy report | GOV.UK"
   pageTitle: Deputy expenses
   pageSectionDescription1: |
     You can use your new deputy report to claim back money for things you paid for on %client%'s behalf before your court order – for example, care home fees or domestic bills.
@@ -15,7 +15,7 @@ startPage:
   startButton: Start deputy expenses
 
 existPage:
-  htmlTitle: "Deputy report - add deputy expense | GOV.UK"
+  htmlTitle: "Deputy expense - Complete the deputy report | GOV.UK"
   supportTitle: Deputy expenses
   form:
     paidForAnything:
@@ -24,7 +24,7 @@ existPage:
       label: Save and continue
 
 addAnotherPage:
-  htmlTitle: "Deputy report - add deputy expense | GOV.UK"
+  htmlTitle: "Add deputy expense - Complete the deputy report | GOV.UK"
   pageTitle: Add an expense
   supportTitle: Deputy expenses
   form:
@@ -32,10 +32,10 @@ addAnotherPage:
       label: The expense has been saved. Would you like to add another now?
       hint: If you prefer, you can come back to this section later to add more expenses
     save:
-       label: Continue
+      label: Continue
 
 addPage:
-  htmlTitle: "Deputy report - deputy expenses | GOV.UK"
+  htmlTitle: "Add an expense - Complete the deputy report | GOV.UK"
   pageTitle: Add an expense
   supportTitle: Deputy expenses
   pageSectionDescription: |
@@ -43,12 +43,12 @@ addPage:
     You can add one or more items of expense and come back to complete the section later.
 
 editPage:
-  htmlTitle: "Deputy report - deputy expenses | GOV.UK"
-  supportTitle: Deputy expenses
+  htmlTitle: "Edit deputy expense - Complete the deputy report | GOV.UK"
   pageTitle: Edit deputy expense
+  supportTitle: Deputy expenses
 
 summaryPage:
-  htmlTitle: "Deputy report - deputy expenses | GOV.UK"
+  htmlTitle: "Deputy expenses - Complete the deputy report | GOV.UK"
   pageTitle: Deputy expenses
   pageSectionDescription: |
     In this section we ask you to tell us about things you paid for on %client%'s behalf before your
@@ -70,4 +70,4 @@ form:
   addAnother:
     label: Add another expense
   save:
-      label: Save expense
+    label: Save expense

--- a/client/src/AppBundle/Resources/translations/ndr-deputy-expenses.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-deputy-expenses.en.yml
@@ -15,7 +15,7 @@ startPage:
   startButton: Start deputy expenses
 
 existPage:
-  htmlTitle: "Deputy expense - Complete the deputy report | GOV.UK"
+  htmlTitle: "Add deputy expense - Complete the deputy report | GOV.UK"
   supportTitle: Deputy expenses
   form:
     paidForAnything:

--- a/client/src/AppBundle/Resources/translations/ndr-homepage.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-homepage.en.yml
@@ -1,5 +1,5 @@
 page:
-  htmlTitle: Deputy report - Your reports | GOV.UK
+  htmlTitle: Your reports - Complete the deputy report | GOV.UK
   pageTitle: Your reports
   addCoDeputy: Add new deputy
 
@@ -24,9 +24,7 @@ history:
     view: View
     attachDocuments: Attach documents
   ndr:
-   title: New deputy report
-   reportingPeriod: Start of deputyship
-   download: Download PDF
-   view: View
-
-
+    title: New deputy report
+    reportingPeriod: Start of deputyship
+    download: Download PDF
+    view: View

--- a/client/src/AppBundle/Resources/translations/ndr-income-benefits.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-income-benefits.en.yml
@@ -24,7 +24,7 @@ stepPage:
 
 summaryPage:
   weAskAbout: In this section, we ask you about %client%'s income and benefits.
-  htmlTitle: "Deputy report - income and benefits | GOV.UK"
+  htmlTitle: "Income and benefits - Complete the deputy report | GOV.UK"
   pageTitle: Income and benefits
   supportTitle: ""
 

--- a/client/src/AppBundle/Resources/translations/ndr-income-benefits.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-income-benefits.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - income and benefits | GOV.UK"
+  htmlTitle: "Income and benefits - Complete the deputy report | GOV.UK"
   pageTitle: Income and benefits
   pageSectionDescription: |
     As a deputy, it's important that you look after %client%'s financial affairs throughout the year and explain any decisions you've made.
@@ -13,8 +13,8 @@ startPage:
   startButton: Start income and benefits
 
 stepPage:
+  htmlTitle: "Income and benefits - Complete the deputy report | GOV.UK"
   supportTitle: Income and benefits
-  htmlTitle: "Deputy report - income and benefits | GOV.UK"
   pageTitle:
     stateBenefits: State benefits
     pensions: Pensions and other income
@@ -65,9 +65,9 @@ form:
     label: Does %client% receive any other regular income?
     hint: For example, private pension, dividends, wages or salary
   receiveOtherIncomeDetails:
-      label: Please tell us more about %client%'s other regular sources of income
-      hint: For example, what the sources of income are, the amount they pay and how often
-      labelSummaryPage: More about %client%'s other regular sources of income
+    label: Please tell us more about %client%'s other regular sources of income
+    hint: For example, what the sources of income are, the amount they pay and how often
+    labelSummaryPage: More about %client%'s other regular sources of income
   expectCompensationDamages:
     label: Are you expecting %client% to get any money from compensation awards or damages?
   expectCompensationDamagesDetails:
@@ -91,4 +91,3 @@ form:
         label: Sale of investment
       sale_of_property:
         label: Sale of property
-

--- a/client/src/AppBundle/Resources/translations/ndr-more-info.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-more-info.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "New deputy report - any other information | GOV.UK"
+  htmlTitle: "Any other information - Complete the deputy report | GOV.UK"
   pageTitle: Any other information
   pageSectionDescription1: |
     You can use this section to give us information that isn't covered elsewhere in this report.
@@ -14,7 +14,7 @@ stepPage:
   supportTitle: Any other information
 
 summaryPage:
-  htmlTitle: "New deputy report - any other information | GOV.UK"
+  htmlTitle: "Any other information - Complete the deputy report | GOV.UK"
   pageTitle: Any other information
   weAskAbout: |
     In this section, you can raise concerns about your deputyship and give us any other information

--- a/client/src/AppBundle/Resources/translations/ndr-overview.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-overview.en.yml
@@ -1,4 +1,4 @@
-page.htmlTitle: "New deputy report - overview | GOV.UK"
+page.htmlTitle: "New deputy report - Complete the deputy report | GOV.UK"
 report: "New deputy report"
 pageTitle: "New deputy report"
 pageSectionDescription: "Your new deputy report:"
@@ -20,9 +20,9 @@ sectionsRemaining: "sections remaining"
 overview: New deputy report
 
 status:
-    notStarted: "Not started"
-    notFinished: "Not finished"
-    readyToSubmit: "Ready to submit"
+  notStarted: "Not started"
+  notFinished: "Not finished"
+  readyToSubmit: "Ready to submit"
 
 options:
   previewReport: "Preview report"
@@ -38,85 +38,83 @@ completeNotice: |
   All sections are now complete. Please review then submit your report.
 
 labels:
-    not-started: "Not started"
-    incomplete: "Not finished"
-    done: "Finished"
-    previewReport: "Preview report"
+  not-started: "Not started"
+  incomplete: "Not finished"
+  done: "Finished"
+  previewReport: "Preview report"
 
 visits_care:
-    subSectionTitle: "Visits and care"
-    subSectionDescription: "Give us an overview of who is looking after %client%"
-    edit: "Edit"
-    start: "Start"
-    label:
-      done: "Finished"
+  subSectionTitle: "Visits and care"
+  subSectionDescription: "Give us an overview of who is looking after %client%"
+  edit: "Edit"
+  start: "Start"
+  label:
+    done: "Finished"
 deputy_expenses:
-    subSectionTitle: "Deputy expenses"
-    subSectionDescription: "Claim for things you paid for on %client%'s behalf before your court order "
-    edit: "Edit"
-    start: "Start"
-    label:
-      done: "{0} no expenses | {1} 1 expense | ]1,Inf[ %count% expenses"
+  subSectionTitle: "Deputy expenses"
+  subSectionDescription: "Claim for things you paid for on %client%'s behalf before your court order "
+  edit: "Edit"
+  start: "Start"
+  label:
+    done: "{0} no expenses | {1} 1 expense | ]1,Inf[ %count% expenses"
 income_benefits:
-    subSectionTitle: "Income and benefits"
-    subSectionDescription: "Give us details of %client%'s income and any state benefits"
-    edit: "Edit"
-    start: "Start"
-    label:
-      done: "Finished"
+  subSectionTitle: "Income and benefits"
+  subSectionDescription: "Give us details of %client%'s income and any state benefits"
+  edit: "Edit"
+  start: "Start"
+  label:
+    done: "Finished"
 bank_accounts:
-    subSectionTitle: "Accounts"
-    subSectionDescription: "Add %client%'s bank, building society and savings accounts"
-    edit: "Edit"
-    start: "Start"
-    label:
-      done: "{0} no accounts | {1} 1 account | ]1,Inf[ %count% accounts"
+  subSectionTitle: "Accounts"
+  subSectionDescription: "Add %client%'s bank, building society and savings accounts"
+  edit: "Edit"
+  start: "Start"
+  label:
+    done: "{0} no accounts | {1} 1 account | ]1,Inf[ %count% accounts"
 assets:
-    subSectionTitle: "Assets"
-    subSectionDescription: "Enter details of %client%'s property, investments and other valuables"
-    edit: "Edit"
-    start: "Start"
-    label:
-      done: "{0} no assets | {1} 1 asset | ]1,Inf[ %count% assets"
+  subSectionTitle: "Assets"
+  subSectionDescription: "Enter details of %client%'s property, investments and other valuables"
+  edit: "Edit"
+  start: "Start"
+  label:
+    done: "{0} no assets | {1} 1 asset | ]1,Inf[ %count% assets"
 debts:
-    subSectionTitle: "Debts"
-    subSectionDescription: "Let us know about any debts %client% owes"
-    edit: "Edit"
-    start: "Start"
-    label:
-       done: "Finished"
+  subSectionTitle: "Debts"
+  subSectionDescription: "Let us know about any debts %client% owes"
+  edit: "Edit"
+  start: "Start"
+  label:
+    done: "Finished"
 actions:
-    subSectionTitle: "Actions you plan to take"
-    subSectionDescription: "What major financial decisions will you need to take for %client% in the next year?"
-    edit: "Edit"
-    start: "Start"
-    label:
-      done: "Finished"
+  subSectionTitle: "Actions you plan to take"
+  subSectionDescription: "What major financial decisions will you need to take for %client% in the next year?"
+  edit: "Edit"
+  start: "Start"
+  label:
+    done: "Finished"
 other_info:
-    subSectionTitle: "Any other information"
-    subSectionDescription: "Is there anything else you want to tell us about the deputyship?"
-    edit: "Edit"
-    start: "Start"
-    label:
-      done: "Finished"
+  subSectionTitle: "Any other information"
+  subSectionDescription: "Is there anything else you want to tell us about the deputyship?"
+  edit: "Edit"
+  start: "Start"
+  label:
+    done: "Finished"
 ndr_submit:
-    subSectionTitle: "Submit report"
-    edit: "Submit report"
-    start: "Submit report"
-    label:
-          done: "Ready to submit"
+  subSectionTitle: "Submit report"
+  edit: "Submit report"
+  start: "Submit report"
+  label:
+    done: "Ready to submit"
 
 additionalInformation:
   subSectionTitle: More information
 
 ndrSubmit:
-    checkbox:
-        label: I have reviewed and checked this new deputy report.
+  checkbox:
+    label: I have reviewed and checked this new deputy report.
 
 decisionsMadeAsDeputy: Decisions made as deputy
 
 announcement: |
   We've made some changes to the layout of this page.<br/>
   Use the links on this page to view and edit the different sections of your new deputy report.
-
-

--- a/client/src/AppBundle/Resources/translations/ndr-visits-care.en.yml
+++ b/client/src/AppBundle/Resources/translations/ndr-visits-care.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - visits and care | GOV.UK"
+  htmlTitle: "Visits and care - Complete the deputy report | GOV.UK"
   pageTitle: Visits and care
   pageSectionDescription: |
     Use this section to tell us about %client%'s care and contact with you and other people.
@@ -8,12 +8,12 @@ startPage:
   startButton: Start visits and care
 
 stepPage:
-  htmlTitle: "Deputy report - visits and care | GOV.UK"
+  htmlTitle: "Visits and care - Complete the deputy report | GOV.UK"
   supportTitle: Visits and care
   backLink: Back
 
 summaryPage:
-  htmlTitle: "Deputy report - visits and care | GOV.UK"
+  htmlTitle: "Visits and care - Complete the deputy report | GOV.UK"
   pageTitle: Visits and care
   supportTitle: ""
   weAskAbout: In this section, we ask you about %client%'s care and contact with you and other people.
@@ -46,8 +46,8 @@ form:
       If %client% receives care from a private organisation or local social services, they may have
       a plan that sets out how %client%'s care needs will be met.
   whenWasCarePlanLastReviewed:
-      label: When was the care plan last reviewed?
-      hint: For example, 12 2015
+    label: When was the care plan last reviewed?
+    hint: For example, 12 2015
   planMoveNewResidence:
     label: Are there any plans to move %client% to a new residence?
   planMoveNewResidenceDetails:

--- a/client/src/AppBundle/Resources/translations/org-client-archive.en.yml
+++ b/client/src/AppBundle/Resources/translations/org-client-archive.en.yml
@@ -1,4 +1,4 @@
-htmlTitle: "Archive client | GOV.UK"
+htmlTitle: "Archive client - Complete the deputy report | GOV.UK"
 pageTitle: "Archive client"
 supportTitle: "Client profile: %fullName%"
 question: Are you sure you want to archive this client?

--- a/client/src/AppBundle/Resources/translations/org-client-edit.en.yml
+++ b/client/src/AppBundle/Resources/translations/org-client-edit.en.yml
@@ -1,4 +1,4 @@
-htmlTitle: "Edit client details | GOV.UK"
+htmlTitle: "Edit client details - Complete the deputy report | GOV.UK"
 pageTitle: Edit client details
 supportTitle: "Client profile: %fullName%"
 
@@ -6,28 +6,28 @@ form:
   nameHeading: Client name
   contactHeading: Contact details
   firstname:
-      label: First name
+    label: First name
   lastname:
-      label: Last name
+    label: Last name
   address:
-      label: Address
-      context: line 1 of 2
+    label: Address
+    context: line 1 of 2
   address2:
-      label: ' '
-      context: Address line 2 of 2
-      hint: ""
+    label: " "
+    context: Address line 2 of 2
+    hint: ""
   county:
-      label: County
-      hint: ""
+    label: County
+    hint: ""
   postcode:
-      label: Postcode
-      hint: ""
+    label: Postcode
+    hint: ""
   dateOfBirth:
-      legend: Date of Birth
-      hint: For example, 31 3 1955
+    legend: Date of Birth
+    hint: For example, 31 3 1955
   email:
-      label: Email
+    label: Email
   phone:
-      label: Phone number
+    label: Phone number
   save:
-      label: Save client details
+    label: Save client details

--- a/client/src/AppBundle/Resources/translations/org-dashboard.en.yml
+++ b/client/src/AppBundle/Resources/translations/org-dashboard.en.yml
@@ -1,4 +1,4 @@
-htmlTitle: Deputy reports dashboard | GOV.UK
+htmlTitle: Deputy reports dashboard - Complete the deputy report | GOV.UK
 pageTitle: Deputy reports dashboard
 searchBy: Search by client name or court order number
 tabClients: Clients

--- a/client/src/AppBundle/Resources/translations/org-team.en.yml
+++ b/client/src/AppBundle/Resources/translations/org-team.en.yml
@@ -12,19 +12,19 @@ listPage:
   resendActivation: Resend activation
 
 addPage:
-  htmlTitle: Deputy report - add user account | GOV.UK
+  htmlTitle: Add user account - Complete the deputy report | GOV.UK
   pageTitle: Add user account
   supportTitle: User account
   informationBannerText: Any users you add will be able to see and edit all your organisation's reports
 
 editPage:
-  htmlTitle: Deputy report - edit user account | GOV.UK
+  htmlTitle: Edit user account - Complete the deputy report | GOV.UK
   pageTitle: Edit user account
   supportTitle: User account
   moreThanOneTeamNotification: This user is also a team member on other deputyships. Any changes you make will update their account across all deputyship teams.
 
 deletePage:
-  htmlTitle: "Client profile - remove user account | GOV.UK"
+  htmlTitle: "Remove user account - Complete the deputy report | GOV.UK"
   subject: user account
   summary:
     fullName: Name

--- a/client/src/AppBundle/Resources/translations/org-team.en.yml
+++ b/client/src/AppBundle/Resources/translations/org-team.en.yml
@@ -1,6 +1,6 @@
 # //TODO rename to org-team and replace occurences in TWIG files using regexpr search
 listPage:
-  htmlTitle: Deputy report - user accounts | GOV.UK
+  htmlTitle: User accounts - Complete the deputy report | GOV.UK
   pageTitle: User accounts
   introPara: View team members
   introParaAdmin: Add, edit and remove user accounts for your team members. Any users you add will be able to see and edit all your organisation's reports.
@@ -40,7 +40,7 @@ deletePage:
         plural: User will remain a member of %count% other teams
 
 view:
-    pageTitle: My details
+  pageTitle: My details
 
 form:
   add:

--- a/client/src/AppBundle/Resources/translations/pa-terms-use.en.yml
+++ b/client/src/AppBundle/Resources/translations/pa-terms-use.en.yml
@@ -1,4 +1,4 @@
-htmlTitle: Terms of use | GOV.UK
+htmlTitle: Terms of use - Complete the deputy report | GOV.UK
 pageTitle: Terms of use
 section01:
   heading: |

--- a/client/src/AppBundle/Resources/translations/password-forgotten.en.yml
+++ b/client/src/AppBundle/Resources/translations/password-forgotten.en.yml
@@ -1,11 +1,11 @@
 page:
-  htmlTitle: "Deputy report - forgotten password | GOV.UK"
+  htmlTitle: "Forgotten your password? - Complete the deputy report | GOV.UK"
 pageTitle: Forgotten your password?
 subtitle: To reset your password, enter your email address and check your email for confirmation.
 returnToSignIn: Return to sign in
 form:
-   email:
-     label: Email Address
-     hint: We sent your registration link to this email address
-   submit:
-     label: Reset your password
+  email:
+    label: Email Address
+    hint: We sent your registration link to this email address
+  submit:
+    label: Reset your password

--- a/client/src/AppBundle/Resources/translations/password-reset-expired.en.yml
+++ b/client/src/AppBundle/Resources/translations/password-reset-expired.en.yml
@@ -1,5 +1,5 @@
 page:
-  htmlTitle: "Deputy report - page expired | GOV.UK"
+  htmlTitle: "This page has expired - Complete the deputy report | GOV.UK"
 pageTitle: This page has expired
 subtitle: The link we sent you was only active for %tokenExpireHours% hours, and this page has now expired.
 goBackLink: Go back to 'reset password form'

--- a/client/src/AppBundle/Resources/translations/password-reset.en.yml
+++ b/client/src/AppBundle/Resources/translations/password-reset.en.yml
@@ -1,19 +1,19 @@
 page:
-  htmlTitle: "Deputy report - reset password | GOV.UK"
+    htmlTitle: "Reset your password - Complete the deputy report | GOV.UK"
 pageTitle: Reset your password
 subtitle: To reset your password, type your new password in the box below and then confirm the password in the second box
 form:
-  password:
-      label: Password
-      hint: "Your password must have:"
-      hintList: |
-          at least 8 characters
-          at least 1 uppercase letter
-          at least 1 lowercase letter
-          at least 1 number
-      validation:
-          passwordMismatch: The passwords you entered don't match.
-  password_confirm:
-      label: Confirm password
-  submit:
-      label: Save password
+    password:
+        label: Password
+        hint: "Your password must have:"
+        hintList: |
+            at least 8 characters
+            at least 1 uppercase letter
+            at least 1 lowercase letter
+            at least 1 number
+        validation:
+            passwordMismatch: The passwords you entered don't match.
+    password_confirm:
+        label: Confirm password
+    submit:
+        label: Save password

--- a/client/src/AppBundle/Resources/translations/password-sent.en.yml
+++ b/client/src/AppBundle/Resources/translations/password-sent.en.yml
@@ -1,5 +1,5 @@
 page:
-  htmlTitle: "Deputy report - new registration link | GOV.UK"
+  htmlTitle: "Reset your password - Complete the deputy report | GOV.UK"
 pageTitle: Reset your password
 subtitle: We have sent a new registration link to your email. Use the link to reset your password.
 didntReceive: Didn't receive the email?

--- a/client/src/AppBundle/Resources/translations/prof-terms-use.en.yml
+++ b/client/src/AppBundle/Resources/translations/prof-terms-use.en.yml
@@ -1,4 +1,4 @@
-htmlTitle: Terms of use | GOV.UK
+htmlTitle: Terms of use - Complete the deputy report | GOV.UK
 pageTitle: Terms of use
 section01:
   heading: |

--- a/client/src/AppBundle/Resources/translations/register.en.yml
+++ b/client/src/AppBundle/Resources/translations/register.en.yml
@@ -1,5 +1,5 @@
+htmlTitle: "Registration details - Deputy report | GOV.UK"
 pageTitle: Registration details
-htmlTitle: "Deputy report | GOV.UK"
 
 intro: "You need to give your name, your email address, your postcode and your client's case number. This is so you can create your secure deputy account."
 signin: "sign in"
@@ -9,62 +9,62 @@ moreThanOneDescription: |
   The deputy who pays the OPG fee should do the report. This applies if you make decisions together (called 'jointly') or separately and together (called 'jointly and severally').<br/><br/>
   All the information you enter is saved so you can show your report to the other deputies before you send it to OPG.
 firstname:
-    label: "Your first name"
-    hint: ""
+  label: "Your first name"
+  hint: ""
 lastname:
-    label: "Your last name"
-    hint: ""
+  label: "Your last name"
+  hint: ""
 email:
-    first:
-      label: "Your email"
-      hint: ""
-      existingError: |
-        This email address has already been registered.
-      invalid: Enter a valid email address
-    second:
-      label: "Confirm your email"
-      hint: ""
+  first:
+    label: "Your email"
+    hint: ""
+    existingError: |
+      This email address has already been registered.
+    invalid: Enter a valid email address
+  second:
+    label: "Confirm your email"
+    hint: ""
 postcode:
-    label: "Your post code"
-    hint: ""
-    matchingError: |
-      You haven't entered a post code we recognise. Do you live in the UK?
-      If you have a UK post code, please enter it.
-      If you continue to have problems, please call the helpline to make sure
-      we have a correct record of your details.
+  label: "Your post code"
+  hint: ""
+  matchingError: |
+    You haven't entered a post code we recognise. Do you live in the UK?
+    If you have a UK post code, please enter it.
+    If you continue to have problems, please call the helpline to make sure
+    we have a correct record of your details.
 clientFirstname:
-    label: "Client's first names"
-    hint: ""
+  label: "Client's first names"
+  hint: ""
 clientLastname:
-    label: "Client's last name"
-    hint: ""
+  label: "Client's last name"
+  hint: ""
 caseNumber:
-    label: "Case number"
-    hint: This is 8 characters long and usually starts with a 1 or 9
+  label: "Case number"
+  hint: This is 8 characters long and usually starts with a 1 or 9
 save:
-    label: "Sign up"
+  label: "Sign up"
 
 thankyou:
-    subheading: Please check your email
-    pageDescription1: |
-      We've sent you a link to <strong class="bold-small">%email%</strong> that you need to click to activate your deputy service account.
-    pageDescription2: |
-      You'll need to use this link within 48 hours, or enter your details again.
-    pageDescription3: |
-      If you haven't received the email within a few minutes, please check your spam,
-      bulk or junk email folder - it may have been mistakenly blocked by your email system.
-    pageDescription4: |
-      If you've already activated your account, you can <a href="%link%">sign in</a>.
+  subheading: Please check your email
+  pageDescription1: |
+    We've sent you a link to <strong class="bold-small">%email%</strong> that you need to click to activate your deputy service account.
+  pageDescription2: |
+    You'll need to use this link within 48 hours, or enter your details again.
+  pageDescription3: |
+    If you haven't received the email within a few minutes, please check your spam,
+    bulk or junk email folder - it may have been mistakenly blocked by your email system.
+  pageDescription4: |
+    If you've already activated your account, you can <a href="%link%">sign in</a>.
 
 formErrors:
-    # the following is split in two lines otherwise the number gets split on two lines
-    matching: |
-          The information you've given us does not match our records.
-          Please call 0115 934 2700 to make sure we have a record of your deputyship.
-    generic: |
-          The information you've given us does not match our records.
-          Please call 0115 934 2700 to make sure we have a record of your deputyship.
-    caseNumberAlreadyUsed: Someone else has already registered with this case number. Please check your case number and try again. If you're worried that someone else has used your case number, call our helpline on 0115 934 2700.
-    coDepCaseAlreadyRegistered: |
-          You are attempting to register a case which already has other deputies assigned to it.
-          Please ask one of these deputies to invite you directly.
+  # the following is split in two lines otherwise the number gets split on two lines
+  matching: |
+    The information you've given us does not match our records.
+    Please call 0115 934 2700 to make sure we have a record of your deputyship.
+  generic: |
+    The information you've given us does not match our records.
+    Please call 0115 934 2700 to make sure we have a record of your deputyship.
+  caseNumberAlreadyUsed: Someone else has already registered with this case number. Please check your case number and try again. If you're worried that someone else has used your case number, call our helpline on 0115 934 2700.
+  coDepCaseAlreadyRegistered: |
+    You are attempting to register a case which already has other deputies assigned to it.
+    Please ask one of these deputies to invite you directly.

--- a/client/src/AppBundle/Resources/translations/register.en.yml
+++ b/client/src/AppBundle/Resources/translations/register.en.yml
@@ -1,4 +1,4 @@
-htmlTitle: "Registration details - Deputy report | GOV.UK"
+htmlTitle: "Registration details - Complete the deputy report | GOV.UK"
 pageTitle: Registration details
 
 intro: "You need to give your name, your email address, your postcode and your client's case number. This is so you can create your secure deputy account."

--- a/client/src/AppBundle/Resources/translations/registration.en.yml
+++ b/client/src/AppBundle/Resources/translations/registration.en.yml
@@ -1,44 +1,44 @@
 addClient:
-    htmlTitle: "Deputy report - add your client's details | GOV.UK"
-    pageTitle: Add your client's details
-    pageTitleWithClient: Add %client%'s details
-    formHeading: Client's details
+  htmlTitle: "Add your client's details - Complete the deputy report | GOV.UK"
+  pageTitle: Add your client's details
+  pageTitleWithClient: Add %client%'s details
+  formHeading: Client's details
 courtDate:
-    legend: Court order date
-    hint: For example, 31 3 2015
+  legend: Court order date
+  hint: For example, 31 3 2015
 firstname:
-    label: First name
+  label: First name
 lastname:
-    label: Last name
+  label: Last name
 caseNumber:
-    label: Case number
-    hint: You will find the case number on the first page of the court order (top right-hand corner)
+  label: Case number
+  hint: You will find the case number on the first page of the court order (top right-hand corner)
 address:
-    label: Address
-    context: line 1 of 2
+  label: Address
+  context: line 1 of 2
 address2:
-    label: ' '
-    context: Address line 2 of 2
-    hint: ""
+  label: " "
+  context: Address line 2 of 2
+  hint: ""
 county:
-    label: County
-    hint: ""
+  label: County
+  hint: ""
 postcode:
-    label: Postcode
-    hint: ""
+  label: Postcode
+  hint: ""
 country:
-    label: Country
-    hint: ""
-    defaultOption: Please select ...
+  label: Country
+  hint: ""
+  defaultOption: Please select ...
 phone:
-    label: Phone number
+  label: Phone number
 save:
-    label: Save
+  label: Save
 saveAndContinue:
-    label: Save and continue
+  label: Save and continue
 createReport:
-    htmlTitle: "Deputy report - create a report | GOV.UK"
-    pageTitle: Create a report
+  htmlTitle: "Deputy report - create a report | GOV.UK"
+  pageTitle: Create a report
 form:
   newReportForm:
     addStartDate: "Add the report start date"

--- a/client/src/AppBundle/Resources/translations/registration.en.yml
+++ b/client/src/AppBundle/Resources/translations/registration.en.yml
@@ -37,7 +37,7 @@ save:
 saveAndContinue:
   label: Save and continue
 createReport:
-  htmlTitle: "Deputy report - create a report | GOV.UK"
+  htmlTitle: "Create a report - Complete the deputy report | GOV.UK"
   pageTitle: Create a report
 form:
   newReportForm:

--- a/client/src/AppBundle/Resources/translations/report-actions.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-actions.en.yml
@@ -30,12 +30,12 @@ startPage:
   startButton: Start actions
 
 stepPage:
-  htmlTitle: "Deputy report - actions you plan to take | GOV.UK"
+  htmlTitle: "Actions you plan to take - Complete the deputy report | GOV.UK"
   supportTitle: Actions you plan to take
   backLink: Back
 
 summaryPage:
-  htmlTitle: "Deputy report - actions you plan to take | GOV.UK"
+  htmlTitle: "Actions you plan to take - Complete the deputy report | GOV.UK"
   pageTitle: Actions you plan to take
   supportTitle: ""
   weAskAbout: |

--- a/client/src/AppBundle/Resources/translations/report-actions.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-actions.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - actions you plan to take | GOV.UK"
+  htmlTitle: "Actions you plan to take - Complete the deputy report | GOV.UK"
   pageTitle: Actions you plan to take
   pageSectionDescription1: |
     Use this section to tell us about any significant financial decisions you plan to
@@ -76,22 +76,22 @@ form:
           If %client% has a small estate (low funds), you can apply to pay a smaller or no fee.
         para04: <a href="https://www.gov.uk/joint-property-ownership/selling-when-an-owner-has-lost-mental-capacity" target="_blank">Find out more</a>
   doYouExpectFinancialDecisionsDetails:
-      label: Please give us details about your decisions
-      label-104: Please give us details of these changes
-      label-4: Please give us details of these changes
+    label: Please give us details about your decisions
+    label-104: Please give us details of these changes
+    label-4: Please give us details of these changes
   doYouHaveConcerns:
-      label: Do you have any concerns about your deputyship?
-      hint: |
-        For example, paying care home fees if %client%'s money runs low, managing %client%'s property,
-        family members' involvement with %client%'s funds
-      hint-104: |
-        For example, people not recognising or understanding your court order, not being involved in
-        making decisions stated on your court order on behalf of %client%, any complaints about
-        %client%'s care or treatment
-      hint-4: |
-        For example, people not recognising or understanding your court order, not being involved in
-        making decisions stated on your court order on behalf of %client%, any complaints about
-        %client%'s care or treatment, paying care home fees if %client%'s money runs low, managing
-        %client%'s property, family members' involvement with %client%'s funds.
+    label: Do you have any concerns about your deputyship?
+    hint: |
+      For example, paying care home fees if %client%'s money runs low, managing %client%'s property,
+      family members' involvement with %client%'s funds
+    hint-104: |
+      For example, people not recognising or understanding your court order, not being involved in
+      making decisions stated on your court order on behalf of %client%, any complaints about
+      %client%'s care or treatment
+    hint-4: |
+      For example, people not recognising or understanding your court order, not being involved in
+      making decisions stated on your court order on behalf of %client%, any complaints about
+      %client%'s care or treatment, paying care home fees if %client%'s money runs low, managing
+      %client%'s property, family members' involvement with %client%'s funds.
   doYouHaveConcernsDetails:
-      label: Please give us details about your concerns
+    label: Please give us details about your concerns

--- a/client/src/AppBundle/Resources/translations/report-assets.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-assets.en.yml
@@ -29,17 +29,17 @@ typePage:
   backLink: Back
 
 addPage:
-  htmlTitle: "Deputy report - Assets | GOV.UK"
-  supportTitle: Assets
+  htmlTitle: "Add an asset: %assetTitle% - Complete the deputy report | GOV.UK"
   pageTitle: "Add an asset: %assetTitle%"
+  supportTitle: Assets
 
 editPage:
-  htmlTitle: "Deputy report - Assets | GOV.UK"
-  supportTitle: Assets
+  htmlTitle: "Edit %assetTitle% - Complete the deputy report | GOV.UK"
   pageTitle: Edit %assetTitle%
+  supportTitle: Assets
 
 addAnotherPage:
-  htmlTitle: "Deputy report - assets | GOV.UK"
+  htmlTitle: "Assets - Complete the deputy report | GOV.UK"
   pageTitle: Assets
   form:
     addAnother:
@@ -49,12 +49,12 @@ addAnotherPage:
       label: Continue
 
 stepPageProperty:
-  htmlTitle: "Deputy report - Property | GOV.UK"
-  supportTitle: Assets
+  htmlTitle: "Add an asset: property - Complete the deputy report | GOV.UK"
   pageTitle: "Add an asset: property"
+  supportTitle: Assets
 
 summaryPage:
-  htmlTitle: "Deputy report - assets | GOV.UK"
+  htmlTitle: "Assets - Complete the deputy report | GOV.UK"
   pageTitle: Assets
   supportTitle: ""
   weAskAbout: In this section, we ask you about %client%'s assets, including property, vehicles, valuables or investments.
@@ -64,7 +64,7 @@ summaryPage:
   totalValueOfAssets: Total value of assets
 
 deletePage:
-  htmlTitle: "Deputy report - remove asset | GOV.UK"
+  htmlTitle: "Remove asset - Complete the deputy report | GOV.UK"
   subject: asset
   summary:
     type: Type

--- a/client/src/AppBundle/Resources/translations/report-assets.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-assets.en.yml
@@ -18,8 +18,8 @@ existPage:
 
 typePage:
   htmlTitle: "Add an asset - Complete the deputy report | GOV.UK"
-  supportTitle: Assets
   pageTitle: Add an asset
+  supportTitle: Assets
   pageSectionDescription1: |
     Please tell us a bit more about %client%'s assets. Add a type of asset, then we'll ask you
     for some details about it. You can come back and add more assets if you need to.

--- a/client/src/AppBundle/Resources/translations/report-assets.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-assets.en.yml
@@ -7,7 +7,7 @@ startPage:
   startButton: Start assets
 
 existPage:
-  htmlTitle: "Deputy report - assets | GOV.UK"
+  htmlTitle: "Assets - Complete the deputy report | GOV.UK"
   supportTitle: Assets
   form:
     noAssetToAdd:
@@ -17,7 +17,7 @@ existPage:
       label: Save and continue
 
 typePage:
-  htmlTitle: "Add an asset - Complete the duty report | GOV.UK"
+  htmlTitle: "Add an asset - Complete the deputy report | GOV.UK"
   supportTitle: Assets
   pageTitle: Add an asset
   pageSectionDescription1: |

--- a/client/src/AppBundle/Resources/translations/report-assets.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-assets.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - assets | GOV.UK"
+  htmlTitle: "Assets - Complete the deputy report | GOV.UK"
   pageTitle: Assets
   pageSectionDescription: |
     Use this section to tell us about %client%'s assets. They may include property, vehicles,
@@ -17,7 +17,7 @@ existPage:
       label: Save and continue
 
 typePage:
-  htmlTitle: "Deputy report - assets | GOV.UK"
+  htmlTitle: "Add an asset - Complete the duty report | GOV.UK"
   supportTitle: Assets
   pageTitle: Add an asset
   pageSectionDescription1: |
@@ -46,7 +46,7 @@ addAnotherPage:
       label: The asset has been saved. Would you like to add another now?
       hint: If you prefer, you can come back to this section later to add more assets
     save:
-       label: Continue
+      label: Continue
 
 stepPageProperty:
   htmlTitle: "Deputy report - Property | GOV.UK"
@@ -158,4 +158,4 @@ form:
       label: What is the rental income each month?
       hint: ""
   save:
-      label: Save and continue
+    label: Save and continue

--- a/client/src/AppBundle/Resources/translations/report-balance.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-balance.en.yml
@@ -1,4 +1,4 @@
-htmlTitle: Deputy report - balance | GOV.UK
+htmlTitle: Accounts balance check - Complete the deputy report | GOV.UK
 pageTitle: Accounts balance check
 
 alerts:

--- a/client/src/AppBundle/Resources/translations/report-bank-accounts.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-bank-accounts.en.yml
@@ -12,11 +12,11 @@ startPage:
     summary: More on how to carry out your duties
     content:
       para01: |
-          OPG's <a href="https://www.gov.uk/government/publications/deputy-guidance-how-to-carry-out-your-duties" target="_blank">'How to be a deputy' (SD3)</a> booklet gives detailed guidance on how to look after %client%'s financial affairs.
+        OPG's <a href="https://www.gov.uk/government/publications/deputy-guidance-how-to-carry-out-your-duties" target="_blank">'How to be a deputy' (SD3)</a> booklet gives detailed guidance on how to look after %client%'s financial affairs.
   startButton: Start accounts
 
 stepPage:
-  htmlTitle: "Deputy report - Accounts | GOV.UK"
+  htmlTitle: "Add an account - Complete the deputy report | GOV.UK"
   pageTitle:
     add: Add an account
     edit: Edit an account
@@ -26,14 +26,14 @@ stepPage:
   backLink: Back
 
 addAnotherPage:
-  htmlTitle: "Deputy report - add another account | GOV.UK"
+  htmlTitle: "Add another account - Complete the deputy deport | GOV.UK"
   pageTitle: Accounts
   form:
     addAnother:
       label: The account has been saved. Would you like to add another now?
       hint: If you prefer, you can come back to this section later to add more accounts
     save:
-       label: Continue
+      label: Continue
 
 summaryPage:
   htmlTitle: "Deputy report - Accounts | GOV.UK"
@@ -60,16 +60,16 @@ deletePage:
 
 form:
   accountType:
-      label: What type of account is it?
-      hint: ""
-      choices:
-        current: Current account
-        savings: Savings account
-        isa: ISA
-        postoffice: Post Office account
-        cfo: Court Funds Office account
-        other: Other type of account
-        other_no_sortcode: Other type of account without sort code
+    label: What type of account is it?
+    hint: ""
+    choices:
+      current: Current account
+      savings: Savings account
+      isa: ISA
+      postoffice: Post Office account
+      cfo: Court Funds Office account
+      other: Other type of account
+      other_no_sortcode: Other type of account without sort code
   bank:
     label: Bank or building society name
     hint: ""
@@ -93,10 +93,9 @@ form:
       Joint accounts are often used by married couples or couples who live together. The money in
       a joint account is owned by both account holders.
   isClosed:
-      label: You currently have £0 in this account on %endDate%. Have you closed this account?
-      hint: ""
+    label: You currently have £0 in this account on %endDate%. Have you closed this account?
+    hint: ""
   save:
     label: Save and continue
   cancel:
     label: Cancel
-

--- a/client/src/AppBundle/Resources/translations/report-bank-accounts.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-bank-accounts.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - Accounts | GOV.UK"
+  htmlTitle: "Accounts - Complete the deputy report | GOV.UK"
   pageTitle: Accounts
   pageSectionDescription1: |
     Use this section to tell us about all of %client%'s bank accounts, building society accounts,
@@ -36,7 +36,7 @@ addAnotherPage:
       label: Continue
 
 summaryPage:
-  htmlTitle: "Deputy report - Accounts | GOV.UK"
+  htmlTitle: "Accounts - Complete the deputy report | GOV.UK"
   pageTitle: Accounts
   weAskAbout: |
     In this section, we ask you about %client%'s bank accounts, building society accounts,
@@ -46,7 +46,7 @@ summaryPage:
   addBalance: Add balance
 
 deletePage:
-  htmlTitle: "Deputy report - remove account | GOV.UK"
+  htmlTitle: "Remove account - Complete the deputy report | GOV.UK"
   subject: account
   summary:
     bank: Bank or building society name

--- a/client/src/AppBundle/Resources/translations/report-contacts.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-contacts.en.yml
@@ -24,8 +24,8 @@ existPage:
       label: Save and continue
 
 addAnotherPage:
-  htmlTitle: "Add contact - Complete the deputy report | GOV.UK"
-  pageTitle: Contacts
+  htmlTitle: "Add another contact - Complete the deputy report | GOV.UK"
+  pageTitle: Add another contact
   form:
     addAnother:
       label: The person has been saved. Would you like to add another now?

--- a/client/src/AppBundle/Resources/translations/report-contacts.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-contacts.en.yml
@@ -6,7 +6,7 @@ startPage:
   startButton: Start contacts
 
 existPage:
-  htmlTitle: "Deputy report - add contact | GOV.UK"
+  htmlTitle: "Add contact - Complete the deputy report | GOV.UK"
   supportTitle: Contacts
   form:
     hasContacts:
@@ -24,7 +24,7 @@ existPage:
       label: Save and continue
 
 addAnotherPage:
-  htmlTitle: "Deputy report - add contact | GOV.UK"
+  htmlTitle: "Add contact - Complete the deputy report | GOV.UK"
   pageTitle: Contacts
   form:
     addAnother:
@@ -34,7 +34,7 @@ addAnotherPage:
       label: Continue
 
 addPage:
-  htmlTitle: "Deputy report - contacts | GOV.UK"
+  htmlTitle: "Add a contact - Complete the deputy report | GOV.UK"
   pageTitle: Add a contact
   supportTitle: Contacts
   pageSectionDescription: |
@@ -42,12 +42,12 @@ addPage:
     You'll be able to add more people later if you need to.
 
 editPage:
-  htmlTitle: "Deputy report - contacts | GOV.UK"
-  supportTitle: Contacts
+  htmlTitle: "Edit contact - Complete the deputy report | GOV.UK"
   pageTitle: Edit contact
+  supportTitle: Contacts
 
 summaryPage:
-  htmlTitle: "Deputy report - contacts | GOV.UK"
+  htmlTitle: "Contacts - Complete the deputy report | GOV.UK"
   pageTitle: Contacts
   addButton: Add a contact
   weAskAbout: |
@@ -58,7 +58,7 @@ summaryPage:
   reasonForContact: Reason for contact
 
 deletePage:
-  htmlTitle: "Deputy report - remove contact | GOV.UK"
+  htmlTitle: "Remove contact - Complete the deputy report | GOV.UK"
   subject: contact
   summary:
     contactName: Contact name

--- a/client/src/AppBundle/Resources/translations/report-contacts.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-contacts.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - contacts | GOV.UK"
+  htmlTitle: "Contacts - Complete the deputy report | GOV.UK"
   pageTitle: Contacts
   pageSectionDescription1: |
     Please tell us about the people who helped you make significant decisions as a deputy. They might include friends or family, and professionals like a GP, solicitor, accountant or care worker.
@@ -31,7 +31,7 @@ addAnotherPage:
       label: The person has been saved. Would you like to add another now?
       hint: If you prefer, you can come back to this section later to add more people
     save:
-       label: Continue
+      label: Continue
 
 addPage:
   htmlTitle: "Deputy report - contacts | GOV.UK"
@@ -79,7 +79,7 @@ form:
     label: Address (optional)
     context: line 1 of 2
   address2:
-    label: ' '
+    label: " "
     context: Address line 2 of 2 (optional)
     hint: ""
   county:

--- a/client/src/AppBundle/Resources/translations/report-debts.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-debts.en.yml
@@ -7,7 +7,7 @@ startPage:
   startButton: Start debts
 
 existPage:
-  htmlTitle: "Deputy report - debts | GOV.UK"
+  htmlTitle: "Debts - Complete the deputy report | GOV.UK"
   supportTitle: Debts
   form:
     exist:
@@ -16,7 +16,7 @@ existPage:
       label: Save and continue
 
 managementPage:
-  htmlTitle: "Deputy report - debts | GOV.UK"
+  htmlTitle: "Debts - Complete the deputy report | GOV.UK"
   supportTitle: Debts
   pageTitle: How is the debt being managed or reduced?
   pageHint: For example, list any regular payments to creditors or payment plans in place
@@ -26,7 +26,7 @@ managementPage:
       hint: For example, give details of any regular payments to creditors or payment plans
 
 editPage:
-  htmlTitle: "Deputy report - debts | GOV.UK"
+  htmlTitle: "Debts - Complete the deputy report | GOV.UK"
   supportTitle: Debts
   pageTitle: Please tell us more about %client%'s debts.
   pageHint: If %client% has a mortgage on a property, use the Assets section to tell us about it

--- a/client/src/AppBundle/Resources/translations/report-debts.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-debts.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - debts | GOV.UK"
+  htmlTitle: "Debts - Complete the deputy report | GOV.UK"
   pageTitle: "Debts"
   pageSectionDescription: |
     Use this section to tell us about %client%'s debts, for example, overdue

--- a/client/src/AppBundle/Resources/translations/report-decisions.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-decisions.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - decisions | GOV.UK"
+  htmlTitle: "Decisions - Complete the deputy report | GOV.UK"
   pageTitle: Decisions
   startButton: Start decisions
   description1: "Use this section to tell us about %client%'s mental capacity and the significant decisions you've made on %client%'s behalf."
@@ -56,11 +56,11 @@ mentalCapacity:
         changed: Changed
         stayedSame: Stayed the same
     hasCapacityChangedDetails:
-        label: "Please tell us more."
-        hint: "For example, %client% may be able to make some types of decisions but not others – or only make decisions at some times"
+      label: "Please tell us more."
+      hint: "For example, %client% may be able to make some types of decisions but not others – or only make decisions at some times"
     mentalAssessmentDate:
-        legend: "When was %client%'s mental capacity to make decisions last assessed by a professional (such as a psychiatrist or social worker)?"
-        hint: For example, 12 2015
+      legend: "When was %client%'s mental capacity to make decisions last assessed by a professional (such as a psychiatrist or social worker)?"
+      hint: For example, 12 2015
 
 existPage:
   htmlTitle: "Deputy report - add decision | GOV.UK"
@@ -81,7 +81,7 @@ addAnotherPage:
       label: The decision has been saved. Would you like to add another now?
       hint: If you prefer, you can come back to this section later to add more decisions
     save:
-       label: Continue
+      label: Continue
 
 addPage:
   htmlTitle: "Deputy report - decisions | GOV.UK"
@@ -98,7 +98,7 @@ editPage:
 
 summaryPage:
   weAskAbout: |
-      In this section, we ask about %client%'s mental capacity and the significant decisions you've made for %client% over the reporting period.
+    In this section, we ask about %client%'s mental capacity and the significant decisions you've made for %client% over the reporting period.
   htmlTitle: "Deputy report - decisions | GOV.UK"
   pageTitle: Decisions
   capacityChangeDetails: Mental capacity changes details

--- a/client/src/AppBundle/Resources/translations/report-decisions.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-decisions.en.yml
@@ -44,7 +44,7 @@ startPage:
     You don't need to include small, day-to-day decisions like buying food or toiletries.
 
 mentalCapacity:
-  htmlTitle: "Deputy report - mental capacity | GOV.UK"
+  htmlTitle: "Mental capacity - Complete the deputy report | GOV.UK"
   supportTitle: Decisions
   form:
     hasCapacityChanged:
@@ -63,7 +63,7 @@ mentalCapacity:
       hint: For example, 12 2015
 
 existPage:
-  htmlTitle: "Deputy report - add decision | GOV.UK"
+  htmlTitle: "Add decision - Complete the deputy report | GOV.UK"
   supportTitle: Decisions
   form:
     hasDecisions:
@@ -74,7 +74,7 @@ existPage:
       hint: ""
 
 addAnotherPage:
-  htmlTitle: "Deputy report - add decision | GOV.UK"
+  htmlTitle: "Add decision - Complete the deputy report | GOV.UK"
   pageTitle: Decisions
   form:
     addAnother:
@@ -84,7 +84,7 @@ addAnotherPage:
       label: Continue
 
 addPage:
-  htmlTitle: "Deputy report - decisions | GOV.UK"
+  htmlTitle: "Add a decision - Complete the deputy report | GOV.UK"
   pageTitle: Add a decision
   supportTitle: Decisions
   pageSectionDescription: |
@@ -92,14 +92,14 @@ addPage:
     able to add more decisions later if you need to.
 
 editPage:
-  htmlTitle: "Deputy report - decisions | GOV.UK"
+  htmlTitle: "Decisions - Complete the deputy report | GOV.UK"
   supportTitle: Decisions
   pageTitle: Edit decision
 
 summaryPage:
   weAskAbout: |
     In this section, we ask about %client%'s mental capacity and the significant decisions you've made for %client% over the reporting period.
-  htmlTitle: "Deputy report - decisions | GOV.UK"
+  htmlTitle: "Decisions - Complete the deputy report | GOV.UK"
   pageTitle: Decisions
   capacityChangeDetails: Mental capacity changes details
   addButton: Add significant decision

--- a/client/src/AppBundle/Resources/translations/report-decisions.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-decisions.en.yml
@@ -74,8 +74,8 @@ existPage:
       hint: ""
 
 addAnotherPage:
-  htmlTitle: "Add decision - Complete the deputy report | GOV.UK"
-  pageTitle: Decisions
+  htmlTitle: "Add another decision - Complete the deputy report | GOV.UK"
+  pageTitle: Add another decision
   form:
     addAnother:
       label: The decision has been saved. Would you like to add another now?
@@ -92,9 +92,9 @@ addPage:
     able to add more decisions later if you need to.
 
 editPage:
-  htmlTitle: "Decisions - Complete the deputy report | GOV.UK"
-  supportTitle: Decisions
+  htmlTitle: "Edit decision - Complete the deputy report | GOV.UK"
   pageTitle: Edit decision
+  supportTitle: Decisions
 
 summaryPage:
   weAskAbout: |

--- a/client/src/AppBundle/Resources/translations/report-decisions.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-decisions.en.yml
@@ -110,7 +110,7 @@ summaryPage:
   decisionTableColumnHeading3: If not, explain why; if yes, provide detail
 
 deletePage:
-  htmlTitle: "Deputy report - remove decision | GOV.UK"
+  htmlTitle: "Remove decision - Complete the deputy report | GOV.UK"
   subject: decision
   summary:
     description: Decision description

--- a/client/src/AppBundle/Resources/translations/report-declaration.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-declaration.en.yml
@@ -1,5 +1,5 @@
 page:
-  htmlTitle: "Deputy report - deputy's declaration | GOV.UK"
+  htmlTitle: "Report submission - Complete the deputy report | GOV.UK"
   pageTitle: "Report submission"
   contactDetailsHeader: "Contact details"
   contactDetailsIntro: "Please review and update any incorrect contact details before submitting the report"
@@ -9,9 +9,9 @@ page:
   declarationTerms03:
     lay: "I am submitting this report on behalf of myself and each of the deputies named in the court order (unless I have stated otherwise and provided reasons)."
     nonLay:
-        intro: "I am submitting this report as either:"
-        option1: "a deputy, and on behalf of any other deputies named in the court order (unless I have stated otherwise and provided reasons)"
-        option2: "someone authorised by the named deputies, and confirm they are aware of the contents of this report"
+      intro: "I am submitting this report as either:"
+      option1: "a deputy, and on behalf of any other deputies named in the court order (unless I have stated otherwise and provided reasons)"
+      option2: "someone authorised by the named deputies, and confirm they are aware of the contents of this report"
   declarationTerms04: "I confirm I have had regard to the Mental Capacity Act 2005, its Code of Practice and the court order in this case. I understand the duties and obligations placed on me."
   reportSubmittedFlashMessage: "The report has been submitted."
   goBackLink: "Go back to make changes to the report"

--- a/client/src/AppBundle/Resources/translations/report-deputy-expenses.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-deputy-expenses.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - deputy expenses | GOV.UK"
+  htmlTitle: "Deputy expenses - Complete the deputy report | GOV.UK"
   pageTitle: Deputy expenses
   pageSectionDescription1: |
     Over the course of your deputyship, you can claim expenses for things you have to do to carry out your role, like phone calls, postage and travel costs.
@@ -44,7 +44,7 @@ addAnotherPage:
       label: The expense has been saved. Would you like to add another now?
       hint: If you prefer, you can come back to this section later to add more expenses
     save:
-       label: Continue
+      label: Continue
 
 addPage:
   htmlTitle: "Deputy report - deputy expenses | GOV.UK"
@@ -86,4 +86,4 @@ form:
     label: Which bank account was this paid from? (optional)
     hint: ""
   save:
-      label: Save expense
+    label: Save expense

--- a/client/src/AppBundle/Resources/translations/report-deputy-expenses.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-deputy-expenses.en.yml
@@ -26,7 +26,7 @@ startPage:
   startButton: Start deputy expenses
 
 existPage:
-  htmlTitle: "Deputy report - add deputy expense | GOV.UK"
+  htmlTitle: "Add deputy expense - Complete the deputy report | GOV.UK"
   supportTitle: Deputy expenses
   form:
     paidForAnything:
@@ -36,7 +36,7 @@ existPage:
       label: Save and continue
 
 addAnotherPage:
-  htmlTitle: "Deputy report - add deputy expense | GOV.UK"
+  htmlTitle: "Add an expense - Complete the deputy report | GOV.UK"
   pageTitle: Add an expense
   supportTitle: Deputy expenses
   form:
@@ -47,19 +47,19 @@ addAnotherPage:
       label: Continue
 
 addPage:
-  htmlTitle: "Deputy report - deputy expenses | GOV.UK"
+  htmlTitle: "Ann an expense - Complete the deputy report | GOV.UK"
   pageTitle: Add an expense
   supportTitle: Deputy expenses
   pageSectionDescription: |
     Tell us about an expense you've claimed for. You'll be able to add more expenses if you need to.
 
 editPage:
-  htmlTitle: "Deputy report - deputy expenses | GOV.UK"
-  supportTitle: Deputy expenses
+  htmlTitle: "Edit deputy expense - Complete the deputy report | GOV.UK"
   pageTitle: Edit deputy expense
+  supportTitle: Deputy expenses
 
 summaryPage:
-  htmlTitle: "Deputy report - deputy expenses | GOV.UK"
+  htmlTitle: "deputy expenses | GOV.UK"
   pageTitle: Deputy expenses
   pageSectionDescription: |
     In this section, we asked you to tell us about any expenses you've claimed for things you have
@@ -67,7 +67,7 @@ summaryPage:
   addButton: Add a deputy expense
 
 deletePage:
-  htmlTitle: "Deputy report - remove deputy expense | GOV.UK"
+  htmlTitle: "Remove deputy expense - Complete the deputy report | GOV.UK"
   subject: expense
   summary:
     explanation: Description of expense

--- a/client/src/AppBundle/Resources/translations/report-deputy-expenses.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-deputy-expenses.en.yml
@@ -47,7 +47,7 @@ addAnotherPage:
       label: Continue
 
 addPage:
-  htmlTitle: "Ann an expense - Complete the deputy report | GOV.UK"
+  htmlTitle: "Add an expense - Complete the deputy report | GOV.UK"
   pageTitle: Add an expense
   supportTitle: Deputy expenses
   pageSectionDescription: |

--- a/client/src/AppBundle/Resources/translations/report-deputy-expenses.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-deputy-expenses.en.yml
@@ -36,8 +36,8 @@ existPage:
       label: Save and continue
 
 addAnotherPage:
-  htmlTitle: "Add an expense - Complete the deputy report | GOV.UK"
-  pageTitle: Add an expense
+  htmlTitle: "Add another expense - Complete the deputy report | GOV.UK"
+  pageTitle: Add another expense
   supportTitle: Deputy expenses
   form:
     addAnother:
@@ -59,7 +59,7 @@ editPage:
   supportTitle: Deputy expenses
 
 summaryPage:
-  htmlTitle: "deputy expenses | GOV.UK"
+  htmlTitle: "Deputy expenses - Complete the deputy report | GOV.UK"
   pageTitle: Deputy expenses
   pageSectionDescription: |
     In this section, we asked you to tell us about any expenses you've claimed for things you have

--- a/client/src/AppBundle/Resources/translations/report-display.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-display.en.yml
@@ -5,35 +5,35 @@ incomplete:
 submitReport: Submit report
 
 preview:
-  htmlTitle: Preview deputy report | GOV.UK
+  htmlTitle: Preview report - Complete the deputy report | GOV.UK
   pageTitle: Preview report
   introPara: |
     Use this section to check the details of the report are correct. When all sections are
     completed you will be able to continue the report submission process.
 
 review:
-  htmlTitle: Review deputy report | GOV.UK
+  htmlTitle: Review report - Complete the deputy report | GOV.UK
   pageTitle: Review report
   introPara: Please review all sections of this report before continuing to the deputy declaration.
 
 submitted:
-  htmlTitle: Submitted deputy report | GOV.UK
+  htmlTitle: Submitted report - Complete the deputy report | GOV.UK
   pageTitle: Submitted report
   introPara: This report was submitted to OPG on
 
 ndr-preview:
-  htmlTitle: Preview new deputy report | GOV.UK
+  htmlTitle: Preview report - Complete the deputy report | GOV.UK
   pageTitle: Preview report
   introPara: |
     Use this section to check the details of the report are correct. When all sections are
     completed you will be able to continue the report submission process.
 
 ndr-review:
-  htmlTitle: Review new deputy report | GOV.UK
+  htmlTitle: Review report - Complete the deputy report | GOV.UK
   pageTitle: Review report
   introPara: Please review all sections of this report before continuing to the deputy declaration.
 
 ndr-submitted:
-  htmlTitle: Submitted new deputy report | GOV.UK
+  htmlTitle: Submitted report - Complete the deputy report | GOV.UK
   pageTitle: Submitted report
   introPara: This report was submitted to OPG on

--- a/client/src/AppBundle/Resources/translations/report-documents.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-documents.en.yml
@@ -13,7 +13,7 @@ form:
     generic: "Cannot upload file, please try again later. Technical details: %techDetails%"
 
 removeDocument:
-  htmlTitle: Deputy report - supporting documents | GOV.UK
+  htmlTitle: Remove document - Complete the deputy report | GOV.UK
   pageTitle: Remove document
   supportTitle: "Supporting documents"
   question: Are you sure you want to remove this document?
@@ -43,7 +43,7 @@ attachPage:
     To stop uploading the file, just refresh the page.
 
 startPage:
-  htmlTitle: "Deputy report - supporting documents | GOV.UK"
+  htmlTitle: "Supporting documents - Complete the deputy report | GOV.UK"
   pageTitle: Supporting documents
   pageSectionDescription1: |
     Use this section to attach supporting documents to this deputy report. For example bank
@@ -56,7 +56,7 @@ startPage:
   startButton: Start
 
 stepPage:
-  htmlTitle: "Deputy report - suporting documents | GOV.UK"
+  htmlTitle: "Suporting documents - Complete the deputy report | GOV.UK"
   pageTitle: Supporting documents
   backLink: Back
   form:
@@ -64,7 +64,7 @@ stepPage:
       label: Would you like to provide any supporting documents?
 
 summaryPage:
-  htmlTitle: "Deputy report - supporting documents | GOV.UK"
+  htmlTitle: "Supporting documents - Complete the deputy report | GOV.UK"
   pageTitle: Supporting documents
   addButton: Attach more documents
   weAskAbout: In this section, we asked you to provide any supporting documents.
@@ -76,16 +76,16 @@ summaryPage:
   setNoAttemptWithDocuments: "Your answer could not be updated to 'No' because you have attached documents. Please remove all attached documents before changing your answer."
 
 deletePage:
-  htmlTitle: "Deputy report - remove supporting document | GOV.UK"
+  htmlTitle: "Remove supporting document - Complete the deputy report | GOV.UK"
   subject: document
   summary:
     fileName: File name
     createdOn: Date attached
 
 submitMoreDocumentsConfirm:
-  htmlTitle: "Deputy report - supporting documents | GOV.UK"
-  supportTitle: Attach documents
+  htmlTitle: "Send your documents to OPG - Complete the deputy report | GOV.UK"
   pageTitle: Send your documents to OPG
+  supportTitle: Attach documents
   para01: |
     Below are the documents you've attached but not yet sent to OPG. When you've finished
     attaching your documents, please click send to submit them to us.

--- a/client/src/AppBundle/Resources/translations/report-documents.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-documents.en.yml
@@ -1,4 +1,4 @@
-htmlTitle: Supporting documents | GOV.UK
+htmlTitle: Supporting documents - Complete the deputy report | GOV.UK
 pageTitle: Supporting documents
 
 form:
@@ -9,7 +9,7 @@ form:
   errors:
     fileSize: "Your uploaded file exceeded the maximum size of 5M"
     risky: "Cannot upload file, risky content found inside. Technical details: %techDetails%"
-    virusFound:  "Cannot upload file, virus found inside. Technical details: %techDetails%"
+    virusFound: "Cannot upload file, virus found inside. Technical details: %techDetails%"
     generic: "Cannot upload file, please try again later. Technical details: %techDetails%"
 
 removeDocument:
@@ -60,8 +60,8 @@ stepPage:
   pageTitle: Supporting documents
   backLink: Back
   form:
-      wishToUploadDocumentation:
-          label: Would you like to provide any supporting documents?
+    wishToUploadDocumentation:
+      label: Would you like to provide any supporting documents?
 
 summaryPage:
   htmlTitle: "Deputy report - supporting documents | GOV.UK"

--- a/client/src/AppBundle/Resources/translations/report-gifts.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-gifts.en.yml
@@ -28,7 +28,7 @@ startPage:
   startButton: Start gifts
 
 existPage:
-  htmlTitle: "Deputy report - add gift | GOV.UK"
+  htmlTitle: "Add gift - Complete the deputy report | GOV.UK"
   supportTitle: Gifts
   form:
     giftsExist:
@@ -38,7 +38,7 @@ existPage:
       label: Save and continue
 
 addAnotherPage:
-  htmlTitle: "Deputy report - add gift | GOV.UK"
+  htmlTitle: "Add a gift - Complete the deputy report | GOV.UK"
   pageTitle: Add a gift
   supportTitle: Gifts
   form:
@@ -49,7 +49,7 @@ addAnotherPage:
       label: Continue
 
 addPage:
-  htmlTitle: "Deputy report - gifts | GOV.UK"
+  htmlTitle: "Add a gift - Complete the deputy report | GOV.UK"
   pageTitle: Add a gift
   supportTitle: Gifts
   pageSectionDescription: |
@@ -57,12 +57,12 @@ addPage:
     You can add one or more gifts and come back to complete the section later.
 
 editPage:
-  htmlTitle: "Deputy report - gifts | GOV.UK"
-  supportTitle: Gifts
+  htmlTitle: "Edit gift - Complete the deputy report | GOV.UK"
   pageTitle: Edit gift
+  supportTitle: Gifts
 
 summaryPage:
-  htmlTitle: "Deputy report - gifts | GOV.UK"
+  htmlTitle: "Gifts - Complete the deputy report | GOV.UK"
   pageTitle: Gifts
   pageSectionDescription: |
     In this section, we asked you about the gifts you have given on %client%'s behalf during this reporting period.
@@ -71,7 +71,7 @@ summaryPage:
   bankAccount: Bank account
 
 deletePage:
-  htmlTitle: "Deputy report - remove gift | GOV.UK"
+  htmlTitle: "Remove gift - Complete the deputy report | GOV.UK"
   subject: gift
   summary:
     explanation: Description of gift

--- a/client/src/AppBundle/Resources/translations/report-gifts.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-gifts.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - gifts | GOV.UK"
+  htmlTitle: "Gifts - Complete the deputy report | GOV.UK"
   pageTitle: Gifts
   pageSectionDescription1: |
     Your court order will say if you can buy gifts or give gifts of money on %client%'s behalf.
@@ -46,7 +46,7 @@ addAnotherPage:
       label: The gift has been saved. Would you like to add another now?
       hint: If you prefer, you can come back to this section later to add more gifts
     save:
-       label: Continue
+      label: Continue
 
 addPage:
   htmlTitle: "Deputy report - gifts | GOV.UK"
@@ -93,4 +93,4 @@ form:
     label: Which bank account was the gift bought from? (optional)
     hint: ""
   save:
-      label: Save gift
+    label: Save gift

--- a/client/src/AppBundle/Resources/translations/report-gifts.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-gifts.en.yml
@@ -38,8 +38,8 @@ existPage:
       label: Save and continue
 
 addAnotherPage:
-  htmlTitle: "Add a gift - Complete the deputy report | GOV.UK"
-  pageTitle: Add a gift
+  htmlTitle: "Add another gift - Complete the deputy report | GOV.UK"
+  pageTitle: Add another gift
   supportTitle: Gifts
   form:
     addAnother:

--- a/client/src/AppBundle/Resources/translations/report-lifestyle.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-lifestyle.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - Health and lifestyle | GOV.UK"
+  htmlTitle: "Health and lifestyle - Complete the deputy report | GOV.UK"
   pageTitle: Health and lifestyle
   pageSectionDescription: |
     Tell us about %client%'s care arrangements, health and leisure or social activities. We want to understand %client%'s current circumstances.

--- a/client/src/AppBundle/Resources/translations/report-lifestyle.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-lifestyle.en.yml
@@ -6,11 +6,11 @@ startPage:
   startButton: Start health and lifestyle
 
 stepPage:
-  htmlTitle: "Deputy report - Health and lifestyle | GOV.UK"
+  htmlTitle: "Health and lifestyle - Complete the deputy report | GOV.UK"
   supportTitle: Health and lifestyle
 
 summaryPage:
-  htmlTitle: "Deputy report - Health and lifestyle | GOV.UK"
+  htmlTitle: "Health and lifestyle - Complete the deputy report | GOV.UK"
   pageTitle: Health and lifestyle
   supportTitle: ""
   weAskAbout: In this section, we ask you about %client%'s care and contact with you and other people.

--- a/client/src/AppBundle/Resources/translations/report-money-in.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-money-in.en.yml
@@ -1,5 +1,5 @@
 deletePage:
-    htmlTitle: "Deputy report - Money in | GOV.UK"
+    htmlTitle: "Money in - Complete the deputy report | GOV.UK"
     subject: item of income
     summary:
         category: Type

--- a/client/src/AppBundle/Resources/translations/report-money-out.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-money-out.en.yml
@@ -1,5 +1,5 @@
 deletePage:
-    htmlTitle: "Deputy report - Money out | GOV.UK"
+    htmlTitle: "Money out - Complete the deputy report | GOV.UK"
     subject: payment
     summary:
         category: Type

--- a/client/src/AppBundle/Resources/translations/report-money-short.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-money-short.en.yml
@@ -1,13 +1,13 @@
 startPage:
   moneyIn:
-    htmlTitle: "Deputy report - Money in | GOV.UK"
+    htmlTitle: "Money in - Complete the deputy report | GOV.UK"
     pageTitle: Money in
     pageSectionDescription1: |
       Tell us about how you have managed %client%'s money during this reporting period.
       We need this information to understand the client's financial situation.
     startButton: Start money in
   moneyOut:
-    htmlTitle: "Deputy report - Money out | GOV.UK"
+    htmlTitle: "Money out - Complete the deputy report | GOV.UK"
     pageTitle: Money out
     pageSectionDescription1: |
       Tell us about how you have managed %client%'s money during this reporting period.
@@ -20,18 +20,18 @@ startPage:
 
 categoryPage:
   moneyIn:
-    htmlTitle: "Deputy report - Money in | GOV.UK"
+    htmlTitle: "Money in - Complete the deputy report | GOV.UK"
     supportTitle: Money in
   moneyOut:
-    htmlTitle: "Deputy report - Money out | GOV.UK"
+    htmlTitle: "Money out - Complete the deputy report | GOV.UK"
     supportTitle: Money out
 
 existPage:
   moneyIn:
-    htmlTitle: "Deputy report - Money in | GOV.UK"
+    htmlTitle: "Money in - Complete the deputy report | GOV.UK"
     supportTitle: Money in
   moneyOut:
-    htmlTitle: "Deputy report - Money out | GOV.UK"
+    htmlTitle: "Money out - Complete the deputy report | GOV.UK"
     supportTitle: Money out
   form:
     moneyTransactionsShortInExist:
@@ -43,7 +43,7 @@ existPage:
 
 addPage:
   moneyIn:
-    htmlTitle: "Deputy report - money in | GOV.UK"
+    htmlTitle: "Add an item of income - Complete the deputy report | GOV.UK"
     pageTitle: Add an item of income
     supportTitle: Money in
     pageSectionDescription1: |
@@ -53,40 +53,40 @@ addPage:
     pageSectionDescription3: |
       You can add one or more items of income and come back to complete the section later.
   moneyOut:
-      htmlTitle: "Deputy report - money out | GOV.UK"
-      pageTitle: Add a payment
-      supportTitle: Money out
-      pageSectionDescription1: |
-        List all one-off payments of over £1,000
-      pageSectionDescription2: |
-        You may find it easier to use %client%'s bank statements to find this information.
-        Don't tell us about any regular payments, such as care home fees.
-      pageSectionDescription3: |
-        You can add one or more payment items and come back to complete the section later.
+    htmlTitle: "Add a payment - Complete the deputy report | GOV.UK"
+    pageTitle: Add a payment
+    supportTitle: Money out
+    pageSectionDescription1: |
+      List all one-off payments of over £1,000
+    pageSectionDescription2: |
+      You may find it easier to use %client%'s bank statements to find this information.
+      Don't tell us about any regular payments, such as care home fees.
+    pageSectionDescription3: |
+      You can add one or more payment items and come back to complete the section later.
 
 editPage:
   moneyIn:
-    htmlTitle: "Deputy report - money in - edit item of income | GOV.UK"
-    supportTitle: Money in
+    htmlTitle: "Edit item of income - Complete the deputy report | GOV.UK"
     pageTitle: Edit item of income
+    supportTitle: Money in
   moneyOut:
-    htmlTitle: "Deputy report - money out - edit payment | GOV.UK"
-    supportTitle: Money out
+    htmlTitle: "Edit payment - Complete the deputy report | GOV.UK"
     pageTitle: Edit payment
+    supportTitle: Money out
 
 addAnotherPage:
   moneyIn:
-    htmlTitle: "Deputy report - Add another item of income | GOV.UK"
-    supportTitle: Money in
+    htmlTitle: "Add another item - Complete the deputy report | GOV.UK"
     pageTitle: Add another item
+    supportTitle: Money in
     form:
       addAnother:
         label: The item of income has been saved. Would you like to add another item of income over £1,000 now?
         hint: If you prefer, you can come back to this section later to add more items of income
       save:
-         label: Continue
+        label: Continue
   moneyOut:
-    htmlTitle: "Deputy report - Add another payment | GOV.UK"
+    htmlTitle: "Add another payment - Complete the deputy report | GOV.UK"
     supportTitle: Money out
     pageTitle: Add another payment
     form:
@@ -96,72 +96,70 @@ addAnotherPage:
       save:
         label: Continue
 
-
 summaryPage:
   moneyIn:
-    htmlTitle: "Deputy report - Money in | GOV.UK"
+    htmlTitle: "Money in - Complete the deputy report | GOV.UK"
     pageTitle: Money in
     weAskAbout: |
       In this section we ask for details of how you have managed
       %client%'s money during this reporting period.
     addButton: Add an item of income over £1,000
   moneyOut:
-    htmlTitle: "Deputy report - Money out | GOV.UK"
+    htmlTitle: "Money out - Complete the deputy report | GOV.UK"
     pageTitle: Money out
     weAskAbout: |
       In this section we ask for details of how you have managed
       %client%'s money during this reporting period.
     addButton: Add an payment over £1,000
 
-
 form:
   categoriesIn:
     label: Tell us about the different categories of money paid into %client%'s accounts
     hint: Please tick all that apply
   categoriesOut:
-      label: Tell us about the different categories of money paid out of %client%'s accounts
-      hint: Please tick all that apply
+    label: Tell us about the different categories of money paid out of %client%'s accounts
+    hint: Please tick all that apply
   categoriesEntries:
-      # in
-      state_pension_and_benefit.label: State pension and benefits
-      bequests.label: Bequests – for example, inheritance, gifts received
-      income_from_invesments_dividends_rental.label: Income from investments, dividends, property rental
-      sale_of_investments_property_assets.label: Sale of investments, property or assets
-      salary_or_wages.label: Salary or wages
-      compensations_and_damages_awards.label: Compensations and damages awards
-      personal_pension.label: Personal pension
-      # out
-      accomodation_costs.label:  Accommodation costs – for example, rent, mortgage, service charges
-      care_fees.label: Care fees or local authority charges for care
-      holidays.label: Holidays and trips
-      households_bills.label: Household bills – for example, water, gas, electricity, phone, council tax
-      personal_allowance.label: "%client%'s personal allowance"
-      professional_fees.label: Professional fees – for example, solicitor or accountant fees
-      new_investments.label: New investments – for example, buying shares, new bonds
-      travel_costs.label: Travel costs – for example, bus, train, taxi fares
+    # in
+    state_pension_and_benefit.label: State pension and benefits
+    bequests.label: Bequests – for example, inheritance, gifts received
+    income_from_invesments_dividends_rental.label: Income from investments, dividends, property rental
+    sale_of_investments_property_assets.label: Sale of investments, property or assets
+    salary_or_wages.label: Salary or wages
+    compensations_and_damages_awards.label: Compensations and damages awards
+    personal_pension.label: Personal pension
+    # out
+    accomodation_costs.label: Accommodation costs – for example, rent, mortgage, service charges
+    care_fees.label: Care fees or local authority charges for care
+    holidays.label: Holidays and trips
+    households_bills.label: Household bills – for example, water, gas, electricity, phone, council tax
+    personal_allowance.label: "%client%'s personal allowance"
+    professional_fees.label: Professional fees – for example, solicitor or accountant fees
+    new_investments.label: New investments – for example, buying shares, new bonds
+    travel_costs.label: Travel costs – for example, bus, train, taxi fares
 
   transactionsIn:
-      description:
-        label: Description of item
-      amount:
-        label: Amount
-      date:
-         label: What date did this money come in? (optional)
-         hint: For example, 20 12 2015
-      addAnother:
-        label: Add another item
-      save:
-          label: Save item
+    description:
+      label: Description of item
+    amount:
+      label: Amount
+    date:
+      label: What date did this money come in? (optional)
+      hint: For example, 20 12 2015
+    addAnother:
+      label: Add another item
+    save:
+      label: Save item
 
   transactionsOut:
-        description:
-          label: Description of payment
-        amount:
-          label: Amount
-        date:
-           label: What date did this money go out? (optional)
-           hint: For example, 20 12 2015
-        addAnother:
-          label: 12345345646
-        save:
-            label: Save payment
+    description:
+      label: Description of payment
+    amount:
+      label: Amount
+    date:
+      label: What date did this money go out? (optional)
+      hint: For example, 20 12 2015
+    addAnother:
+      label: 12345345646
+    save:
+      label: Save payment

--- a/client/src/AppBundle/Resources/translations/report-money-transaction.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-money-transaction.en.yml
@@ -1,6 +1,6 @@
 startPage:
   moneyIn:
-    htmlTitle: "Deputy report - Money in | GOV.UK"
+    htmlTitle: "Money in - Complete the deputy report | GOV.UK"
     pageTitle: Money in
     pageSectionDescription1: |
       In this section, we ask you about money paid into %client%'s accounts between %startDate%
@@ -23,7 +23,7 @@ startPage:
       before you start this section.
     startButton: Start money in
   moneyOut:
-    htmlTitle: "Deputy report - Money out | GOV.UK"
+    htmlTitle: "Money out - Complete the deputy report | GOV.UK"
     pageTitle: Money out
     pageSectionDescription1: |
       In this section, we ask you about money paid out of %client%'s accounts between %startDate%
@@ -40,10 +40,10 @@ startPage:
       There are different sections for you to tell us about <a href="%moneyTransfersPath%">
       money transfers</a> between %client%'s accounts, your <a href="%deputyCostsPath%">
       deputy costs</a>, and <a href="%giftsPath%">gifts</a>.
-#    pageSectionDescription2-PROF: |
-#      There are different sections for you to tell us about <a href="%moneyTransfersPath%">
-#      money transfers</a> between %client%'s accounts, your <a href="%deputyCostsPath%">
-#      deputy costs</a>, and <a href="%giftsPath%">gifts</a>.
+    #    pageSectionDescription2-PROF: |
+    #      There are different sections for you to tell us about <a href="%moneyTransfersPath%">
+    #      money transfers</a> between %client%'s accounts, your <a href="%deputyCostsPath%">
+    #      deputy costs</a>, and <a href="%giftsPath%">gifts</a>.
     pageSectionDescription3: |
       Make sure you only enter each payment in one place, so we don't count it twice.
     totalOrIndividualHeading: |
@@ -58,10 +58,9 @@ startPage:
       bank accounts</a> before you start this section.
     startButton: Start money out
 
-
 stepPage:
   moneyIn:
-    htmlTitle: "Deputy report - Money in | GOV.UK"
+    htmlTitle: "Add an item of income - Complete the deputy report | GOV.UK"
     pageTitle: Add an item of income
     supportTitle: Money in
     pageSectionDescription:
@@ -70,7 +69,7 @@ stepPage:
         Don't include transfers between %client%'s accounts here. Enter them in the
         <a href="%moneyTransfersPath%">money transfers</a> section
   moneyOut:
-    htmlTitle: "Deputy report - Money out | GOV.UK"
+    htmlTitle: "Add a payment - Complete the deputy report | GOV.UK"
     pageTitle: Add a payment
     supportTitle: Money out
     pageSectionDescription:
@@ -89,7 +88,7 @@ stepPage:
 
 addAnotherPage:
   moneyIn:
-    htmlTitle: "Deputy report - Add another item of income | GOV.UK"
+    htmlTitle: "Add another item - Complete the deputy report | GOV.UK"
     pageTitle: Add another item
     supportTitle: Money in
     form:
@@ -97,9 +96,9 @@ addAnotherPage:
         label: The item has been saved. Would you like to add another now?
         hint: If you prefer, you can come back later to add more items
       save:
-         label: Continue
+        label: Continue
   moneyOut:
-    htmlTitle: "Deputy report - Add another payment | GOV.UK"
+    htmlTitle: "Add a payment - Complete the deputy report | GOV.UK"
     pageTitle: Add a payment
     supportTitle: Money out
     form:
@@ -107,17 +106,16 @@ addAnotherPage:
         label: The payment has been saved. Would you like to add another now?
         hint: If you prefer, you can come back later to add more payments
       save:
-         label: Continue
-
+        label: Continue
 
 summaryPage:
   moneyIn:
-    htmlTitle: "Deputy report - Money in | GOV.UK"
+    htmlTitle: "Money in - Complete the deputy report | GOV.UK"
     pageTitle: Money in
     moreDetails: More details about this section
     totalValue: "Total money in: £%value%"
   moneyOut:
-    htmlTitle: "Deputy report - Money out | GOV.UK"
+    htmlTitle: "Money out - Complete the deputy report | GOV.UK"
     pageTitle: Money out
     moreDetails: More details about this section
     totalValue: "Total money out: £%value%"
@@ -149,8 +147,8 @@ form:
       transfers-out-to-other-accounts: Transfers from %client%'s account to other accounts
       moneyout-other: Other
   amount:
-      label: Amount
-      hint: ""
+    label: Amount
+    hint: ""
   description:
     mandatory:
       label: Description
@@ -196,7 +194,7 @@ form:
         label2ndStep: Personal Independence Payment
       severe-disablement-allowance:
         label: Severe Disablement Allowance
-        label2ndStep  : Severe Disablement Allowance
+        label2ndStep: Severe Disablement Allowance
       winter-fuel-cold-weather-payment:
         label: Winter Fuel/Cold Weather Payment
         label2ndStep: Winter Fuel/Cold Weather Payment

--- a/client/src/AppBundle/Resources/translations/report-money-transaction.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-money-transaction.en.yml
@@ -98,8 +98,8 @@ addAnotherPage:
       save:
         label: Continue
   moneyOut:
-    htmlTitle: "Add a payment - Complete the deputy report | GOV.UK"
-    pageTitle: Add a payment
+    htmlTitle: "Add another payment - Complete the deputy report | GOV.UK"
+    pageTitle: Add another payment
     supportTitle: Money out
     form:
       addAnother:

--- a/client/src/AppBundle/Resources/translations/report-money-transfer.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-money-transfer.en.yml
@@ -19,8 +19,8 @@ existPage:
       label: Save and continue
 
 addAnotherPage:
-  htmlTitle: "Money transfers - Complete the deputy report | GOV.UK"
-  pageTitle: Money transfers
+  htmlTitle: "Add another money transfer - Complete the deputy report | GOV.UK"
+  pageTitle: Add another money transfer
   form:
     addAnother:
       label: The transfer has been saved. Would you like to add another now?

--- a/client/src/AppBundle/Resources/translations/report-money-transfer.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-money-transfer.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - money transfers | GOV.UK"
+  htmlTitle: "Money transfers - Complete the deputy report | GOV.UK"
   pageTitle: Money transfers
   pageSectionDescription1: |
     Use this section to tell us about money you've transferred between %client%'s accounts.
@@ -9,7 +9,7 @@ startPage:
   startButton: Start money transfers
 
 existPage:
-  htmlTitle: "Deputy report - money transfers | GOV.UK"
+  htmlTitle: "Money transfers - Complete the deputy report | GOV.UK"
   supportTitle: Money transfers
   form:
     noTransfersToAdd:
@@ -19,28 +19,28 @@ existPage:
       label: Save and continue
 
 addAnotherPage:
-  htmlTitle: "Deputy report - add another transfer | GOV.UK"
+  htmlTitle: "Money transfers - Complete the deputy report | GOV.UK"
   pageTitle: Money transfers
   form:
     addAnother:
       label: The transfer has been saved. Would you like to add another now?
       hint: If you prefer, you can come back to this section later to add more transfers
     save:
-       label: Continue
+      label: Continue
 
 stepPage:
-  htmlTitle: "Deputy report - Money transfer | GOV.UK"
-  supportTitle: Money transfers
+  htmlTitle: "Add a money transfer - Complete the deputy report | GOV.UK"
   pageTitle: Add a money transfer
+  supportTitle: Money transfers
 
 summaryPage:
-  htmlTitle: "Deputy report - money transfers | GOV.UK"
+  htmlTitle: "Money transfers - Complete the deputy report | GOV.UK"
   pageTitle: Money transfers
   weAskAbout: In this section, we ask you about money you've transferred between %client%'s accounts.
   addButton: Add a transfer
 
 deletePage:
-  htmlTitle: "Deputy report - remove money transfer | GOV.UK"
+  htmlTitle: "Remove money transfer - Complete the deputy report | GOV.UK"
   subject: transfer
   summary:
     accountFrom: Transferred from
@@ -48,13 +48,12 @@ deletePage:
     amount: Amount
 
 errorPage:
-  htmlTitle: "Deputy report - money transfers | GOV.UK"
+  htmlTitle: "Money transfers - Complete the deputy report | GOV.UK"
   pageTitle: Money transfers
   errors:
     atLeastTwoBankAccounts: You don't need to complete this section if you have fewer than two bank accounts.
   backToOverview: Back to overview page
   backToClientProfile: Back to client profile
-
 
 form:
   accountFrom:

--- a/client/src/AppBundle/Resources/translations/report-more-info.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-more-info.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - any other information | GOV.UK"
+  htmlTitle: "Any other information - Complete the deputy report | GOV.UK"
   pageTitle: Any other information
   pageSectionDescription1: |
     You can use this section to give us information that isn't covered elsewhere in this report.
@@ -8,9 +8,9 @@ startPage:
   pageSectionDescription3: |
     OPG is here to support you in your deputyship. Our <a href="https://www.gov.uk/government/publications/deputy-guidance-how-to-carry-out-your-duties" target="_blank">'How to be a deputy' (SD3)</a> booklet gives detailed guidance on all aspects of your role.
   pageSectionDescription3-4: |
-      OPG is here to support you in your deputyship.
-      OPG's <a href="https://www.gov.uk/government/publications/deputy-guidance-how-to-carry-out-your-duties" target="_blank">'How to be a property and affairs deputy' (SD3)</a>
-       and <a href="https://www.gov.uk/government/publications/deputy-guidance-how-to-carry-out-your-duties" target="_blank">'How to be a health and welfare deputy' (SD4)</a> booklets give detailed guidance on how to look after %client%'s property, finance, health and welfare.
+    OPG is here to support you in your deputyship.
+    OPG's <a href="https://www.gov.uk/government/publications/deputy-guidance-how-to-carry-out-your-duties" target="_blank">'How to be a property and affairs deputy' (SD3)</a>
+     and <a href="https://www.gov.uk/government/publications/deputy-guidance-how-to-carry-out-your-duties" target="_blank">'How to be a health and welfare deputy' (SD4)</a> booklets give detailed guidance on how to look after %client%'s property, finance, health and welfare.
   pageSectionDescription3-104: |
     OPG is here to support you in your deputyship.
     OPG's <a href="https://www.gov.uk/government/publications/deputy-guidance-how-to-carry-out-your-duties" target="_blank">'How to be a health and welfare deputy' (SD4)</a> booklet give detailed guidance on how to look after %client%'s property, finance, health and welfare.
@@ -18,11 +18,11 @@ startPage:
   startButton: Start any other information
 
 stepPage:
-  htmlTitle: "Deputy report - any other information | GOV.UK"
+  htmlTitle: "Any other information - Complete the deputy report | GOV.UK"
   supportTitle: Any other information
 
 summaryPage:
-  htmlTitle: "Deputy report - any other information | GOV.UK"
+  htmlTitle: "Any other information - Complete the deputy report | GOV.UK"
   pageTitle: Any other information
   weAskAbout: |
     In this section, we ask you to give us any other information you think we should have about

--- a/client/src/AppBundle/Resources/translations/report-overview.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-overview.en.yml
@@ -1,5 +1,5 @@
 htmlTitle: "Deputy report - overview | GOV.UK"
-htmlTitle-ORG: "Client profile | GOV.UK"
+htmlTitle-ORG: "Client profile - Complete the deputy report | GOV.UK"
 report: "report"
 pageTitle: "The deputy report"
 pageSectionDescription: "Your report:"
@@ -54,7 +54,6 @@ unsubmittedConfirm:
     agree.label: I have reviewed the items highlighted on this page.
     save.label: Review report
 
-
 previewNoticeNotDue: |
   You may preview your report at anytime. You can't submit your report until %date%.
 
@@ -65,49 +64,49 @@ completeNotice: |
   All sections are now complete. Please review then submit your report.
 
 labels:
-    not-started: "Not started"
-    incomplete: "Not finished"
-    needs-attention: "Changes needed"
+  not-started: "Not started"
+  incomplete: "Not finished"
+  needs-attention: "Changes needed"
 
 heading.decisionsContacts: "Decisions and contacts"
 decisions:
-    subSectionTitle: "Decisions"
-    subSectionDescription: "Tell us about the significant decisions you've made for %client%"
-    label:
-      done: "{0} no decisions | {1} 1 decision | ]1,Inf[ %count% decisions"
+  subSectionTitle: "Decisions"
+  subSectionDescription: "Tell us about the significant decisions you've made for %client%"
+  label:
+    done: "{0} no decisions | {1} 1 decision | ]1,Inf[ %count% decisions"
 contacts:
-    subSectionTitle: "Contacts"
-    subSectionDescription: Tell us who helped you make significant decisions as a deputy
-    label:
-      done: "{0} no contacts | {1} 1 contact | ]1,Inf[ %count% contacts"
+  subSectionTitle: "Contacts"
+  subSectionDescription: Tell us who helped you make significant decisions as a deputy
+  label:
+    done: "{0} no contacts | {1} 1 contact | ]1,Inf[ %count% contacts"
 
 heading.healthAndWelfare: "Health and welfare"
 visits_care:
-    subSectionTitle: "Visits and care"
-    subSectionDescription: "Give us an overview of who is looking after %client%"
-    label:
-      done: "Finished"
+  subSectionTitle: "Visits and care"
+  subSectionDescription: "Give us an overview of who is looking after %client%"
+  label:
+    done: "Finished"
 lifestyle:
-    subSectionTitle: "Health and lifestyle"
-    subSectionDescription: "Describe %client%'s health and any activities %client% is involved in"
-    label:
-      done: "Finished"
+  subSectionTitle: "Health and lifestyle"
+  subSectionDescription: "Describe %client%'s health and any activities %client% is involved in"
+  label:
+    done: "Finished"
 heading.propFinance: "%client%'s property and finances"
 deputy_expenses:
-    subSectionTitle: "Deputy expenses"
-    subSectionDescription: "Claim for things you paid for on %client%'s behalf"
-    label:
-      done: "{0} no expenses | {1} 1 expense | ]1,Inf[ %count% expenses"
+  subSectionTitle: "Deputy expenses"
+  subSectionDescription: "Claim for things you paid for on %client%'s behalf"
+  label:
+    done: "{0} no expenses | {1} 1 expense | ]1,Inf[ %count% expenses"
 pa_fee_expense:
-    subSectionTitle: "Deputy fees and expenses"
-    subSectionDescription: "Any fees or expenses you have charged in line with the practice direction"
-    label:
-      done: "Finished"
+  subSectionTitle: "Deputy fees and expenses"
+  subSectionDescription: "Any fees or expenses you have charged in line with the practice direction"
+  label:
+    done: "Finished"
 prof_current_fees:
-    subSectionTitle: "Current fees and expenses"
-    subSectionDescription: "Any fees or expenses you have charged in line with the practice direction"
-    label:
-      done: "Finished"
+  subSectionTitle: "Current fees and expenses"
+  subSectionDescription: "Any fees or expenses you have charged in line with the practice direction"
+  label:
+    done: "Finished"
 prof_deputy_costs:
   subSectionTitle: "Deputy costs"
   label:
@@ -118,89 +117,89 @@ prof_deputy_costs_estimate:
     done: "Finished"
 
 gifts:
-    subSectionTitle: "Gifts"
-    subSectionDescription: Tell us about gifts you've given to other people on %client%'s behalf
-    label:
-      done: "{0} no gifts | {1} 1 gift | ]1,Inf[ %count% gifts"
+  subSectionTitle: "Gifts"
+  subSectionDescription: Tell us about gifts you've given to other people on %client%'s behalf
+  label:
+    done: "{0} no gifts | {1} 1 gift | ]1,Inf[ %count% gifts"
 bank_accounts:
-    subSectionTitle: "Accounts"
-    subSectionTitleNotBalanced: "Accounts not balanced"
-    subSectionDescription: "Add %client%'s bank, building society and savings accounts"
-    label:
-      done: "{0} no accounts | {1} 1 account | ]1,Inf[ %count% accounts"
-      addReason: "Add reason"
+  subSectionTitle: "Accounts"
+  subSectionTitleNotBalanced: "Accounts not balanced"
+  subSectionDescription: "Add %client%'s bank, building society and savings accounts"
+  label:
+    done: "{0} no accounts | {1} 1 account | ]1,Inf[ %count% accounts"
+    addReason: "Add reason"
 money_transfers:
-    subSectionTitle: "Money transfers"
-    subSectionDescription: "Provide details of money transferred between %client%'s accounts"
-    label:
-       done: "{0} no transfers | {1} 1 transfer | ]1,Inf[ %count% transfers"
+  subSectionTitle: "Money transfers"
+  subSectionDescription: "Provide details of money transferred between %client%'s accounts"
+  label:
+    done: "{0} no transfers | {1} 1 transfer | ]1,Inf[ %count% transfers"
 money_in:
-    subSectionTitle: "Money in"
-    subSectionDescription: "Enter details of money paid into %client%'s accounts"
-    label:
-      done: "{0} no items | {1} 1 item | ]1,Inf[ %count% items"
+  subSectionTitle: "Money in"
+  subSectionDescription: "Enter details of money paid into %client%'s accounts"
+  label:
+    done: "{0} no items | {1} 1 item | ]1,Inf[ %count% items"
 money_out:
-    subSectionTitle: "Money out"
-    subSectionDescription: "Enter details of money you've spent on %client%'s living and other costs"
-    label:
-      done: "{0} no items | {1} 1 item | ]1,Inf[ %count% items"
+  subSectionTitle: "Money out"
+  subSectionDescription: "Enter details of money you've spent on %client%'s living and other costs"
+  label:
+    done: "{0} no items | {1} 1 item | ]1,Inf[ %count% items"
 
 money_in_short:
-    subSectionTitle: "Money in"
-    subSectionDescription: "Tell us about money paid into %client%'s accounts"
-    label:
-      done: "{0} no items | {1} 1 item | ]1,Inf[ %count% items"
+  subSectionTitle: "Money in"
+  subSectionDescription: "Tell us about money paid into %client%'s accounts"
+  label:
+    done: "{0} no items | {1} 1 item | ]1,Inf[ %count% items"
 money_out_short:
-    subSectionTitle: "Money out"
-    subSectionDescription: "Tell us about money you have spent on %client%'s living and welfare costs"
-    label:
-      done: "{0} no items | {1} 1 item | ]1,Inf[ %count% items"
+  subSectionTitle: "Money out"
+  subSectionDescription: "Tell us about money you have spent on %client%'s living and welfare costs"
+  label:
+    done: "{0} no items | {1} 1 item | ]1,Inf[ %count% items"
 balance:
-    subSectionTitle: "Accounts balance check"
-    subSectionDescription:
-      default: Check that %client%'s accounts balance
-      addExplanation: "Add explanation"
-      editExplanation: "Edit explanation"
-    label:
-      not-started: "more information needed"
-      not-matching: "not balanced"
-      done: "balanced"
-      explained: "not balanced"
+  subSectionTitle: "Accounts balance check"
+  subSectionDescription:
+    default: Check that %client%'s accounts balance
+    addExplanation: "Add explanation"
+    editExplanation: "Edit explanation"
+  label:
+    not-started: "more information needed"
+    not-matching: "not balanced"
+    done: "balanced"
+    explained: "not balanced"
 assets:
-    subSectionTitle: "Assets"
-    subSectionDescription: "Tell us about %client%'s property, investments and other valuables"
-    label:
-      done: "{0} no assets | {1} 1 asset | ]1,Inf[ %count% assets"
+  subSectionTitle: "Assets"
+  subSectionDescription: "Tell us about %client%'s property, investments and other valuables"
+  label:
+    done: "{0} no assets | {1} 1 asset | ]1,Inf[ %count% assets"
 debts:
-    subSectionTitle: "Debts"
-    subSectionDescription: "Let us know about any debts %client% owes"
-    label:
-       done: "Finished"
+  subSectionTitle: "Debts"
+  subSectionDescription: "Let us know about any debts %client% owes"
+  label:
+    done: "Finished"
 heading.other: "Other information"
 actions:
-    subSectionTitle: "Actions you plan to take"
-    subSectionDescription: What significant decisions will you need to take for %client% in the next year?
-    label:
-      done: "Finished"
+  subSectionTitle: "Actions you plan to take"
+  subSectionDescription: What significant decisions will you need to take for %client% in the next year?
+  label:
+    done: "Finished"
 other_info:
-    subSectionTitle: "Any other information"
-    subSectionDescription: "Is there anything else you want to tell us about the deputyship?"
-    label:
-      done: "Finished"
+  subSectionTitle: "Any other information"
+  subSectionDescription: "Is there anything else you want to tell us about the deputyship?"
+  label:
+    done: "Finished"
 
 heading.caseDocuments: "Case documents"
 documents:
-    subSectionTitle: "Supporting documents"
-    subSectionDescription: "Provide documents to support your report, for example bank statements"
-    label:
-      done: "{0} no documents | {1} 1 document | ]1,Inf[ %count% documents"
+  subSectionTitle: "Supporting documents"
+  subSectionDescription: "Provide documents to support your report, for example bank statements"
+  label:
+    done: "{0} no documents | {1} 1 document | ]1,Inf[ %count% documents"
 
 additionalInformation:
   subSectionTitle: More information
 
 reportSubmit:
-    checkbox:
-        label: I have reviewed and checked this report.
+  checkbox:
+    label: I have reviewed and checked this report.
 
 decisionsMadeAsDeputy: Decisions made as deputy
 

--- a/client/src/AppBundle/Resources/translations/report-pa-fee-expense.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-pa-fee-expense.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - Deputy fees and expenses | GOV.UK"
+  htmlTitle: "Deputy fees and expenses - Complete the deputy report | GOV.UK"
   pageTitle: Deputy fees and expenses
   pageSectionDescription1: |
     Public authority deputies can be paid, or claim expenses, for the following
@@ -18,7 +18,7 @@ startPage:
   startButton: Start deputy fees and expenses
 
 feeExistPage:
-  htmlTitle: "Deputy report - Deputy fees and expenses | GOV.UK"
+  htmlTitle: "Deputy fees and expenses - Complete the deputy report | GOV.UK"
   supportTitle: Deputy fees and expenses
   form:
     hasFees:
@@ -29,13 +29,12 @@ feeExistPage:
       label: Save and continue
 
 editPage:
-  htmlTitle: "Deputy report - Deputy fees and expenses | GOV.UK"
+  htmlTitle: "Deputy fees and expenses - Complete the deputy report | GOV.UK"
   pageTitle: Deputy fees and expenses
   pageSectionDescription: Please tell us about any fees or expenses you've claimed from the client's funds in line with the practice direction.
 
-
 otherExistPage:
-  htmlTitle: "Deputy report - Deputy fees and expenses  | GOV.UK"
+  htmlTitle: "Deputy fees and expenses - Complete the deputy report | GOV.UK"
   pageTitle: Deputy fees and expenses
   form:
     paidForAnything:
@@ -43,35 +42,33 @@ otherExistPage:
     save:
       label: Save and continue
 
-
-
 otherAddPage:
-  htmlTitle: "Deputy report - Deputy fees and expenses | GOV.UK"
+  htmlTitle: "Add an expense - Complete the deputy report | GOV.UK"
   pageTitle: Add an expense
 
 otherAddAnotherPage:
-  htmlTitle: "Deputy report - Deputy fees and expenses | GOV.UK"
+  htmlTitle: "Add an expense - Complete the deputy report | GOV.UK"
   pageTitle: Add an expense
   form:
     addAnother:
       label: The expense has been saved. Would you like to add another now?
       hint: If you prefer, you can come back to this section later to add more expenses
     save:
-       label: Continue
+      label: Continue
 
 otherEditPage:
-  htmlTitle: "Deputy report - Deputy fees and expenses | GOV.UK"
+  htmlTitle: "Edit expense - Complete the deputy report | GOV.UK"
   pageTitle: Edit expense
 
 summaryPage:
-  htmlTitle: "Deputy report -  Deputy fees and expenses | GOV.UK"
-  pageTitle:  Deputy fees and expenses
+  htmlTitle: "Deputy fees and expenses - Complete the deputy report | GOV.UK"
+  pageTitle: Deputy fees and expenses
   pageSectionDescription: |
     In this section, we asked you to tell us about any fees or expenses you have charged in line with the practice direction.
   addButton: Add a deputy expense
 
 deletePage:
-  htmlTitle: "Deputy report - Deputy fees and expenses | GOV.UK"
+  htmlTitle: "Deputy fees and expenses - Complete the deputy report | GOV.UK"
   subject: expense
   summary:
     explanation: Description of expense
@@ -91,4 +88,4 @@ form.entries:
     moreInformations: Please provide some detail
 
 common:
- supportTitle: Deputy fees and expenses
+  supportTitle: Deputy fees and expenses

--- a/client/src/AppBundle/Resources/translations/report-pa-fee-expense.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-pa-fee-expense.en.yml
@@ -29,8 +29,8 @@ feeExistPage:
       label: Save and continue
 
 editPage:
-  htmlTitle: "Deputy fees and expenses - Complete the deputy report | GOV.UK"
-  pageTitle: Deputy fees and expenses
+  htmlTitle: "Edit fees and expenses - Complete the deputy report | GOV.UK"
+  pageTitle: Edit fees and expenses
   pageSectionDescription: Please tell us about any fees or expenses you've claimed from the client's funds in line with the practice direction.
 
 otherExistPage:
@@ -47,8 +47,8 @@ otherAddPage:
   pageTitle: Add an expense
 
 otherAddAnotherPage:
-  htmlTitle: "Add an expense - Complete the deputy report | GOV.UK"
-  pageTitle: Add an expense
+  htmlTitle: "Add another expense - Complete the deputy report | GOV.UK"
+  pageTitle: Add another expense
   form:
     addAnother:
       label: The expense has been saved. Would you like to add another now?

--- a/client/src/AppBundle/Resources/translations/report-prof-current-fees.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-prof-current-fees.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - Current fees and expenses | GOV.UK"
+  htmlTitle: "Current fees and expenses - Complete the deputy report | GOV.UK"
   pageTitle: Current fees and expenses
   pageSectionDescription1: |
     In cases where fixed costs have not been applied, professional deputy costs may include:
@@ -17,14 +17,14 @@ startPage:
   startButton: Start current fees and expenses
 
 existPage:
-  htmlTitle: "Deputy report - Current fees and expenses | GOV.UK"
+  htmlTitle: "Current fees and expenses - Complete the deputy report | GOV.UK"
   pageTitle: Current fees and expenses
   form:
     hasFees:
       label: During this reporting period, have you charged the client for any services?
 
 addTypePage:
-  htmlTitle: "Deputy report - Current fees and expenses | GOV.UK"
+  htmlTitle: "Add a charge - Complete the deputy report | GOV.UK"
   pageTitle: Add a charge
   supportTitle: Current fees and expenses
   form:
@@ -40,7 +40,7 @@ addTypePage:
       other-costs: Other costs
 
 addDetailsPage:
-  htmlTitle: "Deputy report - Current fees and expenses | GOV.UK"
+  htmlTitle: "Add a charge: - Complete the deputy report | GOV.UK"
   pageTitle: "Add a charge:"
   supportTitle: Current fees and expenses
   form:
@@ -56,7 +56,7 @@ addDetailsPage:
       label: What date was payment received?
 
 estCostsPage:
-  htmlTitle: "Deputy report - Current fees and expenses | GOV.UK"
+  htmlTitle: "Current fees and expenses - Complete the deputy report | GOV.UK"
   pageTitle: Current fees and expenses
   form:
     estimateCosts:
@@ -69,8 +69,8 @@ estCostsPage:
         for the SCCO.
 
 summaryPage:
-  htmlTitle: "Deputy report -  Current fees and expenses | GOV.UK"
-  pageTitle:  Current fees and expenses
+  htmlTitle: "Current fees and expenses - Complete the deputy report | GOV.UK"
+  pageTitle: Current fees and expenses
   pageSectionDescription: |
     In this section, we asked you to tell us about any fees or expenses you have charged in line
     with the practice direction.

--- a/client/src/AppBundle/Resources/translations/report-prof-deputy-costs-estimate.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-prof-deputy-costs-estimate.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - Deputy costs estimate | GOV.UK"
+  htmlTitle: "Deputy costs estimates - Complete the deputy report | GOV.UK"
   pageTitle: Deputy costs estimates
   pageSectionDescription1: |
     Tell us about the costs that you and other fee earners expect to charge the client during
@@ -15,7 +15,7 @@ startPage:
   startButton: Start
 
 howCharged:
-  htmlTitle: "Deputy report - Deputy costs estimate | GOV.UK"
+  htmlTitle: "Deputy costs estimates - Complete the deputy report | GOV.UK"
   supportTitle: Deputy costs estimates
   form:
     profDeputyCostsEstimateHowCharged:
@@ -26,7 +26,7 @@ howCharged:
       both: Both fixed and assessed costs
 
 breakdown:
-  htmlTitle: "Deputy report - Deputy costs estimate | GOV.UK"
+  htmlTitle: "Deputy cost estimates - Complete the deputy report | GOV.UK"
   pageTitle: Deputy cost estimates
   pageSectionDescription: Of the amount for general management costs you expect to charge %client% next period, how much do you expect to charge for each of the following?
   pageHint: ""
@@ -49,7 +49,7 @@ breakdown:
         moreInformationLabelSummary: Details of other costs
 
 moreInfo:
-  htmlTitle: "Deputy report - Deputy costs estimate | GOV.UK"
+  htmlTitle: "Deputy costs estimate - Complete the deputy report | GOV.UK"
   supportTitle: Deputy cost estimates
   pageHeader: More Information
   form:
@@ -64,8 +64,8 @@ moreInfo:
 totalEstimatedCosts: Total estimated costs
 
 summaryPage:
-  htmlTitle: "Deputy report - Deputy costs estimate | GOV.UK"
-  pageTitle:  Deputy costs estimates
+  htmlTitle: "Deputy costs estimates - Complete the deputy report | GOV.UK"
+  pageTitle: Deputy costs estimates
   returnToClientProfile: Return to client profile
   weveListedYourAnswers: We've listed your saved answers below
   checkTheyreCorrect: Check they're correct and edit them where necessary.

--- a/client/src/AppBundle/Resources/translations/report-prof-deputy-costs.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-prof-deputy-costs.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - Deputy costs | GOV.UK"
+  htmlTitle: "Deputy costs - Complete the deputy report | GOV.UK"
   pageTitle: Deputy costs
   pageSectionDescription1: |
     Use this section to tell us how much %client% paid for your professional deputy services
@@ -15,7 +15,7 @@ startPage:
   startButton: Start
 
 howCharged:
-  htmlTitle: "Deputy report - Deputy costs | GOV.UK"
+  htmlTitle: "Deputy costs - Complete the deputy report | GOV.UK"
   supportTitle: Deputy costs
   form:
     profDeputyCostsHow.label: "How did you charge for the services %client% paid you for in this reporting period?"
@@ -28,14 +28,14 @@ howCharged:
       both: Both fixed and assessed costs
 
 previousReceivedExists:
-  htmlTitle: "Deputy report - Deputy costs | GOV.UK"
+  htmlTitle: "Deputy costs - Complete the deputy report | GOV.UK"
   supportTitle: Deputy costs
   form:
     profDeputyCostsHasPrevious:
       label: "Has %client% paid you in this reporting period for work carried out in a previous reporting period?"
 
 previousReceived:
-  htmlTitle: "Deputy report - Deputy costs | GOV.UK"
+  htmlTitle: "Deputy costs - Complete the deputy report | GOV.UK"
   supportTitle: Deputy costs
   pageTitle: Costs for earlier reporting periods
   pageSectionDescription: |
@@ -56,7 +56,7 @@ previousReceived:
       label: Save and continue
 
 interimExists:
-  htmlTitle: "Deputy report - Deputy costs | GOV.UK"
+  htmlTitle: "Deputy costs - Complete the deputy report | GOV.UK"
   supportTitle: Deputy costs
   pageTitle: Costs for this reporting period
   form:
@@ -64,7 +64,7 @@ interimExists:
       label: Have you charged in line with interim billing under Practice Direction 19B for the work you carried out in this reporting period?
 
 interim:
-  htmlTitle: "Deputy report - Deputy costs | GOV.UK"
+  htmlTitle: "Deputy costs - Complete the deputy report | GOV.UK"
   supportTitle: Deputy costs
   pageTitle: Costs for this reporting period
   pageSectionDescription01: |
@@ -78,14 +78,14 @@ interim:
     amount.label: Amount paid
 
 fixedCost:
-  htmlTitle: "Deputy report - Deputy costs | GOV.UK"
+  htmlTitle: "Deputy costs - Complete the deputy report | GOV.UK"
   supportTitle: Deputy costs
   pageTitle: Costs for this reporting period
   form:
     profDeputyFixedCost.label: "How much has %client% paid you in this reporting period for work carried out in this reporting period (including VAT)?"
 
 amountToScco:
-  htmlTitle: "Deputy report - Deputy costs | GOV.UK"
+  htmlTitle: "Deputy costs - Complete the deputy report | GOV.UK"
   pageTitle: Costs for this reporting period
   supportTitle: Deputy costs
   form:
@@ -94,7 +94,7 @@ amountToScco:
     profDeputyCostsReasonBeyondEstimate.labelSummary: "Why are costs 20% or more than estimated in last reporting period?"
 
 breakdown:
-  htmlTitle: "Deputy report - Deputy costs | GOV.UK"
+  htmlTitle: "Deputy costs - Complete the deputy report | GOV.UK"
   pageTitle: Costs for this reporting period
   supportTitle: Deputy costs
   pageSectionDescription: Breakdown of additional professional deputy costs (including VAT) %client% has paid you for in this reporting period.
@@ -119,7 +119,7 @@ breakdown:
         moreInformationLabelSummary: Details of other costs
 
 summaryPage:
-  htmlTitle: "Deputy report - Deputy costs | GOV.UK"
+  htmlTitle: "Deputy costs - Complete the deputy report | GOV.UK"
   pageTitle:  Deputy costs
   returnToClientProfile: Return to client profile
   weveListedYourAnswers: We've listed your saved answers below
@@ -134,7 +134,7 @@ summaryPage:
     totalCosts: Total costs
 
 deletePage:
-  htmlTitle: "Deputy report - Deputy costs | GOV.UK"
+  htmlTitle: "Deputy costs - Complete the deputy report | GOV.UK"
   subject: previous cost
   summary:
     startDate: Reporting period start date

--- a/client/src/AppBundle/Resources/translations/report-submitted.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-submitted.en.yml
@@ -1,5 +1,5 @@
 page:
-  htmlTitle: "Deputy report - report submitted | GOV.UK"
+  htmlTitle: "Report submitted - Complete the deputy report | GOV.UK"
   pageTitle: "Report submitted"
   thankYouForsubmitting: Thank you for submitting your %reportName% report
   yourReportWillBeSent: "Your report has been sent to OPG. You'll get an email shortly to let you know we've received it."

--- a/client/src/AppBundle/Resources/translations/report-visits-care.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-visits-care.en.yml
@@ -1,5 +1,5 @@
 startPage:
-  htmlTitle: "Deputy report - visits and care | GOV.UK"
+  htmlTitle: "Visits and care - Complete the deputy report | GOV.UK"
   pageTitle: Visits and care
   pageSectionDescription: |
     Use this section to tell us about %client%'s care and contact with you and other people.
@@ -8,12 +8,12 @@ startPage:
   startButton: Start visits and care
 
 stepPage:
-  htmlTitle: "Deputy report - visits and care | GOV.UK"
+  htmlTitle: "Visits and care - Complete the deputy report | GOV.UK"
   supportTitle: Visits and care
   backLink: Back
 
 summaryPage:
-  htmlTitle: "Deputy report - visits and care | GOV.UK"
+  htmlTitle: "Visits and care - Complete the deputy report | GOV.UK"
   pageTitle: Visits and care
   supportTitle: ""
   weAskAbout: In this section, we ask you about %client%'s care and contact with you and other people.
@@ -46,8 +46,8 @@ form:
       If %client% receives care from a private organisation or local social services, they may have
       a plan that sets out how %client%'s care needs will be met.
   whenWasCarePlanLastReviewed:
-      label: When was the care plan last reviewed?
-      hint: For example, 12 2015
+    label: When was the care plan last reviewed?
+    hint: For example, 12 2015
   choices:
     everyday: Every day
     once_a_week: At least once a week

--- a/client/src/AppBundle/Resources/translations/report.en.yml
+++ b/client/src/AppBundle/Resources/translations/report.en.yml
@@ -1,5 +1,5 @@
 homepage:
-  htmlTitle: Deputy report - Your reports | GOV.UK
+  htmlTitle: Your reports - Complete the deputy report | GOV.UK
   pageTitle: Your reports
   editReportingPeriodPara: |
     Your reporting period is %startDate% to %endDate%. If these dates are wrong,

--- a/client/src/AppBundle/Resources/translations/signin.en.yml
+++ b/client/src/AppBundle/Resources/translations/signin.en.yml
@@ -1,5 +1,5 @@
 signIn:
-  htmlTitle: "Deputy report - sign in | GOV.UK"
+  htmlTitle: "Sign in - Complete the deputy report | GOV.UK"
   pageTitle: Sign in
   pageTitleNewPassword: Sign in to your new account
   pageTitleUpdatedPassword: Sign in with your new password
@@ -21,11 +21,11 @@ bruteForceLocked: You've tried to sign in with the wrong password too many times
 
 signInForm:
   email:
-      label: Email address
-      hint: We sent your registration link to this email address.
+    label: Email address
+    hint: We sent your registration link to this email address.
   password:
-      label: Password
-      hint: ""
+    label: Password
+    hint: ""
   signin:
-      label: Sign in
-      invalidMessage: You've entered an invalid email or password. Please try again.
+    label: Sign in
+    invalidMessage: You've entered an invalid email or password. Please try again.

--- a/client/src/AppBundle/Resources/translations/user-activate-expired.en.yml
+++ b/client/src/AppBundle/Resources/translations/user-activate-expired.en.yml
@@ -1,5 +1,5 @@
 page:
-  htmlTitle: "Deputy report - ask for a new link | GOV.UK"
+  htmlTitle: "This page has expired - Complete the deputy report | GOV.UK"
 pageTitle: This page has expired
 subtitle: The link we sent you was only active for %tokenExpireHours% hours, and this page has now expired. You can still create a password, but we'll have to send you a new link.
 sendLink: Ask us to send you a new link

--- a/client/src/AppBundle/Resources/translations/user-activate-expired.en.yml
+++ b/client/src/AppBundle/Resources/translations/user-activate-expired.en.yml
@@ -1,5 +1,5 @@
 page:
-  htmlTitle: "This page has expired - Complete the deputy report | GOV.UK"
-pageTitle: This page has expired
+  htmlTitle: "This link has expired - Complete the deputy report | GOV.UK"
+pageTitle: This link has expired
 subtitle: The link we sent you was only active for %tokenExpireHours% hours, and this page has now expired. You can still create a password, but we'll have to send you a new link.
 sendLink: Ask us to send you a new link

--- a/client/src/AppBundle/Resources/translations/user-activate.en.yml
+++ b/client/src/AppBundle/Resources/translations/user-activate.en.yml
@@ -1,6 +1,6 @@
 page:
-  pageSectionDescription:
-htmlTitle: Deputy report - set your password | GOV.UK
+    pageSectionDescription:
+htmlTitle: Set your password - Complete the deputy report | GOV.UK
 pageTitle: Set your password
 headerTitle: Step 1. Set your password
 email:

--- a/client/src/AppBundle/Resources/translations/user-activation-link-sent.en.yml
+++ b/client/src/AppBundle/Resources/translations/user-activation-link-sent.en.yml
@@ -1,5 +1,5 @@
 page:
-  htmlTitle: "Deputy report - we've sent you a new link | GOV.UK"
+  htmlTitle: "We've sent you a new link - Complete the deputy report | GOV.UK"
 pageTitle: We've sent you a new link
 subtitle: Check your email inbox, we've sent you an email with a new link. This link will expire within %tokenExpireHours% hours.
 didntReceive: If you can't see an email from %senderEmail%, check your junk or spam folders, it may be there.

--- a/client/src/AppBundle/Resources/views/Client/edit.html.twig
+++ b/client/src/AppBundle/Resources/views/Client/edit.html.twig
@@ -7,7 +7,7 @@
 {% set page = 'editClient' %}
 {% set translationPrefix = "editClient." %}
 
-{% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
+{% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans({'%client%': client.firstname}) }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans({'%client%': client.firstname}) }}{% endblock %}
 
 {% block breadcrumbs %}

--- a/client/src/AppBundle/Resources/views/Client/show.html.twig
+++ b/client/src/AppBundle/Resources/views/Client/show.html.twig
@@ -6,7 +6,7 @@
 {% trans_default_domain translationDomain %}
 {% set page = 'showClient' %}
 
-{% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
+{% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans({'%client%': client.firstname}) }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans({'%client%': client.firstname}) }}{% endblock %}
 
 {% block breadcrumbs %}

--- a/client/src/AppBundle/Resources/views/Report/ProfDeputyCosts/breakdown.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/ProfDeputyCosts/breakdown.html.twig
@@ -8,7 +8,7 @@
 {% set page = 'breakdown' %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
-{% block pageTitle %}{{ (page ~ '.pageSectionDescription') | trans }}{% endblock %}
+{% block pageTitle %}{{ (page ~ '.pageSectionDescription') | trans(transOptions) }}{% endblock %}
 {% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}
 
 {% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}


### PR DESCRIPTION
## Purpose
As part of the accessibility audit it was found the page titles when
completing a deputy report did not match the top-level heading on the
page. This PR fixes that by changing all the `{{htmlTitle}}` on every part to
read with the value from the ``{{pageTitle}}`` variable. 

`{{pageTitle}}` - Complete the deputy report | GOV.UK

Fixes DDPB-3320

## Approach
Update values inside the translations files for the `{{htmlTitle}}` to reflect the values of the `{{pageTitle}}`

<!-- ## Learning
 _Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_ -->

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant **N/A**
- [x] I have added tests to prove my work **N/A**
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [x] Translations are used and the profiler doesn't identify any missing
- [x] Any links or buttons added are screen reader friendly and contextually complete **N/A**
