### PR TITLE
DDPB-3317: removed the <aside> HTML tag as it should not be contained within a landmark

### DIFF
--- a/client/src/AppBundle/Resources/views/Index/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Index/index.html.twig
@@ -108,8 +108,8 @@
             </div>
 
         </div>
-        <div class="column-third">
-            <aside class="opg-related-items" role="complementary">
+        <div class="govuk-grid-column-one-third">
+            <div class="opg-related-items">
                 <h2 id="related-items-title" class="govuk-heading-m">{{ 'relatedLinks.heading' |trans|raw }}</h2>
                 <nav role="navigation" aria-labelledby="related-items-title">
                     <ul class="govuk-list govuk-!-font-size-16">
@@ -145,7 +145,7 @@
                         </li>
                     </ul>
                 </nav>
-            </aside>
+            </div>
         </div>
     </div>
 

--- a/client/src/AppBundle/Resources/views/Macros/macros.html.twig
+++ b/client/src/AppBundle/Resources/views/Macros/macros.html.twig
@@ -225,7 +225,7 @@
 {% macro relatedSections(report,section) %}
     {% set isOrgUser = app.user.isDeputyOrg() %}
 
-    <aside class="opg-related-items" role="complementary">
+    <div class="opg-related-items">
         <nav role="navigation">
             <ul class="govuk-list govuk-!-font-size-16">
                 <li>
@@ -263,7 +263,7 @@
                 {% endif %}
             </ul>
         </nav>
-    </aside>
+    </div>
 {% endmacro %}
 
 {# Question/Answer table header for summary pages #}


### PR DESCRIPTION
## Purpose
Improved usability for screenreader users

The <aside> HTML5 tag is considered a landmark tag in and by it's self.
The HTML specification suggestes landmarks should not be contained
within other landmarks and our sidebars are contained within the
<main> tag which is considered a landmark therefore we change the
<aside> tag to a standard <div> tag

Fixes DDPB-3317

<!-- ## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_ -->

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant **N/A**
- [x] I have added tests to prove my work **N/A**
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [x] There are no deprecated CSS classes noted in the profiler **N/A**
- [x] Translations are used and the profiler doesn't identify any missing **N/A**
- [x] Any links or buttons added are screen reader friendly and contextually complete **N/A**
