### PR TITLE
DDPB-3324 - Selected boxes are unclear to screenreaders in report preview

### DIFF
--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
@@ -20,9 +20,9 @@
             <table class="checkboxes labelvalue inline">
                 <tbody>
                     <tr>
-                        <td class="checkbox value">{% if lodgingChecklist.reportingPeriodAccurate == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.reportingPeriodAccurate == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value">{% if lodgingChecklist.reportingPeriodAccurate == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.reportingPeriodAccurate == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                     </tr>
                 </tbody>
@@ -36,7 +36,7 @@
                 <table class="checkboxes labelvalue inline">
                     <tbody>
                         <tr>
-                            <td class="checkbox value">{% if lodgingChecklist.contactDetailsUptoDate == true %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.contactDetailsUptoDate == true %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
                         </tr>
                     </tbody>
@@ -47,7 +47,7 @@
                 <table class="checkboxes labelvalue inline">
                     <tbody>
                         <tr>
-                            <td class="checkbox value">{% if lodgingChecklist.deputyFullNameAccurateInCasrec == true %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.deputyFullNameAccurateInCasrec == true %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
                         </tr>
                     </tbody>
@@ -65,9 +65,9 @@
             <table class="checkboxes labelvalue inline">
                 <tbody>
                     <tr>
-                        <td class="checkbox value">{% if lodgingChecklist.decisionsSatisfactory == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.decisionsSatisfactory == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value">{% if lodgingChecklist.decisionsSatisfactory == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.decisionsSatisfactory == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                     </tr>
                 </tbody>
@@ -82,9 +82,9 @@
             <table class="checkboxes labelvalue inline">
                 <tbody>
                     <tr>
-                        <td class="checkbox value">{% if lodgingChecklist.consultationsSatisfactory == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.consultationsSatisfactory == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value">{% if lodgingChecklist.consultationsSatisfactory == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.consultationsSatisfactory == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                     </tr>
                 </tbody>
@@ -99,9 +99,9 @@
             <table class="checkboxes labelvalue inline">
                 <tbody>
                     <tr>
-                        <td class="checkbox value">{% if lodgingChecklist.careArrangements == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.careArrangements == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value">{% if lodgingChecklist.careArrangements == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.careArrangements == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                     </tr>
                 </tbody>
@@ -117,9 +117,9 @@
                 <table class="checkboxes labelvalue inline">
                     <tbody>
                         <tr>
-                            <td class="checkbox value">{% if lodgingChecklist.satisfiedWithHealthAndLifestyle == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.satisfiedWithHealthAndLifestyle == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if lodgingChecklist.satisfiedWithHealthAndLifestyle == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.satisfiedWithHealthAndLifestyle == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                         </tr>
                     </tbody>
@@ -137,11 +137,11 @@
                 <table class="checkboxes labelvalue inline">
                     <tbody>
                         <tr>
-                            <td class="checkbox value">{% if lodgingChecklist.assetsDeclaredAndManaged == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.assetsDeclaredAndManaged == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if lodgingChecklist.assetsDeclaredAndManaged == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.assetsDeclaredAndManaged == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if lodgingChecklist.assetsDeclaredAndManaged == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.assetsDeclaredAndManaged == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                         </tr>
                     </tbody>
@@ -152,11 +152,11 @@
                 <table class="checkboxes labelvalue inline">
                     <tbody>
                         <tr>
-                            <td class="checkbox value">{% if lodgingChecklist.debtsManaged == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.debtsManaged == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if lodgingChecklist.debtsManaged == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.debtsManaged == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if lodgingChecklist.debtsManaged == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.debtsManaged == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                         </tr>
                     </tbody>
@@ -173,11 +173,11 @@
                 <table class="checkboxes labelvalue inline">
                     <tbody>
                         <tr>
-                            <td class="checkbox value">{% if lodgingChecklist.openClosingBalancesMatch == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.openClosingBalancesMatch == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if lodgingChecklist.openClosingBalancesMatch == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.openClosingBalancesMatch == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if lodgingChecklist.openClosingBalancesMatch == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.openClosingBalancesMatch == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                         </tr>
                     </tbody>
@@ -194,11 +194,11 @@
                 <table class="checkboxes labelvalue inline">
                     <tbody>
                         <tr>
-                            <td class="checkbox value">{% if lodgingChecklist.accountsBalance == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.accountsBalance == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if lodgingChecklist.accountsBalance == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.accountsBalance == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if lodgingChecklist.accountsBalance == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.accountsBalance == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                         </tr>
                     </tbody>
@@ -209,11 +209,11 @@
                 <table class="checkboxes labelvalue inline">
                     <tbody>
                         <tr>
-                            <td class="checkbox value">{% if lodgingChecklist.moneyMovementsAcceptable == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.moneyMovementsAcceptable == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if lodgingChecklist.moneyMovementsAcceptable == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.moneyMovementsAcceptable == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if lodgingChecklist.moneyMovementsAcceptable == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.moneyMovementsAcceptable == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                         </tr>
                     </tbody>
@@ -231,9 +231,9 @@
                 <table class="checkboxes labelvalue inline">
                     <tbody>
                     <tr>
-                        <td class="checkbox value">{% if lodgingChecklist.deputyChargeAllowedByCourt == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.deputyChargeAllowedByCourt == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value">{% if lodgingChecklist.deputyChargeAllowedByCourt == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.deputyChargeAllowedByCourt == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                     </tr>
                     </tbody>
@@ -244,11 +244,11 @@
                 <table class="checkboxes labelvalue inline">
                     <tbody>
                     <tr>
-                        <td class="checkbox value">{% if lodgingChecklist.satisfiedWithPaExpenses == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.satisfiedWithPaExpenses == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value">{% if lodgingChecklist.satisfiedWithPaExpenses == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.satisfiedWithPaExpenses == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value">{% if lodgingChecklist.satisfiedWithPaExpenses == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.satisfiedWithPaExpenses == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                     </tr>
                     </tbody>
@@ -261,11 +261,11 @@
                 <table class="checkboxes labelvalue inline">
                     <tbody>
                         <tr>
-                            <td class="checkbox value">{% if lodgingChecklist.bondAdequate == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.bondAdequate == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if lodgingChecklist.bondAdequate == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.bondAdequate == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if lodgingChecklist.bondAdequate == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.bondAdequate == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                         </tr>
                     </tbody>
@@ -276,11 +276,11 @@
                 <table class="checkboxes labelvalue inline">
                     <tbody>
                         <tr>
-                            <td class="checkbox value">{% if lodgingChecklist.bondOrderMatchCasrec == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.bondOrderMatchCasrec == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if lodgingChecklist.bondOrderMatchCasrec == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.bondOrderMatchCasrec == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if lodgingChecklist.bondOrderMatchCasrec == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if lodgingChecklist.bondOrderMatchCasrec == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                         </tr>
                     </tbody>
@@ -298,9 +298,9 @@
             <table class="checkboxes labelvalue inline">
                 <tbody>
                     <tr>
-                        <td class="checkbox value">{% if lodgingChecklist.paymentsMatchCostCertificate == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.paymentsMatchCostCertificate == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value">{% if lodgingChecklist.paymentsMatchCostCertificate == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.paymentsMatchCostCertificate == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                     </tr>
                 </tbody>
@@ -311,9 +311,9 @@
             <table class="checkboxes labelvalue inline">
                 <tbody>
                     <tr>
-                        <td class="checkbox value">{% if lodgingChecklist.profCostsReasonableAndProportionate == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.profCostsReasonableAndProportionate == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value">{% if lodgingChecklist.profCostsReasonableAndProportionate == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.profCostsReasonableAndProportionate == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                     </tr>
                 </tbody>
@@ -324,11 +324,11 @@
             <table class="checkboxes labelvalue inline">
                 <tbody>
                     <tr>
-                        <td class="checkbox value">{% if lodgingChecklist.hasDeputyOverchargedFromPreviousEstimates == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.hasDeputyOverchargedFromPreviousEstimates == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value">{% if lodgingChecklist.hasDeputyOverchargedFromPreviousEstimates == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.hasDeputyOverchargedFromPreviousEstimates == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value">{% if lodgingChecklist.hasDeputyOverchargedFromPreviousEstimates == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.hasDeputyOverchargedFromPreviousEstimates == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                     </tr>
                 </tbody>
@@ -345,9 +345,9 @@
             <table class="checkboxes labelvalue inline">
                 <tbody>
                     <tr>
-                        <td class="checkbox value">{% if lodgingChecklist.nextBillingEstimatesSatisfactory == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.nextBillingEstimatesSatisfactory == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value">{% if lodgingChecklist.nextBillingEstimatesSatisfactory == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.nextBillingEstimatesSatisfactory == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                     </tr>
                 </tbody>
@@ -374,11 +374,11 @@
             <table class="checkboxes labelvalue inline">
                 <tbody>
                     <tr>
-                        <td class="checkbox value">{% if lodgingChecklist.futureSignificantDecisions == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.futureSignificantDecisions == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value">{% if lodgingChecklist.futureSignificantDecisions == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.futureSignificantDecisions == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value">{% if lodgingChecklist.futureSignificantDecisions == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.futureSignificantDecisions == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                     </tr>
                 </tbody>
@@ -389,11 +389,11 @@
             <table class="checkboxes labelvalue inline">
                 <tbody>
                     <tr>
-                        <td class="checkbox value">{% if lodgingChecklist.hasDeputyRaisedConcerns == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.hasDeputyRaisedConcerns == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value">{% if lodgingChecklist.hasDeputyRaisedConcerns == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.hasDeputyRaisedConcerns == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value">{% if lodgingChecklist.hasDeputyRaisedConcerns == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.hasDeputyRaisedConcerns == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                     </tr>
                 </tbody>
@@ -408,11 +408,11 @@
             <table class="checkboxes labelvalue inline">
                 <tbody>
                     <tr>
-                        <td class="checkbox value">{% if lodgingChecklist.caseWorkerSatisified == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.caseWorkerSatisified == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value">{% if lodgingChecklist.caseWorkerSatisified == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.caseWorkerSatisified == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value">{% if lodgingChecklist.caseWorkerSatisified == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.caseWorkerSatisified == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                     </tr>
                 </tbody>
@@ -432,32 +432,32 @@
                 <table class="checkboxes labelvalue">
                     <tr>
                         <td class="clean-cell">
-                            <span class="checkbox value">
-                                {% if lodgingChecklist.finalDecision == 'for-review' %}X{% else %}&nbsp;{% endif %}
+                            <span class="checkbox value"
+                                {% if lodgingChecklist.finalDecision == 'for-review' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}
                             </span>
                         </td>
                         <td class="label soft-half--bottom">{{ (page ~ '.form.finalDecision.options.forReview') | trans({}, 'admin-checklist') }}</td>
                     </tr>
                     <tr>
                         <td class="clean-cell">
-                            <span class="checkbox value">
-                                {% if lodgingChecklist.finalDecision == 'incomplete' %}X{% else %}&nbsp;{% endif %}
+                            <span class="checkbox value"
+                                {% if lodgingChecklist.finalDecision == 'incomplete' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}
                             </span>
                         </td>
                         <td class="label soft-half--bottom">{{ (page ~ '.form.finalDecision.options.incomplete') | trans({}, 'admin-checklist') }}</td>
                     </tr>
                     <tr>
                         <td class="clean-cell">
-                            <span class="checkbox value">
-                                {% if lodgingChecklist.finalDecision == 'further-casework-required' %}X{% else %}&nbsp;{% endif %}
+                            <span class="checkbox value"
+                                {% if lodgingChecklist.finalDecision == 'further-casework-required' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}
                             </span>
                         </td>
                         <td class="label soft-half--bottom">{{ (page ~ '.form.finalDecision.options.furtherCaseworkRequired') | trans({}, 'admin-checklist') }}</td>
                     </tr>
                     <tr>
                         <td class="clean-cell">
-                            <span class="checkbox value">
-                                {% if lodgingChecklist.finalDecision == 'satisfied' %}X{% else %}&nbsp;{% endif %}
+                            <span class="checkbox value"
+                                {% if lodgingChecklist.finalDecision == 'satisfied' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}
                             </span>
                         </td>
                         <td class="label soft-half--bottom">{{ (page ~ '.form.finalDecision.options.satisfied') | trans({}, 'admin-checklist') }}</td>
@@ -529,11 +529,11 @@
                     <table class="checkboxes labelvalue inline">
                         <tbody>
                         <tr>
-                            <td class="checkbox value">{% if answers.fullBankStatementsExist == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.fullBankStatementsExist == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if answers.fullBankStatementsExist == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.fullBankStatementsExist == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if answers.fullBankStatementsExist == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.fullBankStatementsExist == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                         </tr>
                         </tbody>
@@ -545,11 +545,11 @@
                     <table class="checkboxes labelvalue inline">
                         <tbody>
                         <tr>
-                            <td class="checkbox value">{% if answers.anyLodgingConcerns == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.anyLodgingConcerns == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if answers.anyLodgingConcerns == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.anyLodgingConcerns == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if answers.anyLodgingConcerns == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.anyLodgingConcerns == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                         </tr>
                         </tbody>
@@ -561,11 +561,11 @@
                     <table class="checkboxes labelvalue inline">
                         <tbody>
                         <tr>
-                            <td class="checkbox value">{% if answers.spendingAcceptable == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.spendingAcceptable == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if answers.spendingAcceptable == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.spendingAcceptable == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if answers.spendingAcceptable == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.spendingAcceptable == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                         </tr>
                         </tbody>
@@ -575,11 +575,11 @@
                     <table class="checkboxes labelvalue inline">
                         <tbody>
                         <tr>
-                            <td class="checkbox value">{% if answers.expensesReasonable == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.expensesReasonable == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if answers.expensesReasonable == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.expensesReasonable == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if answers.expensesReasonable == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.expensesReasonable == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                         </tr>
                         </tbody>
@@ -589,11 +589,11 @@
                     <table class="checkboxes labelvalue inline">
                         <tbody>
                         <tr>
-                            <td class="checkbox value">{% if answers.giftingReasonable == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.giftingReasonable == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if answers.giftingReasonable == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.giftingReasonable == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if answers.giftingReasonable == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.giftingReasonable == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                         </tr>
                         </tbody>
@@ -603,11 +603,11 @@
                     <table class="checkboxes labelvalue inline">
                         <tbody>
                         <tr>
-                            <td class="checkbox value">{% if answers.debtManageable == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.debtManageable == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if answers.debtManageable == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.debtManageable == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if answers.debtManageable == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.debtManageable == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                         </tr>
                         </tbody>
@@ -617,11 +617,11 @@
                     <table class="checkboxes labelvalue inline">
                         <tbody>
                         <tr>
-                            <td class="checkbox value">{% if answers.anySpendingConcerns == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.anySpendingConcerns == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if answers.anySpendingConcerns == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.anySpendingConcerns == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if answers.anySpendingConcerns == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.anySpendingConcerns == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                         </tr>
                         </tbody>
@@ -633,9 +633,9 @@
                     <table class="checkboxes labelvalue inline">
                         <tbody>
                         <tr>
-                            <td class="checkbox value">{% if answers.needReferral == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.needReferral == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="checkbox value">{% if answers.needReferral == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="checkbox value"{% if answers.needReferral == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                         </tr>
                         </tbody>
@@ -647,24 +647,24 @@
                         <table class="checkboxes labelvalue">
                             <tr>
                                 <td class="clean-cell">
-                                <span class="checkbox value">
-                                    {% if reviewChecklist.decision == 'satisfied' %}X{% else %}&nbsp;{% endif %}
+                                <span class="checkbox value"
+                                    {% if reviewChecklist.decision == 'satisfied' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}
                                 </span>
                                 </td>
                                 <td class="label soft-half--bottom">{{ (page ~ '.form.finalDecision.fullReviewOptions.satisfied') | trans({}, 'admin-checklist') }}</td>
                             </tr>
                             <tr>
                                 <td class="clean-cell">
-                                <span class="checkbox value">
-                                    {% if reviewChecklist.decision == 'further-casework-required' %}X{% else %}&nbsp;{% endif %}
+                                <span class="checkbox value"
+                                    {% if reviewChecklist.decision == 'further-casework-required' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}
                                 </span>
                                 </td>
                                 <td class="label soft-half--bottom">{{ (page ~ '.form.finalDecision.fullReviewOptions.furtherCaseworkRequired') | trans({}, 'admin-checklist') }}</td>
                             </tr>
                             <tr>
                                 <td class="clean-cell">
-                                <span class="checkbox value">
-                                    {% if reviewChecklist.decision == 'escalate' %}X{% else %}&nbsp;{% endif %}
+                                <span class="checkbox value"
+                                    {% if reviewChecklist.decision == 'escalate' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}
                                 </span>
                                 </td>
                                 <td class="label soft-half--bottom">{{ (page ~ '.form.finalDecision.fullReviewOptions.escalate') | trans({}, 'admin-checklist') }}</td>

--- a/client/src/AppBundle/Resources/views/Macros/macros-review.html.twig
+++ b/client/src/AppBundle/Resources/views/Macros/macros-review.html.twig
@@ -91,9 +91,9 @@
 
         <table class="checkboxes labelvalue inline">
             <tr>
-                <td class="value checkbox">{% if visitsCare.doesClientReceivePaidCare == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                <td class="value checkbox"{% if visitsCare.doesClientReceivePaidCare == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                 <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                <td class="value checkbox">{% if visitsCare.doesClientReceivePaidCare == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                <td class="value checkbox"{% if visitsCare.doesClientReceivePaidCare == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                 <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
             </tr>
         </table>
@@ -103,24 +103,24 @@
             <table class="checkboxes labelvalue">
                 <tr>
                     <td class="clean-cell">
-                        <span class="checkbox value">
-                            {% if visitsCare.doesClientReceivePaidCare == 'yes' and visitsCare.howIsCareFunded == 'client_pays_for_all' %}X{% else %}&nbsp;{% endif %}
+                        <span class="checkbox value"
+                            {% if visitsCare.doesClientReceivePaidCare == 'yes' and visitsCare.howIsCareFunded == 'client_pays_for_all' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}
                         </span>
                     </td>
                     <td class="label soft-half--bottom">{{ 'form.howIsCareFunded.choices.client_pays_for_all' | trans(transOptions, translationDomain) }}</td>
                 </tr>
                 <tr>
                     <td class="clean-cell">
-                        <span class="checkbox value">
-                            {% if visitsCare.doesClientReceivePaidCare == 'yes' and visitsCare.howIsCareFunded == 'client_gets_financial_help' %}X{% else %}&nbsp;{% endif %}
+                        <span class="checkbox value"
+                            {% if visitsCare.doesClientReceivePaidCare == 'yes' and visitsCare.howIsCareFunded == 'client_gets_financial_help' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}
                         </span>
                     </td>
                     <td class="label soft-half--bottom">{{ 'form.howIsCareFunded.choices.client_gets_financial_help' | trans(transOptions, translationDomain) }}</td>
                 </tr>
                 <tr>
                     <td class="clean-cell">
-                        <span class="checkbox value">
-                            {% if visitsCare.doesClientReceivePaidCare == 'yes' and visitsCare.howIsCareFunded == 'all_care_is_paid_by_someone_else' %}X{% else %}&nbsp;{% endif %}
+                        <span class="checkbox value"
+                            {% if visitsCare.doesClientReceivePaidCare == 'yes' and visitsCare.howIsCareFunded == 'all_care_is_paid_by_someone_else' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}
                         </span>
                     </td>
                     <td class="label hard--ends">{{ 'form.howIsCareFunded.choices.all_care_is_paid_by_someone_else' | trans(transOptions, translationDomain) }}</td>
@@ -153,9 +153,9 @@
 
         <table class="checkboxes labelvalue inline">
             <tr>
-                <td class="value checkbox">{% if report.paidForAnything == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                <td class="value checkbox"{% if report.paidForAnything == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                 <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                <td class="value checkbox">{% if report.paidForAnything == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                <td class="value checkbox"{% if report.paidForAnything == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                 <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
             </tr>
         </table>
@@ -191,9 +191,9 @@
 
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox">{% if param.answer == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if param.answer == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                    <td class="value checkbox">{% if param.answer == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if param.answer == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                 </tr>
             </table>

--- a/client/src/AppBundle/Resources/views/Ndr/Formatted/Asset/_property.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Formatted/Asset/_property.html.twig
@@ -25,9 +25,9 @@
             <div class="label question">Is the property fully or part-owned by the client?</div>
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox" >{% if asset.owned =='fully' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.owned =='fully' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">Fully-owned</td>
-                    <td class="value checkbox">{% if asset.owned =='partly' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.owned =='partly' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">Part-owned</td>
                 </tr>
             </table>
@@ -42,9 +42,9 @@
             <div class="label question">Is the property subject to an equity release scheme?</div>
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox" >{% if asset.isSubjectToEquityRelease =='yes' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.isSubjectToEquityRelease =='yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                    <td class="value checkbox">{% if asset.isSubjectToEquityRelease =='no' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.isSubjectToEquityRelease =='no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                 </tr>
             </table>
@@ -59,9 +59,9 @@
             <div class="label question">Is there an outstanding mortgage?</div>
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox" >{% if asset.hasMortgage =='yes' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.hasMortgage =='yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                    <td class="value checkbox">{% if asset.hasMortgage =='no' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.hasMortgage =='no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                 </tr>
             </table>
@@ -73,13 +73,13 @@
                 </dl>
             {% endif %}
 
-            <div class="label question">Is there a charge on the property?</br>
+            <div class="label question">Is there a charge on the property?<br/>
                 For example, Local Authority to recover care fees</div>
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox" >{% if asset.hasCharges =='yes' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.hasCharges =='yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                    <td class="value checkbox">{% if asset.hasCharges =='no' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.hasCharges =='no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                 </tr>
             </table>
@@ -87,9 +87,9 @@
             <div class="label question">Is the property rented out?</div>
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox" >{% if asset.isRentedOut =='yes' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.isRentedOut =='yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                    <td class="value checkbox">{% if asset.isRentedOut =='no' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.isRentedOut =='no' %} aria-label=”Selected”>X{% else %}>Z&nbsp;{% endif %}</td>
                     <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                 </tr>
            </table>

--- a/client/src/AppBundle/Resources/views/Ndr/Formatted/_actions.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Formatted/_actions.html.twig
@@ -13,9 +13,9 @@ or ndr.actionPropertyBuy
 
                 <table class="checkboxes labelvalue inline">
                     <tr>
-                        <td class="value checkbox">{% if ndr.actionGiveGiftsToClient == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="value checkbox"{% if ndr.actionGiveGiftsToClient == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="value checkbox">{% if ndr.actionGiveGiftsToClient == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="value checkbox"{% if ndr.actionGiveGiftsToClient == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                     </tr>
                 </table>
@@ -37,9 +37,9 @@ or ndr.actionPropertyBuy
                     <h3 class="label question bold flush--top">Are there plans for maintenance or alterations to any property owned by the client?</h3>
                     <table class="checkboxes labelvalue inline">
                         <tr>
-                            <td class="value checkbox">{% if ndr.actionPropertyMaintenance == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="value checkbox"{% if ndr.actionPropertyMaintenance == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="value checkbox">{% if ndr.actionPropertyMaintenance == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="value checkbox"{% if ndr.actionPropertyMaintenance == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                         </tr>
                     </table>
@@ -49,9 +49,9 @@ or ndr.actionPropertyBuy
                     <h3 class="label question bold">Are you planning to sell or rent any property owned by the client?</h3>
                     <table class="checkboxes labelvalue inline">
                         <tr>
-                            <td class="value checkbox">{% if ndr.actionPropertySellingRent == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="value checkbox"{% if ndr.actionPropertySellingRent == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="value checkbox">{% if ndr.actionPropertySellingRent == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="value checkbox"{% if ndr.actionPropertySellingRent == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                         </tr>
                     </table>
@@ -61,9 +61,9 @@ or ndr.actionPropertyBuy
                     <h3 class="label question bold">Are you planning to buy a property for the client?</h3>
                     <table class="checkboxes labelvalue inline">
                         <tr>
-                            <td class="value checkbox">{% if ndr.actionPropertyBuy == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="value checkbox"{% if ndr.actionPropertyBuy == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                            <td class="value checkbox">{% if ndr.actionPropertyBuy == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                            <td class="value checkbox"{% if ndr.actionPropertyBuy == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                             <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                         </tr>
                     </table>

--- a/client/src/AppBundle/Resources/views/Ndr/Formatted/_assets.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Formatted/_assets.html.twig
@@ -9,7 +9,7 @@
                 <h3 class="label question bold">Does the client have any assets?</h3>
                 <table class="checkboxes labelvalue inline">
                     <tr>
-                        <td class="value checkbox">X</td>
+                        <td class="value checkbox" aria-label=”Selected”>X</td>
                         <td class="label">My client has no assets</td>
                     </tr>
                 </table>

--- a/client/src/AppBundle/Resources/views/Ndr/Formatted/_contacts.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Formatted/_contacts.html.twig
@@ -6,7 +6,7 @@
             <div class="box contact-item no-contact" id="no-contact">
                 <dl class="labelvalue">
                     <dt class="label">Check this box if you did not consult anyone and use the box below to tell us why.</dt>
-                    <dd class="value checkbox">X</dd>
+                    <dd class="value checkbox" aria-label=”Selected”>X</dd>
                     <dd class="value textarea">{{ ndr.reasonForNoContacts }}</dd>
                 </dl>
             </div>

--- a/client/src/AppBundle/Resources/views/Ndr/Formatted/_debts.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Formatted/_debts.html.twig
@@ -10,7 +10,7 @@
             <h3 class="label question bold">Does the client have any debts?</h3>
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox">X</td>
+                    <td class="value checkbox" aria-label=”Selected”>X</td>
                     <td class="label">My client has no debts</td>
                 </tr>
             </table>

--- a/client/src/AppBundle/Resources/views/Ndr/Formatted/_income_benefits.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Formatted/_income_benefits.html.twig
@@ -15,8 +15,8 @@ or ndr.getExpectCompensationDamages() %}
                     {% for st in ndr.stateBenefits %}
                         <tr>
                             <td class="clean-cell">
-                                <span class="checkbox value">
-                                    {{ st.present ? 'X' : '&nbsp;' }}
+                                <span class="checkbox value"
+                                    {{ st.present ? ' aria-label=”Selected”>X' : '>&nbsp;' }}
                                 </span>
                             </td>
                             <td class="label soft-half--bottom">{{ ('form.stateBenefits.entries.' ~ st.typeId ~ '.label') | trans({}, 'ndr-income-benefits') }}</td>
@@ -43,9 +43,9 @@ or ndr.getExpectCompensationDamages() %}
                 <h3 class="label question bold">Does the client receive a state pension?</h3>
                 <table class="checkboxes labelvalue inline">
                     <tr>
-                        <td class="value checkbox">{% if ndr.receiveStatePension == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="value checkbox"{% if ndr.receiveStatePension == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="value checkbox">{% if ndr.receiveStatePension == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="value checkbox"{% if ndr.receiveStatePension == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                     </tr>
                 </table>
@@ -55,9 +55,9 @@ or ndr.getExpectCompensationDamages() %}
                 <h3 class="label question bold">Does the client receive any other regular income?</h3>
                 <table class="checkboxes labelvalue inline">
                     <tr>
-                        <td class="value checkbox">{% if ndr.receiveOtherIncome == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="value checkbox"{% if ndr.receiveOtherIncome == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="value checkbox">{% if ndr.receiveOtherIncome == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="value checkbox"{% if ndr.receiveOtherIncome == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                     </tr>
                 </table>
@@ -78,9 +78,9 @@ or ndr.getExpectCompensationDamages() %}
                 <h3 class="label question bold">Are you expecting any compensation awards or damages to be paid to the client?</h3>
                 <table class="checkboxes labelvalue inline">
                     <tr>
-                        <td class="value checkbox">{% if ndr.expectCompensationDamages == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="value checkbox"{% if ndr.expectCompensationDamages == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="value checkbox">{% if ndr.expectCompensationDamages == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="value checkbox"{% if ndr.expectCompensationDamages == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                     </tr>
                 </table>
@@ -102,8 +102,8 @@ or ndr.getExpectCompensationDamages() %}
                     {% for st in ndr.oneOff %}
                         <tr>
                             <td class="clean-cell">
-                                <span class="checkbox value">
-                                    {{ st.present ? 'X' : '&nbsp;' }}
+                                <span class="checkbox value"
+                                    {{ st.present ? ' aria-label=”Selected”>X' : '>&nbsp;' }}
                                 </span>
                             </td>
                             <td class="label soft-half--bottom">{{ ('form.oneOff.entries.' ~ st.typeId ~ '.label') | trans({}, 'ndr-income-benefits') }}</td>

--- a/client/src/AppBundle/Resources/views/Report/Formatted/Accounts/_money_in_out_short.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Formatted/Accounts/_money_in_out_short.html.twig
@@ -24,9 +24,9 @@
         <h3 class="label question bold">{{ existQuestion }}</h3>
         <table class="checkboxes labelvalue inline">
             <tr>
-                <td class="value checkbox">{% if transactionsExist == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                <td class="value checkbox"{% if transactionsExist == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                 <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                <td class="value checkbox">{% if transactionsExist == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                <td class="value checkbox"{% if transactionsExist == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                 <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
             </tr>
         </table>

--- a/client/src/AppBundle/Resources/views/Report/Formatted/Asset/_property.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Formatted/Asset/_property.html.twig
@@ -25,9 +25,9 @@
             <div class="label question">Is the property fully or part-owned by the client?</div>
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox" >{% if asset.owned =='fully' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.owned =='fully' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">Fully-owned</td>
-                    <td class="value checkbox">{% if asset.owned =='partly' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.owned =='partly' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">Part-owned</td>
                 </tr>
             </table>
@@ -42,9 +42,9 @@
             <div class="label question">Is the property subject to an equity release scheme?</div>
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox" >{% if asset.isSubjectToEquityRelease =='yes' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.isSubjectToEquityRelease =='yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                    <td class="value checkbox">{% if asset.isSubjectToEquityRelease =='no' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.isSubjectToEquityRelease =='no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                 </tr>
             </table>
@@ -59,9 +59,9 @@
             <div class="label question">Is there an outstanding mortgage?</div>
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox" >{% if asset.hasMortgage =='yes' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.hasMortgage =='yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                    <td class="value checkbox">{% if asset.hasMortgage =='no' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.hasMortgage =='no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                 </tr>
             </table>
@@ -77,9 +77,9 @@
                 For example, Local Authority to recover care fees</div>
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox" >{% if asset.hasCharges =='yes' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.hasCharges =='yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                    <td class="value checkbox">{% if asset.hasCharges =='no' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.hasCharges =='no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                 </tr>
             </table>
@@ -87,9 +87,9 @@
             <div class="label question">Is the property rented out?</div>
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox" >{% if asset.isRentedOut =='yes' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.isRentedOut =='yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                    <td class="value checkbox">{% if asset.isRentedOut =='no' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if asset.isRentedOut =='no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                 </tr>
            </table>

--- a/client/src/AppBundle/Resources/views/Report/Formatted/_assets.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Formatted/_assets.html.twig
@@ -8,7 +8,7 @@
                 <h3 class="label question bold">{{ 'form.doesClientHaveAssets.label' | trans(transOptions, translationDomain) }}</h3>
                 <table class="checkboxes labelvalue inline">
                     <tr>
-                        <td class="value checkbox">X</td>
+                        <td class="value checkbox" aria-label=”Selected”>X</td>
                         <td class="label">{{ 'form.doesClientHaveAssets.noAssets.label' | trans(transOptions, translationDomain) }}</td>
                     </tr>
                 </table>

--- a/client/src/AppBundle/Resources/views/Report/Formatted/_attached_documents.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Formatted/_attached_documents.html.twig
@@ -7,9 +7,9 @@
 
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox">{% if report.wishToProvideDocumentation == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if report.wishToProvideDocumentation == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                    <td class="value checkbox">{% if report.wishToProvideDocumentation == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if report.wishToProvideDocumentation == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                 </tr>
             </table>

--- a/client/src/AppBundle/Resources/views/Report/Formatted/_debts.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Formatted/_debts.html.twig
@@ -10,7 +10,7 @@
             <h3 class="label question bold">{{ 'form.doesClientHaveDebts.label' | trans(transOptions, translationDomain) }}</h3>
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox">X</td>
+                    <td class="value checkbox" aria-label=”Selected”>X</td>
                     <td class="label">{{ 'form.doesClientHaveDebts.noDebts.label' | trans(transOptions, translationDomain) }}</td>
                 </tr>
             </table>

--- a/client/src/AppBundle/Resources/views/Report/Formatted/_gifts.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Formatted/_gifts.html.twig
@@ -7,9 +7,9 @@
 
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox">{% if report.giftsExist == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if report.giftsExist == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                    <td class="value checkbox">{% if report.giftsExist == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if report.giftsExist == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                 </tr>
             </table>

--- a/client/src/AppBundle/Resources/views/Report/Formatted/_mental-capacity.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Formatted/_mental-capacity.html.twig
@@ -7,9 +7,9 @@
 
         <table class="checkboxes labelvalue inline">
             <tr>
-                <td class="checkbox value">{% if mentalCapacity.hasCapacityChanged == 'changed' %}X{% else %}&nbsp;{% endif %}</td>
+                <td class="checkbox value"{% if mentalCapacity.hasCapacityChanged == 'changed' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                 <td class="label">Changed</td>
-                <td class="checkbox value">{% if mentalCapacity.hasCapacityChanged == 'stayedSame' %}X{% else %}&nbsp;{% endif %}</td>
+                <td class="checkbox value"{% if mentalCapacity.hasCapacityChanged == 'stayedSame' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                 <td class="label">Stayed the same</td>
             </tr>
         </table>

--- a/client/src/AppBundle/Resources/views/Report/Formatted/_pa_fee_expenses.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Formatted/_pa_fee_expenses.html.twig
@@ -10,9 +10,9 @@
 
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox">{% if report.hasFees == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if report.hasFees == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                    <td class="value checkbox">{% if report.hasFees == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if report.hasFees == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                 </tr>
             </table>
@@ -72,9 +72,9 @@
 
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox">{% if report.paidForAnything == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if report.paidForAnything == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                    <td class="value checkbox">{% if report.paidForAnything == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if report.paidForAnything == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                 </tr>
             </table>

--- a/client/src/AppBundle/Resources/views/Report/Formatted/_prof_current_fees.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Formatted/_prof_current_fees.html.twig
@@ -11,9 +11,9 @@
 
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox">{% if report.currentProfPaymentsReceived == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if report.currentProfPaymentsReceived == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                    <td class="value checkbox">{% if report.currentProfPaymentsReceived == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if report.currentProfPaymentsReceived == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                 </tr>
             </table>

--- a/client/src/AppBundle/Resources/views/Report/Formatted/_prof_deputy_costs.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Formatted/_prof_deputy_costs.html.twig
@@ -23,9 +23,9 @@
             <h3 class="label question bold">{{ 'previousReceivedExists.form.profDeputyCostsHasPrevious.label'|trans(transOptions) }}</h3>
             <table class="checkboxes labelvalue inline">
                 <tr>
-                    <td class="value checkbox">{% if report.profDeputyCostsHasPrevious == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if report.profDeputyCostsHasPrevious == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'yes' | trans({}, 'common') }}</td>
-                    <td class="value checkbox">{% if report.profDeputyCostsHasPrevious == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                    <td class="value checkbox"{% if report.profDeputyCostsHasPrevious == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                     <td class="label">{{ 'no' | trans({}, 'common') }}</td>
                 </tr>
             </table>
@@ -71,9 +71,9 @@
                 <h3 class="label question bold">{{ 'interimExists.form.profDeputyCostsHasInterim.label'|trans(transOptions) }}</h3>
                 <table class="checkboxes labelvalue inline">
                     <tr>
-                        <td class="value checkbox">{% if report.profDeputyCostsHasInterim == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="value checkbox"{% if report.profDeputyCostsHasInterim == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common') }}</td>
-                        <td class="value checkbox">{% if report.profDeputyCostsHasInterim == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="value checkbox"{% if report.profDeputyCostsHasInterim == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common') }}</td>
                     </tr>
                 </table>

--- a/client/src/AppBundle/Resources/views/Report/Formatted/_prof_deputy_costs_estimate.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Formatted/_prof_deputy_costs_estimate.html.twig
@@ -79,9 +79,9 @@
                 <h3 class="label question bold">{{ 'moreInfo.form.profDeputyCostsEstimateHasMoreInfoSummary.yesno'|trans }}</h3>
                 <table class="checkboxes labelvalue inline">
                     <tr>
-                        <td class="value checkbox">{% if report.profDeputyCostsEstimateHasMoreInfo == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="value checkbox"{% if report.profDeputyCostsEstimateHasMoreInfo == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common') }}</td>
-                        <td class="value checkbox">{% if report.profDeputyCostsEstimateHasMoreInfo == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="value checkbox"{% if report.profDeputyCostsEstimateHasMoreInfo == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common') }}</td>
                     </tr>
                 </table>


### PR DESCRIPTION
## Purpose
In the generated report PDF we use “X” in a box to indicate the user's selection:

This is read out to screenreader users as “cross”, which is unclear. This tickets adds the attribute aria-label=”Selected” so that screenreaders read it as “Selected” instead.

Fixes DDPB-3324

## Approach
Add the attribute aria-label=”Selected” so that screenreaders read it as “Selected” instead.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
