### PR TITLE
DDPB-3628 fix double click when adding documents to a report

### DIFF
--- a/client/src/AppBundle/Resources/assets/javascripts/main.js
+++ b/client/src/AppBundle/Resources/assets/javascripts/main.js
@@ -101,7 +101,6 @@ $(document).ready(function () {
   if ($submitButtons !== null) {
     $submitButtons.forEach(function ($el) {
       $el.addEventListener('click', function ($e) {
-        this.classList.add('opg-submit-link--disabled')
         this.classList.add('opg-submit-link--disabled', 'govuk-button--disabled')
       })
     })

--- a/client/src/AppBundle/Resources/assets/javascripts/main.js
+++ b/client/src/AppBundle/Resources/assets/javascripts/main.js
@@ -96,6 +96,17 @@ $(document).ready(function () {
     })
   }
 
+  const $submitButtons = document.querySelectorAll('[data-module="opg-toggleable-submit"]')
+
+  if ($submitButtons !== null) {
+    $submitButtons.forEach(function ($el) {
+      $el.addEventListener('click', function ($e) {
+        this.classList.add('opg-submit-link--disabled')
+        this.classList.add('opg-submit-link--disabled', 'govuk-button--disabled')
+      })
+    })
+  }
+
   // Error summaries
   const $errorSummaries = document.querySelectorAll('#error-summary')
   if ($errorSummaries !== null) {

--- a/client/src/AppBundle/Resources/assets/scss/_digideps.scss
+++ b/client/src/AppBundle/Resources/assets/scss/_digideps.scss
@@ -8,6 +8,7 @@
 @import "digideps/icon";
 @import 'digideps/indented-block';
 @import 'digideps/layout';
+@import 'digideps/links';
 @import "digideps/forms/form-sort-code";
 @import "digideps/conditionals2";
 @import "digideps/pager";

--- a/client/src/AppBundle/Resources/assets/scss/digideps/_links.scss
+++ b/client/src/AppBundle/Resources/assets/scss/digideps/_links.scss
@@ -1,0 +1,6 @@
+.opg-submit-link {
+  &--disabled {
+    pointer-events: none;
+    cursor: default;
+  }
+}

--- a/client/src/AppBundle/Resources/views/Report/Document/submitMoreDocumentsConfirm.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Document/submitMoreDocumentsConfirm.html.twig
@@ -17,15 +17,11 @@
 {% endblock %}
 
 {% block pageContent %}
-
     <p class="text">{{ (page ~ '.para01') | trans }}</p>
     {% include 'AppBundle:Report/Document:_list_submitted.html.twig'  with {
     'documents': report.submittedDocuments,
     'translationDomain': translationDomain,
     'page' : page,
     } %}
-
-    <a href="{{ nextLink }}" class="button behat-link-confirm-submit">{{ (page ~ '.submitButton') | trans }}</a>
-
+    <a href="{{ nextLink }}" class="button behat-link-confirm-submit" data-module="opg-toggleable-submit">{{ (page ~ '.submitButton') | trans }}</a>
 {% endblock %}
-


### PR DESCRIPTION
## Purpose
When adding documents to a submitted report, we can hit the button multiple times and this causes additional document submission rows to be entered in the DB.

Fixes DDPB-3628

## Approach
Quick fix to only allow us to submit once as once the button is pressed once, it becomes inactive.

## Learning
Learned a bit about how the data-modules work with CSS.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
