### PR TITLE
DDPB-3630 fix sec group rule for mock end point

### DIFF
--- a/behat/tests/features/admin/00-prechecks.feature
+++ b/behat/tests/features/admin/00-prechecks.feature
@@ -1,0 +1,8 @@
+Feature: admin / pre checks
+
+  @infra
+  Scenario: check maintenance page checks
+    When I go to admin page "/manage/availability"
+    Then I should see "Api: OK"
+    And I should see "Redis: OK"
+    And I should see "Notify: OK"

--- a/behat/tests/features/deputy/01-registration-steps/00-prechecks.feature
+++ b/behat/tests/features/deputy/01-registration-steps/00-prechecks.feature
@@ -14,4 +14,4 @@ Feature: pre checks
       And I should see "Redis: OK"
       And I should see "Notify: OK"
       And I should see "ClamAV: OK"
-      And And I should see "wkHtmlToPDf: OK"
+      And I should see "wkHtmlToPDf: OK"

--- a/behat/tests/features/deputy/01-registration-steps/00-prechecks.feature
+++ b/behat/tests/features/deputy/01-registration-steps/00-prechecks.feature
@@ -5,3 +5,13 @@ Feature: pre checks
         Given the deputy area works properly
         And the admin area works properly
         And I reset the behat SQL snapshots
+
+    @infra
+    Scenario: check maintenance page checks
+      When I go to "/manage/availability"
+      Then I should see "Sirius: OK"
+      And I should see "Api: OK"
+      And I should see "Redis: OK"
+      And I should see "Notify: OK"
+      And I should see "ClamAV: OK"
+      And And I should see "wkHtmlToPDf: OK"

--- a/client/composer.lock
+++ b/client/composer.lock
@@ -3701,6 +3701,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2019-09-17T06:23:10+00:00"
         },
         {
@@ -3791,12 +3792,12 @@
             "version": "v1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/nrk/predis.git",
+                "url": "https://github.com/predis/predis.git",
                 "reference": "f0210e38881631afeafb56ab43405a92cafd9fd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nrk/predis/zipball/f0210e38881631afeafb56ab43405a92cafd9fd1",
+                "url": "https://api.github.com/repos/predis/predis/zipball/f0210e38881631afeafb56ab43405a92cafd9fd1",
                 "reference": "f0210e38881631afeafb56ab43405a92cafd9fd1",
                 "shasum": ""
             },
@@ -4931,6 +4932,7 @@
                 "configuration",
                 "distribution"
             ],
+            "abandoned": true,
             "time": "2019-06-18T15:43:58+00:00"
         },
         {
@@ -5199,38 +5201,44 @@
         },
         {
             "name": "symfony/http-client",
-            "version": "v4.3.8",
+            "version": "v5.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "ae3a9cd491f1aadb5583f34a6bda5cca34081ce8"
+                "reference": "9eec6ed50ea38f562ce0a1fc8a7d96a010d58509"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/ae3a9cd491f1aadb5583f34a6bda5cca34081ce8",
-                "reference": "ae3a9cd491f1aadb5583f34a6bda5cca34081ce8",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/9eec6ed50ea38f562ce0a1fc8a7d96a010d58509",
+                "reference": "9eec6ed50ea38f562ce0a1fc8a7d96a010d58509",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": ">=7.2.5",
                 "psr/log": "^1.0",
-                "symfony/http-client-contracts": "^1.1.7",
-                "symfony/polyfill-php73": "^1.11"
+                "symfony/http-client-contracts": "^1.1.8|^2",
+                "symfony/polyfill-php73": "^1.11",
+                "symfony/service-contracts": "^1.0|^2"
             },
             "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
                 "psr/http-client-implementation": "1.0",
                 "symfony/http-client-implementation": "1.1"
             },
             "require-dev": {
+                "guzzlehttp/promises": "^1.3.1",
                 "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
                 "psr/http-client": "^1.0",
-                "symfony/http-kernel": "^4.3",
-                "symfony/process": "^4.2"
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/http-kernel": "^4.4|^5.0",
+                "symfony/process": "^4.4|^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.3-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -5257,7 +5265,7 @@
             ],
             "description": "Symfony HttpClient component",
             "homepage": "https://symfony.com",
-            "time": "2019-11-08T08:23:45+00:00"
+            "time": "2020-07-05T09:43:09+00:00"
         },
         {
             "name": "symfony/mime",
@@ -8623,6 +8631,7 @@
             ],
             "description": "FinderFacade is a convenience wrapper for Symfony's Finder component.",
             "homepage": "https://github.com/sebastianbergmann/finder-facade",
+            "abandoned": true,
             "time": "2020-01-16T08:08:45+00:00"
         },
         {

--- a/client/docker/env/frontend.env
+++ b/client/docker/env/frontend.env
@@ -29,7 +29,7 @@ FILESCANNER_SSLVERIFY=false
 OPG_DOCKER_TAG=latest
 OPG_NGINX_INDEX=app_dev.php
 
-SIRIUS_API_BASE_URI=http://pact-mock
+SIRIUS_API_BASE_URI=http://mock-sirius:8080
 
 # sets xdebug values in PHP ini config when OPG_PHP_XDEBUG_ENABLED is set
 OPG_PHP_XDEBUG_ENABLED=true

--- a/environment/front_sg.tf
+++ b/environment/front_sg.tf
@@ -27,12 +27,19 @@ locals {
       target_type = "security_group_id"
       target      = module.wkhtmltopdf_security_group.id
     }
-    scan_and_mock_sirius_integration = {
+    scan_integration = {
       port        = 8080
       type        = "egress"
       protocol    = "tcp"
       target_type = "security_group_id"
       target      = module.scan_security_group.id
+    }
+    mock_sirius_integration = {
+      port        = 8080
+      type        = "egress"
+      protocol    = "tcp"
+      target_type = "security_group_id"
+      target      = module.mock_sirius_integration_security_group.id
     }
     front_elb = {
       port        = 443

--- a/environment/mock_sirius_integration_service.tf
+++ b/environment/mock_sirius_integration_service.tf
@@ -37,7 +37,7 @@ resource "aws_ecs_service" "mock_sirius_integration" {
   name                    = aws_ecs_task_definition.mock_sirius_integration.family
   cluster                 = aws_ecs_cluster.main.id
   task_definition         = aws_ecs_task_definition.mock_sirius_integration.arn
-  desired_count           = local.account.task_count
+  desired_count           = 1
   launch_type             = "FARGATE"
   platform_version        = "1.4.0"
   enable_ecs_managed_tags = true


### PR DESCRIPTION
## Purpose

Security group rules were missing access from frontend to mock sirius! As part of this fix, I've added a test that would pick this issue up in future (as it was still returning 200 even though the sirius check was timing out).

Also needed to update composer as had a security vulnerability come up that stopped the build.

Fixes DDPB-3630

## Approach
Fixed sec group rule and added a test

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
