### PR TITLE
DDPB-3629: Error summaries do not auto-focus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ up-app-integration-tests: ## Brings the app up using test env vars (see test.env
 
 	docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
 
+down-app: ### Tears down the app
+	docker-compose down -v --remove-orphans
+
 client-unit-tests: prod-mode ## Run the client unit tests
 	docker-compose build frontend admin
 	docker-compose -f docker-compose.yml run --rm frontend bin/phpunit -c tests/phpunit

--- a/client/src/AppBundle/Resources/assets/javascripts/main.js
+++ b/client/src/AppBundle/Resources/assets/javascripts/main.js
@@ -95,6 +95,14 @@ $(document).ready(function () {
       new ButtonToggler().init($el)
     })
   }
+
+  // Error summaries
+  const $errorSummaries = document.querySelectorAll('#error-summary')
+  if ($errorSummaries !== null) {
+    $errorSummaries.forEach((ele) => {
+      ele.focus()
+    })
+  }
 })
 
 GOVUKFrontend.initAll()


### PR DESCRIPTION
There was an issue where if we had a form error on the page we didn't
auto-focus onto the error summary. According to the GOV.uk design system
we should auto-focus onto any error summaries on the page to

Fixes DDPB-3629

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant **N/A**
- [ ] I have added tests to prove my work **N/A**
- [ ] The product team have approved these changes

<!-- ### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete -->
