### PR TITLE
DDPB-3636 adding extra memory to scan task in pre and prod

### DIFF
--- a/environment/scan.tf
+++ b/environment/scan.tf
@@ -32,7 +32,7 @@ resource "aws_ecs_task_definition" "scan" {
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = 1024
-  memory                   = 2048
+  memory                   = local.account.scan_memory
   container_definitions    = "[${local.file_scanner_rest_container},${local.file_scanner_server_container}]"
   task_role_arn            = aws_iam_role.scan.arn
   execution_role_arn       = aws_iam_role.execution_role.arn

--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -20,7 +20,8 @@
       "state_source": "production",
       "elasticache_count": 2,
       "always_on": true,
-      "copy_version_from": "preproduction"
+      "copy_version_from": "preproduction",
+      "scan_memory": 4096
     },
     "preproduction": {
       "account_id": "454262938596",
@@ -40,7 +41,8 @@
       "state_source": "preproduction",
       "elasticache_count": 2,
       "always_on": true,
-      "copy_version_from": "integration"
+      "copy_version_from": "integration",
+      "scan_memory": 4096
     },
     "training": {
       "account_id": "515688267891",
@@ -60,7 +62,8 @@
       "state_source": "production",
       "elasticache_count": 1,
       "always_on": true,
-      "copy_version_from": "preproduction"
+      "copy_version_from": "preproduction",
+      "scan_memory": 2048
     },
     "integration": {
       "account_id": "454262938596",
@@ -80,7 +83,8 @@
       "state_source": "preproduction",
       "elasticache_count": 1,
       "always_on": true,
-      "copy_version_from": "NonApplicable"
+      "copy_version_from": "NonApplicable",
+      "scan_memory": 2048
     },
     "development": {
       "account_id": "248804316466",
@@ -103,7 +107,8 @@
       "state_source": "development",
       "elasticache_count": 1,
       "always_on": false,
-      "copy_version_from": "NonApplicable"
+      "copy_version_from": "NonApplicable",
+      "scan_memory": 2048
     },
     "default": {
       "account_id": "248804316466",
@@ -124,7 +129,8 @@
       "state_source": "development",
       "elasticache_count": 1,
       "always_on": false,
-      "copy_version_from": "NonApplicable"
+      "copy_version_from": "NonApplicable",
+      "scan_memory": 2048
     }
   }
 }

--- a/environment/variables.tf
+++ b/environment/variables.tf
@@ -27,6 +27,7 @@ variable "accounts" {
       elasticache_count    = number
       always_on            = bool
       copy_version_from    = string
+      scan_memory          = number
     })
   )
 }


### PR DESCRIPTION
Scan service is falling over. This should at least alleviate the issue for now. Need to do thorough testing on whether we can make a the settings help minimise this instead.