### PR TITLE
Ddpb 3636

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,6 @@ workflows:
           requires: [ apply environment ]
           filters: { branches: { ignore: [ main ] } }
 
-#      - pa11y-ci:
-#          name: accessibility test
-#          requires: [ apply environment ]
-#          filters: { branches: { ignore: [ main ] } }
       - approve:
           name: approval for further testing
           type: approval
@@ -45,16 +41,18 @@ workflows:
           filters: { branches: { ignore: [ master ] } }
 
       - run-task:
-          name: integration test
+          name: reset environment for testing
           requires: [ approval for further testing ]
+          filters: { branches: { ignore: [ main ] } }
+          task_name: reset_database
+          timeout: 180
+
+      - run-task:
+          name: integration test
+          requires: [ reset environment for testing ]
           filters: { branches: { ignore: [ master ] } }
           task_name: integration_test
           timeout: 2500
-
-#      - pa11y-ci:
-#          name: accessibility test
-#          requires: [ approval for further testing ]
-#          filters: { branches: { ignore: [ main ] } }
 
       - run-task:
           name: backup environment
@@ -95,7 +93,7 @@ workflows:
           tf_workspace: development
           tf_command: apply
 
-      # Notice no reset or restore over development so we can keep test data
+      # Notice, no 'reset' or 'restore' over development so we can keep test data
       - terraform-command:
           name: apply development
           requires: [ apply shared-development ]

--- a/environment/scan.tf
+++ b/environment/scan.tf
@@ -32,7 +32,7 @@ resource "aws_ecs_task_definition" "scan" {
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = 1024
-  memory                   = local.account.scan_memory
+  memory                   = 2048
   container_definitions    = "[${local.file_scanner_rest_container},${local.file_scanner_server_container}]"
   task_role_arn            = aws_iam_role.scan.arn
   execution_role_arn       = aws_iam_role.execution_role.arn

--- a/environment/scheduler.tf
+++ b/environment/scheduler.tf
@@ -5,7 +5,7 @@ data "aws_lambda_function" "redeployer_lambda" {
 resource "aws_cloudwatch_event_rule" "redeploy_file_scanner" {
   name                = "redeploy-file-scanner-${local.environment}"
   description         = "Redeploy the file scanner to use latest virus definitions"
-  schedule_expression = "rate(12 hours)"
+  schedule_expression = "cron(0 1 * * ? *)"
   tags                = local.default_tags
 }
 

--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -20,8 +20,7 @@
       "state_source": "production",
       "elasticache_count": 2,
       "always_on": true,
-      "copy_version_from": "preproduction",
-      "scan_memory": 4096
+      "copy_version_from": "preproduction"
     },
     "preproduction": {
       "account_id": "454262938596",
@@ -41,8 +40,7 @@
       "state_source": "preproduction",
       "elasticache_count": 2,
       "always_on": true,
-      "copy_version_from": "integration",
-      "scan_memory": 4096
+      "copy_version_from": "integration"
     },
     "training": {
       "account_id": "515688267891",
@@ -62,8 +60,7 @@
       "state_source": "production",
       "elasticache_count": 1,
       "always_on": true,
-      "copy_version_from": "preproduction",
-      "scan_memory": 2048
+      "copy_version_from": "preproduction"
     },
     "integration": {
       "account_id": "454262938596",
@@ -83,8 +80,7 @@
       "state_source": "preproduction",
       "elasticache_count": 1,
       "always_on": true,
-      "copy_version_from": "NonApplicable",
-      "scan_memory": 2048
+      "copy_version_from": "NonApplicable"
     },
     "development": {
       "account_id": "248804316466",
@@ -107,8 +103,7 @@
       "state_source": "development",
       "elasticache_count": 1,
       "always_on": false,
-      "copy_version_from": "NonApplicable",
-      "scan_memory": 2048
+      "copy_version_from": "NonApplicable"
     },
     "default": {
       "account_id": "248804316466",
@@ -129,8 +124,7 @@
       "state_source": "development",
       "elasticache_count": 1,
       "always_on": false,
-      "copy_version_from": "NonApplicable",
-      "scan_memory": 2048
+      "copy_version_from": "NonApplicable"
     }
   }
 }

--- a/environment/variables.tf
+++ b/environment/variables.tf
@@ -27,7 +27,6 @@ variable "accounts" {
       elasticache_count    = number
       always_on            = bool
       copy_version_from    = string
-      scan_memory          = number
     })
   )
 }


### PR DESCRIPTION
## Purpose
After seeing some timeouts on availability which were tracked down to clamav becoming unavailable, we have seen a gone on a mad goose chase because of misinterpretation of the logs and metrics. It can run out of memory occasionally when doing a restart but the actual issue is just that the restart can happen during the day. It always seems to recover fine so having the restart at 1am only will help 

Fixes DDPB-3636

## Approach
Change cron job to only run at 1 and put the memory back down to what it was before

## Learning
Learned a lot of useful information about putting traps and extra container logging inside containers. Was completely useless for this but hopefully it will prove useful at some point in the future...

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
