### PR TITLE
DDPB-3315: Illogical heading structure

### DIFF
--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/macros.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/macros.html.twig
@@ -9,9 +9,9 @@
         <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-hint">
                 <strong>{{ ('checklistPage.form.' ~ name ~ '.qid') | trans({}, form.vars.translation_domain) }}</strong>
-                <h4 class="govuk-fieldset__heading">
+                <h3 class="govuk-fieldset__heading">
                     {{ ('checklistPage.form.' ~ name ~ '.label') | trans({}, form.vars.translation_domain) }}
-                </h4>
+                </h3>
             </legend>
 
             {{ form_errors(form) }}

--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/partials/_deputy-and-client-info.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/partials/_deputy-and-client-info.html.twig
@@ -27,7 +27,7 @@
 
 {% set contents %}
     {# CLIENT DETAILS #}
-    <h4 class="govuk-heading-m">Client details</h4>
+    <h3 class="govuk-heading-m">Client details</h3>
 
     <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">
@@ -66,7 +66,7 @@
 
     {# DEPUTY DETAILS #}
     {% set deputy = report.submittedBy.isDeputyOrg and report.client.getNamedDeputy ? report.client.getNamedDeputy : report.submittedBy %}
-    <h4 class="govuk-heading-m">Deputy details</h4>
+    <h3 class="govuk-heading-m">Deputy details</h3>
 
     <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">

--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/partials/_lodging-summary.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/partials/_lodging-summary.html.twig
@@ -29,7 +29,7 @@
     </dl>
 
     {% if report.checklist.checklistInformation %}
-        <h4 class="govuk-heading-m">{{ (page ~ '.form.furtherInformation.label') | trans }}</h4>
+        <h3 class="govuk-heading-m">{{ (page ~ '.form.furtherInformation.label') | trans }}</h3>
 
         {{ include('AppBundle:Admin/Client/Report/partials:_further-information-table.html.twig', {
             information: report.checklist.checklistInformation

--- a/client/src/AppBundle/Resources/views/Report/Decision/_form.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Decision/_form.html.twig
@@ -4,15 +4,15 @@
 
 {{ form_start(form, {attr: {novalidate: 'novalidate'} }) }}
 
-    <h4 class="govuk-heading-m">
+    <h3 class="govuk-heading-m">
         {{ 'form.description.heading' | trans({}, translationDomain) }}
-    </h4>
+    </h3>
 
     {{ form_input(form.description,'form.description') }}
 
-    <h4 class="govuk-heading-m">
+    <h3 class="govuk-heading-m">
         {{ 'form.clientInvolvedBoolean.heading' | trans(transOptions, translationDomain) }}
-    </h4>
+    </h3>
 
     {{ form_checkbox_group(form.clientInvolvedBoolean, 'form.clientInvolvedBoolean', {
         'fieldSetClass' : 'inline',


### PR DESCRIPTION
Heading that are of the same semantic level should use the same HTML
heading level tag. For example all `<h2>` but when a sub-heading is added
it should increment the level by one `<h3>`. This ticket does that while
also removing `<h4>` as they should rarely be needed.

Fixes DDPB-3315

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant **N/A**
- [ ] I have added tests to prove my work **N/A**
- [ ] The product team have approved these changes