### PR TITLE
Reinstate separate app volumes

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -5,7 +5,11 @@ version: '3.2'
 services:
   admin:
     volumes:
-      - ./client/app:/var/www/app
+      - ./client/app/config/security.yml:/var/www/app/config/security.yml
+      - ./client/app/config/config.yml:/var/www/app/config/config.yml
+      - ./client/app/config/config_dev.yml:/var/www/app/config/config_dev.yml
+      - ./client/app/config/services.yml:/var/www/app/config/services.yml
+      - ./client/app/config/services:/var/www/app/config/services
       - ./client/src:/var/www/src
       - ./client/tests:/var/www/tests
       - ./client/phpstan.neon:/var/www/phpstan.neon
@@ -21,7 +25,11 @@ services:
 
   frontend:
     volumes:
-      - ./client/app:/var/www/app
+      - ./client/app/config/security.yml:/var/www/app/config/security.yml
+      - ./client/app/config/config.yml:/var/www/app/config/config.yml
+      - ./client/app/config/config_dev.yml:/var/www/app/config/config_dev.yml
+      - ./client/app/config/services.yml:/var/www/app/config/services.yml
+      - ./client/app/config/services:/var/www/app/config/services
       - ./client/src:/var/www/src
       - ./client/tests:/var/www/tests
       - ./client/phpstan.neon:/var/www/phpstan.neon


### PR DESCRIPTION
## Purpose
By having a single volume for /app there is some kind of overwriting going on for the value of the client secret app env in admin that determines which roles are allowed to sign in to which side of the frontend. I've reinstated them to how they were before so this should fix local docker login issues for admin.

## Approach
_Explain how your code addresses the purpose of the change_