### PR TITLE
Move replication bucket to account level in development only

### DIFF
--- a/environment/s3.tf
+++ b/environment/s3.tf
@@ -1,9 +1,12 @@
 locals {
-  dev_bucket_arn             = "arn:aws:s3:::pa-uploads-development"
   non-replication_workspaces = ["production02", "preproduction", "training", "integration", "development"]
   bucket_replication_status  = contains(local.non-replication_workspaces, local.environment) ? "Disabled" : "Enabled"
   long_expiry_workspaces     = ["production02", "development", "training"]
   expiration_days            = contains(local.long_expiry_workspaces, local.environment) ? 490 : 14
+}
+
+data "aws_s3_bucket" "replication_bucket" {
+  bucket = "pa-uploads-branch-replication"
 }
 
 resource "aws_s3_bucket" "pa_uploads" {
@@ -34,7 +37,7 @@ resource "aws_s3_bucket" "pa_uploads" {
       status = local.bucket_replication_status
 
       destination {
-        bucket        = local.dev_bucket_arn
+        bucket        = data.aws_s3_bucket.replication_bucket.arn
         storage_class = "STANDARD"
       }
     }
@@ -133,7 +136,7 @@ resource "aws_iam_policy" "replication" {
         "s3:ReplicateDelete"
       ],
       "Effect": "Allow",
-      "Resource": "${local.dev_bucket_arn}/*"
+      "Resource": "${data.aws_s3_bucket.replication_bucket.arn}/*"
     }
   ]
 }

--- a/shared/s3_replication.tf
+++ b/shared/s3_replication.tf
@@ -1,0 +1,123 @@
+resource "aws_s3_bucket" "pa_uploads_branch_replication" {
+  count         = local.account.name == "development" ? 1 : 0
+  bucket        = "pa-uploads-branch-replication"
+  acl           = "private"
+  force_destroy = true
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = 10
+    }
+
+    noncurrent_version_expiration {
+      days = 10
+    }
+  }
+
+  tags = local.default_tags
+}
+
+resource "aws_s3_bucket_public_access_block" "pa_uploads_branch_replication" {
+  count  = local.account.name == "development" ? 1 : 0
+  bucket = aws_s3_bucket.pa_uploads_branch_replication[0].bucket
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "pa_uploads_branch_replication" {
+  count  = local.account.name == "development" ? 1 : 0
+  bucket = aws_s3_bucket_public_access_block.pa_uploads_branch_replication[0].bucket
+  policy = data.aws_iam_policy_document.pa_uploads_branch_replication.json
+}
+
+data "aws_iam_policy_document" "pa_uploads_branch_replication" {
+  policy_id = "PutObjPolicy"
+
+  statement {
+    sid    = "DenyUnEncryptedObjectUploads"
+    effect = "Deny"
+
+    principals {
+      identifiers = ["*"]
+      type        = "AWS"
+    }
+
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.pa_uploads_branch_replication[0].arn}/*"]
+
+    condition {
+      test     = "StringNotEquals"
+      values   = ["AES256"]
+      variable = "s3:x-amz-server-side-encryption"
+    }
+  }
+}
+
+resource "aws_iam_role" "replication" {
+  count = local.account.name == "development" ? 1 : 0
+  name  = "replication-role.replication"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "s3.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_policy" "replication" {
+  count = local.account.name == "development" ? 1 : 0
+  name  = "replication-policy.replication"
+
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetReplicationConfiguration",
+        "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${aws_s3_bucket.pa_uploads_branch_replication[0].arn}"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetObjectVersion",
+        "s3:GetObjectVersionAcl"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${aws_s3_bucket.pa_uploads_branch_replication[0].arn}/*"
+      ]
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "replication" {
+  count      = local.account.name == "development" ? 1 : 0
+  role       = aws_iam_role.replication[0].name
+  policy_arn = aws_iam_policy.replication[0].arn
+}


### PR DESCRIPTION
## Purpose
Our existing structure of S3 bucket replication settings broke when we tried to apply it to the same bucket we are replicating to. To fix this we've moved the replication bucket to account level to be created in the development account only.

We will need to update the bucket reference in Sirius to point to this in order for testing the Document flow on branches to work.
