### PR TITLE
DDPB-3627 exclude missing sections from checklist pdf

### DIFF
--- a/client/src/AppBundle/Resources/views/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
+++ b/client/src/AppBundle/Resources/views/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
@@ -189,6 +189,7 @@
                     {% set nonLayAppend = '' %}
                 {% endif %}
 
+                {% if report.hasSection('balance') %}
                 <h3 class="label question bold">{{ (page ~ '.form.accountsBalance' ~ nonLayAppend ~ '.label') | trans({}, 'admin-checklist') }}</h3>
 
                 <table class="checkboxes labelvalue inline">
@@ -203,6 +204,7 @@
                         </tr>
                     </tbody>
                 </table>
+                {% endif %}
 
                 <h3 class="label question bold">{{ (page ~ '.form.moneyMovementsAcceptable.label') | trans({}, 'admin-checklist') }}</h3>
 


### PR DESCRIPTION
## Purpose
Checklist question l7.2 is an only applicable on certain report types and only shows up to check on the checklist where it exists on those reports. Whilst some users found this confusing, it's how it was designed to work. 

However to avoid confusion it shouldn't then appear on the PDF when it doesn't exist on the checklist. 

Checked all the checklist options with different report types and this was the only instance of this I could find. Full sections were already handled properly. As such the end fix for this is a very straight forward fix

Fixes DDPB-3627

## Approach
Only displays the balance on spreadsheet where that section exists in report

## Learning
Certainly learned a bit more about how checklists worked. Easy fix but interesting area for business logic

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
