### PR TITLE
Lock replication bucket ARN to development provider

### DIFF
--- a/environment/s3.tf
+++ b/environment/s3.tf
@@ -6,7 +6,8 @@ locals {
 }
 
 data "aws_s3_bucket" "replication_bucket" {
-  bucket = "pa-uploads-branch-replication"
+  bucket   = "pa-uploads-branch-replication"
+  provider = aws.development
 }
 
 resource "aws_s3_bucket" "pa_uploads" {


### PR DESCRIPTION
## Purpose
The pipeline was still broken following #449 as the ARN is only available in the development account. This change locks the data source for the bucket to using the development provider to ensure the ARN is always available but replication is disabled in non-branch environments.
