### PR TITLE
Add missing count to dev only resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,4 @@ _See [deployment documentation](docs/DEPLOYMENT.md)_
 
 The OPG Digideps Client is released under the MIT license, a copy of which can be found in [LICENSE](LICENSE).
 
-[repo-api]: https://github.com/ministryofjustice/opg-digi-deps-api
-[repo-infra]: https://github.com/ministryofjustice/digideps-infrastructure
-[repo-docker]: https://github.com/ministryofjustice/opg-digi-deps-docker
 [service]: https://complete-deputy-report.service.gov.uk/

--- a/shared/s3_replication.tf
+++ b/shared/s3_replication.tf
@@ -40,6 +40,7 @@ resource "aws_s3_bucket_policy" "pa_uploads_branch_replication" {
 }
 
 data "aws_iam_policy_document" "pa_uploads_branch_replication" {
+  count     = local.account.name == "development" ? 1 : 0
   policy_id = "PutObjPolicy"
 
   statement {


### PR DESCRIPTION
## Purpose
Missing this count meant non-development environments were trying to reference a non-existent resource.