### PR TITLE
DDPB-3632: Add accessibility page

### DIFF
--- a/client/app/config/security.yml
+++ b/client/app/config/security.yml
@@ -113,6 +113,7 @@ security:
         - { path: ^/terms, roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/privacy, roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/cookies, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/accessibility, roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/$ , roles: IS_AUTHENTICATED_ANONYMOUSLY }
         # all the rest needs authentication
         - { path: ^/ , roles: IS_AUTHENTICATED_FULLY }

--- a/client/src/AppBundle/Controller/IndexController.php
+++ b/client/src/AppBundle/Controller/IndexController.php
@@ -249,6 +249,16 @@ class IndexController extends AbstractController
     }
 
     /**
+     * @Route("/accessibility", name="accessibility")
+     */
+    public function accessibilityAction(Request $request)
+    {
+        return $this->render('AppBundle:Index:accessibility.html.twig', [
+            'backlink' => $this->getRefererUrlSafe($request, ['accessibility'])
+        ]);
+    }
+
+    /**
      * @Route("/logout", name="logout")
      */
     public function logoutAction(Request $request)
@@ -274,7 +284,7 @@ class IndexController extends AbstractController
         if ($request->cookies->has('cookie_policy')) {
             $policy = json_decode($request->cookies->get('cookie_policy'));
             $form->get('usage')->setData($policy->usage);
-        } else if ($request->query->get('accept') === 'all') {
+        } elseif ($request->query->get('accept') === 'all') {
             $form->get('usage')->setData(true);
         }
 

--- a/client/src/AppBundle/Resources/translations/accessibility.en.yml
+++ b/client/src/AppBundle/Resources/translations/accessibility.en.yml
@@ -9,7 +9,8 @@ intro:
         navigateKeyboard: navigate most of the website using just a keyboard
         navigateSpeech: navigate most of the website using speech recognition software
         screenReader: listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
-    para02: '<a href="https://mcmw.abilitynet.org.uk/" class="govuk-link">AbilityNet</a> has advice on making your device easier to use if you have a disability.'
+    para02: We’ve also made the service text as simple as possible to understand.
+    para03: '<a href="https://mcmw.abilitynet.org.uk/" class="govuk-link">AbilityNet</a> has advice on making your device easier to use if you have a disability.'
 
 cannotAccess:
     heading: What to do if you cannot access parts of this service
@@ -26,7 +27,7 @@ reportProblems:
 
 enforcementProcedure:
     heading: Enforcement procedure
-    para01: 'The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, contact the <a href="https://www.equalityadvisoryservice.com/" class="govuk-link">Equality Advisory and Support Service (EASS)</a>.'
+    para01: 'The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, <a href="https://www.equalityadvisoryservice.com/" class="govuk-link">contact the Equality Advisory and Support Service (EASS)</a>.'
 
 technicalInfo:
     heading: Technical information about this website’s accessibility
@@ -41,9 +42,12 @@ burden:
 
 outsideScope:
     heading: Content that’s not within the scope of the accessibility regulations
-    bullets:
-        pdfsDocs: PDFs and other documents
+    para01: The service lets you download a PDF of your completed report.
+    para02: The headers and footers on this PDF are not all the same on each page. This fails WCAG 2.0 AA success criteria 3.2.3 on consistent navigation.
+    para03: The default language of the PDF is not defined in the document catalog. This fails WCAG 2.0 PDF16.
 
 howTested:
     heading: How we tested this website
     para01: This service was last tested on 24th March 2020. The test was carried out by the Digital Accessibility Centre.
+
+lastUpdatedDate: 'Last updated: 22 September 2020'

--- a/client/src/AppBundle/Resources/translations/accessibility.en.yml
+++ b/client/src/AppBundle/Resources/translations/accessibility.en.yml
@@ -14,7 +14,7 @@ intro:
 
 cannotAccess:
     heading: What to do if you cannot access parts of this service
-    para01: 'If you cannot use this service, you can <a href="https://www.gov.uk/government/publications/deputy-annual-report-accounting-for-your-actions" class="govuk-link">complete your deputy report using a paper form</a>. If you need the form in a more accessible format, email <a href="mailto:digideps@digital.justice.gov.uk">digideps@digital.justice.gov.uk</a> and tell us what format you need.'
+    para01: 'If you cannot use this service, you can <a href="https://www.gov.uk/government/publications/deputy-annual-report-accounting-for-your-actions" class="govuk-link">complete your deputy report using a paper form</a>. If you need the form in a more accessible format, email <a href="mailto:customerservices@publicguardian.gov.uk">customerservices@publicguardian.gov.uk</a> and tell us what format you need.'
 
 reportProblems:
     heading: Reporting accessibility problems with this service

--- a/client/src/AppBundle/Resources/translations/accessibility.en.yml
+++ b/client/src/AppBundle/Resources/translations/accessibility.en.yml
@@ -1,0 +1,49 @@
+htmlTitle: Accessibility Statement | GOV.UK
+pageTitle: Accessibility statement for the Complete the deputy report service
+
+intro:
+    para01: 'This online service is run by the <a href="https://www.gov.uk/government/organisations/office-of-the-public-guardian" class="govuk-link">Office of the Public Guardian</a>. We want as many people as possible to be able to use this service. For example, that means you should be able to:'
+    bullets:
+        changeColours: change colours, contrast levels and fonts using accessibility software you have installed on your computer
+        zoom: zoom in up to 300% without the text spilling off the screen
+        navigateKeyboard: navigate most of the website using just a keyboard
+        navigateSpeech: navigate most of the website using speech recognition software
+        screenReader: listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+    para02: '<a href="https://mcmw.abilitynet.org.uk/" class="govuk-link">AbilityNet</a> has advice on making your device easier to use if you have a disability.'
+
+cannotAccess:
+    heading: What to do if you cannot access parts of this service
+    para01: 'If you cannot use this service, you can <a href="https://www.gov.uk/government/publications/deputy-annual-report-accounting-for-your-actions" class="govuk-link">complete your deputy report using a paper form</a>. If you need the form in a more accessible format, email <a href="mailto:digideps@digital.justice.gov.uk">digideps@digital.justice.gov.uk</a> and tell us what format you need.'
+
+reportProblems:
+    heading: Reporting accessibility problems with this service
+    para01: 'We’re always looking to improve the accessibility of this service. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, please contact us:'
+    bullets:
+        email: 'Email: <a href="mailto:digideps@digital.justice.gov.uk">digideps@digital.justice.gov.uk</a>'
+        phone: 'Telephone: 0300 456 0300'
+        textPhone: 'Textphone: 0115 934 2778'
+    para02: We’re available Monday, Tuesday, Thursday, Friday 9:30am to 5pm. Wednesday 10am to 5pm
+
+enforcementProcedure:
+    heading: Enforcement procedure
+    para01: 'The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, contact the <a href="https://www.equalityadvisoryservice.com/" class="govuk-link">Equality Advisory and Support Service (EASS)</a>.'
+
+technicalInfo:
+    heading: Technical information about this website’s accessibility
+    para01: The Office of the Public Guardian is committed to making its online services accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+    para02: 'This website fully conforms to the <a href="https://www.w3.org/TR/WCAG21/" class="govuk-link">Web Content Accessibility Guidelines version 2.1</a> AA standard.'
+    para03: The content listed below is non-accessible for the following reasons.
+
+burden:
+    heading: Disproportionate burden
+    para01: If you upload scans or photographs of documents to your deputy report, there will not be a text alternative to this ‘non-text content’ (WCAG 2.1 AA guideline 1.1.1).
+    para02: We cannot change any photographs, PDFs of other files you upload to make them more accessible.
+
+outsideScope:
+    heading: Content that’s not within the scope of the accessibility regulations
+    bullets:
+        pdfsDocs: PDFs and other documents
+
+howTested:
+    heading: How we tested this website
+    para01: This service was last tested on 24th March 2020. The test was carried out by the Digital Accessibility Centre.

--- a/client/src/AppBundle/Resources/views/Index/accessibility.html.twig
+++ b/client/src/AppBundle/Resources/views/Index/accessibility.html.twig
@@ -24,6 +24,7 @@
     </ul>
 
     <p class="govuk-body">{{ 'intro.para02' | trans | raw  }}</p>
+    <p class="govuk-body">{{ 'intro.para03' | trans | raw  }}</p>
 
     <h2 class="govuk-heading-l">{{ 'cannotAccess.heading' | trans }}</h2>
     <p class="govuk-body">{{ 'cannotAccess.para01' | trans | raw  }}</p>
@@ -55,11 +56,14 @@
     <p class="govuk-body">{{ 'burden.para02' | trans }}</p>
 
     <h2 class="govuk-heading-l">{{ 'outsideScope.heading' | trans }}</h2>
-    <ul class="govuk-list govuk-list--bullet">
-        <li>{{ 'outsideScope.bullets.pdfsDocs' | trans }}</li>
-    </ul>
+    <p class="govuk-body">{{ 'outsideScope.para01' | trans }}</p>
+    <p class="govuk-body">{{ 'outsideScope.para02' | trans }}</p>
+    <p class="govuk-body">{{ 'outsideScope.para03' | trans }}</p>
 
     <h2 class="govuk-heading-l">{{ 'howTested.heading' | trans }}</h2>
     <p class="govuk-body">{{ 'howTested.para01' | trans }}</p>
 
+    {{ '\n'|nl2br }}
+
+    <p class="govuk-body">{{ 'lastUpdatedDate' | trans }}</p>
 {% endblock %}

--- a/client/src/AppBundle/Resources/views/Index/accessibility.html.twig
+++ b/client/src/AppBundle/Resources/views/Index/accessibility.html.twig
@@ -1,0 +1,65 @@
+{% extends 'AppBundle:Layouts:application.html.twig' %}
+
+{% set translationDomain = "accessibility" %}
+{% trans_default_domain translationDomain %}
+
+{% block htmlTitle %}{{ 'htmlTitle' | trans }}{% endblock %}
+{% block pageTitle %}{{ 'pageTitle' | trans }}{% endblock %}
+
+{% block linkBack %}
+    {% if backlink %}
+        <a href="{{ backlink }}" class="link-back behat-link-step-back">{{ 'back' | trans({}, 'common' ) }}</a>
+    {% endif %}
+{% endblock %}
+
+{% block pageContent %}
+    <p class="govuk-body">{{ 'intro.para01' | trans | raw }}</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'intro.bullets.changeColours' | trans }}</p></li>
+        <li>{{ 'intro.bullets.zoom' | trans }}</p> </li>
+        <li>{{ 'intro.bullets.navigateKeyboard' | trans }}</p> </li>
+        <li>{{ 'intro.bullets.navigateSpeech' | trans }}</p></li>
+        <li>{{ 'intro.bullets.screenReader' | trans }}</p></li>
+    </ul>
+
+    <p class="govuk-body">{{ 'intro.para02' | trans | raw  }}</p>
+
+    <h2 class="govuk-heading-l">{{ 'cannotAccess.heading' | trans }}</h2>
+    <p class="govuk-body">{{ 'cannotAccess.para01' | trans | raw  }}</p>
+
+    <h2 class="govuk-heading-l">{{ 'reportProblems.heading' | trans }}</h2>
+    <p class="govuk-body">{{ 'reportProblems.para01' | trans }}</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'reportProblems.bullets.email' | trans | raw }}</li>
+        <li>{{ 'reportProblems.bullets.phone' | trans }}</li>
+        <li>{{ 'reportProblems.bullets.textPhone' | trans }}</li>
+    </ul>
+
+    <p class="govuk-body">{{ 'reportProblems.para02' | trans }}</p>
+
+    <h2 class="govuk-heading-l">{{ 'enforcementProcedure.heading' | trans }}</h2>
+    <p class="govuk-body">{{ 'enforcementProcedure.para01' | trans | raw }}</p>
+
+    <h2 class="govuk-heading-l">{{ 'technicalInfo.heading' | trans }}</h2>
+    <p class="govuk-body">{{ 'technicalInfo.para01' | trans }}</p>
+
+    <p class="govuk-body">{{ 'technicalInfo.para02' | trans | raw }}</p>
+
+    <p class="govuk-body">{{ 'technicalInfo.para03' | trans }}</p>
+
+    <h2 class="govuk-heading-l">{{ 'burden.heading' | trans }}</h2>
+    <p class="govuk-body">{{ 'burden.para01' | trans }}</p>
+
+    <p class="govuk-body">{{ 'burden.para02' | trans }}</p>
+
+    <h2 class="govuk-heading-l">{{ 'outsideScope.heading' | trans }}</h2>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'outsideScope.bullets.pdfsDocs' | trans }}</li>
+    </ul>
+
+    <h2 class="govuk-heading-l">{{ 'howTested.heading' | trans }}</h2>
+    <p class="govuk-body">{{ 'howTested.para01' | trans }}</p>
+
+{% endblock %}

--- a/client/src/AppBundle/Resources/views/Layouts/application.html.twig
+++ b/client/src/AppBundle/Resources/views/Layouts/application.html.twig
@@ -127,12 +127,6 @@
 
 {% block footerSupportLinks %}
     <li class="govuk-footer__inline-list-item">
-        <a href="{{path('accessibility')}}" class="govuk-footer__link">
-            Accessibility
-        </a>
-    </li>
-
-    <li class="govuk-footer__inline-list-item">
         <a href="{{path('terms')}}" class="govuk-footer__link">
             Terms of use
         </a>
@@ -145,6 +139,11 @@
     <li class="govuk-footer__inline-list-item">
         <a href="{{ path('cookies') }}" class="govuk-footer__link">
             Cookies
+        </a>
+    </li>
+    <li class="govuk-footer__inline-list-item">
+        <a href="{{path('accessibility')}}" class="govuk-footer__link">
+            Accessibility
         </a>
     </li>
 {% endblock %}

--- a/client/src/AppBundle/Resources/views/Layouts/application.html.twig
+++ b/client/src/AppBundle/Resources/views/Layouts/application.html.twig
@@ -127,6 +127,12 @@
 
 {% block footerSupportLinks %}
     <li class="govuk-footer__inline-list-item">
+        <a href="{{path('accessibility')}}" class="govuk-footer__link">
+            Accessibility
+        </a>
+    </li>
+
+    <li class="govuk-footer__inline-list-item">
         <a href="{{path('terms')}}" class="govuk-footer__link">
             Terms of use
         </a>


### PR DESCRIPTION
## Purpose
Composed the google doc with our accessibility statement into a twig template using translations.

I wasn't around for the majority of the accessibility tickets so would appreciate some feedback on if external links etc are handled properly.

Fixes DDPB-3632

## Learning
Small thing but you need to apply a `raw` filter when using translations that contain html.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [x] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [x] There are no deprecated CSS classes noted in the profiler
- [x] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
