### PR TITLE
DDPB-3659 fix to s3 read integration role

### DIFF
--- a/shared/document_sync.tf
+++ b/shared/document_sync.tf
@@ -1,6 +1,6 @@
 locals {
   sirius_root       = "arn:aws:iam::${local.account.sirius_account_id}:root"
-  sirius_env_lambda = "arn:aws:iam::${local.account.sirius_account_id}:role/sirius-reports-${local.account.name}-v1"
+  sirius_env_lambda = "arn:aws:iam::${local.account.sirius_account_id}:role/deputy-reporting-${local.account.name}-v2"
 }
 
 resource "aws_iam_role" "integrations_s3_read" {
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "integrations_s3_read" {
   statement {
     sid       = "AllowIntegrationsLambdaS3"
     effect    = "Allow"
-    resources = local.account.name == "development" ? ["arn:aws:s3:::pa-uploads-*"] : ["arn:aws:s3:::pa-uploads-${local.account.name}}"]
+    resources = local.account.name == "development" ? ["arn:aws:s3:::pa-uploads-*"] : ["arn:aws:s3:::pa-uploads-${local.account.name}", "arn:aws:s3:::pa-uploads-${local.account.name}/*"]
     actions   = ["s3:GetObject"]
   }
 }


### PR DESCRIPTION
## Purpose
The naming was wrong on s3 read integration role. Make it so that it works properly in prod and preprod.

Fixes DDPB-3659

## Approach
Make it work
## Learning

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
