### PR TITLE
DDPB-3644 scale down existing infra to manage costs

### DIFF
--- a/api/docker/confd/templates/pool.conf.tmpl
+++ b/api/docker/confd/templates/pool.conf.tmpl
@@ -530,7 +530,7 @@ access.log = /dev/null
 
 php_flag[display_errors] = off
 
-php_admin_value[memory_limit] = 256M
+php_admin_value[memory_limit] = 512M
 
 php_admin_value[post_max_size] = 64M
 php_admin_value[upload_max_filesize] = 64M

--- a/client/docker/confd/templates/pool.conf.tmpl
+++ b/client/docker/confd/templates/pool.conf.tmpl
@@ -533,7 +533,7 @@ php_value[max_file_uploads] = 100
 
 php_flag[display_errors] = off
 
-php_admin_value[memory_limit] = 256M
+php_admin_value[memory_limit] = 512M
 
 php_admin_value[post_max_size] = 64M
 php_admin_value[upload_max_filesize] = 64M

--- a/environment/api_rds.tf
+++ b/environment/api_rds.tf
@@ -28,7 +28,7 @@ resource "aws_db_instance" "api" {
   instance_class             = "db.m3.medium"
   allocated_storage          = "10"
   availability_zone          = "eu-west-1a"
-  backup_retention_period    = "14"
+  backup_retention_period    = local.account.backup_retention_period
   backup_window              = "00:00-00:30"
   db_subnet_group_name       = local.account.db_subnet_group
   engine                     = "postgres"
@@ -78,7 +78,7 @@ resource "aws_rds_cluster" "api" {
   master_username              = "digidepsmaster"
   master_password              = data.aws_secretsmanager_secret_version.database_password.secret_string
   skip_final_snapshot          = true
-  backup_retention_period      = 14
+  backup_retention_period      = local.account.backup_retention_period
   preferred_backup_window      = "07:00-09:00"
   db_subnet_group_name         = local.account.db_subnet_group
   kms_key_id                   = data.aws_kms_key.rds.arn

--- a/environment/front_service.tf
+++ b/environment/front_service.tf
@@ -2,8 +2,8 @@ resource "aws_ecs_task_definition" "front" {
   family                   = "front-${local.environment}"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 512
-  memory                   = 1024
+  cpu                      = local.account.cpu_low
+  memory                   = local.account.memory_low
   container_definitions    = "[${local.front_container}]"
   task_role_arn            = aws_iam_role.front.arn
   execution_role_arn       = aws_iam_role.execution_role.arn

--- a/environment/mock_sirius_integration_service.tf
+++ b/environment/mock_sirius_integration_service.tf
@@ -25,8 +25,8 @@ resource "aws_ecs_task_definition" "mock_sirius_integration" {
   family                   = "mock-sirius-integration-${local.environment}"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 512
-  memory                   = 1024
+  cpu                      = local.account.cpu_low
+  memory                   = local.account.memory_low
   container_definitions    = "[${local.mock_sirius_integration_container}]"
   task_role_arn            = aws_iam_role.front.arn
   execution_role_arn       = aws_iam_role.execution_role.arn

--- a/environment/scan.tf
+++ b/environment/scan.tf
@@ -32,7 +32,7 @@ resource "aws_ecs_task_definition" "scan" {
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = 1024
-  memory                   = 2048
+  memory                   = local.account.memory_high
   container_definitions    = "[${local.file_scanner_rest_container},${local.file_scanner_server_container}]"
   task_role_arn            = aws_iam_role.scan.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
@@ -43,7 +43,7 @@ resource "aws_ecs_service" "scan" {
   name                    = aws_ecs_task_definition.scan.family
   cluster                 = aws_ecs_cluster.main.id
   task_definition         = aws_ecs_task_definition.scan.arn
-  desired_count           = 2
+  desired_count           = local.account.scan_count
   launch_type             = "FARGATE"
   platform_version        = "1.4.0"
   enable_ecs_managed_tags = true

--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -13,6 +13,7 @@
       "is_production": 1,
       "secrets_prefix": "production02",
       "task_count": 3,
+      "scan_count": 2,
       "symfony_env": "prod",
       "db_subnet_group": "rds-private-subnets-prod-vpc",
       "ec_subnet_group": "ec-pvt-subnets-prod-vpc",
@@ -20,7 +21,14 @@
       "state_source": "production",
       "elasticache_count": 2,
       "always_on": true,
-      "copy_version_from": "preproduction"
+      "copy_version_from": "preproduction",
+      "cpu_low": "512",
+      "cpu_medium": "1024",
+      "cpu_high": "2048",
+      "memory_low": "1024",
+      "memory_medium": "2048",
+      "memory_high": "4096",
+      "backup_retention_period": 14
     },
     "preproduction": {
       "account_id": "454262938596",
@@ -32,7 +40,8 @@
       "subdomain_enabled": true,
       "is_production": 0,
       "secrets_prefix": "",
-      "task_count": 3,
+      "task_count": 2,
+      "scan_count": 1,
       "symfony_env": "prod",
       "db_subnet_group": "private",
       "ec_subnet_group": "private",
@@ -40,7 +49,14 @@
       "state_source": "preproduction",
       "elasticache_count": 2,
       "always_on": true,
-      "copy_version_from": "integration"
+      "copy_version_from": "integration",
+      "cpu_low": "512",
+      "cpu_medium": "1024",
+      "cpu_high": "2048",
+      "memory_low": "1024",
+      "memory_medium": "2048",
+      "memory_high": "4096",
+      "backup_retention_period": 1
     },
     "training": {
       "account_id": "515688267891",
@@ -53,6 +69,7 @@
       "is_production": 0,
       "secrets_prefix": "training",
       "task_count": 1,
+      "scan_count": 1,
       "symfony_env": "prod",
       "db_subnet_group": "rds-private-subnets-prod-vpc",
       "ec_subnet_group": "ec-pvt-subnets-prod-vpc",
@@ -60,7 +77,14 @@
       "state_source": "production",
       "elasticache_count": 1,
       "always_on": true,
-      "copy_version_from": "preproduction"
+      "copy_version_from": "preproduction",
+      "cpu_low": "512",
+      "cpu_medium": "1024",
+      "cpu_high": "2048",
+      "memory_low": "1024",
+      "memory_medium": "2048",
+      "memory_high": "4096",
+      "backup_retention_period": 1
     },
     "integration": {
       "account_id": "454262938596",
@@ -72,7 +96,8 @@
       "subdomain_enabled": true,
       "is_production": 0,
       "secrets_prefix": "",
-      "task_count": 3,
+      "task_count": 2,
+      "scan_count": 1,
       "symfony_env": "test",
       "db_subnet_group": "private",
       "ec_subnet_group": "private",
@@ -80,7 +105,14 @@
       "state_source": "preproduction",
       "elasticache_count": 1,
       "always_on": true,
-      "copy_version_from": "NonApplicable"
+      "copy_version_from": "NonApplicable",
+      "cpu_low": "256",
+      "cpu_medium": "512",
+      "cpu_high": "1024",
+      "memory_low": "512",
+      "memory_medium": "1024",
+      "memory_high": "2048",
+      "backup_retention_period": 1
     },
     "development": {
       "account_id": "248804316466",
@@ -96,6 +128,7 @@
       "is_production": 0,
       "secrets_prefix": "default",
       "task_count": 1,
+      "scan_count": 1,
       "symfony_env": "test",
       "db_subnet_group": "private",
       "ec_subnet_group": "private",
@@ -103,7 +136,14 @@
       "state_source": "development",
       "elasticache_count": 1,
       "always_on": false,
-      "copy_version_from": "NonApplicable"
+      "copy_version_from": "NonApplicable",
+      "cpu_low": "256",
+      "cpu_medium": "512",
+      "cpu_high": "1024",
+      "memory_low": "512",
+      "memory_medium": "1024",
+      "memory_high": "2048",
+      "backup_retention_period": 1
     },
     "default": {
       "account_id": "248804316466",
@@ -117,6 +157,7 @@
       "is_production": 0,
       "secrets_prefix": "default",
       "task_count": 1,
+      "scan_count": 1,
       "symfony_env": "test",
       "db_subnet_group": "private",
       "ec_subnet_group": "private",
@@ -124,7 +165,14 @@
       "state_source": "development",
       "elasticache_count": 1,
       "always_on": false,
-      "copy_version_from": "NonApplicable"
+      "copy_version_from": "NonApplicable",
+      "cpu_low": "256",
+      "cpu_medium": "512",
+      "cpu_high": "1024",
+      "memory_low": "512",
+      "memory_medium": "1024",
+      "memory_high": "2048",
+      "backup_retention_period": 1
     }
   }
 }

--- a/environment/variables.tf
+++ b/environment/variables.tf
@@ -9,24 +9,32 @@ variable "OPG_DOCKER_TAG" {
 variable "accounts" {
   type = map(
     object({
-      account_id           = string
-      admin_allow_list     = list(string)
-      force_destroy_bucket = bool
-      front_allow_list     = list(string)
-      ga_default           = string
-      ga_gds               = string
-      subdomain_enabled    = bool
-      is_production        = number
-      secrets_prefix       = string
-      task_count           = number
-      symfony_env          = string
-      db_subnet_group      = string
-      ec_subnet_group      = string
-      sirius_api_account   = string
-      state_source         = string
-      elasticache_count    = number
-      always_on            = bool
-      copy_version_from    = string
+      account_id              = string
+      admin_allow_list        = list(string)
+      force_destroy_bucket    = bool
+      front_allow_list        = list(string)
+      ga_default              = string
+      ga_gds                  = string
+      subdomain_enabled       = bool
+      is_production           = number
+      secrets_prefix          = string
+      task_count              = number
+      scan_count              = number
+      symfony_env             = string
+      db_subnet_group         = string
+      ec_subnet_group         = string
+      sirius_api_account      = string
+      state_source            = string
+      elasticache_count       = number
+      always_on               = bool
+      copy_version_from       = string
+      cpu_low                 = number
+      cpu_medium              = number
+      cpu_high                = number
+      memory_low              = number
+      memory_medium           = number
+      memory_high             = number
+      backup_retention_period = number
     })
   )
 }

--- a/environment/wkhtmltopdf.tf
+++ b/environment/wkhtmltopdf.tf
@@ -31,8 +31,8 @@ resource "aws_ecs_task_definition" "wkhtmltopdf" {
   family                   = "wkhtmltopdf-${local.environment}"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 512
-  memory                   = 1024
+  cpu                      = local.account.cpu_low
+  memory                   = local.account.memory_low
   container_definitions    = "[${local.wkhtmltopdf_container}]"
   task_role_arn            = aws_iam_role.wkhtmltopdf.arn
   execution_role_arn       = aws_iam_role.execution_role.arn


### PR DESCRIPTION
## Purpose
Scale down infra as we have way too much unused CPU and RAM. In fact previously RAM was set to 256 max for PHP so I have upped that to be inline with the container size.

Integration tests should use the app far more than we would use it for UAT and they all pass with normal times. 

I haven't scaled down prod as I don't deem it to be worth it. In fact for the scan containers I've given them extra RAM again as they seemed happier with the extra memory.

Fixes DDPB-3644

## Approach
Make changes in terraform and to the PHP ini file.

## Learning

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
