### PR TITLE
DDPB-3664 - Terraform 0.13 Upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,8 +304,8 @@ orbs:
           - image: circleci/golang:1.12
         resource_class: small
         environment:
-          TF_VERSION: 0.12.26
-          TF_SHA256SUM: 607bc802b1c6c2a5e62cc48640f38aaa64bef1501b46f0ae4829feb51594b257
+          TF_VERSION: 0.13.3
+          TF_SHA256SUM: 35c662be9d32d38815cde5fa4c9fa61a3b7f39952ecd50ebf92fd1b2ddd6109b
           TF_CLI_ARGS_plan: -input=false -lock=false
           TF_CLI_ARGS_apply: -input=false -auto-approve
           TF_CLI_ARGS_destroy: -input=false -auto-approve

--- a/environment/provider.tf
+++ b/environment/provider.tf
@@ -16,7 +16,6 @@ provider "aws" {
     role_arn     = "arn:aws:iam::${local.account["account_id"]}:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
-  version = "2.70.0"
 }
 
 provider "aws" {
@@ -27,7 +26,6 @@ provider "aws" {
     role_arn     = "arn:aws:iam::311462405659:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
-  version = "2.70.0"
 }
 
 # DD has it's public DNS in production, not management
@@ -39,7 +37,6 @@ provider "aws" {
     role_arn     = "arn:aws:iam::515688267891:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
-  version = "2.70.0"
 }
 
 provider "aws" {
@@ -70,7 +67,6 @@ provider "aws" {
     role_arn     = "arn:aws:iam::515688267891:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
-  version = "2.70.0"
 }
 
 provider "aws" {
@@ -81,5 +77,4 @@ provider "aws" {
     role_arn     = "arn:aws:iam::${local.account["account_id"]}:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
-
 }

--- a/environment/versions.tf
+++ b/environment/versions.tf
@@ -1,4 +1,16 @@
-
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    archive = {
+      source = "hashicorp/archive"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "2.70.0"
+
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+  }
 }

--- a/shared/provider.tf
+++ b/shared/provider.tf
@@ -16,7 +16,6 @@ provider "aws" {
     role_arn     = "arn:aws:iam::${var.accounts[terraform.workspace].account_id}:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
-  version = "2.70.0"
 }
 
 provider "aws" {
@@ -27,7 +26,6 @@ provider "aws" {
     role_arn     = "arn:aws:iam::311462405659:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
-  version = "2.70.0"
 }
 
 provider "aws" {
@@ -38,5 +36,4 @@ provider "aws" {
     role_arn     = "arn:aws:iam::${local.account["account_id"]}:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
-  version = "2.70.0"
 }

--- a/shared/versions.tf
+++ b/shared/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    archive = {
+      source = "hashicorp/archive"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "2.70.0"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
## Purpose
Upgrades Terraform to 0.13, change fixes some annoying bugs and adds the ability to use count on modules

Fixes DDPB-3664

## Approach
Used HashiCorp provided upgrade tool
Performed manual state moves in each terraform workspace for providers

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
