### PR TITLE
DDPB-3568 - Add missing security headers

### DIFF
--- a/client/docker/confd/templates/app.conf.tmpl
+++ b/client/docker/confd/templates/app.conf.tmpl
@@ -9,6 +9,10 @@ server {
 
     ## Headers
     add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
+    add_header Referrer-Policy           "same-origin"                                                                                 always;
+    add_header Content-Security-Policy   "default-src https:; script-src https: 'unsafe-inline'; style-src https: 'unsafe-inline';"    always;
+    add_header X-Content-Type-Options    "nosniff"                                                                                     always;
+    add_header Permissions-Policy        "geolocation none;"                                                                           always;
 
     # This is handled by PHP
     client_max_body_size 0;


### PR DESCRIPTION
## Purpose
Add missing security headers to requests

Fixes DDPB-3568

## Approach
Updated nginx config to add missing headers

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
