### PR TITLE
DDPB-3228 - Upgrade postgres to 10.7

### DIFF
--- a/environment/api_rds.tf
+++ b/environment/api_rds.tf
@@ -2,25 +2,6 @@ data "aws_kms_key" "rds" {
   key_id = "alias/aws/rds"
 }
 
-data "terraform_remote_state" "previous_workspace" {
-  count     = local.account.copy_version_from == "NonApplicable" ? 0 : 1
-  backend   = "s3"
-  workspace = local.account.copy_version_from
-  config = {
-    bucket         = "opg.terraform.state"
-    key            = "opg-digi-deps-infrastructure/terraform.tfstate"
-    encrypt        = true
-    region         = "eu-west-1"
-    role_arn       = "arn:aws:iam::311462405659:role/${var.DEFAULT_ROLE}"
-    dynamodb_table = "remote_lock"
-  }
-}
-
-locals {
-  engine_version = local.account.copy_version_from == "NonApplicable" ? "9.6" : data.terraform_remote_state.previous_workspace[0].outputs["db_engine_version"]
-}
-
-
 resource "aws_db_instance" "api" {
   count                      = local.account.always_on ? 1 : 0
   name                       = "api"
@@ -32,7 +13,7 @@ resource "aws_db_instance" "api" {
   backup_window              = "00:00-00:30"
   db_subnet_group_name       = local.account.db_subnet_group
   engine                     = "postgres"
-  engine_version             = local.engine_version
+  engine_version             = local.account.psql_engine_version
   kms_key_id                 = data.aws_kms_key.rds.arn
   license_model              = "postgresql-license"
   maintenance_window         = "sun:01:00-sun:02:30"
@@ -47,11 +28,9 @@ resource "aws_db_instance" "api" {
   password                   = data.aws_secretsmanager_secret_version.database_password.secret_string
   deletion_protection        = true
   delete_automated_backups   = false
-  auto_minor_version_upgrade = local.account.copy_version_from == "NonApplicable" ? true : false
+  auto_minor_version_upgrade = false
   final_snapshot_identifier  = "api-${local.environment}-final"
-
-
-  vpc_security_group_ids = [module.api_rds_security_group.id]
+  vpc_security_group_ids     = [module.api_rds_security_group.id]
 
   tags = merge(
     local.default_tags,
@@ -64,7 +43,6 @@ resource "aws_db_instance" "api" {
     ignore_changes  = [password]
     prevent_destroy = true
   }
-
 }
 
 resource "aws_rds_cluster" "api" {
@@ -72,7 +50,7 @@ resource "aws_rds_cluster" "api" {
   cluster_identifier           = "api-${local.environment}"
   engine                       = "aurora-postgresql"
   engine_mode                  = local.account.always_on ? "provisioned" : "serverless"
-  engine_version               = "10.7"
+  engine_version               = local.account.psql_engine_version
   availability_zones           = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   database_name                = "api"
   master_username              = "digidepsmaster"

--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -21,14 +21,14 @@
       "state_source": "production",
       "elasticache_count": 2,
       "always_on": true,
-      "copy_version_from": "preproduction",
       "cpu_low": "512",
       "cpu_medium": "1024",
       "cpu_high": "2048",
       "memory_low": "1024",
       "memory_medium": "2048",
       "memory_high": "4096",
-      "backup_retention_period": 14
+      "backup_retention_period": 14,
+      "psql_engine_version": "9.6.16"
     },
     "preproduction": {
       "account_id": "454262938596",
@@ -49,14 +49,14 @@
       "state_source": "preproduction",
       "elasticache_count": 2,
       "always_on": true,
-      "copy_version_from": "integration",
       "cpu_low": "512",
       "cpu_medium": "1024",
       "cpu_high": "2048",
       "memory_low": "1024",
       "memory_medium": "2048",
       "memory_high": "4096",
-      "backup_retention_period": 1
+      "backup_retention_period": 1,
+      "psql_engine_version": "10.7"
     },
     "training": {
       "account_id": "515688267891",
@@ -77,14 +77,14 @@
       "state_source": "production",
       "elasticache_count": 1,
       "always_on": true,
-      "copy_version_from": "preproduction",
       "cpu_low": "512",
       "cpu_medium": "1024",
       "cpu_high": "2048",
       "memory_low": "1024",
       "memory_medium": "2048",
       "memory_high": "4096",
-      "backup_retention_period": 1
+      "backup_retention_period": 1,
+      "psql_engine_version": "10.7"
     },
     "integration": {
       "account_id": "454262938596",
@@ -105,14 +105,14 @@
       "state_source": "preproduction",
       "elasticache_count": 1,
       "always_on": true,
-      "copy_version_from": "NonApplicable",
       "cpu_low": "256",
       "cpu_medium": "512",
       "cpu_high": "1024",
       "memory_low": "512",
       "memory_medium": "1024",
       "memory_high": "2048",
-      "backup_retention_period": 1
+      "backup_retention_period": 1,
+      "psql_engine_version": "10.7"
     },
     "development": {
       "account_id": "248804316466",
@@ -136,14 +136,14 @@
       "state_source": "development",
       "elasticache_count": 1,
       "always_on": false,
-      "copy_version_from": "NonApplicable",
       "cpu_low": "256",
       "cpu_medium": "512",
       "cpu_high": "1024",
       "memory_low": "512",
       "memory_medium": "1024",
       "memory_high": "2048",
-      "backup_retention_period": 1
+      "backup_retention_period": 1,
+      "psql_engine_version": "10.7"
     },
     "default": {
       "account_id": "248804316466",
@@ -165,14 +165,14 @@
       "state_source": "development",
       "elasticache_count": 1,
       "always_on": false,
-      "copy_version_from": "NonApplicable",
       "cpu_low": "256",
       "cpu_medium": "512",
       "cpu_high": "1024",
       "memory_low": "512",
       "memory_medium": "1024",
       "memory_high": "2048",
-      "backup_retention_period": 1
+      "backup_retention_period": 1,
+      "psql_engine_version": "10.7"
     }
   }
 }

--- a/environment/variables.tf
+++ b/environment/variables.tf
@@ -27,7 +27,6 @@ variable "accounts" {
       state_source            = string
       elasticache_count       = number
       always_on               = bool
-      copy_version_from       = string
       cpu_low                 = number
       cpu_medium              = number
       cpu_high                = number
@@ -35,6 +34,7 @@ variable "accounts" {
       memory_medium           = number
       memory_high             = number
       backup_retention_period = number
+      psql_engine_version     = string
     })
   )
 }


### PR DESCRIPTION
## Purpose
Upgrades postgresql from `9.6.16` to `10.7` to unblock the move to RDS Aurora

Fixes DDPB-3228

## Approach

- Update all env to 10.7 immediately (apart from production)
- Make sure things are working, Ie tests etc
- second PR (probably next week) to update production version

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [x] The product team have approved these changes
