### PR TITLE
Monitoring & Alerting

### DIFF
--- a/api/docker/confd/conf.d/nginx.conf.toml
+++ b/api/docker/confd/conf.d/nginx.conf.toml
@@ -1,3 +1,4 @@
 [template]
 src  = "nginx.conf.tmpl"
 dest = "/etc/nginx/nginx.conf"
+keys = ["/nginx/app/name"]

--- a/api/docker/confd/templates/nginx.conf.tmpl
+++ b/api/docker/confd/templates/nginx.conf.tmpl
@@ -27,7 +27,33 @@ http {
     #keepalive_timeout  0;
     keepalive_timeout  65;
 
-    access_log  /var/log/nginx/access.log;
+    log_format main escape=json '{'
+                             '"timestamp_msec": "$msec", '
+                             '"remote_addr": "$remote_addr", '
+                             '"real_ip": "$http_x_real_ip", '
+                             '"real_forwarded_for": "$http_x_forwarded_for", '
+                             '"real_forwarded_proto": "$http_x_forwarded_proto", '
+                             '"request_id": "$http_x_request_id", '
+                             '"remote_user": "$remote_user", '
+                             '"request_time": $request_time, '
+                             '"request_uri": "$request_uri", '
+                             '"status": $status, '
+                             '"request": "$request", '
+                             '"request_method": "$request_method", '
+                             '"http_referrer": "$http_referer", '
+                             '"http_user_agent": "$http_user_agent", '
+                             '"bytes_sent": $bytes_sent, '
+                             '"http_host": "$host", '
+                             '"sent_http_location": "$sent_http_location", '
+                             '"service_name": "{{ getv "/nginx/app/name" "api" }}", '
+                             '"server_port": "$server_port", '
+                             '"upstream_addr": "$upstream_addr", '
+                             '"upstream_response_length": "$upstream_response_length", '
+                             '"upstream_response_time": "$upstream_response_time", '
+                             '"upstream_status": "$upstream_status" '
+                             '}';
+
+    access_log  /var/log/nginx/access.log  main;
 
     ## Compression
     gzip on;

--- a/api/docker/env/api.env
+++ b/api/docker/env/api.env
@@ -16,6 +16,7 @@ SECRETS_ADMIN_KEY=api-admin-key
 
 OPG_DOCKER_TAG=latest
 OPG_NGINX_INDEX=app_dev.php
+NGINX_APP_NAME=api
 
 # sets xdebug values in PHP ini config when OPG_PHP_XDEBUG_ENABLED is set
 OPG_PHP_XDEBUG_ENABLED=true

--- a/client/docker/confd/conf.d/nginx.conf.toml
+++ b/client/docker/confd/conf.d/nginx.conf.toml
@@ -1,3 +1,4 @@
 [template]
 src  = "nginx.conf.tmpl"
 dest = "/etc/nginx/nginx.conf"
+keys = ["/nginx/app/name"]

--- a/client/docker/confd/templates/nginx.conf.tmpl
+++ b/client/docker/confd/templates/nginx.conf.tmpl
@@ -27,7 +27,33 @@ http {
     #keepalive_timeout  0;
     keepalive_timeout  65;
 
-    access_log  /var/log/nginx/access.log;
+    log_format main escape=json '{'
+                             '"timestamp_msec": "$msec", '
+                             '"remote_addr": "$remote_addr", '
+                             '"real_ip": "$http_x_real_ip", '
+                             '"real_forwarded_for": "$http_x_forwarded_for", '
+                             '"real_forwarded_proto": "$http_x_forwarded_proto", '
+                             '"request_id": "$http_x_request_id", '
+                             '"remote_user": "$remote_user", '
+                             '"request_time": $request_time, '
+                             '"request_uri": "$request_uri", '
+                             '"status": $status, '
+                             '"request": "$request", '
+                             '"request_method": "$request_method", '
+                             '"http_referrer": "$http_referer", '
+                             '"http_user_agent": "$http_user_agent", '
+                             '"bytes_sent": $bytes_sent, '
+                             '"http_host": "$host", '
+                             '"sent_http_location": "$sent_http_location", '
+                             '"service_name": "{{ getv "/nginx/app/name" "client" }}", '
+                             '"server_port": "$server_port", '
+                             '"upstream_addr": "$upstream_addr", '
+                             '"upstream_response_length": "$upstream_response_length", '
+                             '"upstream_response_time": "$upstream_response_time", '
+                             '"upstream_status": "$upstream_status" '
+                             '}';
+
+    access_log  /var/log/nginx/access.log  main;
 
     ## Compression
     gzip on;

--- a/client/docker/env/admin.env
+++ b/client/docker/env/admin.env
@@ -3,6 +3,7 @@
 API_CLIENT_SECRET=api-admin-key
 ROLE=admin
 SESSION_REDIS_DSN=redis://redisadmin
+NGINX_APP_NAME=admin
 
 # sets xdebug values in PHP ini config when OPG_PHP_XDEBUG_ENABLED is set
 OPG_PHP_XDEBUG_ENABLED=true

--- a/client/docker/env/frontend.env
+++ b/client/docker/env/frontend.env
@@ -28,6 +28,7 @@ FILESCANNER_SSLVERIFY=false
 
 OPG_DOCKER_TAG=latest
 OPG_NGINX_INDEX=app_dev.php
+NGINX_APP_NAME=frontend
 
 SIRIUS_API_BASE_URI=http://mock-sirius:8080
 

--- a/environment/.envrc
+++ b/environment/.envrc
@@ -1,3 +1,4 @@
 export TF_WORKSPACE=develop
+export TF_VAR_OPG_DOCKER_TAG="main-4eb2ae8"
 export TF_VAR_DEFAULT_ROLE=operator
 export TF_CLI_ARGS_init="-backend-config=role_arn=arn:aws:iam::311462405659:role/operator -upgrade=true"

--- a/environment/admin_service.tf
+++ b/environment/admin_service.tf
@@ -91,7 +91,8 @@ locals {
       { "name": "SYMFONY_ENV", "value": "${local.account.symfony_env}" },
       { "name": "OPG_DOCKER_TAG", "value": "${var.OPG_DOCKER_TAG}" },
       { "name": "WKHTMLTOPDF_ADDRESS", "value": "http://${local.wkhtmltopdf_service_fqdn}" },
-      { "name": "ENVIRONMENT", "value": "${local.environment}" }
+      { "name": "ENVIRONMENT", "value": "${local.environment}" },
+      { "name": "NGINX_APP_NAME", "value": "admin" }
     ]
   }
 

--- a/environment/alarms.tf
+++ b/environment/alarms.tf
@@ -1,4 +1,4 @@
-resource "aws_cloudwatch_log_metric_filter" "php_errors" {
+resource "aws_cloudwatch_log_metric_filter" "php_critical_errors" {
   name           = "CriticalPHPErrorFilter.${local.environment}"
   pattern        = "CRITICAL"
   log_group_name = aws_cloudwatch_log_group.opg_digi_deps.name
@@ -11,8 +11,34 @@ resource "aws_cloudwatch_log_metric_filter" "php_errors" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "php_errors" {
+resource "aws_cloudwatch_metric_alarm" "php_critical_errors" {
   alarm_name          = "CriticalPHPErrors.${local.environment}"
+  statistic           = "Sum"
+  metric_name         = aws_cloudwatch_log_metric_filter.php_critical_errors.metric_transformation[0].name
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 3
+  period              = 3600
+  evaluation_periods  = 1
+  namespace           = aws_cloudwatch_log_metric_filter.php_critical_errors.metric_transformation[0].namespace
+  alarm_actions       = [data.aws_sns_topic.alerts.arn]
+  tags                = local.default_tags
+}
+
+resource "aws_cloudwatch_log_metric_filter" "php_errors" {
+  name           = "PHPErrorFilter.${local.environment}"
+  pattern        = "?\"[error]\" ?\"[crit]\" ?\"[alert]\" ?\"[emerg]\""
+  log_group_name = aws_cloudwatch_log_group.opg_digi_deps.name
+
+  metric_transformation {
+    name          = "PHPErrors.${local.environment}"
+    namespace     = "DigiDeps/Error"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "php_errors" {
+  alarm_name          = "PHPErrors.${local.environment}"
   statistic           = "Sum"
   metric_name         = aws_cloudwatch_log_metric_filter.php_errors.metric_transformation[0].name
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -20,32 +46,6 @@ resource "aws_cloudwatch_metric_alarm" "php_errors" {
   period              = 3600
   evaluation_periods  = 1
   namespace           = aws_cloudwatch_log_metric_filter.php_errors.metric_transformation[0].namespace
-  alarm_actions       = [data.aws_sns_topic.alerts.arn]
-  tags                = local.default_tags
-}
-
-resource "aws_cloudwatch_log_metric_filter" "nginx_errors" {
-  name           = "CriticalNginxErrorFilter.${local.environment}"
-  pattern        = "?\"[error]\" ?\"[crit]\" ?\"[alert]\" ?\"[emerg]\""
-  log_group_name = aws_cloudwatch_log_group.opg_digi_deps.name
-
-  metric_transformation {
-    name          = "CriticalNginxErrors.${local.environment}"
-    namespace     = "DigiDeps/Error"
-    value         = "1"
-    default_value = "0"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "nginx_errors" {
-  alarm_name          = "CriticalNginxErrors.${local.environment}"
-  statistic           = "Sum"
-  metric_name         = aws_cloudwatch_log_metric_filter.nginx_errors.metric_transformation[0].name
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = 3
-  period              = 3600
-  evaluation_periods  = 1
-  namespace           = aws_cloudwatch_log_metric_filter.nginx_errors.metric_transformation[0].namespace
   alarm_actions       = [data.aws_sns_topic.alerts.arn]
   tags                = local.default_tags
 }
@@ -72,6 +72,7 @@ resource "aws_cloudwatch_metric_alarm" "queued_documents" {
   threshold           = 1
   period              = 1800
   evaluation_periods  = 1
+  treat_missing_data  = "notBreaching"
   namespace           = aws_cloudwatch_log_metric_filter.queued_documents.metric_transformation[0].namespace
   alarm_actions       = [data.aws_sns_topic.alerts.arn]
   tags                = local.default_tags
@@ -143,5 +144,197 @@ resource "aws_cloudwatch_metric_alarm" "availability-admin" {
 
   dimensions = {
     HealthCheckId = aws_route53_health_check.availability-admin[0].id
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "frontend_5xx_errors" {
+  name           = "Frontend5XXErrors.${local.environment}"
+  pattern        = "{($.service_name = \"frontend\") && ($.status = 5*)}"
+  log_group_name = aws_cloudwatch_log_group.opg_digi_deps.name
+
+  metric_transformation {
+    name          = "Frontend5XXErrors.${local.environment}"
+    namespace     = "DigiDeps/Error"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "frontend_5xx_errors" {
+  alarm_name          = "Frontend5XXErrors.${local.environment}"
+  statistic           = "Sum"
+  metric_name         = aws_cloudwatch_log_metric_filter.frontend_5xx_errors.metric_transformation[0].name
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 3
+  period              = 3600
+  evaluation_periods  = 1
+  treat_missing_data  = "notBreaching"
+  namespace           = aws_cloudwatch_log_metric_filter.frontend_5xx_errors.metric_transformation[0].namespace
+  alarm_actions       = [data.aws_sns_topic.alerts.arn]
+  tags                = local.default_tags
+}
+
+resource "aws_cloudwatch_log_metric_filter" "admin_5xx_errors" {
+  name           = "Admin5XXErrors.${local.environment}"
+  pattern        = "{($.service_name = \"admin\") && ($.status = 5*)}"
+  log_group_name = aws_cloudwatch_log_group.opg_digi_deps.name
+
+  metric_transformation {
+    name          = "Admin5XXErrors.${local.environment}"
+    namespace     = "DigiDeps/Error"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "admin_5xx_errors" {
+  alarm_name          = "Admin5XXErrors.${local.environment}"
+  statistic           = "Sum"
+  metric_name         = aws_cloudwatch_log_metric_filter.admin_5xx_errors.metric_transformation[0].name
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 3
+  period              = 3600
+  evaluation_periods  = 1
+  treat_missing_data  = "notBreaching"
+  namespace           = aws_cloudwatch_log_metric_filter.admin_5xx_errors.metric_transformation[0].namespace
+  alarm_actions       = [data.aws_sns_topic.alerts.arn]
+  tags                = local.default_tags
+}
+
+resource "aws_cloudwatch_log_metric_filter" "api_5xx_errors" {
+  name           = "API5XXErrors.${local.environment}"
+  pattern        = "{($.service_name = \"api\") && ($.status = 5*)}"
+  log_group_name = aws_cloudwatch_log_group.opg_digi_deps.name
+
+  metric_transformation {
+    name          = "API5XXErrors.${local.environment}"
+    namespace     = "DigiDeps/Error"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "api_5xx_errors" {
+  alarm_name          = "API5XXErrors.${local.environment}"
+  statistic           = "Sum"
+  metric_name         = aws_cloudwatch_log_metric_filter.api_5xx_errors.metric_transformation[0].name
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 3
+  period              = 3600
+  evaluation_periods  = 1
+  treat_missing_data  = "notBreaching"
+  namespace           = aws_cloudwatch_log_metric_filter.api_5xx_errors.metric_transformation[0].namespace
+  alarm_actions       = [data.aws_sns_topic.alerts.arn]
+  tags                = local.default_tags
+}
+
+
+resource "aws_cloudwatch_metric_alarm" "frontend_alb_5xx_errors" {
+  actions_enabled     = true
+  alarm_actions       = [data.aws_sns_topic.alerts.arn]
+  alarm_description   = "Number of 5XX Errors returned to Public Users from the ${local.environment} Frontend ALB."
+  alarm_name          = "FrontendALB5XXErrors.${local.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  dimensions = {
+    "LoadBalancer" = trimprefix(split(":", aws_lb.front.arn)[5], "loadbalancer/")
+  }
+  evaluation_periods = 1
+  metric_name        = "HTTPCode_Target_5XX_Count"
+  namespace          = "AWS/ApplicationELB"
+  period             = 3600
+  statistic          = "Sum"
+  tags               = local.default_tags
+  threshold          = 3
+  treat_missing_data = "notBreaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "admin_alb_5xx_errors" {
+  actions_enabled     = true
+  alarm_actions       = [data.aws_sns_topic.alerts.arn]
+  alarm_description   = "Number of 5XX Errors returned to Internal Users from the ${local.environment} Admin ALB."
+  alarm_name          = "AdminALB5XXErrors.${local.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  dimensions = {
+    "LoadBalancer" = trimprefix(split(":", aws_lb.admin.arn)[5], "loadbalancer/")
+  }
+  evaluation_periods = 1
+  metric_name        = "HTTPCode_Target_5XX_Count"
+  namespace          = "AWS/ApplicationELB"
+  period             = 3600
+  statistic          = "Sum"
+  tags               = local.default_tags
+  threshold          = 3
+  treat_missing_data = "notBreaching"
+}
+
+resource "aws_cloudwatch_metric_alarm" "frontend_alb_average_response_time" {
+  actions_enabled           = true
+  alarm_actions             = [data.aws_sns_topic.alerts.arn]
+  alarm_description         = "Response Time for Frontend ALB in ${local.environment}"
+  alarm_name                = "FrontendALBAverageResponseTime.${local.environment}"
+  comparison_operator       = "GreaterThanUpperThreshold"
+  datapoints_to_alarm       = 3
+  evaluation_periods        = 60
+  insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
+  threshold_metric_id       = "ad1"
+  tags                      = local.default_tags
+
+  metric_query {
+    id          = "m1"
+    return_data = true
+
+    metric {
+      dimensions = {
+        "LoadBalancer" = trimprefix(split(":", aws_lb.front.arn)[5], "loadbalancer/")
+      }
+      metric_name = "TargetResponseTime"
+      namespace   = "AWS/ApplicationELB"
+      period      = 60
+      stat        = "Average"
+    }
+  }
+
+  metric_query {
+    expression  = "ANOMALY_DETECTION_BAND(m1, 1)"
+    id          = "ad1"
+    label       = "TargetResponseTime (expected)"
+    return_data = true
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "admin_alb_average_response_time" {
+  actions_enabled           = true
+  alarm_actions             = [data.aws_sns_topic.alerts.arn]
+  alarm_description         = "Response Time for Admin ALB in ${local.environment}"
+  alarm_name                = "AdminALBAverageResponseTime.${local.environment}"
+  comparison_operator       = "GreaterThanUpperThreshold"
+  datapoints_to_alarm       = 3
+  evaluation_periods        = 60
+  insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
+  threshold_metric_id       = "ad1"
+  tags                      = local.default_tags
+
+  metric_query {
+    id          = "m1"
+    return_data = true
+
+    metric {
+      dimensions = {
+        "LoadBalancer" = trimprefix(split(":", aws_lb.admin.arn)[5], "loadbalancer/")
+      }
+      metric_name = "TargetResponseTime"
+      namespace   = "AWS/ApplicationELB"
+      period      = 60
+      stat        = "Average"
+    }
+  }
+
+  metric_query {
+    expression  = "ANOMALY_DETECTION_BAND(m1, 1)"
+    id          = "ad1"
+    label       = "TargetResponseTime (expected)"
+    return_data = true
   }
 }

--- a/environment/api_service.tf
+++ b/environment/api_service.tf
@@ -101,7 +101,8 @@ locals {
       { "name": "OPG_DOCKER_TAG", "value": "${var.OPG_DOCKER_TAG}" },
       { "name": "DATABASE_HOSTNAME", "value": "${local.db.endpoint}" },
       { "name": "DATABASE_NAME", "value": "${local.db.name}" },
-      { "name": "DATABASE_USERNAME", "value": "${local.db.username}" }
+      { "name": "DATABASE_USERNAME", "value": "${local.db.username}" },
+      { "name": "NGINX_APP_NAME", "value": "api" }
     ]
   }
 

--- a/environment/front_service.tf
+++ b/environment/front_service.tf
@@ -91,7 +91,8 @@ locals {
       { "name": "SYMFONY_ENV", "value": "${local.account.symfony_env}" },
       { "name": "OPG_DOCKER_TAG", "value": "${var.OPG_DOCKER_TAG}" },
       { "name": "WKHTMLTOPDF_ADDRESS", "value": "http://${local.wkhtmltopdf_service_fqdn}" },
-      { "name": "ENVIRONMENT", "value": "${local.environment}" }
+      { "name": "ENVIRONMENT", "value": "${local.environment}" },
+      { "name": "NGINX_APP_NAME", "value": "frontend" }
     ]
   }
 


### PR DESCRIPTION
## Purpose
Addresses DDPB-3579 adding in alerting at each app tier for application errors and tracking response times for the two application load balancers

## Approach
I switched out the log format in the NGINX config to pass JSON to cloudwatch.  This change allows the logs to be queried intelligently rather than string matching.  It also allows metric filters on the log files to be configured more easily.
I used metric filters to track 5XX errors in NGINX in frontend, admin, & API tiers and alert.
I enabled anomaly detection on the Average Response Times for both ALB's and alerting on that.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [x] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
