### PR TITLE
DDPB-3724: Return unauthorised rather than server error for expired user tokens

### DIFF
--- a/client/src/AppBundle/Controller/UserController.php
+++ b/client/src/AppBundle/Controller/UserController.php
@@ -37,8 +37,7 @@ class UserController extends AbstractController
         DeputyProvider $deputyProvider,
         string $action,
         string $token
-    ): Response
-    {
+    ): Response {
         /** @var TranslatorInterface */
         $translator = $this->get('translator');
         $isActivatePage = 'activate' === $action;
@@ -48,7 +47,7 @@ class UserController extends AbstractController
             $user = $this->getRestClient()->loadUserByToken($token);
             /* @var $user EntityDir\User */
         } catch (\Throwable $e) {
-            return $this->renderError('This link is not working or has already been used');
+            return $this->renderError('This link is not working or has already been used', Response::HTTP_UNAUTHORIZED);
         }
 
         // token expired
@@ -72,9 +71,12 @@ class UserController extends AbstractController
         // define form and template that differs depending on the action (activate or password-reset)
         if ($isActivatePage) {
             $passwordMismatchMessage = $translator->trans('password.validation.passwordMismatch', [], 'user-activate');
-            $form = $this->createForm(FormDir\SetPasswordType::class, $user, [ 'passwordMismatchMessage' => $passwordMismatchMessage, 'showTermsAndConditions'  => $user->isDeputy()
+            $form = $this->createForm(
+                FormDir\SetPasswordType::class,
+                $user,
+                [ 'passwordMismatchMessage' => $passwordMismatchMessage, 'showTermsAndConditions'  => $user->isDeputy()
                                        ]
-                                     );
+            );
             $template = 'AppBundle:User:activate.html.twig';
         } else { // 'password-reset'
             $passwordMismatchMessage = $translator->trans('form.password.validation.passwordMismatch', [], 'password-reset');
@@ -299,7 +301,8 @@ class UserController extends AbstractController
 
                     case 422:
                         $form->addError(new FormError(
-                            $translator->trans('email.first.existingError', [], 'register')));
+                            $translator->trans('email.first.existingError', [], 'register')
+                        ));
                         break;
 
                     case 400:


### PR DESCRIPTION
## Purpose
We're currently returning 500 responses for expired user tokens. Now we're alerting on 500s a little more consistently this has led to some slack spam. We should return the more appropriate response code of 401 for unauthorised access to an endpoint.

Fixes DDPB-3724

## Approach
Return 401 (and find a way to use 418 in future tickets 🍵 )

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
