### PR TITLE
Use the response code from API when token is invalid

### DIFF
--- a/client/src/AppBundle/Controller/UserController.php
+++ b/client/src/AppBundle/Controller/UserController.php
@@ -47,7 +47,7 @@ class UserController extends AbstractController
             $user = $this->getRestClient()->loadUserByToken($token);
             /* @var $user EntityDir\User */
         } catch (\Throwable $e) {
-            return $this->renderError('This link is not working or has already been used', Response::HTTP_UNAUTHORIZED);
+            return $this->renderError('This link is not working or has already been used', $e->getCode());
         }
 
         // token expired


### PR DESCRIPTION
## Purpose
Follow up to #485 to use whatever we return from the API rather than a 401.
