### PR TITLE
DDPB-3721 add docker auth variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,6 +277,16 @@ orbs:
   aws-cli: circleci/aws-cli@0.1.13
   slack: circleci/slack@3.4.2
   codecov: codecov/codecov@1.1.1
+  dockerhub_helper:
+    orbs:
+      docker: circleci/docker@1.4.0
+    commands:
+      dockerhub_login:
+        steps:
+          - docker/install-docker-credential-helper
+          - docker/check:
+              docker-password: DOCKER_ACCESS_TOKEN
+              docker-username: DOCKER_USER
   ecs_helper:
     commands:
       install:
@@ -302,6 +312,9 @@ orbs:
       terraform:
         docker:
           - image: circleci/golang:1.12
+            auth:
+              username: $DOCKER_USER
+              password: $DOCKER_ACCESS_TOKEN
         resource_class: small
         environment:
           TF_VERSION: 0.13.3
@@ -398,6 +411,9 @@ jobs:
   build:
     docker:
       - image: circleci/python:3
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_ACCESS_TOKEN
     resource_class: small
     environment:
       AWS_REGION: eu-west-1
@@ -409,6 +425,7 @@ jobs:
         type: boolean
         default: false
     steps:
+      - dockerhub_helper/dockerhub_login
       - setup_remote_docker
       - aws-cli/install
       - add_ssh_keys:
@@ -513,8 +530,12 @@ jobs:
   client-unit-test:
     docker:
       - image: circleci/python:3
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_ACCESS_TOKEN
     resource_class: small
     steps:
+      - dockerhub_helper/dockerhub_login
       - setup_remote_docker
       - checkout
       - attach_workspace: { at: ~/project }
@@ -559,8 +580,12 @@ jobs:
   api-unit-tests:
     docker:
       - image: circleci/php
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_ACCESS_TOKEN
     resource_class: small
     steps:
+      - dockerhub_helper/dockerhub_login
       - setup_remote_docker
       - checkout
       - attach_workspace: { at: ~/project }
@@ -585,6 +610,7 @@ jobs:
     machine:
       image: circleci/classic:latest
     steps:
+      - dockerhub_helper/dockerhub_login
       - checkout
       - attach_workspace: { at: ~/project }
       - run:

--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -116,7 +116,7 @@
       "memory_high": "2048",
       "backup_retention_period": 1,
       "psql_engine_version": "10.13",
-      "dr_backup": true
+      "dr_backup": false
     },
     "development": {
       "account_id": "248804316466",
@@ -178,7 +178,7 @@
       "memory_high": "2048",
       "backup_retention_period": 1,
       "psql_engine_version": "10.7",
-      "dr_backup": true
+      "dr_backup": false
     }
   }
 }


### PR DESCRIPTION
## Purpose
There are some changes due for beginning of November that mean that there will be limit on no. of pulls from dockerhub for unauthenticated PRs using circleci.

Fixes DDPB-3721

## Approach

Set up our dockerhub user and creds in org infra.

This is the digideps side of things that forces our pipeline to use the credentials.

## Learning

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
