### PR TITLE
DDPB-3663c first pass with mock fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,13 +17,6 @@ workflows:
           filters: { branches: { ignore: [ main ] } }
           tf_command: apply
 
-      - run-task:
-          name: reset environment
-          requires: [ apply environment ]
-          filters: { branches: { ignore: [ main ] } }
-          task_name: reset_database
-          timeout: 180
-
       - client-unit-test:
           name: client unit test
           requires: [ apply environment ]
@@ -41,7 +34,7 @@ workflows:
       - approve:
           name: approval for further testing
           type: approval
-          requires: [ reset environment ]
+          requires: [ api unit test, client unit test, apply environment ]
           filters: { branches: { ignore: [ master ] } }
 
       - run-task:

--- a/environment/admin_sg.tf
+++ b/environment/admin_sg.tf
@@ -45,8 +45,8 @@ locals {
       port        = 8080
       type        = "egress"
       protocol    = "tcp"
-      target_type = "cidr_block"
-      target      = "0.0.0.0/0"
+      target_type = "security_group_id"
+      target      = module.mock_sirius_integration_security_group.id
     }
   }
 }

--- a/environment/checklist_sync.tf
+++ b/environment/checklist_sync.tf
@@ -29,8 +29,8 @@ locals {
       port        = 8080
       type        = "egress"
       protocol    = "tcp"
-      target_type = "cidr_block"
-      target      = "0.0.0.0/0"
+      target_type = "security_group_id"
+      target      = module.mock_sirius_integration_security_group.id
     }
   }
 }

--- a/environment/document_sync.tf
+++ b/environment/document_sync.tf
@@ -22,8 +22,8 @@ locals {
       port        = 8080
       type        = "egress"
       protocol    = "tcp"
-      target_type = "cidr_block"
-      target      = "0.0.0.0/0"
+      target_type = "security_group_id"
+      target      = module.mock_sirius_integration_security_group.id
     }
   }
 

--- a/environment/scan_sg.tf
+++ b/environment/scan_sg.tf
@@ -12,8 +12,8 @@ locals {
       port        = 80
       type        = "egress"
       protocol    = "tcp"
-      target_type = "cidr_block"
-      target      = "0.0.0.0/0"
+      target_type = "security_group_id"
+      target      = module.scan_security_group.id
     }
     front = {
       port        = 8080


### PR DESCRIPTION
## Purpose
Quick wins for tightening security rules that don't break things.

Part a of this ticket was looking at making the cidr ranges tighter but broke on lots of things

Part b is looking at a spike for squid egress proxy.

This part is some quick wins that can easily implement now.

Fixes DDPB-3663

## Approach
Tighten some of the 0.0.0.0/0 outbounds down to security groups

## Learning

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
