### PR TITLE
DDPB-3228 - System Availability Dash

### DIFF
--- a/environment/.envrc
+++ b/environment/.envrc
@@ -1,3 +1,4 @@
 export TF_WORKSPACE=develop
 export TF_VAR_DEFAULT_ROLE=operator
 export TF_CLI_ARGS_init="-backend-config=role_arn=arn:aws:iam::311462405659:role/operator -upgrade=true"
+export TF_VAR_OPG_DOCKER_TAG=main-54d8f42

--- a/environment/alarms.tf
+++ b/environment/alarms.tf
@@ -16,9 +16,10 @@ resource "aws_cloudwatch_metric_alarm" "php_critical_errors" {
   statistic           = "Sum"
   metric_name         = aws_cloudwatch_log_metric_filter.php_critical_errors.metric_transformation[0].name
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = 3
-  period              = 3600
-  evaluation_periods  = 1
+  datapoints_to_alarm = 5
+  evaluation_periods  = 5
+  threshold           = 1
+  period              = 60
   namespace           = aws_cloudwatch_log_metric_filter.php_critical_errors.metric_transformation[0].namespace
   alarm_actions       = [data.aws_sns_topic.alerts.arn]
   actions_enabled     = local.account.alarms_active
@@ -43,9 +44,10 @@ resource "aws_cloudwatch_metric_alarm" "php_errors" {
   statistic           = "Sum"
   metric_name         = aws_cloudwatch_log_metric_filter.php_errors.metric_transformation[0].name
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = 3
-  period              = 3600
-  evaluation_periods  = 1
+  datapoints_to_alarm = 5
+  evaluation_periods  = 5
+  threshold           = 1
+  period              = 60
   namespace           = aws_cloudwatch_log_metric_filter.php_errors.metric_transformation[0].namespace
   alarm_actions       = [data.aws_sns_topic.alerts.arn]
   actions_enabled     = local.account.alarms_active
@@ -63,8 +65,6 @@ resource "aws_cloudwatch_log_metric_filter" "queued_documents" {
     value     = "$.count"
   }
 }
-
-//aws_cloudwatch_log_group.monitoring_lambda.name
 
 resource "aws_cloudwatch_metric_alarm" "queued_documents" {
   alarm_name          = "QueuedDocsOver1Hr.${local.environment}"
@@ -87,7 +87,6 @@ data "aws_sns_topic" "availability-alert" {
 }
 
 resource "aws_route53_health_check" "availability-front" {
-  count             = local.account.always_on ? 1 : 0
   fqdn              = aws_route53_record.front.fqdn
   resource_path     = "/manage/availability"
   port              = 443
@@ -99,28 +98,26 @@ resource "aws_route53_health_check" "availability-front" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "availability-front" {
-  count               = local.account.always_on ? 1 : 0
   provider            = aws.us-east-1
   alarm_name          = "${local.environment}-availability-front"
   statistic           = "Minimum"
   metric_name         = "HealthCheckStatus"
   comparison_operator = "LessThanThreshold"
-  datapoints_to_alarm = 1
+  datapoints_to_alarm = 2
   threshold           = 1
-  period              = 3600
-  evaluation_periods  = 1
+  period              = 60
+  evaluation_periods  = 5
   namespace           = "AWS/Route53"
   alarm_actions       = [data.aws_sns_topic.availability-alert.arn]
   actions_enabled     = local.account.alarms_active
   tags                = local.default_tags
 
   dimensions = {
-    HealthCheckId = aws_route53_health_check.availability-front[0].id
+    HealthCheckId = aws_route53_health_check.availability-front.id
   }
 }
 
 resource "aws_route53_health_check" "availability-admin" {
-  count             = local.account.always_on ? 1 : 0
   fqdn              = aws_route53_record.admin.fqdn
   resource_path     = "/manage/availability"
   port              = 443
@@ -132,23 +129,22 @@ resource "aws_route53_health_check" "availability-admin" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "availability-admin" {
-  count               = local.account.always_on ? 1 : 0
   provider            = aws.us-east-1
   alarm_name          = "${local.environment}-availability-admin"
   statistic           = "Minimum"
   metric_name         = "HealthCheckStatus"
   comparison_operator = "LessThanThreshold"
-  datapoints_to_alarm = 1
+  datapoints_to_alarm = 2
   threshold           = 1
-  period              = 3600
-  evaluation_periods  = 1
+  period              = 60
+  evaluation_periods  = 5
   namespace           = "AWS/Route53"
   alarm_actions       = [data.aws_sns_topic.availability-alert.arn]
   actions_enabled     = local.account.alarms_active
   tags                = local.default_tags
 
   dimensions = {
-    HealthCheckId = aws_route53_health_check.availability-admin[0].id
+    HealthCheckId = aws_route53_health_check.availability-admin.id
   }
 }
 
@@ -170,9 +166,10 @@ resource "aws_cloudwatch_metric_alarm" "frontend_5xx_errors" {
   statistic           = "Sum"
   metric_name         = aws_cloudwatch_log_metric_filter.frontend_5xx_errors.metric_transformation[0].name
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = 3
-  period              = 3600
-  evaluation_periods  = 1
+  datapoints_to_alarm = 5
+  evaluation_periods  = 5
+  threshold           = 1
+  period              = 60
   treat_missing_data  = "notBreaching"
   namespace           = aws_cloudwatch_log_metric_filter.frontend_5xx_errors.metric_transformation[0].namespace
   alarm_actions       = [data.aws_sns_topic.alerts.arn]
@@ -198,9 +195,10 @@ resource "aws_cloudwatch_metric_alarm" "admin_5xx_errors" {
   statistic           = "Sum"
   metric_name         = aws_cloudwatch_log_metric_filter.admin_5xx_errors.metric_transformation[0].name
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = 3
-  period              = 3600
-  evaluation_periods  = 1
+  datapoints_to_alarm = 5
+  evaluation_periods  = 5
+  threshold           = 1
+  period              = 60
   treat_missing_data  = "notBreaching"
   namespace           = aws_cloudwatch_log_metric_filter.admin_5xx_errors.metric_transformation[0].namespace
   alarm_actions       = [data.aws_sns_topic.alerts.arn]
@@ -226,9 +224,10 @@ resource "aws_cloudwatch_metric_alarm" "api_5xx_errors" {
   statistic           = "Sum"
   metric_name         = aws_cloudwatch_log_metric_filter.api_5xx_errors.metric_transformation[0].name
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  threshold           = 3
-  period              = 3600
-  evaluation_periods  = 1
+  datapoints_to_alarm = 5
+  evaluation_periods  = 5
+  threshold           = 1
+  period              = 60
   treat_missing_data  = "notBreaching"
   namespace           = aws_cloudwatch_log_metric_filter.api_5xx_errors.metric_transformation[0].namespace
   alarm_actions       = [data.aws_sns_topic.alerts.arn]
@@ -246,14 +245,15 @@ resource "aws_cloudwatch_metric_alarm" "frontend_alb_5xx_errors" {
   dimensions = {
     "LoadBalancer" = trimprefix(split(":", aws_lb.front.arn)[5], "loadbalancer/")
   }
-  evaluation_periods = 1
-  metric_name        = "HTTPCode_Target_5XX_Count"
-  namespace          = "AWS/ApplicationELB"
-  period             = 3600
-  statistic          = "Sum"
-  tags               = local.default_tags
-  threshold          = 3
-  treat_missing_data = "notBreaching"
+  datapoints_to_alarm = 5
+  evaluation_periods  = 5
+  threshold           = 1
+  period              = 60
+  metric_name         = "HTTPCode_Target_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  statistic           = "Sum"
+  tags                = local.default_tags
+  treat_missing_data  = "notBreaching"
 }
 
 resource "aws_cloudwatch_metric_alarm" "admin_alb_5xx_errors" {
@@ -281,8 +281,8 @@ resource "aws_cloudwatch_metric_alarm" "frontend_alb_average_response_time" {
   alarm_description         = "Response Time for Frontend ALB in ${local.environment}"
   alarm_name                = "FrontendALBAverageResponseTime.${local.environment}"
   comparison_operator       = "GreaterThanUpperThreshold"
-  datapoints_to_alarm       = 3
-  evaluation_periods        = 60
+  datapoints_to_alarm       = 5
+  evaluation_periods        = 5
   insufficient_data_actions = []
   treat_missing_data        = "notBreaching"
   threshold_metric_id       = "ad1"
@@ -304,7 +304,7 @@ resource "aws_cloudwatch_metric_alarm" "frontend_alb_average_response_time" {
   }
 
   metric_query {
-    expression  = "ANOMALY_DETECTION_BAND(m1, 6)"
+    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
     id          = "ad1"
     label       = "TargetResponseTime (expected)"
     return_data = true
@@ -317,8 +317,8 @@ resource "aws_cloudwatch_metric_alarm" "admin_alb_average_response_time" {
   alarm_description         = "Response Time for Admin ALB in ${local.environment}"
   alarm_name                = "AdminALBAverageResponseTime.${local.environment}"
   comparison_operator       = "GreaterThanUpperThreshold"
-  datapoints_to_alarm       = 3
-  evaluation_periods        = 60
+  datapoints_to_alarm       = 5
+  evaluation_periods        = 5
   insufficient_data_actions = []
   treat_missing_data        = "notBreaching"
   threshold_metric_id       = "ad1"
@@ -340,7 +340,7 @@ resource "aws_cloudwatch_metric_alarm" "admin_alb_average_response_time" {
   }
 
   metric_query {
-    expression  = "ANOMALY_DETECTION_BAND(m1, 6)"
+    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
     id          = "ad1"
     label       = "TargetResponseTime (expected)"
     return_data = true

--- a/environment/dashboard.tf
+++ b/environment/dashboard.tf
@@ -1,0 +1,184 @@
+resource "aws_cloudwatch_dashboard" "main" {
+  dashboard_name = upper(local.environment)
+
+  dashboard_body = jsonencode({
+    "widgets" : [
+      {
+        "type" : "metric",
+        "x" : 15,
+        "y" : 0,
+        "width" : 9,
+        "height" : 3,
+        "properties" : {
+          "metrics" : [
+            ["AWS/Route53", "HealthCheckPercentageHealthy", "HealthCheckId", aws_route53_health_check.availability-front.id, { "region" : "us-east-1", "label" : "Public Frontend" }],
+            ["AWS/Route53", "HealthCheckPercentageHealthy", "HealthCheckId", aws_route53_health_check.availability-admin.id, { "region" : "us-east-1", "label" : "Admin Frontend" }]
+          ],
+          "region" : "eu-west-1",
+          "view" : "singleValue",
+          "stacked" : false,
+          "start" : "-P28D",
+          "end" : "P0D",
+          "period" : 60,
+          "title" : "Service Availability",
+          "stat" : "Average",
+          "singleValueFullPrecision" : false,
+          "setPeriodToTimeRange" : true
+        }
+      },
+      {
+        "type" : "metric",
+        "x" : 0,
+        "y" : 0,
+        "width" : 15,
+        "height" : 9,
+        "properties" : {
+          "metrics" : [
+            ["AWS/ApplicationELB", "TargetResponseTime", "LoadBalancer", trimprefix(split(":", aws_lb.front.arn)[5], "loadbalancer/"), { "id" : "m1", "stat" : "Average", "label" : "Frontend Average Response Time" }],
+            ["AWS/ApplicationELB", "TargetResponseTime", "LoadBalancer", trimprefix(split(":", aws_lb.admin.arn)[5], "loadbalancer/"), { "id" : "m2", "stat" : "Average", "label" : "Admin Average Response Time" }],
+            ["AWS/ApplicationELB", "TargetResponseTime", "LoadBalancer", trimprefix(split(":", aws_lb.front.arn)[5], "loadbalancer/"), { "id" : "m3", "yAxis" : "right", "stat" : "Maximum", "label" : "Frontend Max Response Time" }],
+            ["AWS/ApplicationELB", "TargetResponseTime", "LoadBalancer", trimprefix(split(":", aws_lb.admin.arn)[5], "loadbalancer/"), { "id" : "m4", "yAxis" : "right", "stat" : "Maximum", "label" : "Admin Max Response Time" }]
+          ],
+          "view" : "timeSeries",
+          "stacked" : false,
+          "region" : "eu-west-1",
+          "stat" : "Sum",
+          "period" : 60,
+          "start" : "-PT3H",
+          "end" : "P0D",
+          "title" : "ALB Response Times",
+          "legend" : {
+            "position" : "bottom"
+          }
+        }
+      },
+      {
+        "type" : "metric",
+        "x" : 0,
+        "y" : 9,
+        "width" : 15,
+        "height" : 9,
+        "properties" : {
+          "metrics" : [
+            ["AWS/ApplicationELB", "RequestCount", "LoadBalancer", trimprefix(split(":", aws_lb.front.arn)[5], "loadbalancer/"), { "id" : "m1", "label" : "Frontend Requests Count" }],
+            ["AWS/ApplicationELB", "RequestCount", "LoadBalancer", trimprefix(split(":", aws_lb.admin.arn)[5], "loadbalancer/"), { "id" : "m2", "label" : "Admin Request Count" }],
+          ],
+          "view" : "timeSeries",
+          "stacked" : false,
+          "region" : "eu-west-1",
+          "stat" : "Sum",
+          "period" : 60,
+          "start" : "-PT3H",
+          "end" : "P0D",
+          "title" : "ALB Requests per minute",
+          "legend" : {
+            "position" : "bottom"
+          }
+        }
+      },
+      {
+        "type" : "metric",
+        "x" : 15,
+        "y" : 9,
+        "width" : 9,
+        "height" : 9,
+        "properties" : {
+          "metrics" : [
+            ["AWS/ApplicationELB", "HTTPCode_Target_5XX_Count", "LoadBalancer", trimprefix(split(":", aws_lb.front.arn)[5], "loadbalancer/"), { "id" : "m1", "label" : "Frontend ALB 5XX Errors" }],
+            ["AWS/ApplicationELB", "HTTPCode_Target_5XX_Count", "LoadBalancer", trimprefix(split(":", aws_lb.admin.arn)[5], "loadbalancer/"), { "id" : "m2", "label" : "Admin ALB 5XX Errors" }],
+            ["DigiDeps/Error", aws_cloudwatch_log_metric_filter.frontend_5xx_errors.name, { "id" : "m3", "label" : "Frontend Service 5XX Errors" }],
+            ["DigiDeps/Error", aws_cloudwatch_log_metric_filter.admin_5xx_errors.name, { "id" : "m4", "label" : "Admin Service 5XX Errors" }],
+            ["DigiDeps/Error", aws_cloudwatch_log_metric_filter.api_5xx_errors.name, { "id" : "m5", "label" : "API Service 5XX Errors" }]
+          ],
+          "view" : "timeSeries",
+          "stacked" : false,
+          "region" : "eu-west-1",
+          "stat" : "Sum",
+          "period" : 60,
+          "start" : "-PT3H",
+          "end" : "P0D",
+          "title" : "HTTP Request Error Count",
+          "legend" : {
+            "position" : "bottom"
+          }
+        }
+      },
+      {
+        "type" : "metric",
+        "x" : 15,
+        "y" : 3,
+        "width" : 9,
+        "height" : 6,
+        "properties" : {
+          "metrics" : [
+            ["ECS/ContainerInsights", "RunningTaskCount", "ServiceName", aws_ecs_service.front.name, "ClusterName", aws_ecs_cluster.main.name, { "label" : "Frontend" }],
+            ["ECS/ContainerInsights", "RunningTaskCount", "ServiceName", aws_ecs_service.admin.name, "ClusterName", aws_ecs_cluster.main.name, { "label" : "Admin" }],
+            ["ECS/ContainerInsights", "RunningTaskCount", "ServiceName", aws_ecs_service.api.name, "ClusterName", aws_ecs_cluster.main.name, { "label" : "API" }],
+            ["ECS/ContainerInsights", "RunningTaskCount", "ServiceName", aws_ecs_service.scan.name, "ClusterName", aws_ecs_cluster.main.name, { "label" : "Scan Service" }],
+            ["ECS/ContainerInsights", "RunningTaskCount", "ServiceName", aws_ecs_service.wkhtmltopdf.name, "ClusterName", aws_ecs_cluster.main.name, { "label" : "HTML to PDF" }],
+            ["ECS/ContainerInsights", "RunningTaskCount", "ServiceName", aws_ecs_service.mock_sirius_integration.name, "ClusterName", aws_ecs_cluster.main.name, { "label" : "Mock Sirius Integration" }]
+          ],
+          "view" : "singleValue",
+          "stacked" : false,
+          "region" : "eu-west-1",
+          "stat" : "Average",
+          "period" : 60,
+          "start" : "-PT3H",
+          "end" : "P0D",
+          "title" : "Average Running Task Count",
+          "legend" : {
+            "position" : "bottom"
+          },
+          "setPeriodToTimeRange" : true
+        }
+      },
+      {
+        "type" : "metric",
+        "x" : 15,
+        "y" : 18,
+        "width" : 9,
+        "height" : 9,
+        "properties" : {
+          "metrics" : [
+            ["AWS/ElastiCache", "CPUUtilization", "CacheClusterId", "${aws_elasticache_replication_group.front.id}-001", { "label" : "Frontend" }],
+            ["AWS/ElastiCache", "CPUUtilization", "CacheClusterId", "${aws_elasticache_replication_group.admin.id}-001", { "label" : "Admin" }],
+            ["AWS/ElastiCache", "CPUUtilization", "CacheClusterId", "${aws_elasticache_replication_group.api.id}-001", { "label" : "API" }]
+          ],
+          "view" : "timeSeries",
+          "stacked" : false,
+          "region" : "eu-west-1",
+          "stat" : "Average",
+          "period" : 60,
+          "title" : "Elasticache Primary Cluster Average CPU Utilisation"
+        }
+      },
+      {
+        "type" : "metric",
+        "x" : 0,
+        "y" : 18,
+        "width" : 15,
+        "height" : 9,
+        "properties" : {
+          "metrics" : [
+            ["AWS/ECS", "CPUUtilization", "ServiceName", aws_ecs_service.front.name, "ClusterName", aws_ecs_cluster.main.name, { "label" : "Frontend CPU" }],
+            ["AWS/ECS", "CPUUtilization", "ServiceName", aws_ecs_service.admin.name, "ClusterName", aws_ecs_cluster.main.name, { "label" : "Admin CPU" }],
+            ["AWS/ECS", "CPUUtilization", "ServiceName", aws_ecs_service.api.name, "ClusterName", aws_ecs_cluster.main.name, { "label" : "API CPU" }],
+            ["AWS/ECS", "CPUUtilization", "ServiceName", aws_ecs_service.wkhtmltopdf.name, "ClusterName", aws_ecs_cluster.main.name, { "label" : "HTML2PDF CPU" }],
+            ["AWS/ECS", "CPUUtilization", "ServiceName", aws_ecs_service.scan.name, "ClusterName", aws_ecs_cluster.main.name, { "label" : "AV Scan CPU" }],
+            ["AWS/ECS", "MemoryUtilization", "ServiceName", aws_ecs_service.front.name, "ClusterName", aws_ecs_cluster.main.name, { "yAxis" : "right", "label" : "Frontend Memory" }],
+            ["AWS/ECS", "MemoryUtilization", "ServiceName", aws_ecs_service.admin.name, "ClusterName", aws_ecs_cluster.main.name, { "yAxis" : "right", "label" : "Admin Memory" }],
+            ["AWS/ECS", "MemoryUtilization", "ServiceName", aws_ecs_service.api.name, "ClusterName", aws_ecs_cluster.main.name, { "yAxis" : "right", "label" : "API Memory" }],
+            ["AWS/ECS", "MemoryUtilization", "ServiceName", aws_ecs_service.wkhtmltopdf.name, "ClusterName", aws_ecs_cluster.main.name, { "yAxis" : "right", "label" : "HTML2PDF Memory" }],
+            ["AWS/ECS", "MemoryUtilization", "ServiceName", aws_ecs_service.scan.name, "ClusterName", aws_ecs_cluster.main.name, { "yAxis" : "right", "label" : "AV Scan Memory" }]
+          ],
+          "view" : "timeSeries",
+          "stacked" : false,
+          "region" : "eu-west-1",
+          "stat" : "Average",
+          "period" : 60,
+          "title" : "ECS CPU & Memory Utilisation"
+        }
+      }
+    ]
+  })
+}

--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -59,7 +59,7 @@
       "memory_high": "4096",
       "backup_retention_period": 1,
       "psql_engine_version": "10.13",
-      "alarms_active": false,
+      "alarms_active": true,
       "dr_backup": false
     },
     "training": {


### PR DESCRIPTION
## Purpose
Add in a CloudWatch dashboard for some observability of the DigiDeps service.  
Easily expose the uptime stats from the Route53 Healthchecks.
I have tuned down the alarm thresholds to counter false triggers.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [x] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
