### PR TITLE
DDPB-3184 create enc to test adding encryption to s3

### DIFF
--- a/environment/alarms.tf
+++ b/environment/alarms.tf
@@ -281,8 +281,8 @@ resource "aws_cloudwatch_metric_alarm" "frontend_alb_average_response_time" {
   alarm_description         = "Response Time for Frontend ALB in ${local.environment}"
   alarm_name                = "FrontendALBAverageResponseTime.${local.environment}"
   comparison_operator       = "GreaterThanUpperThreshold"
-  datapoints_to_alarm       = 5
-  evaluation_periods        = 5
+  datapoints_to_alarm       = 3
+  evaluation_periods        = 60
   insufficient_data_actions = []
   treat_missing_data        = "notBreaching"
   threshold_metric_id       = "ad1"
@@ -304,7 +304,7 @@ resource "aws_cloudwatch_metric_alarm" "frontend_alb_average_response_time" {
   }
 
   metric_query {
-    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
+    expression  = "ANOMALY_DETECTION_BAND(m1, 6)"
     id          = "ad1"
     label       = "TargetResponseTime (expected)"
     return_data = true
@@ -317,8 +317,8 @@ resource "aws_cloudwatch_metric_alarm" "admin_alb_average_response_time" {
   alarm_description         = "Response Time for Admin ALB in ${local.environment}"
   alarm_name                = "AdminALBAverageResponseTime.${local.environment}"
   comparison_operator       = "GreaterThanUpperThreshold"
-  datapoints_to_alarm       = 5
-  evaluation_periods        = 5
+  datapoints_to_alarm       = 3
+  evaluation_periods        = 60
   insufficient_data_actions = []
   treat_missing_data        = "notBreaching"
   threshold_metric_id       = "ad1"
@@ -340,7 +340,7 @@ resource "aws_cloudwatch_metric_alarm" "admin_alb_average_response_time" {
   }
 
   metric_query {
-    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
+    expression  = "ANOMALY_DETECTION_BAND(m1, 6)"
     id          = "ad1"
     label       = "TargetResponseTime (expected)"
     return_data = true

--- a/environment/alarms.tf
+++ b/environment/alarms.tf
@@ -281,8 +281,8 @@ resource "aws_cloudwatch_metric_alarm" "frontend_alb_average_response_time" {
   alarm_description         = "Response Time for Frontend ALB in ${local.environment}"
   alarm_name                = "FrontendALBAverageResponseTime.${local.environment}"
   comparison_operator       = "GreaterThanUpperThreshold"
-  datapoints_to_alarm       = 3
-  evaluation_periods        = 60
+  datapoints_to_alarm       = 5
+  evaluation_periods        = 5
   insufficient_data_actions = []
   treat_missing_data        = "notBreaching"
   threshold_metric_id       = "ad1"
@@ -304,7 +304,7 @@ resource "aws_cloudwatch_metric_alarm" "frontend_alb_average_response_time" {
   }
 
   metric_query {
-    expression  = "ANOMALY_DETECTION_BAND(m1, 6)"
+    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
     id          = "ad1"
     label       = "TargetResponseTime (expected)"
     return_data = true
@@ -317,8 +317,8 @@ resource "aws_cloudwatch_metric_alarm" "admin_alb_average_response_time" {
   alarm_description         = "Response Time for Admin ALB in ${local.environment}"
   alarm_name                = "AdminALBAverageResponseTime.${local.environment}"
   comparison_operator       = "GreaterThanUpperThreshold"
-  datapoints_to_alarm       = 3
-  evaluation_periods        = 60
+  datapoints_to_alarm       = 5
+  evaluation_periods        = 5
   insufficient_data_actions = []
   treat_missing_data        = "notBreaching"
   threshold_metric_id       = "ad1"
@@ -340,7 +340,7 @@ resource "aws_cloudwatch_metric_alarm" "admin_alb_average_response_time" {
   }
 
   metric_query {
-    expression  = "ANOMALY_DETECTION_BAND(m1, 6)"
+    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
     id          = "ad1"
     label       = "TargetResponseTime (expected)"
     return_data = true

--- a/environment/s3.tf
+++ b/environment/s3.tf
@@ -33,6 +33,14 @@ resource "aws_s3_bucket" "pa_uploads" {
     }
   }
 
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+
   replication_configuration {
     role = aws_iam_role.replication.arn
 

--- a/environment/s3.tf
+++ b/environment/s3.tf
@@ -34,7 +34,7 @@ resource "aws_s3_bucket" "pa_uploads" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        sse_algorithm = "aws:kms"
+        sse_algorithm = "AES256"
       }
     }
   }

--- a/environment/s3.tf
+++ b/environment/s3.tf
@@ -1,3 +1,5 @@
+//Add encryption on next commit
+
 locals {
   non-replication_workspaces = ["production02", "preproduction", "training", "integration", "development"]
   bucket_replication_status  = contains(local.non-replication_workspaces, local.environment) ? "Disabled" : "Enabled"

--- a/environment/s3.tf
+++ b/environment/s3.tf
@@ -1,5 +1,3 @@
-//Add encryption on next commit
-
 locals {
   non-replication_workspaces = ["production02", "preproduction", "training", "integration", "development"]
   bucket_replication_status  = contains(local.non-replication_workspaces, local.environment) ? "Disabled" : "Enabled"

--- a/shared/s3_replication.tf
+++ b/shared/s3_replication.tf
@@ -23,7 +23,7 @@ resource "aws_s3_bucket" "pa_uploads_branch_replication" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        sse_algorithm = "aws:kms"
+        sse_algorithm = "AES256"
       }
     }
   }

--- a/shared/s3_replication.tf
+++ b/shared/s3_replication.tf
@@ -20,6 +20,14 @@ resource "aws_s3_bucket" "pa_uploads_branch_replication" {
     }
   }
 
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+
   tags = local.default_tags
 }
 


### PR DESCRIPTION
## Purpose

We currently encrypt data on s3 using a policy. To show that that the buckets use encryption we can set it at the bucket level. AES256 encryption which the policy specifies is the same as the aws kms key uses so they should be compatibly and we can leave in the policy as it was previously working.

Fixes DDPB-3184

## Approach
Got a bit nervous about how this would affect existing data so spun it up without the encryption, ran the end to end tests then manually ran the encryption on the buckets through terraform and checked I could still access the existing files and that I could upload new files through the app.

Checked the integrations still work fine in environment.

![image](https://user-images.githubusercontent.com/58939809/96892994-24c31200-1482-11eb-8391-a24b480cc5ed.png)

## Learning

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
