### PR TITLE
DDPB-3564 - Secret Management

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,8 +310,8 @@ orbs:
               password: $DOCKER_ACCESS_TOKEN
         resource_class: small
         environment:
-          TF_VERSION: 0.13.3
-          TF_SHA256SUM: 35c662be9d32d38815cde5fa4c9fa61a3b7f39952ecd50ebf92fd1b2ddd6109b
+          TF_VERSION: 0.13.5
+          TF_SHA256SUM: f7b7a7b1bfbf5d78151cfe3d1d463140b5fd6a354e71a7de2b5644e652ca5147
           TF_CLI_ARGS_plan: -input=false -lock=false
           TF_CLI_ARGS_apply: -input=false -auto-approve
           TF_CLI_ARGS_destroy: -input=false -auto-approve

--- a/shared/environment_secrets/main.tf
+++ b/shared/environment_secrets/main.tf
@@ -1,0 +1,7 @@
+resource "aws_secretsmanager_secret" "secret" {
+  for_each = var.secrets
+
+  name        = join("/", [var.environment, each.value])
+  description = "${each.value} secret for ${var.environment}"
+  tags        = var.tags
+}

--- a/shared/environment_secrets/variables.tf
+++ b/shared/environment_secrets/variables.tf
@@ -1,0 +1,12 @@
+variable "environment" {
+  description = "Name of the environment to create secrets for."
+}
+
+variable "secrets" {
+  description = "List of secrets to create for the environment."
+  type        = set(string)
+}
+
+variable "tags" {
+  description = "Tags to apply to secrets."
+}

--- a/shared/secrets.tf
+++ b/shared/secrets.tf
@@ -1,7 +1,24 @@
-data "aws_secretsmanager_secret" "slack_webhook_url" {
+resource "aws_secretsmanager_secret" "slack_webhook_url" {
   name = "slack-webhook-url"
 }
 
 data "aws_secretsmanager_secret_version" "slack_webhook_url" {
-  secret_id = data.aws_secretsmanager_secret.slack_webhook_url.id
+  secret_id = aws_secretsmanager_secret.slack_webhook_url.id
+}
+
+module "environment_secrets" {
+  for_each = local.account.environments
+
+  source      = "./environment_secrets"
+  environment = each.value
+  secrets = [
+    "api-secret",
+    "admin-api-client-secret",
+    "admin-frontend-secret",
+    "database-password",
+    "front-api-client-secret",
+    "front-frontend-secret",
+    "front-notify-api-key"
+  ]
+  tags = local.default_tags
 }

--- a/shared/secrets.tf
+++ b/shared/secrets.tf
@@ -1,5 +1,7 @@
 resource "aws_secretsmanager_secret" "slack_webhook_url" {
-  name = "slack-webhook-url"
+  name        = "slack-webhook-url"
+  description = "URL of webhook for Slack Integration"
+  tags        = local.default_tags
 }
 
 data "aws_secretsmanager_secret_version" "slack_webhook_url" {

--- a/shared/terraform.tfvars.json
+++ b/shared/terraform.tfvars.json
@@ -5,6 +5,10 @@
       "name": "production",
       "db_subnet_group": "rds-private-subnets-prod-vpc",
       "ec_subnet_group": "ec-pvt-subnets-prod-vpc",
+      "environments": [
+        "production02",
+        "training"
+      ],
       "sirius_account_id": "649098267436"
     },
     "preproduction": {
@@ -12,6 +16,10 @@
       "name": "preproduction",
       "db_subnet_group": "private",
       "ec_subnet_group": "private",
+      "environments": [
+        "integration",
+        "preproduction"
+      ],
       "sirius_account_id": "492687888235"
     },
     "development": {
@@ -19,6 +27,10 @@
       "name": "development",
       "db_subnet_group": "private",
       "ec_subnet_group": "private",
+      "environments": [
+        "default",
+        "development"
+      ],
       "sirius_account_id": "288342028542"
     }
   }

--- a/shared/variables.tf
+++ b/shared/variables.tf
@@ -9,6 +9,7 @@ variable "accounts" {
       name              = string
       db_subnet_group   = string
       ec_subnet_group   = string
+      environments      = set(string)
       sirius_account_id = string
     })
   )


### PR DESCRIPTION
## Purpose
Bring secret management (creation/deletion) under the control of terraform.

Fixes DDPB-3564

## Approach
As there are three different approaches to secrets, I've chosen to unify them by having each environment have it's own set of secrets generated at the account/shared level.  The downside to this is that secrets must be created at the environment level before a new persistent environment can be created.
I've taken the approach of passing a list of environments per workspace into a module with a list of secrets that are required, I feel this is the cleanest and easiest to manage approach.

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
