### PR TITLE
Push release time to OPG Metrics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,6 +211,10 @@ workflows:
           tf_workspace: production02
           tf_command: apply
 
+      - add-to-metrics:
+          name: add to metrics
+          requires: [ apply production ]
+
       - run-task:
           name: backup production
           requires: [ apply production ]
@@ -602,6 +606,26 @@ jobs:
       - codecov/upload:
           file: ./api-unit-tests.xml
           flags: api
+
+  add-to-metrics:
+    docker:
+      - image: cimg/base:2020.10
+    resource_class: small
+    steps:
+      - run:
+          name: PUT release time to OPG metrics
+          command: |
+          EPOCH=$(date +'%s')
+          curl --location --request PUT '${METRICS_ENDPOINT}' \
+            --header 'Content-Type: application/json' \
+            --data-raw '{
+              "records": [
+                {
+                  "data": "{ 'Dimensions': dimensions, 'Project': 'complete-the-deputy-report', 'MeasureName': 'release', 'MeasureValue': '1.0', 'MeasureValueType': 'DOUBLE', 'Time': '${EPOCH}' }",
+                  "partition-key": "some key"
+                }
+              ]
+            }'
 
   pa11y-ci:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,8 +314,8 @@ orbs:
               password: $DOCKER_ACCESS_TOKEN
         resource_class: small
         environment:
-          TF_VERSION: 0.13.3
-          TF_SHA256SUM: 35c662be9d32d38815cde5fa4c9fa61a3b7f39952ecd50ebf92fd1b2ddd6109b
+          TF_VERSION: 0.13.5
+          TF_SHA256SUM: f7b7a7b1bfbf5d78151cfe3d1d463140b5fd6a354e71a7de2b5644e652ca5147
           TF_CLI_ARGS_plan: -input=false -lock=false
           TF_CLI_ARGS_apply: -input=false -auto-approve
           TF_CLI_ARGS_destroy: -input=false -auto-approve

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -619,14 +619,14 @@ jobs:
       - run:
           name: PUT release time to OPG metrics
           command: |
-            EPOCH=$(date +'%s')
+            EPOCH_MILLISECONDS=$(date +%s%3N)
 
             curl --location --request PUT ${METRICS_ENDPOINT} \
             --header 'Content-Type: application/json' \
               --data-raw "{
                 \"records\": [
                   {
-                    \"data\": \"{'Dimensions': dimensions, 'Project': 'complete-the-deputy-report', 'MeasureName': 'release', 'MeasureValue': '1.0', 'MeasureValueType': 'DOUBLE', 'Time': '${EPOCH}'}\",
+                    \"data\": \"{'Dimensions': dimensions, 'Project': 'complete-the-deputy-report', 'MeasureName': 'release', 'MeasureValue': '1.0', 'MeasureValueType': 'DOUBLE', 'Time': '${EPOCH_MILLISECONDS}'}\",
                     \"partition-key\": \"some key\"
                   }
                 ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,6 @@ version: 2.1
 workflows:
   pull_request:
     jobs:
-      - add-to-metrics:
-          name: add to metrics
-          filters: { branches: { ignore: [ main ] } }
-
       - lint:
           name: lint terraform
           filters: { branches: { ignore: [ main ] } }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ workflows:
       - add-to-metrics:
           name: add to metrics
           requires: [ apply environment ]
+          filters: { branches: { ignore: [ main ] } }
 
       - client-unit-test:
           name: client unit test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,10 @@ workflows:
           filters: { branches: { ignore: [ main ] } }
           tf_command: apply
 
+      - add-to-metrics:
+          name: add to metrics
+          requires: [ apply environment ]
+
       - client-unit-test:
           name: client unit test
           requires: [ apply environment ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -617,7 +617,7 @@ jobs:
           command: |
             EPOCH_MILLISECONDS=$(date +%s%3N)
 
-            curl --location --request PUT ${METRICS_ENDPOINT} \
+            curl --max-time 30 --location --request PUT ${METRICS_ENDPOINT} \
             --header 'Content-Type: application/json' \
               --data-raw "{
                 \"records\": [

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -619,17 +619,17 @@ jobs:
       - run:
           name: PUT release time to OPG metrics
           command: |
-          EPOCH=$(date +'%s')
-          curl --location --request PUT '${METRICS_ENDPOINT}' \
-            --header 'Content-Type: application/json' \
-            --data-raw '{
-              "records": [
-                {
-                  "data": "{ 'Dimensions': dimensions, 'Project': 'complete-the-deputy-report', 'MeasureName': 'release', 'MeasureValue': '1.0', 'MeasureValueType': 'DOUBLE', 'Time': '${EPOCH}' }",
-                  "partition-key": "some key"
-                }
-              ]
-            }'
+            EPOCH=$(date +'%s')
+            curl --location --request PUT '${METRICS_ENDPOINT}' \
+              --header 'Content-Type: application/json' \
+              --data-raw '{
+                "records": [
+                  {
+                    "data": "{ 'Dimensions': dimensions, 'Project': 'complete-the-deputy-report', 'MeasureName': 'release', 'MeasureValue': '1.0', 'MeasureValueType': 'DOUBLE', 'Time': '${EPOCH}' }",
+                    "partition-key": "some key"
+                  }
+                ]
+              }'
 
   pa11y-ci:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,10 @@ version: 2.1
 workflows:
   pull_request:
     jobs:
+      - add-to-metrics:
+          name: add to metrics
+          filters: { branches: { ignore: [ main ] } }
+
       - lint:
           name: lint terraform
           filters: { branches: { ignore: [ main ] } }
@@ -16,11 +20,6 @@ workflows:
           requires: [ build pr, lint terraform ]
           filters: { branches: { ignore: [ main ] } }
           tf_command: apply
-
-      - add-to-metrics:
-          name: add to metrics
-          requires: [ apply environment ]
-          filters: { branches: { ignore: [ main ] } }
 
       - client-unit-test:
           name: client unit test
@@ -621,16 +620,17 @@ jobs:
           name: PUT release time to OPG metrics
           command: |
             EPOCH=$(date +'%s')
-            curl --location --request PUT '${METRICS_ENDPOINT}' \
-              --header 'Content-Type: application/json' \
-              --data-raw '{
-                "records": [
+
+            curl --location --request PUT ${METRICS_ENDPOINT} \
+            --header 'Content-Type: application/json' \
+              --data-raw "{
+                \"records\": [
                   {
-                    "data": "{ 'Dimensions': dimensions, 'Project': 'complete-the-deputy-report', 'MeasureName': 'release', 'MeasureValue': '1.0', 'MeasureValueType': 'DOUBLE', 'Time': '${EPOCH}' }",
-                    "partition-key": "some key"
+                    \"data\": \"{'Dimensions': dimensions, 'Project': 'complete-the-deputy-report', 'MeasureName': 'release', 'MeasureValue': '1.0', 'MeasureValueType': 'DOUBLE', 'Time': '${EPOCH}'}\",
+                    \"partition-key\": \"some key\"
                   }
                 ]
-              }'
+              }"
 
   pa11y-ci:
     machine:


### PR DESCRIPTION
## Purpose
Adding a step to push digideps release times to OPG metrics. This will give us an overview of when releases are pushed out to production. This won't be totally accurate as there will be a short delay between apply production and the metrics job running but its POC for now and we can look at exporting the actual release time to a variable and sharing it with the metrics job in the future.