### PR TITLE
DDPB-3749 - Update ALB Response Alarms to static threshold

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,19 +12,40 @@ workflows:
           filters: { branches: { ignore: [ main ] } }
 
       - terraform-command:
+          name: plan shared development
+          requires: [lint terraform ]
+          filters: { branches: { ignore: [ main ] } }
+          tf_apply: false
+          tf_command: plan
+          tf_tier: shared
+          tf_workspace: development
+
+      - terraform-command:
+          name: plan pr environment
+          requires: [lint terraform ]
+          filters: { branches: { ignore: [ main ] } }
+          tf_apply: false
+          tf_command: plan
+          tf_tier: environment
+
+      - terraform-command:
           name: apply environment
-          requires: [ build pr, lint terraform ]
+          requires: [
+            build pr,
+            plan shared development,
+            plan pr environment
+             ]
           filters: { branches: { ignore: [ main ] } }
           tf_command: apply
 
       - client-unit-test:
           name: client unit test
-          requires: [ apply environment ]
+          requires: [ build pr ]
           filters: { branches: { ignore: [ main ] } }
 
       - api-unit-tests:
           name: api unit test
-          requires: [ apply environment ]
+          requires: [ build pr ]
           filters: { branches: { ignore: [ main ] } }
 
 #      - pa11y-ci:
@@ -53,7 +74,7 @@ workflows:
 
       - run-task:
           name: backup environment
-          requires: [ api unit test, client unit test, integration test ]
+          requires: [ integration test ]
           filters: { branches: { ignore: [ main ] } }
           task_name: backup
 
@@ -362,6 +383,10 @@ jobs:
       tf_command:
         description: terraform command
         type: string
+      tf_apply:
+        description: whether this is a terraform apply
+        default: true
+        type: boolean
       pact_tag:
         description: whether to add environment tag to pact broker
         default: false
@@ -376,10 +401,13 @@ jobs:
       - terraform/install
       - ecs_helper/install
       - attach_workspace: { at: ~/project }
-      - run:
-          name: Extract lambda layers
-          working_directory:  ~/project/lambda_functions
-          command: tar xvf ~/project/lambda_functions/layer.tar
+      - when:
+          condition: << parameters.tf_apply >>
+          steps:
+            - run:
+                name: Extract lambda layers
+                working_directory:  ~/project/lambda_functions
+                command: tar xvf ~/project/lambda_functions/layer.tar
       - run:
           name: Initialize
           command: terraform init
@@ -389,12 +417,15 @@ jobs:
       - run:
           name: Run << parameters.tf_command >>
           command: terraform << parameters.tf_command >>
-      - run:
-          name: Output
-          command: terraform output -json > terraform.output.json
-      - run:
-          name: Stabilize
-          command: stabilizer
+      - when:
+          condition: << parameters.tf_apply >>
+          steps:
+            - run:
+                name: Output
+                command: terraform output -json > terraform.output.json
+            - run:
+                name: Stabilize
+                command: stabilizer
       - when:
           condition: << parameters.pact_tag >>
           steps:

--- a/environment/admin.tf
+++ b/environment/admin.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "admin_s3" {
       "s3:GetObject",
     ]
     resources = [
-      "${aws_s3_bucket.pa_uploads.arn}",
+      aws_s3_bucket.pa_uploads.arn,
       "${aws_s3_bucket.pa_uploads.arn}/*",
     ]
   }

--- a/environment/alarms.tf
+++ b/environment/alarms.tf
@@ -276,73 +276,43 @@ resource "aws_cloudwatch_metric_alarm" "admin_alb_5xx_errors" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "frontend_alb_average_response_time" {
-  actions_enabled           = local.account.alarms_active
-  alarm_actions             = [data.aws_sns_topic.alerts.arn]
-  alarm_description         = "Response Time for Frontend ALB in ${local.environment}"
-  alarm_name                = "FrontendALBAverageResponseTime.${local.environment}"
-  comparison_operator       = "GreaterThanUpperThreshold"
-  datapoints_to_alarm       = 5
-  evaluation_periods        = 5
+  actions_enabled     = local.account.alarms_active
+  alarm_actions       = [data.aws_sns_topic.alerts.arn]
+  alarm_description   = "Response Time for Frontend ALB in ${local.environment}"
+  alarm_name          = "FrontendALBAverageResponseTime.${local.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  dimensions = {
+    "LoadBalancer" = trimprefix(split(":", aws_lb.front.arn)[5], "loadbalancer/")
+  }
+  datapoints_to_alarm       = 3
+  evaluation_periods        = 3
+  threshold                 = 1
+  period                    = 60
+  namespace                 = "AWS/ApplicationELB"
+  metric_name               = "TargetResponseTime"
+  statistic                 = "Average"
   insufficient_data_actions = []
   treat_missing_data        = "notBreaching"
-  threshold_metric_id       = "ad1"
   tags                      = local.default_tags
-
-  metric_query {
-    id          = "m1"
-    return_data = true
-
-    metric {
-      dimensions = {
-        "LoadBalancer" = trimprefix(split(":", aws_lb.front.arn)[5], "loadbalancer/")
-      }
-      metric_name = "TargetResponseTime"
-      namespace   = "AWS/ApplicationELB"
-      period      = 60
-      stat        = "Average"
-    }
-  }
-
-  metric_query {
-    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
-    id          = "ad1"
-    label       = "TargetResponseTime (expected)"
-    return_data = true
-  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "admin_alb_average_response_time" {
-  actions_enabled           = local.account.alarms_active
-  alarm_actions             = [data.aws_sns_topic.alerts.arn]
-  alarm_description         = "Response Time for Admin ALB in ${local.environment}"
-  alarm_name                = "AdminALBAverageResponseTime.${local.environment}"
-  comparison_operator       = "GreaterThanUpperThreshold"
-  datapoints_to_alarm       = 5
-  evaluation_periods        = 5
+  actions_enabled     = local.account.alarms_active
+  alarm_actions       = [data.aws_sns_topic.alerts.arn]
+  alarm_description   = "Response Time for Admin ALB in ${local.environment}"
+  alarm_name          = "AdminALBAverageResponseTime.${local.environment}"
+  comparison_operator = "GreaterThanThreshold"
+  dimensions = {
+    "LoadBalancer" = trimprefix(split(":", aws_lb.admin.arn)[5], "loadbalancer/")
+  }
+  datapoints_to_alarm       = 3
+  evaluation_periods        = 3
+  threshold                 = 1
+  period                    = 60
+  namespace                 = "AWS/ApplicationELB"
+  metric_name               = "TargetResponseTime"
+  statistic                 = "Average"
   insufficient_data_actions = []
   treat_missing_data        = "notBreaching"
-  threshold_metric_id       = "ad1"
   tags                      = local.default_tags
-
-  metric_query {
-    id          = "m1"
-    return_data = true
-
-    metric {
-      dimensions = {
-        "LoadBalancer" = trimprefix(split(":", aws_lb.admin.arn)[5], "loadbalancer/")
-      }
-      metric_name = "TargetResponseTime"
-      namespace   = "AWS/ApplicationELB"
-      period      = 60
-      stat        = "Average"
-    }
-  }
-
-  metric_query {
-    expression  = "ANOMALY_DETECTION_BAND(m1, 2)"
-    id          = "ad1"
-    label       = "TargetResponseTime (expected)"
-    return_data = true
-  }
 }

--- a/environment/front.tf
+++ b/environment/front.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "front_s3" {
       "s3:PutObjectTagging",
     ]
     resources = [
-      "${aws_s3_bucket.pa_uploads.arn}",
+      aws_s3_bucket.pa_uploads.arn,
       "${aws_s3_bucket.pa_uploads.arn}/*",
     ]
   }

--- a/environment/run_tasks.tf
+++ b/environment/run_tasks.tf
@@ -42,7 +42,7 @@ locals {
   psql_analyse = jsonencode({
     cpu       = 0,
     essential = true,
-    image     = "${local.images.sync}"
+    image     = local.images.sync,
     command   = ["sh", "./analyse.sh"],
     name      = "psql-analyse",
     logConfiguration = {


### PR DESCRIPTION
## Purpose
Reduce the amount of alerting spam from ALB Response Time alarms which were tracking anomaly detection, change this to the static threshold of 1 second as agreed with the team.
Fixes DDPB-3749

I have also refactored the PR Pipeline to plan against shared development and the pr environment whilst the PR is building to give quicker (and in the case of shared missing) feedback on terraform issues.

I also noted that the unit tests were being blocked by deployment, but had no dependency on AWS Infrastructure so I have removed that dependency reducing the time to the integration tests being playable from 24 minutes to 16, a saving of 8 minutes.

### Original PR Flow
![image](https://user-images.githubusercontent.com/5802072/97427550-a1377400-190c-11eb-8704-ccbc60d192aa.png)

### Revised PR Flow
![image](https://user-images.githubusercontent.com/5802072/97427457-79481080-190c-11eb-988e-d1cfd6784802.png)


## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
