### PR TITLE
Return null rather than false when dates dont parse

### DIFF
--- a/api/src/AppBundle/Service/ReportUtils.php
+++ b/api/src/AppBundle/Service/ReportUtils.php
@@ -35,7 +35,7 @@ class ReportUtils
      * @param string $dateString e.g. 16-Dec-2014
      * @param string $century    e.g. 20/19 Prefix added to 2-digits year
      *
-     * @return \DateTime|false
+     * @return \DateTime|null
      */
     public function parseCsvDate($dateString, $century)
     {
@@ -48,12 +48,12 @@ class ReportUtils
         }
         // check format is d-M-Y
         if ((int) $pieces[0] < 1 || (int) $pieces[0] > 31 || strlen($pieces[1]) !== 3 || strlen($pieces[2]) !== 4) {
-            return false;
+            return null;
         }
 
         $ret = \DateTime::createFromFormat('d-M-Y', implode($sep, $pieces));
         if (!$ret instanceof \DateTime) {
-            return false;
+            return null;
         }
 
         return $ret;

--- a/api/src/AppBundle/Service/ReportUtils.php
+++ b/api/src/AppBundle/Service/ReportUtils.php
@@ -11,11 +11,11 @@ class ReportUtils
      * Generates and returns the report start date from a given end date.
      * -365 days + 1 if note a leap day (otherwise we get 2nd March)
      *
-     * @param \DateTime $reportEndDate
+     * @param \DateTime|null $reportEndDate
      *
      * @return \DateTime $reportStartDate
      */
-    public function generateReportStartDateFromEndDate(\DateTime $reportEndDate)
+    public function generateReportStartDateFromEndDate(?\DateTime $reportEndDate)
     {
         $reportStartDate = clone $reportEndDate;
 

--- a/api/src/AppBundle/v2/Registration/Assembler/CasRecToOrgDeputyshipDtoAssembler.php
+++ b/api/src/AppBundle/v2/Registration/Assembler/CasRecToOrgDeputyshipDtoAssembler.php
@@ -41,7 +41,7 @@ class CasRecToOrgDeputyshipDtoAssembler
 
         $clientDateOfBirth = $this->reportUtils->parseCsvDate($row['Client Date of Birth'], '19');
         $reportEndDate = $this->reportUtils->parseCsvDate($row['Last Report Day'], '20');
-        $reportStartDate = $this->reportUtils->generateReportStartDateFromEndDate($reportEndDate);
+        $reportStartDate = $reportEndDate ? $this->reportUtils->generateReportStartDateFromEndDate($reportEndDate) : null;
         $caseNumber = $this->reportUtils->padCasRecNumber(strtolower($row['Case']));
         $deputyNumber = $this->reportUtils->padCasRecNumber(strtolower($row['Deputy No']));
 

--- a/api/src/AppBundle/v2/Registration/DTO/OrgDeputyshipDto.php
+++ b/api/src/AppBundle/v2/Registration/DTO/OrgDeputyshipDto.php
@@ -141,10 +141,10 @@ class OrgDeputyshipDto
     }
 
     /**
-     * @param DateTime $courtDate
+     * @param DateTime|null $courtDate
      * @return OrgDeputyshipDto
      */
-    public function setCourtDate(DateTime $courtDate): self
+    public function setCourtDate(?DateTime $courtDate): self
     {
         $this->courtDate = $courtDate;
 
@@ -342,10 +342,10 @@ class OrgDeputyshipDto
     }
 
     /**
-     * @param DateTime $reportStartDate
+     * @param DateTime|null $reportStartDate
      * @return OrgDeputyshipDto
      */
-    public function setReportStartDate(DateTime $reportStartDate): self
+    public function setReportStartDate(?DateTime $reportStartDate): self
     {
         $this->reportStartDate = $reportStartDate;
         return $this;
@@ -360,10 +360,10 @@ class OrgDeputyshipDto
     }
 
     /**
-     * @param DateTime $reportEndDate
+     * @param DateTime|null $reportEndDate
      * @return OrgDeputyshipDto
      */
-    public function setReportEndDate(DateTime $reportEndDate): self
+    public function setReportEndDate(?DateTime $reportEndDate): self
     {
         $this->reportEndDate = $reportEndDate;
         return $this;

--- a/api/src/AppBundle/v2/Registration/DTO/OrgDeputyshipDto.php
+++ b/api/src/AppBundle/v2/Registration/DTO/OrgDeputyshipDto.php
@@ -334,9 +334,9 @@ class OrgDeputyshipDto
     }
 
     /**
-     * @return DateTime
+     * @return DateTime|null
      */
-    public function getReportStartDate(): DateTime
+    public function getReportStartDate(): ?DateTime
     {
         return $this->reportStartDate;
     }
@@ -352,9 +352,9 @@ class OrgDeputyshipDto
     }
 
     /**
-     * @return DateTime
+     * @return DateTime|null
      */
-    public function getReportEndDate(): DateTime
+    public function getReportEndDate(): ?DateTime
     {
         return $this->reportEndDate;
     }

--- a/api/src/AppBundle/v2/Registration/Uploader/OrgDeputyshipUploader.php
+++ b/api/src/AppBundle/v2/Registration/Uploader/OrgDeputyshipUploader.php
@@ -70,6 +70,8 @@ class OrgDeputyshipUploader
 
         foreach ($deputyshipDtos as $deputyshipDto) {
             try {
+                $this->canHandleDto($deputyshipDto);
+
                 $this->handleNamedDeputy($deputyshipDto);
                 $this->handleOrganisation($deputyshipDto);
                 $this->handleClient($deputyshipDto);
@@ -236,5 +238,27 @@ class OrgDeputyshipUploader
     private function resetAdded()
     {
         $this->added = ['clients' => [], 'named_deputies' => [], 'reports' => [], 'organisations' => []];
+    }
+
+    private function canHandleDto(OrgDeputyshipDto $dto)
+    {
+        $missingDataTypes = [];
+
+        if (is_null($dto->getReportStartDate())) {
+            $errors[] = 'Report Start Date';
+        }
+
+        if (is_null($dto->getReportEndDate())) {
+            $errors[] = 'Report End Date';
+        }
+
+        if (is_null($dto->getCourtDate())) {
+            $errors[] = 'Court Date';
+        }
+
+        if (!empty($missingDataTypes)) {
+            $errorMessage = sprintf('Missing required data to upload case: %s', implode(",", $missingDataTypes));
+            throw new RuntimeException($errorMessage);
+        }
     }
 }

--- a/api/src/AppBundle/v2/Registration/Uploader/OrgDeputyshipUploader.php
+++ b/api/src/AppBundle/v2/Registration/Uploader/OrgDeputyshipUploader.php
@@ -92,18 +92,11 @@ class OrgDeputyshipUploader
      */
     private function handleNamedDeputy(OrgDeputyshipDto $dto)
     {
-        if (empty($dto->getDeputyEmail())) {
-            throw new RuntimeException('deputy email missing');
-        }
-
-        if (empty($dto->getDeputyFirstname())) {
-            throw new RuntimeException('deputy first name missing');
-        }
-
         $namedDeputy = ($this->em->getRepository(NamedDeputy::class))->findOneBy(
             [
                 'email1' => $dto->getDeputyEmail(),
                 'deputyNo' => $dto->getDeputyNumber(),
+                // We accept blank firstnames for trust corps
                 'firstname' => $dto->getDeputyFirstname(),
                 'lastname' => $dto->getDeputyLastname(),
                 'address1' => $dto->getDeputyAddress1(),
@@ -253,6 +246,10 @@ class OrgDeputyshipUploader
 
         if (is_null($dto->getCourtDate())) {
             $errors[] = 'Court Date';
+        }
+
+        if (is_null($dto->getDeputyEmail())) {
+            $errors[] = 'Deputy Email';
         }
 
         if (!empty($missingDataTypes)) {

--- a/api/src/AppBundle/v2/Registration/Uploader/OrgDeputyshipUploader.php
+++ b/api/src/AppBundle/v2/Registration/Uploader/OrgDeputyshipUploader.php
@@ -70,8 +70,7 @@ class OrgDeputyshipUploader
 
         foreach ($deputyshipDtos as $deputyshipDto) {
             try {
-                $this->canHandleDto($deputyshipDto);
-
+                $this->handleDtoErrors($deputyshipDto);
                 $this->handleNamedDeputy($deputyshipDto);
                 $this->handleOrganisation($deputyshipDto);
                 $this->handleClient($deputyshipDto);
@@ -232,28 +231,28 @@ class OrgDeputyshipUploader
         $this->added = ['clients' => [], 'named_deputies' => [], 'reports' => [], 'organisations' => []];
     }
 
-    private function canHandleDto(OrgDeputyshipDto $dto)
+    private function handleDtoErrors(OrgDeputyshipDto $dto)
     {
         $missingDataTypes = [];
 
-        if (is_null($dto->getReportStartDate())) {
-            $errors[] = 'Report Start Date';
+        if (empty($dto->getReportStartDate())) {
+            $missingDataTypes[] = 'Report Start Date';
         }
 
-        if (is_null($dto->getReportEndDate())) {
-            $errors[] = 'Report End Date';
+        if (empty($dto->getReportEndDate())) {
+            $missingDataTypes[] = 'Report End Date';
         }
 
-        if (is_null($dto->getCourtDate())) {
-            $errors[] = 'Court Date';
+        if (empty($dto->getCourtDate())) {
+            $missingDataTypes[] = 'Court Date';
         }
 
-        if (is_null($dto->getDeputyEmail())) {
-            $errors[] = 'Deputy Email';
+        if (empty($dto->getDeputyEmail())) {
+            $missingDataTypes[] = 'Deputy Email';
         }
 
         if (!empty($missingDataTypes)) {
-            $errorMessage = sprintf('Missing required data to upload case: %s', implode(",", $missingDataTypes));
+            $errorMessage = sprintf('Missing data to upload row: %s', implode(", ", $missingDataTypes));
             throw new RuntimeException($errorMessage);
         }
     }

--- a/api/src/AppBundle/v2/Registration/Uploader/OrgDeputyshipUploader.php
+++ b/api/src/AppBundle/v2/Registration/Uploader/OrgDeputyshipUploader.php
@@ -128,8 +128,7 @@ class OrgDeputyshipUploader
      */
     private function handleOrganisation(OrgDeputyshipDto $dto)
     {
-        $orgDomainIdentifier = explode('@', $dto->getDeputyEmail())[1];
-        $this->currentOrganisation = $foundOrganisation = ($this->em->getRepository(Organisation::class))->findOneBy(['emailIdentifier' => $orgDomainIdentifier]);
+        $this->currentOrganisation = $foundOrganisation = ($this->em->getRepository(Organisation::class))->findByEmailIdentifier($dto->getDeputyEmail());
 
         if (is_null($foundOrganisation)) {
             $organisation = $this->orgFactory->createFromFullEmail(OrgService::DEFAULT_ORG_NAME, $dto->getDeputyEmail());

--- a/api/tests/AppBundle/v2/Registration/Uploader/OrgDeputyshipUploaderTest.php
+++ b/api/tests/AppBundle/v2/Registration/Uploader/OrgDeputyshipUploaderTest.php
@@ -315,16 +315,19 @@ class OrgDeputyshipUploaderTest extends KernelTestCase
      * @test
      *@dataProvider errorProvider
      */
-    public function upload_errors_are_added_to_error_array(OrgDeputyshipDto $dto, string $expectedErrorMessage)
+    public function upload_errors_are_added_to_error_array(OrgDeputyshipDto $dto, array $expectedErrorStrings)
     {
         $uploadResults = $this->sut->upload([$dto]);
 
-        $errorMessage = sprintf('Error for case "%s": %s', $dto->getCaseNumber(), $expectedErrorMessage);
-
-        self::assertTrue(
-            in_array($errorMessage, $uploadResults['errors']),
-            sprintf('Expected error message "%s" was not in the errors array', $errorMessage)
-        );
+        foreach ($expectedErrorStrings as $expectedErrorString) {
+            foreach ($uploadResults['errors'] as $actualError) {
+                self::assertStringContainsString(
+                    $expectedErrorString,
+                    $actualError,
+                    sprintf('Expected error string "%s" was not in the errors array', $expectedErrorString)
+                );
+            }
+        }
     }
 
     public function errorProvider()
@@ -332,8 +335,14 @@ class OrgDeputyshipUploaderTest extends KernelTestCase
         $deputyships = OrgDeputyshipDTOTestHelper::generateOrgDeputyshipDtos(1, 0);
 
         return [
-            'Missing deputy email' => [(clone($deputyships[0]))->setDeputyEmail(null), 'deputy email missing'],
-            'Missing deputy first name' => [(clone($deputyships[0]))->setDeputyFirstname(null), 'deputy first name missing']
+            'Missing deputy email' => [(clone($deputyships[0]))->setDeputyEmail(null), ['Deputy Email']],
+            'Missing start date' => [(clone($deputyships[0]))->setReportStartDate(null), ['Report Start Date']],
+            'Missing end date' => [(clone($deputyships[0]))->setReportEndDate(null), ['Report End Date']],
+            'Missing court date' => [(clone($deputyships[0]))->setCourtDate(null), ['Court Date']],
+            'All missing' => [
+                (clone($deputyships[0]))->setDeputyEmail(null)->setReportStartDate(null)->setReportEndDate(null)->setCourtDate(null),
+                ['Report Start Date', 'Report End Date', 'Court Date', 'Deputy Email']
+            ],
         ];
     }
 


### PR DESCRIPTION
## Purpose
Ensures we provide an accepted type to `OrgDeputyshipDto::setCourtDate()` so the org CSV upload doesn't fail when we get unexpected/blank dates.

Fixes DDPB-3757

## Approach
During the Org CSV upload process we parse some dates that relate to the client and court order. We use a custom parsing function to do this in order to handle dates that don't explicitly include the century in the year (think 14 vs 2014/1914). When a Date doesn't parse correctly we're currently returning false but we should return null instead so the value can be set in the DTO. 

Additionally, this change centralises the error handling for missing essential data into a single function.

Getting this out quickly so the pro team can upload the CSV but I'll be making a follow-up ticket with expanded behat tests to include some dodgy data in the CSV as our current CSV doesn't have a wide enough range of data formats.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
