### PR TITLE
DDPB-3778 - Updating clam image version

### DIFF
--- a/environment/ecr.tf
+++ b/environment/ecr.tf
@@ -5,7 +5,7 @@ locals {
   images = {
     api          = "${data.aws_ecr_repository.images["api"].repository_url}:${var.OPG_DOCKER_TAG}"
     client       = "${data.aws_ecr_repository.images["client"].repository_url}:${local.client_tag}"
-    file_scanner = "${data.aws_ecr_repository.images["file-scanner"].repository_url}:${var.OPG_DOCKER_TAG}"
+    file_scanner = "${data.aws_ecr_repository.images["file-scanner"].repository_url}:20201113"
     sync         = "${data.aws_ecr_repository.images["sync"].repository_url}:${var.OPG_DOCKER_TAG}"
     test         = "${data.aws_ecr_repository.images["test"].repository_url}:${var.OPG_DOCKER_TAG}"
     wkhtmltopdf  = "${data.aws_ecr_repository.images["wkhtmltopdf"].repository_url}:${var.OPG_DOCKER_TAG}"

--- a/environment/scan.tf
+++ b/environment/scan.tf
@@ -104,7 +104,7 @@ EOF
       "name": "server",
       "essential": true,
       "cpu": 0,
-      "image": "mkodockx/docker-clamav",
+      "image": "${local.images.file_scanner}",
       "mountPoints": [],
       "volumesFrom": [],
       "healthCheck": {


### PR DESCRIPTION
## Purpose
An update to Clam has caused it to break. Reverting image version back to a previous working version.

Fixes DDPB-3778

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
