### PR TITLE
Revert to using v2 endpoint for client details

### DIFF
--- a/api/src/AppBundle/Entity/Repository/ClientRepository.php
+++ b/api/src/AppBundle/Entity/Repository/ClientRepository.php
@@ -111,7 +111,7 @@ class ClientRepository extends EntityRepository
 
         $query = $this
             ->getEntityManager()
-            ->createQuery('SELECT c, r, ndr, o, nd FROM AppBundle\Entity\Client c LEFT JOIN c.reports r LEFT JOIN c.ndr ndr LEFT JOIN c.namedDeputy nd LEFT JOIN c.organisation o WHERE c.id = ?1')
+            ->createQuery('SELECT c, r, ndr, o, nd, u FROM AppBundle\Entity\Client c LEFT JOIN c.reports r LEFT JOIN c.ndr ndr LEFT JOIN c.namedDeputy nd LEFT JOIN c.organisation o LEFT JOIN c.users u WHERE c.id = ?1')
             ->setParameter(1, $id);
 
         $result = $query->getArrayResult();

--- a/api/src/AppBundle/FixtureFactory/UserFactory.php
+++ b/api/src/AppBundle/FixtureFactory/UserFactory.php
@@ -96,7 +96,6 @@ class UserFactory
             ->setRoleName('ROLE_PROF');
 
         $user->setPassword($this->encoder->encodePassword($user, 'Abcd1234'));
-        $user->setActive(false);
 
         return $user;
     }

--- a/api/src/AppBundle/v2/Assembler/ClientAssembler.php
+++ b/api/src/AppBundle/v2/Assembler/ClientAssembler.php
@@ -4,6 +4,7 @@ namespace AppBundle\v2\Assembler;
 
 use AppBundle\v2\Assembler\Report\ReportAssemblerInterface;
 use AppBundle\v2\DTO\ClientDto;
+use AppBundle\v2\DTO\DeputyDto;
 use AppBundle\v2\DTO\DtoPropertySetterTrait;
 use AppBundle\Entity\Client;
 use AppBundle\v2\Registration\DTO\OrgDeputyshipDto;
@@ -69,6 +70,10 @@ class ClientAssembler
 
         if (isset($data['namedDeputy']) && is_array($data['namedDeputy'])) {
             $dto->setNamedDeputy($this->assembleClientNamedDeputy($data['namedDeputy']));
+        }
+
+        if (isset($data['users']) && is_array($data['users'])) {
+            $dto->setDeputies($this->assembleClientDeputies($data['users']));
         }
 
         return $dto;
@@ -146,5 +151,18 @@ class ClientAssembler
         }
 
         return $client;
+    }
+
+    private function assembleClientDeputies(array $deputies)
+    {
+        $dtos = [];
+
+        foreach ($deputies as $deputy) {
+            $dto = new DeputyDto();
+            $this->setPropertiesFromData($dto, $deputy, ['clients']);
+            $dtos[] = $dto;
+        }
+
+        return $dtos;
     }
 }

--- a/api/src/AppBundle/v2/Assembler/UserAssembler.php
+++ b/api/src/AppBundle/v2/Assembler/UserAssembler.php
@@ -1,0 +1,8 @@
+<?php
+
+
+namespace AppBundle\v2\Assembler;
+
+class UserAssembler
+{
+}

--- a/api/src/AppBundle/v2/Assembler/UserAssembler.php
+++ b/api/src/AppBundle/v2/Assembler/UserAssembler.php
@@ -1,8 +1,0 @@
-<?php
-
-
-namespace AppBundle\v2\Assembler;
-
-class UserAssembler
-{
-}

--- a/api/src/AppBundle/v2/DTO/ClientDto.php
+++ b/api/src/AppBundle/v2/DTO/ClientDto.php
@@ -42,6 +42,9 @@ class ClientDto
     /** @var NamedDeputyDto */
     private $namedDeputy;
 
+    /** @var array */
+    private $deputies;
+
     /**
      * @return int
      */
@@ -255,6 +258,24 @@ class ClientDto
     public function setNamedDeputy(NamedDeputyDto $namedDeputy)
     {
         $this->namedDeputy = $namedDeputy;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDeputies()
+    {
+        return $this->deputies;
+    }
+
+    /**
+     * @param array $deputies
+     * @return ClientDto
+     */
+    public function setDeputies(array $deputies): ClientDto
+    {
+        $this->deputies = $deputies;
         return $this;
     }
 }

--- a/api/src/AppBundle/v2/DTO/DeputyDto.php
+++ b/api/src/AppBundle/v2/DTO/DeputyDto.php
@@ -19,8 +19,20 @@ class DeputyDto
     /** @var string */
     private $roleName;
 
+    /** @var string|null */
+    private $address1;
+
+    /** @var string|null */
+    private $address2;
+
+    /** @var string|null */
+    private $address3;
+
     /** @var string */
     private $addressPostcode;
+
+    /** @var string|null */
+    private $addressCountry;
 
     /** @var bool */
     private $ndrEnabled;
@@ -234,5 +246,76 @@ class DeputyDto
         $this->clients = $clients;
         return $this;
     }
-}
 
+    /**
+     * @return string|null
+     */
+    public function getAddress1(): ?string
+    {
+        return $this->address1;
+    }
+
+    /**
+     * @param string|null $address1
+     * @return DeputyDto
+     */
+    public function setAddress1(?string $address1): DeputyDto
+    {
+        $this->address1 = $address1;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAddress2(): ?string
+    {
+        return $this->address2;
+    }
+
+    /**
+     * @param string|null $address2
+     * @return DeputyDto
+     */
+    public function setAddress2(?string $address2): DeputyDto
+    {
+        $this->address2 = $address2;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAddress3(): ?string
+    {
+        return $this->address3;
+    }
+
+    /**
+     * @param string|null $address3
+     * @return DeputyDto
+     */
+    public function setAddress3(?string $address3): DeputyDto
+    {
+        $this->address3 = $address3;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAddressCountry(): ?string
+    {
+        return $this->addressCountry;
+    }
+
+    /**
+     * @param string|null $addressCountry
+     * @return DeputyDto
+     */
+    public function setAddressCountry(?string $addressCountry): DeputyDto
+    {
+        $this->addressCountry = $addressCountry;
+        return $this;
+    }
+}

--- a/api/src/AppBundle/v2/Transformer/ClientTransformer.php
+++ b/api/src/AppBundle/v2/Transformer/ClientTransformer.php
@@ -3,6 +3,7 @@
 namespace AppBundle\v2\Transformer;
 
 use AppBundle\v2\DTO\ClientDto;
+use AppBundle\v2\DTO\DeputyDto;
 use AppBundle\v2\DTO\NamedDeputyDto;
 use AppBundle\v2\DTO\NdrDto;
 use AppBundle\v2\DTO\OrganisationDto;
@@ -27,7 +28,7 @@ class ClientTransformer
      * @param ReportTransformer $reportTransformer
      * @param NdrTransformer $ndrTransformer
      * @param OrganisationTransformer $organisationTransformer
-     * @param DeputyTransformer $deputyTransformer
+     * @param NamedDeputyTransformer $namedDeputyTransformer
      */
     public function __construct(
         ReportTransformer $reportTransformer,
@@ -59,7 +60,7 @@ class ClientTransformer
             'total_report_count' => $dto->getReportCount()
         ];
 
-        if (!in_array('reports', $exclude)) {
+        if (!in_array('reports', $exclude) && !empty($dto->getReports())) {
             $transformed['reports'] = $this->transformReports($dto->getReports());
         }
 
@@ -73,6 +74,10 @@ class ClientTransformer
 
         if (!in_array('namedDeputy', $exclude) && $dto->getNamedDeputy() instanceof NamedDeputyDto) {
             $transformed['named_deputy'] = $this->transformNamedDeputy($dto->getNamedDeputy());
+        }
+
+        if (!in_array('deputies', $exclude) && !empty($dto->getDeputies())) {
+            $transformed['users'] = $this->transformDeputies($dto->getDeputies());
         }
 
         return $transformed;
@@ -142,5 +147,38 @@ class ClientTransformer
     private function transformNamedDeputy(NamedDeputyDto $namedDeputy)
     {
         return $this->namedDeputyTransformer->transform($namedDeputy);
+    }
+
+    private function transformDeputies(array $deputyDtos)
+    {
+        if (empty($deputyDtos)) {
+            return [];
+        }
+
+        $transformed = [];
+
+        foreach ($deputyDtos as $deputyDto) {
+            if ($deputyDto instanceof DeputyDto) {
+                $transformed[] = [
+                    'id' => $deputyDto->getId(),
+                    'firstname' => $deputyDto->getFirstName(),
+                    'lastname' => $deputyDto->getLastName(),
+                    'email' => $deputyDto->getEmail(),
+                    'role_name' => $deputyDto->getRoleName(),
+                    'address1' => $deputyDto->getAddress1(),
+                    'address2' => $deputyDto->getAddress2(),
+                    'address3' => $deputyDto->getAddress3(),
+                    'address_postcode' => $deputyDto->getAddressPostcode(),
+                    'address_country' => $deputyDto->getAddressCountry(),
+                    'ndr_enabled' => $deputyDto->getNdrEnabled(),
+                    'active' => $deputyDto->isActive(),
+                    'job_title' => $deputyDto->getJobTitle(),
+                    'phone_main' => $deputyDto->getPhoneMain()
+                ];
+                ;
+            }
+        }
+
+        return $transformed;
     }
 }

--- a/client/src/AppBundle/Controller/Admin/Client/ClientController.php
+++ b/client/src/AppBundle/Controller/Admin/Client/ClientController.php
@@ -42,7 +42,7 @@ class ClientController extends AbstractController
      */
     public function detailsAction($id)
     {
-        $client = $this->clientApi->getWithUsers($id);
+        $client = $this->clientApi->getWithUsersV2($id);
 
         return [
             'client'      => $client,

--- a/client/src/AppBundle/Controller/Admin/IndexController.php
+++ b/client/src/AppBundle/Controller/Admin/IndexController.php
@@ -72,7 +72,7 @@ class IndexController extends AbstractController
     public function indexAction(Request $request)
     {
         $filters = [
-            'limit'           => 100,
+            'limit'           => 30,
             'offset'          => $request->get('offset', 'id'),
             'role_name'       => '',
             'q'               => '',

--- a/client/src/AppBundle/Controller/Admin/IndexController.php
+++ b/client/src/AppBundle/Controller/Admin/IndexController.php
@@ -72,7 +72,7 @@ class IndexController extends AbstractController
     public function indexAction(Request $request)
     {
         $filters = [
-            'limit'           => 30,
+            'limit'           => 65,
             'offset'          => $request->get('offset', 'id'),
             'role_name'       => '',
             'q'               => '',

--- a/client/src/AppBundle/Entity/Client.php
+++ b/client/src/AppBundle/Entity/Client.php
@@ -981,8 +981,10 @@ class Client
 
         foreach ($this->getUsers() as $user) {
             if ($user->isLayDeputy()) {
-                return $this->getUsers()[0];
+                return $user;
             }
         }
+
+        return null;
     }
 }

--- a/client/src/AppBundle/Resources/translations/admin.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin.en.yml
@@ -7,7 +7,7 @@ home:
     upload: Upload users
   userTable:
     heading: User list
-    resultsLimited: Search results are limited to 30 users.<br>Use search to filter the wanted users.
+    resultsLimited: Search results are limited to 65 users.<br>Use search to filter the wanted users.
     results: Found %numberOfUsers% users
     header:
       name: Name

--- a/client/src/AppBundle/Resources/translations/admin.en.yml
+++ b/client/src/AppBundle/Resources/translations/admin.en.yml
@@ -7,7 +7,7 @@ home:
     upload: Upload users
   userTable:
     heading: User list
-    resultsLimited: Results limited to 100 users.<br>Use search to filter the wanted users.
+    resultsLimited: Search results are limited to 30 users.<br>Use search to filter the wanted users.
     results: Found %numberOfUsers% users
     header:
       name: Name


### PR DESCRIPTION
## Purpose
Fixes timeouts on the client details page and when searching for users by case number with a case reference linked to a client in a large Org.

Fixes DDPB-3781

## Approach
As part of the audit logging refactor we had reverted to using the old client endpoint rather than v2. Testing locally with a large org (1000 client and 150 users) there were no issues but on prod we've witnessed timeouts so this suggests its more than the users and clients causing the slowdown. I'll put a ticket in the backlog to try to recreate the problem locally but this fix should get us back to a working state.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes
