### PR TITLE
DDPB-3557 - Confirm we use secure and http only cookies.

### DIFF
--- a/client/docker/confd/templates/pool.conf.tmpl
+++ b/client/docker/confd/templates/pool.conf.tmpl
@@ -539,3 +539,5 @@ php_admin_value[post_max_size] = 64M
 php_admin_value[upload_max_filesize] = 64M
 
 php_value[max_input_vars] = 10000
+
+php_value[session.cookie_secure] = On

--- a/client/docker/confd/templates/pool.conf.tmpl
+++ b/client/docker/confd/templates/pool.conf.tmpl
@@ -541,3 +541,4 @@ php_admin_value[upload_max_filesize] = 64M
 php_value[max_input_vars] = 10000
 
 php_value[session.cookie_secure] = On
+php_value[session.cookie_httponly] = On


### PR DESCRIPTION
## Purpose
Ensure that all session cookies have the Secure and HTTPOnly flags enabled.

Fixes DDPB-3557

## Approach
Looking at the cookies we currently have, there seems to be only 1 session cookie, and these already have the Secure and HTTPOnly flags (See comments of [DDPB-3557](https://opgtransform.atlassian.net/browse/DDPB-3557)).

There seems to be no obvious declaration in the code where this cookie is instantiated. I have therefore added settings to our php.ini should ensure any further cookies we create will have the necessary headers.

## Learning
https://www.php.net/manual/en/session.security.ini.php

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
