### PR TITLE
DDPB-3668: Remove direct container access from client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,7 @@ workflows:
       - cross-browser-test:
           name: cross browser test
           requires: [ apply integration ]
-          filters: { branches: { ignore: [ main ] } }
+          filters: { branches: { only: [ main ] } }
       - run-task:
           name: integration test
           requires: [ reset integration ]

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ up-app-xdebug-api: ## Brings the app up, rebuilds containers and enabled xdebug 
 	REQUIRE_XDEBUG_API=true docker-compose up -d --build
 
 up-app-integration-tests: ## Brings the app up using test env vars (see test.env)
-	REQUIRE_XDEBUG_FRONTEND=false REQUIRE_XDEBUG_API=false docker-compose build frontend admin api
+	REQUIRE_XDEBUG_FRONTEND=false REQUIRE_XDEBUG_API=false docker-compose -f docker-compose.yml -f docker-compose.dev.yml build frontend admin api
 	docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
 
 down-app: ### Tears down the app

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -38,7 +38,7 @@ WORKDIR /var/www
 EXPOSE 80
 EXPOSE 443
 ENV TIMEOUT=60
-ENV PHP_EXT_DIR=/usr/lib/php7/modules
+ENV PHP_EXT_DIR=/usr/local/lib/php/extensions/no-debug-non-zts-20190902
 
 # Install core PHP extensions
 RUN apk add --no-cache openssl nginx nginx-mod-http-headers-more su-exec postgresql-client libzip-dev unzip php7-igbinary php7-pecl-redis
@@ -47,8 +47,9 @@ RUN docker-php-ext-enable opcache
 
 # Install Xdebug if directed to with build arg from docker-compose.yml
 ARG REQUIRE_XDEBUG=false
-RUN if [[ $REQUIRE_XDEBUG = "true" ]] ; then \
-        apk add --no-cache php7-pecl-xdebug; \
+RUN if [[ $REQUIRE_XDEBUG = true ]] ; then \
+        apk add --no-cache $PHPIZE_DEPS; \
+        pecl install xdebug-2.9.8; \
         docker-php-ext-enable $PHP_EXT_DIR/xdebug.so; \
     fi ;
 

--- a/client/app/config/services.yml
+++ b/client/app/config/services.yml
@@ -13,18 +13,15 @@ services:
     AppBundle\Controller\IndexController:
         autowire: true
         autoconfigure: true
-        public: true
         class: AppBundle\Controller\IndexController
         arguments:
           $environment: '%env(ENVIRONMENT)%'
 
     AppBundle\Service\Redirector:
-        public: true
         class: AppBundle\Service\Redirector
         arguments: [ "@security.token_storage", "@security.authorization_checker", "@router", "@session", "%env%" ]
 
     AppBundle\Service\WkHtmlToPdfGenerator:
-        public: true
         arguments: [ "%wkhtmltopdf_address%", 30]
 
     wkhtmltopdf:
@@ -43,7 +40,6 @@ services:
                 allow_redirects: false
 
     AppBundle\Service\Client\Sirius\SiriusApiGatewayClient:
-        public: true
         class: AppBundle\Service\Client\Sirius\SiriusApiGatewayClient
         arguments:
             $httpClient: '@guzzle_api_gateway_client'
@@ -75,7 +71,6 @@ services:
         arguments: ["%ssm_client_params%"]
 
     AppBundle\Service\FeatureFlagService:
-        public: true
         arguments: ['@Aws\Ssm\SsmClient', '%env(FEATURE_FLAG_PREFIX)%']
 
     AppBundle\Service\ParameterStoreService:
@@ -89,23 +84,18 @@ services:
     # Make optional availability services pullable
     AppBundle\Service\Availability\ClamAvAvailability:
         arguments: ['@guzzle_file_scanner_client']
-        public: true
 
     AppBundle\Service\Availability\SiriusApiAvailability:
         arguments: ['@AppBundle\Service\Client\Sirius\SiriusApiGatewayClient']
-        public: true
 
     AppBundle\Service\Availability\WkHtmlToPdfAvailability:
         arguments: ['@AppBundle\Service\WkHtmlToPdfGenerator']
-        public: true
 
     AppBundle\Service\Availability\NotifyAvailability:
-         public: true
          arguments:
              $notifyClient: '@Alphagov\Notifications\Client'
 
     AppBundle\Service\DocumentSyncService:
-        public: true
         autowire: true
         autoconfigure: true
         arguments:

--- a/client/app/config/services/defaults.yml
+++ b/client/app/config/services/defaults.yml
@@ -3,6 +3,7 @@ services:
         autowire: true
         autoconfigure: true
         bind:
+            $symfonyEnvironment: "%kernel.environment%"
             Predis\ClientInterface: '@snc_redis.default'
 
     AppBundle\:

--- a/client/app/config/services/file_uploads.yml
+++ b/client/app/config/services/file_uploads.yml
@@ -15,7 +15,6 @@ services:
 
   guzzle_file_scanner_client:
     class: GuzzleHttp\Client
-    public: true
     arguments:
       $config:
         base_uri: "%file_scanner_url%"

--- a/client/app/config/services_api.yml
+++ b/client/app/config/services_api.yml
@@ -13,7 +13,6 @@ services:
         alias: AppBundle\Service\Client\RestClient
 
     AppBundle\Service\Client\RestClient:
-        public: true
         arguments:
             - '@service_container'
             - '@GuzzleHttp\Client'
@@ -24,4 +23,3 @@ services:
 
     rest_client:
         alias: AppBundle\Service\Client\RestClient
-        public: true

--- a/client/app/config/services_mail.yml
+++ b/client/app/config/services_mail.yml
@@ -4,15 +4,11 @@ services:
         autoconfigure: true
 
     AppBundle\Service\Mailer\MailFactory:
-        public: true
         arguments:
             $emailParams: "%email_params%"
             $baseURLs:
                 front: '%env(NONADMIN_HOST)%'
                 admin: '%env(ADMIN_HOST)%'
-
-    AppBundle\Service\Mailer\MailSender:
-        public: true
 
     AppBundle\Service\Mailer\MailSenderInterface: '@AppBundle\Service\Mailer\MailSender'
 

--- a/client/src/AppBundle/Controller/Admin/IndexController.php
+++ b/client/src/AppBundle/Controller/Admin/IndexController.php
@@ -14,12 +14,11 @@ use AppBundle\Service\Client\RestClient;
 use AppBundle\Service\CsvUploader;
 use AppBundle\Service\DataImporter\CsvToArray;
 use AppBundle\Service\Logger;
-use AppBundle\Service\Mailer\MailFactory;
-use AppBundle\Service\Mailer\MailSenderInterface;
 use AppBundle\Service\OrgService;
+use Predis\Client;
+use Predis\ClientInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Bundle\FrameworkBundle\Translation\Translator;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Redis;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -30,26 +29,18 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @Route("/admin")
  */
 class IndexController extends AbstractController
 {
-    /** @var OrgService */
-    private $orgService;
-
-    /** @var UserVoter */
-    private $userVoter;
-
-    /** @var Logger */
-    private $logger;
-
-    /** @var RestClient */
-    private $restClient;
-
-    /** @var UserApi */
-    private $userApi;
+    private OrgService $orgService;
+    private UserVoter $userVoter;
+    private Logger $logger;
+    private RestClient $restClient;
+    private UserApi$userApi;
 
     public function __construct(
         OrgService $orgService,
@@ -163,7 +154,7 @@ class IndexController extends AbstractController
      * @return array|Response
      * @throws \Throwable
      */
-    public function editUserAction(Request $request)
+    public function editUserAction(Request $request, TranslatorInterface $translator)
     {
         $filter = $request->get('filter');
 
@@ -192,8 +183,6 @@ class IndexController extends AbstractController
                 $this->addFlash('notice', 'Your changes were saved');
                 $this->redirectToRoute('admin_editUser', ['filter' => $user->getId()]);
             } catch (\Throwable $e) {
-                /** @var Translator $translator */
-                $translator = $this->get('translator');
                 switch ((int) $e->getCode()) {
                     case 422:
                         $form->get('email')->addError(new FormError($translator->trans('editUserForm.email.existingError', [], 'admin')));
@@ -361,7 +350,7 @@ class IndexController extends AbstractController
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
      * @Template("AppBundle:Admin/Index:uploadUsers.html.twig")
      */
-    public function uploadUsersAction(Request $request)
+    public function uploadUsersAction(Request $request, ClientInterface $redisClient)
     {
         $chunkSize = 2000;
 
@@ -404,13 +393,10 @@ class IndexController extends AbstractController
                 // big amount of data => store in redis + redirect
                 $chunks = array_chunk($data, $chunkSize);
 
-                /** @var \Redis $redis */
-                $redis = $this->get('snc_redis.default');
                 foreach ($chunks as $k => $chunk) {
                     $compressedData = CsvUploader::compressData($chunk);
-                    $redis->set('chunk' . $k, $compressedData);
+                    $redisClient->set('chunk' . $k, $compressedData);
                 }
-
 
                 return $this->redirect($this->generateUrl('casrec_upload', ['nOfChunks' => count($chunks), 'source' => $source]));
             } catch (\Throwable $e) {

--- a/client/src/AppBundle/Controller/ClientController.php
+++ b/client/src/AppBundle/Controller/ClientController.php
@@ -33,12 +33,6 @@ class ClientController extends AbstractController
     /** @var RestClient */
     private $restClient;
 
-    /** @var MailSender */
-    private $mailSender;
-
-    /** @var MailFactory */
-    private $mailFactory;
-
     /** @var RouterInterface */
     private $router;
 
@@ -46,15 +40,11 @@ class ClientController extends AbstractController
         UserApi $userApi,
         ClientApi $clientApi,
         RestClient $restClient,
-        MailSender $mailSender,
-        MailFactory $mailFactory,
         RouterInterface $router
     ) {
         $this->userApi = $userApi;
         $this->clientApi = $clientApi;
         $this->restClient = $restClient;
-        $this->mailSender = $mailSender;
-        $this->mailFactory = $mailFactory;
         $this->router = $router;
     }
 
@@ -133,8 +123,9 @@ class ClientController extends AbstractController
     /**
      * @Route("/client/add", name="client_add")
      * @Template("AppBundle:Client:add.html.twig")
+     * @return array|RedirectResponse
      */
-    public function addAction(Request $request, Redirector $redirector)
+    public function addAction(Request $request, Redirector $redirector, TranslatorInterface $translator, LoggerInterface $logger)
     {
         // redirect if user has missing details or is on wrong page
         $user = $this->userApi->getUserWithData();
@@ -177,12 +168,6 @@ class ClientController extends AbstractController
                     : $this->generateUrl('report_create', ['clientId' => $response['id']]);
                 return $this->redirect($url);
             } catch (\Throwable $e) {
-                /** @var TranslatorInterface $translator */
-                $translator = $this->get('translator');
-
-                /** @var LoggerInterface $logger */
-                $logger = $this->get('logger');
-
                 switch ((int) $e->getCode()) {
                     case 400:
                         $form->addError(new FormError($translator->trans('formErrors.matching', [], 'register')));

--- a/client/src/AppBundle/Controller/IndexController.php
+++ b/client/src/AppBundle/Controller/IndexController.php
@@ -54,8 +54,7 @@ class IndexController extends AbstractController
         TranslatorInterface $translator,
         RouterInterface $router,
         string $environment
-    )
-    {
+    ) {
         $this->deputyProvider = $deputyProvider;
         $this->eventDispatcher = $eventDispatcher;
         $this->tokenStorage = $tokenStorage;
@@ -167,10 +166,6 @@ class IndexController extends AbstractController
      */
     public function adLoginAction(Request $request, $userToken, $adId, $adFirstname, $adLastname)
     {
-        // logout first
-//        $this->get('security.token_storage')->setToken(null);
-//        $request->getSession()->invalidate();
-
         $this->logUserIn(['token' => $userToken], $request, [
             '_adId' => $adId,
             '_adFirstname' =>  $adFirstname,
@@ -353,11 +348,15 @@ class IndexController extends AbstractController
     {
         $referer = $request->headers->get('referer');
 
-        if (!is_string($referer)) return null;
+        if (!is_string($referer)) {
+            return null;
+        }
 
         $refererUrlPath = parse_url($referer, \PHP_URL_PATH);
 
-        if (!$refererUrlPath) return null;
+        if (!$refererUrlPath) {
+            return null;
+        }
 
         try {
             $routeParams = $this->router->match($refererUrlPath);

--- a/client/src/AppBundle/Controller/ManageController.php
+++ b/client/src/AppBundle/Controller/ManageController.php
@@ -18,7 +18,12 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
  */
 class ManageController extends AbstractController
 {
-    public function __construct(){}
+    private string $symfonyEnvironment;
+
+    public function __construct(string $symfonyEnvironment)
+    {
+        $this->symfonyEnvironment = $symfonyEnvironment;
+    }
 
     /**
      * @Route("/availability", methods={"GET"})
@@ -27,7 +32,7 @@ class ManageController extends AbstractController
      * @param ApiAvailability $apiAvailability
      * @param NotifyAvailability $notifyAvailability
      * @param RedisAvailability $redisAvailability
-     *
+
      * @return Response|null
      */
     public function availabilityAction(
@@ -35,9 +40,7 @@ class ManageController extends AbstractController
         ApiAvailability $apiAvailability,
         NotifyAvailability $notifyAvailability,
         RedisAvailability $redisAvailability
-    )
-    {
-
+    ) {
         $services = [
             $apiAvailability,
             $redisAvailability,
@@ -55,7 +58,7 @@ class ManageController extends AbstractController
         $response = $this->render('AppBundle:Manage:availability.html.twig', [
             'services' => $services,
             'errors' => $errors,
-            'environment' => $this->get('kernel')->getEnvironment(),
+            'environment' => $this->symfonyEnvironment,
         ]);
 
         $response->setStatusCode($healthy ? 200 : 500);
@@ -76,8 +79,7 @@ class ManageController extends AbstractController
         ApiAvailability $apiAvailability,
         NotifyAvailability $notifyAvailability,
         RedisAvailability $redisAvailability
-    )
-    {
+    ) {
         $services = [
             $apiAvailability,
             $redisAvailability,

--- a/client/src/AppBundle/Controller/Ndr/IncomeBenefitController.php
+++ b/client/src/AppBundle/Controller/Ndr/IncomeBenefitController.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class IncomeBenefitController extends AbstractController
 {
@@ -42,8 +43,7 @@ class IncomeBenefitController extends AbstractController
         ReportApi $reportApi,
         RestClient $restClient,
         StepRedirector $stepRedirector
-    )
-    {
+    ) {
         $this->reportApi = $reportApi;
         $this->restClient = $restClient;
         $this->stepRedirector = $stepRedirector;
@@ -73,7 +73,7 @@ class IncomeBenefitController extends AbstractController
      * @Route("/ndr/{ndrId}/income-benefits/step/{step}", name="ndr_income_benefits_step")
      * @Template("AppBundle:Ndr/IncomeBenefit:step.html.twig")
      */
-    public function stepAction(Request $request, $ndrId, $step)
+    public function stepAction(Request $request, $ndrId, $step, TranslatorInterface $translator)
     {
         $totalSteps = 5;
         if ($step < 1 || $step > $totalSteps) {
@@ -89,9 +89,12 @@ class IncomeBenefitController extends AbstractController
             ->setCurrentStep($step)->setTotalSteps($totalSteps)
             ->setRouteBaseParams(['ndrId' => $ndrId]);
 
-        $form = $this->createForm(FormDir\Ndr\IncomeBenefitType::class, $ndr, [ 'step'            => $step, 'translator'      => $this->get('translator'), 'clientFirstName' => $ndr->getClient()->getFirstname()
-                                   ]
-                                 );
+        $form = $this->createForm(
+            FormDir\Ndr\IncomeBenefitType::class,
+            $ndr,
+            [ 'step' => $step, 'translator'  => $translator, 'clientFirstName' => $ndr->getClient()->getFirstname() ]
+        );
+
         $form->handleRequest($request);
 
         if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {

--- a/client/src/AppBundle/Controller/Ndr/VisitsCareController.php
+++ b/client/src/AppBundle/Controller/Ndr/VisitsCareController.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class VisitsCareController extends AbstractController
 {
@@ -39,8 +40,7 @@ class VisitsCareController extends AbstractController
         ReportApi $reportApi,
         RestClient $restClient,
         StepRedirector $stepRedirector
-    )
-    {
+    ) {
         $this->reportApi = $reportApi;
         $this->restClient = $restClient;
         $this->stepRedirector = $stepRedirector;
@@ -77,7 +77,7 @@ class VisitsCareController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function stepAction(Request $request, $ndrId, $step)
+    public function stepAction(Request $request, $ndrId, $step, TranslatorInterface $translator)
     {
         $totalSteps = 5;
         if ($step < 1 || $step > $totalSteps) {
@@ -94,9 +94,16 @@ class VisitsCareController extends AbstractController
             ->setCurrentStep($step)->setTotalSteps($totalSteps)
             ->setRouteBaseParams(['ndrId'=>$ndrId]);
 
-        $form = $this->createForm(FormDir\Ndr\VisitsCareType::class, $visitsCare, [ 'step'            => $step, 'translator'      => $this->get('translator'), 'clientFirstName' => $ndr->getClient()->getFirstname()
-                                   ]
-                                 );
+        $form = $this->createForm(
+            FormDir\Ndr\VisitsCareType::class,
+            $visitsCare,
+            [
+                'step' => $step,
+                'translator' => $translator,
+                'clientFirstName' => $ndr->getClient()->getFirstname()
+            ]
+        );
+
         $form->handleRequest($request);
 
         if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {

--- a/client/src/AppBundle/Controller/Org/ClientContactController.php
+++ b/client/src/AppBundle/Controller/Org/ClientContactController.php
@@ -7,6 +7,7 @@ use AppBundle\Entity as EntityDir;
 use AppBundle\Form as FormDir;
 use AppBundle\Service\Client\Internal\ClientApi;
 use AppBundle\Service\Client\RestClient;
+use Psr\Log\LoggerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -33,8 +34,7 @@ class ClientContactController extends AbstractController
     public function __construct(
         ClientApi $clientApi,
         RestClient $restClient
-    )
-    {
+    ) {
         $this->clientApi = $clientApi;
         $this->restClient = $restClient;
     }
@@ -63,7 +63,10 @@ class ClientContactController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->restClient->post('clients/' . $client->getId() . '/clientcontacts', $form->getData(), ['add_clientcontact']
+            $this->restClient->post(
+                'clients/' . $client->getId() . '/clientcontacts',
+                $form->getData(),
+                ['add_clientcontact']
             );
             $request->getSession()->getFlashBag()->add('notice', 'The contact has been added');
 
@@ -94,7 +97,10 @@ class ClientContactController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $this->restClient->put('/clientcontacts/' . $id, $form->getData(), ['edit_clientcontact']
+            $this->restClient->put(
+                '/clientcontacts/' . $id,
+                $form->getData(),
+                ['edit_clientcontact']
             );
             $request->getSession()->getFlashBag()->add('notice', 'The contact has been updated');
             return $this->redirect($backLink);
@@ -113,7 +119,7 @@ class ClientContactController extends AbstractController
      * @Template("AppBundle:Common:confirmDelete.html.twig")
      * @throws \Exception
      */
-    public function deleteConfirmAction(Request $request, $id, $confirmed = false)
+    public function deleteConfirmAction(Request $request, $id, $confirmed = false, LoggerInterface $logger)
     {
         $form = $this->createForm(FormDir\ConfirmDeleteType::class);
         $form->handleRequest($request);
@@ -127,7 +133,7 @@ class ClientContactController extends AbstractController
                 $this->restClient->delete('clientcontacts/' . $id);
                 $request->getSession()->getFlashBag()->add('notice', 'Contact has been removed');
             } catch (\Throwable $e) {
-                $this->get('logger')->error($e->getMessage());
+                $logger->error($e->getMessage());
                 $request->getSession()->getFlashBag()->add(
                     'error',
                     'Client contact could not be removed'

--- a/client/src/AppBundle/Controller/Org/IndexController.php
+++ b/client/src/AppBundle/Controller/Org/IndexController.php
@@ -146,7 +146,7 @@ class IndexController extends AbstractController
      * @Route("/client/{clientId}/archive", name="org_client_archive")
      * @Template("AppBundle:Org/Index:clientArchive.html.twig")
      */
-    public function clientArchiveAction(Request $request, $clientId)
+    public function clientArchiveAction(Request $request, $clientId, TranslatorInterface $translator)
     {
         /** @var Client $client */
         $client = $this->restClient->get('client/' . $clientId, 'Client', ['client', 'report-id', 'current-report']);
@@ -164,9 +164,6 @@ class IndexController extends AbstractController
                 $this->addFlash('notice', 'The client has been archived');
                 return $this->redirectToRoute('org_dashboard');
             } else {
-                /** @var TranslatorInterface $translator */
-                $translator = $this->get('translator');
-
                 $form->get('confirmArchive')->addError(new FormError($translator->trans('form.error.confirmArchive', [], 'pa-client-archive')));
             }
         }

--- a/client/src/AppBundle/Controller/Org/NoteController.php
+++ b/client/src/AppBundle/Controller/Org/NoteController.php
@@ -7,6 +7,7 @@ use AppBundle\Entity as EntityDir;
 use AppBundle\Form as FormDir;
 use AppBundle\Service\Client\Internal\ClientApi;
 use AppBundle\Service\Client\RestClient;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
@@ -33,8 +34,7 @@ class NoteController extends AbstractController
     public function __construct(
         ClientApi $clientApi,
         RestClient $restClient
-    )
-    {
+    ) {
         $this->clientApi = $clientApi;
         $this->restClient = $restClient;
     }
@@ -129,12 +129,11 @@ class NoteController extends AbstractController
      *
      * @param Request $request
      * @param $noteId
-     * @param bool $confirmed
-     *
+     * @param LoggerInterface $logger
      * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
      * @throws \Exception
      */
-    public function deleteConfirmAction(Request $request, $noteId, $confirmed = false)
+    public function deleteConfirmAction(Request $request, $noteId, LoggerInterface $logger)
     {
         /** @var EntityDir\Note $note */
         $note = $this->getNote($noteId);
@@ -155,7 +154,7 @@ class NoteController extends AbstractController
 
                 $request->getSession()->getFlashBag()->add('notice', 'Note has been removed');
             } catch (\Throwable $e) {
-                $this->get('logger')->error($e->getMessage());
+                $logger->error($e->getMessage());
 
                 $request->getSession()->getFlashBag()->add('error', 'Note could not be removed');
             }

--- a/client/src/AppBundle/Controller/Org/OrganisationController.php
+++ b/client/src/AppBundle/Controller/Org/OrganisationController.php
@@ -12,7 +12,6 @@ use AppBundle\Service\Client\Internal\UserApi;
 use AppBundle\Service\Client\RestClient;
 use AppBundle\Service\Logger;
 use AppBundle\Service\Time\DateTimeProvider;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Form\FormError;
@@ -26,33 +25,27 @@ use Symfony\Component\Translation\TranslatorInterface;
  */
 class OrganisationController extends AbstractController
 {
-    /** @var DateTimeProvider */
-    private $dateTimeProvider;
-
-    /** @var Logger */
-    private $logger;
-
-    /** @var UserApi */
-    private $userApi;
-
-    /** @var RestClient */
-    private $restClient;
-
-    /** @var OrganisationApi */
-    private $organisationApi;
+    private DateTimeProvider $dateTimeProvider;
+    private Logger $logger;
+    private UserApi $userApi;
+    private RestClient $restClient;
+    private OrganisationApi $organisationApi;
+    private TranslatorInterface $translator;
 
     public function __construct(
         DateTimeProvider $dateTimeProvider,
         Logger $logger,
         UserApi $userApi,
         RestClient $restClient,
-        OrganisationApi $organisationApi
+        OrganisationApi $organisationApi,
+        TranslatorInterface $translator
     ) {
         $this->dateTimeProvider = $dateTimeProvider;
         $this->logger = $logger;
         $this->userApi = $userApi;
         $this->restClient = $restClient;
         $this->organisationApi = $organisationApi;
+        $this->translator = $translator;
     }
 
     /**
@@ -148,7 +141,7 @@ class OrganisationController extends AbstractController
                 switch ((int) $e->getCode()) {
                     case 422:
                         /** @var TranslatorInterface */
-                        $translator = $this->get('translator');
+                        $translator = $this->translator;
 
                         $form->get('email')->addError(new FormError($translator->trans('form.email.existingError', [], 'org-organisation')));
                         break;
@@ -218,7 +211,7 @@ class OrganisationController extends AbstractController
                 switch ((int) $e->getCode()) {
                     case 422:
                         /** @var TranslatorInterface */
-                        $translator = $this->get('translator');
+                        $translator = $this->translator;
                         $form->get('email')->addError(new FormError($translator->trans('form.email.existingError', [], 'org-organisation')));
                         break;
 
@@ -308,9 +301,7 @@ class OrganisationController extends AbstractController
                 'An activation email has been sent to the user.'
             );
         } catch (\Throwable $e) {
-            /** @var LoggerInterface */
-            $logger = $this->get('logger');
-            $logger->debug($e->getMessage());
+            $this->logger->debug($e->getMessage());
 
             $this->addFlash(
                 'error',

--- a/client/src/AppBundle/Controller/Org/TeamController.php
+++ b/client/src/AppBundle/Controller/Org/TeamController.php
@@ -8,29 +8,34 @@ use AppBundle\Exception\RestClientException;
 use AppBundle\Form as FormDir;
 use AppBundle\Service\Client\Internal\UserApi;
 use AppBundle\Service\Client\RestClient;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @Route("/org/settings/user-accounts")
  */
 class TeamController extends AbstractController
 {
-    /**@var RestClient */
-    private $restClient;
-
-    /** @var UserApi */
-    private $userApi;
+    private RestClient $restClient;
+    private UserApi $userApi;
+    private LoggerInterface $logger;
+    private TranslatorInterface $translator;
 
     public function __construct(
         RestClient $restClient,
-        UserApi $userApi
+        UserApi $userApi,
+        LoggerInterface $logger,
+        TranslatorInterface $translator
     ) {
         $this->restClient = $restClient;
         $this->userApi = $userApi;
+        $this->logger = $logger;
+        $this->translator = $translator;
     }
 
     /**
@@ -110,7 +115,7 @@ class TeamController extends AbstractController
             } catch (\Throwable $e) {
                 switch ((int) $e->getCode()) {
                     case 422:
-                        $form->get('email')->addError(new FormError($this->get('translator')->trans('form.email.existingError', [], 'org-team')));
+                        $form->get('email')->addError(new FormError($this->translator->trans('form.email.existingError', [], 'org-team')));
                         break;
 
                     default:
@@ -177,7 +182,7 @@ class TeamController extends AbstractController
             } catch (\Throwable $e) {
                 switch ((int) $e->getCode()) {
                     case 422:
-                        $form->get('email')->addError(new FormError($this->get('translator')->trans('form.email.existingError', [], 'org-team')));
+                        $form->get('email')->addError(new FormError($this->translator->trans('form.email.existingError', [], 'org-team')));
                         break;
 
                     default:
@@ -215,7 +220,7 @@ class TeamController extends AbstractController
                 'An activation email has been sent to the user.'
             );
         } catch (\Throwable $e) {
-            $this->get('logger')->debug($e->getMessage());
+            $this->logger->debug($e->getMessage());
             $request->getSession()->getFlashBag()->add(
                 'error',
                 'An activation email could not be sent.'
@@ -248,7 +253,7 @@ class TeamController extends AbstractController
 
                 $request->getSession()->getFlashBag()->add('notice', 'User account removed');
             } catch (\Throwable $e) {
-                $this->get('logger')->debug($e->getMessage());
+                $this->logger->debug($e->getMessage());
 
                 if ($e instanceof RestClientException && isset($e->getData()['message'])) {
                     $request->getSession()->getFlashBag()->add(

--- a/client/src/AppBundle/Controller/Report/ActionController.php
+++ b/client/src/AppBundle/Controller/Report/ActionController.php
@@ -5,13 +5,13 @@ namespace AppBundle\Controller\Report;
 use AppBundle\Controller\AbstractController;
 use AppBundle\Entity as EntityDir;
 use AppBundle\Form as FormDir;
-
 use AppBundle\Service\Client\Internal\ReportApi;
 use AppBundle\Service\Client\RestClient;
 use AppBundle\Service\StepRedirector;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class ActionController extends AbstractController
 {
@@ -33,8 +33,7 @@ class ActionController extends AbstractController
         RestClient $restClient,
         ReportApi $reportApi,
         StepRedirector $stepRedirector
-    )
-    {
+    ) {
         $this->restClient = $restClient;
         $this->reportApi = $reportApi;
         $this->stepRedirector = $stepRedirector;
@@ -60,7 +59,7 @@ class ActionController extends AbstractController
      * @Route("/report/{reportId}/actions/step/{step}", name="actions_step")
      * @Template("AppBundle:Report/Action:step.html.twig")
      */
-    public function stepAction(Request $request, $reportId, $step)
+    public function stepAction(Request $request, $reportId, $step, TranslatorInterface $translator)
     {
         $totalSteps = 2;
         if ($step < 1 || $step > $totalSteps) {
@@ -76,9 +75,16 @@ class ActionController extends AbstractController
             ->setCurrentStep($step)->setTotalSteps($totalSteps)
             ->setRouteBaseParams(['reportId' => $reportId]);
 
-        $form = $this->createForm(FormDir\Report\ActionType::class, $action, [ 'step'            => $step, 'translator'      => $this->get('translator'), 'clientFirstName' => $report->getClient()->getFirstname()
-                                   ]
-                                 );
+        $form = $this->createForm(
+            FormDir\Report\ActionType::class,
+            $action,
+            [
+                'step' => $step,
+                'translator' => $translator,
+                'clientFirstName' => $report->getClient()->getFirstname()
+            ]
+        );
+
         $form->handleRequest($request);
 
         if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {

--- a/client/src/AppBundle/Controller/Report/BankAccountController.php
+++ b/client/src/AppBundle/Controller/Report/BankAccountController.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class BankAccountController extends AbstractController
 {
@@ -34,8 +35,7 @@ class BankAccountController extends AbstractController
         RestClient $restClient,
         ReportApi $reportApi,
         StepRedirector $stepRedirector
-    )
-    {
+    ) {
         $this->restClient = $restClient;
         $this->reportApi = $reportApi;
         $this->stepRedirector = $stepRedirector;
@@ -239,9 +239,8 @@ class BankAccountController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function deleteConfirmAction(Request $request, $reportId, $accountId)
+    public function deleteConfirmAction(Request $request, $reportId, $accountId, TranslatorInterface $translator)
     {
-        $translator = $this->get('translator');
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         $summaryPageUrl = $this->generateUrl('bank_accounts_summary', ['reportId' => $reportId]);
 
@@ -301,7 +300,9 @@ class BankAccountController extends AbstractController
         if ($dependentRecords['transactionsCount'] > 0) {
             $transactionTypes = [];
             foreach ($dependentRecords['transactions'] as $type => $count) {
-                if ($count > 0) $transactionTypes[] = $translator->trans($type, [], 'common');
+                if ($count > 0) {
+                    $transactionTypes[] = $translator->trans($type, [], 'common');
+                }
             }
 
             $templateData['warning'] = $translator->trans(

--- a/client/src/AppBundle/Controller/Report/VisitsCareController.php
+++ b/client/src/AppBundle/Controller/Report/VisitsCareController.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class VisitsCareController extends AbstractController
 {
@@ -34,8 +35,7 @@ class VisitsCareController extends AbstractController
         RestClient $restClient,
         ReportApi $reportApi,
         StepRedirector $stepRedirector
-    )
-    {
+    ) {
         $this->restClient = $restClient;
         $this->reportApi = $reportApi;
         $this->stepRedirector = $stepRedirector;
@@ -72,7 +72,7 @@ class VisitsCareController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function stepAction(Request $request, $reportId, $step)
+    public function stepAction(Request $request, $reportId, $step, TranslatorInterface $translator)
     {
         $totalSteps = 4;
         if ($step < 1 || $step > $totalSteps) {
@@ -88,9 +88,16 @@ class VisitsCareController extends AbstractController
             ->setCurrentStep($step)->setTotalSteps($totalSteps)
             ->setRouteBaseParams(['reportId' => $reportId]);
 
-        $form = $this->createForm(FormDir\Report\VisitsCareType::class, $visitsCare, [ 'step'            => $step, 'translator'      => $this->get('translator'), 'clientFirstName' => $report->getClient()->getFirstname()
-                                   ]
-                                 );
+        $form = $this->createForm(
+            FormDir\Report\VisitsCareType::class,
+            $visitsCare,
+            [
+                'step' => $step,
+                'translator' => $translator,
+                'clientFirstName' => $report->getClient()->getFirstname()
+            ]
+        );
+
         $form->handleRequest($request);
 
         if ($form->get('save')->isClicked() && $form->isSubmitted() && $form->isValid()) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,7 +148,7 @@ services:
         restart: always
 
     file-scanner-server:
-        image: mkodockx/docker-clamav
+        image: mkodockx/docker-clamav:alpine
         environment:
             CLAMD_CONF_SelfCheck: 0
             FRESHCLAM_CONF_NotifyClamd: 'no'


### PR DESCRIPTION
## Purpose
Following other refactors this change removes any remaining instances of accessing services directly in controllers or other services and instead replaces with DI.

This is one of two PRs for the client and API apps - split up to make the review (hopefully) easier.

Fixes DDPB-3668

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes
