### PR TITLE
DDPB-3668: Remove direct container access from API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ up-app-xdebug-api: ## Brings the app up, rebuilds containers and enabled xdebug 
 	REQUIRE_XDEBUG_API=true docker-compose up -d --build
 
 up-app-integration-tests: ## Brings the app up using test env vars (see test.env)
-	REQUIRE_XDEBUG_FRONTEND=false REQUIRE_XDEBUG_API=false docker-compose build frontend admin api
+	REQUIRE_XDEBUG_FRONTEND=false REQUIRE_XDEBUG_API=false docker-compose -f docker-compose.yml -f docker-compose.dev.yml build frontend admin api
 	docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
 
 down-app: ### Tears down the app

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /var/www
 EXPOSE 80
 EXPOSE 443
 ENV TIMEOUT=20
-ENV PHP_EXT_DIR=/usr/lib/php7/modules
+ENV PHP_EXT_DIR=/usr/local/lib/php/extensions/no-debug-non-zts-20190902
 
 RUN apk --no-cache add \
 postgresql-dev \
@@ -37,8 +37,9 @@ RUN docker-php-ext-enable opcache
 
 # Install Xdebug if directed to with build arg from docker-compose.yml
 ARG REQUIRE_XDEBUG=false
-RUN if [[ $REQUIRE_XDEBUG = "true" ]] ; then \
-        apk add --no-cache php7-pecl-xdebug; \
+RUN if [[ $REQUIRE_XDEBUG = true ]] ; then \
+        apk add --no-cache $PHPIZE_DEPS; \
+        pecl install xdebug-2.9.8; \
         docker-php-ext-enable $PHP_EXT_DIR/xdebug.so; \
     fi ;
 

--- a/api/app/config/security.yml
+++ b/api/app/config/security.yml
@@ -11,7 +11,6 @@ services:
         arguments: [ '@em', "@snc_redis.default", "@logger", { "timeout_seconds": "%user_provider_timeout_seconds%" }, '@AppBundle\Entity\Repository\UserRepository' ]
 
     AppBundle\Service\Auth\AuthService:
-        public: true
         arguments:
             $encoderFactory: '@security.encoder_factory'
             $logger: '@logger'
@@ -25,9 +24,9 @@ services:
             - [ setRedisPrefix, ["ac_ret_code"] ]
             # after 5 attempts in the last 10 minutes, return a different return code (activate captcha)
             - [ addTrigger, [  5, 600 ] ]
+
     AppBundle\Service\BruteForce\AttemptsIncrementalWaitingChecker:
         arguments: [ "@snc_redis.default" ]
-        public: true
         calls:
             - [ setRedisPrefix, ["ac_exception"] ]
             # after 10 attempts, freeze for 30 minutes

--- a/api/app/config/services.yml
+++ b/api/app/config/services.yml
@@ -12,7 +12,6 @@ imports:
 services:
     em:
         alias: doctrine.orm.entity_manager
-        public: true
 
     monolog.processor.add_request_id:
         class: AppBundle\Service\RequestIdLoggerProcessor

--- a/api/app/config/services/controllers.yml
+++ b/api/app/config/services/controllers.yml
@@ -9,3 +9,5 @@ services:
       - '@AppBundle\Entity\Repository\ReportRepository'
       - '@AppBundle\Service\ReportService'
       - '@em'
+      - '@AppBundle\Service\Auth\AuthService'
+      - '@AppBundle\Service\Formatter\RestFormatter'

--- a/api/app/config/services/defaults.yml
+++ b/api/app/config/services/defaults.yml
@@ -2,6 +2,9 @@ services:
     _defaults:
         autowire: true
         autoconfigure: true
+        bind:
+            $symfonyEnvironment: "%kernel.environment%"
+
 
     AppBundle\:
         resource: "@AppBundle/*"

--- a/api/app/config/services/event_listeners.yml
+++ b/api/app/config/services/event_listeners.yml
@@ -1,7 +1,6 @@
 services:
     AppBundle\EventListener\RestInputOuputFormatter:
         arguments: [ "@jms_serializer", "@logger", ["json"], "json", "%kernel.debug%" ]
-        public: true
         tags:
             - { name: kernel.event_listener, event: kernel.view, method: onKernelView }
             - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }

--- a/api/app/config/services/factories.yml
+++ b/api/app/config/services/factories.yml
@@ -25,6 +25,5 @@ parameters:
 
 services:
   AppBundle\Factory\OrganisationFactory:
-    public: true
     class: AppBundle\Factory\OrganisationFactory
     arguments: ['%shared_email_domains%']

--- a/api/src/AppBundle/Controller/AuthController.php
+++ b/api/src/AppBundle/Controller/AuthController.php
@@ -4,37 +4,57 @@ namespace AppBundle\Controller;
 
 use AppBundle\EventListener\RestInputOuputFormatter;
 use AppBundle\Exception as AppException;
+use AppBundle\Service\Auth\AuthService;
 use AppBundle\Service\Auth\HeaderTokenAuthenticator;
 use AppBundle\Service\Auth\UserProvider;
 use AppBundle\Service\BruteForce\AttemptsIncrementalWaitingChecker;
 use AppBundle\Service\BruteForce\AttemptsInTimeChecker;
+use AppBundle\Service\Formatter\RestFormatter;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * @Route("/auth")
  */
 class AuthController extends RestController
 {
+    private AuthService $authService;
+    private RestFormatter $formatter;
+
+    public function __construct(AuthService $authService, RestFormatter $restFormatter)
+    {
+        $this->authService = $authService;
+        $this->formatter = $restFormatter;
+    }
+
     /**
      * Return the user by email&password or token
      * expected keys in body: 'token' or ('email' and 'password').
      *
-     *
      * @Route("/login", methods={"POST"})
+     * @param Request $request
+     * @param UserProvider $userProvider
+     * @param AttemptsInTimeChecker $attemptsInTimechecker
+     * @param AttemptsIncrementalWaitingChecker $incrementalWaitingTimechecker
+     * @param RestInputOuputFormatter $restInputOuputFormatter
+     * @param EntityManagerInterface $em
+     * @param AuthService $authService
+     * @return \AppBundle\Entity\User|bool|null
      */
     public function login(
         Request $request,
         UserProvider $userProvider,
         AttemptsInTimeChecker $attemptsInTimechecker,
         AttemptsIncrementalWaitingChecker $incrementalWaitingTimechecker,
-        RestInputOuputFormatter $restInputOuputFormatter
-    )
-    {
-        if (!$this->getAuthService()->isSecretValid($request)) {
+        RestInputOuputFormatter $restInputOuputFormatter,
+        EntityManagerInterface $em
+    ) {
+        if (!$this->authService->isSecretValid($request)) {
             throw new AppException\UnauthorisedException('client secret not accepted.');
         }
-        $data = $this->deserializeBodyContent($request);
+        $data = $this->formatter->deserializeBodyContent($request);
 
         //brute force checks
         $index = array_key_exists('token', $data) ? 'token' : 'email';
@@ -55,9 +75,9 @@ class AuthController extends RestController
 
         // load user by credentials (token or username & password)
         if (array_key_exists('token', $data)) {
-            $user = $this->getAuthService()->getUserByToken($data['token']);
+            $user = $this->authService->getUserByToken($data['token']);
         } else {
-            $user = $this->getAuthService()->getUserByEmailAndPassword(strtolower($data['email']), $data['password']);
+            $user = $this->authService->getUserByEmailAndPassword(strtolower($data['email']), $data['password']);
         }
 
         if (!$user) {
@@ -68,7 +88,7 @@ class AuthController extends RestController
                 throw new AppException\UserWrongCredentials();
             }
         }
-        if (!$this->getAuthService()->isSecretValidForRole($user->getRoleName(), $request)) {
+        if (!$this->authService->isSecretValidForRole($user->getRoleName(), $request)) {
             throw new AppException\UnauthorisedException($user->getRoleName() . ' user role not allowed from this client.');
         }
 
@@ -78,7 +98,8 @@ class AuthController extends RestController
 
         $randomToken = $userProvider->generateRandomTokenAndStore($user);
         $user->setLastLoggedIn(new \DateTime());
-        $this->get('em')->flush($user);
+        $em->persist($user);
+        $em->flush();
 
         // add token into response
         $restInputOuputFormatter->addResponseModifier(function ($response) use ($randomToken) {
@@ -86,7 +107,7 @@ class AuthController extends RestController
         });
 
         // needed for redirector
-        $this->setJmsSerialiserGroups(['user', 'user-login']);
+        $this->formatter->setJmsSerialiserGroups(['user', 'user-login']);
 
         return $user;
     }
@@ -109,10 +130,10 @@ class AuthController extends RestController
      *
      * @Route("/get-logged-user", methods={"GET"})
      */
-    public function getLoggedUser()
+    public function getLoggedUser(TokenStorageInterface $tokenStorage)
     {
-        $this->setJmsSerialiserGroups(['user']);
+        $this->formatter->setJmsSerialiserGroups(['user']);
 
-        return $this->get('security.token_storage')->getToken()->getUser();
+        return $tokenStorage->getToken()->getUser();
     }
 }

--- a/api/src/AppBundle/Controller/CasRecController.php
+++ b/api/src/AppBundle/Controller/CasRecController.php
@@ -5,12 +5,10 @@ namespace AppBundle\Controller;
 use AppBundle\Entity\CasRec;
 use AppBundle\Entity\Repository\CasRecRepository;
 use AppBundle\Service\CasrecVerificationService;
-use AppBundle\Service\CsvUploader;
-use Doctrine\ORM\QueryBuilder;
+use AppBundle\Service\Formatter\RestFormatter;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -18,14 +16,13 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class CasRecController extends RestController
 {
-    /**
-     * @var CasrecVerificationService
-     */
-    private $casrecVerification;
+    private CasrecVerificationService $casrecVerification;
+    private RestFormatter $formatter;
 
-    public function __construct(CasrecVerificationService $casrecVerification)
+    public function __construct(CasrecVerificationService $casrecVerification, RestFormatter $formatter)
     {
         $this->casrecVerification = $casrecVerification;
+        $this->formatter = $formatter;
     }
 
     /**
@@ -55,7 +52,7 @@ class CasRecController extends RestController
      */
     public function verify(Request $request, CasrecVerificationService $verificationService)
     {
-        $clientData = $this->deserializeBodyContent($request);
+        $clientData = $this->formatter->deserializeBodyContent($request);
         $user = $this->getUser();
 
         $casrecVerified = $verificationService->validate(

--- a/api/src/AppBundle/Controller/ManageController.php
+++ b/api/src/AppBundle/Controller/ManageController.php
@@ -2,6 +2,8 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Service\Formatter\RestFormatter;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -9,20 +11,31 @@ use Symfony\Component\Routing\Annotation\Route;
  */
 class ManageController extends RestController
 {
+    private string $symfonyEnvironment;
+    private LoggerInterface $logger;
+    private RestFormatter $restFormatter;
+
+    public function __construct(string $symfonyEnvironment, LoggerInterface $logger, RestFormatter $restFormatter)
+    {
+        $this->symfonyEnvironment = $symfonyEnvironment;
+        $this->logger = $logger;
+        $this->restFormatter = $restFormatter;
+    }
+
     /**
      * @Route("/availability", methods={"GET"})
+     *
+     * @return array
      */
     public function availabilityAction()
     {
         list($dbHealthy, $dbError) = $this->dbInfo();
 
-        $data = [
+        return [
             'healthy' => $dbHealthy,
-            'environment' => $this->get('kernel')->getEnvironment(),
+            'environment' => $this->symfonyEnvironment,
             'errors' => implode("\n", array_filter([$dbError])),
         ];
-
-        return $data;
     }
 
     /**
@@ -34,6 +47,7 @@ class ManageController extends RestController
     }
 
     /**
+     * @param LoggerInterface $logger
      * @return array [boolean healthy, error string]
      */
     private function dbInfo()
@@ -52,8 +66,7 @@ class ManageController extends RestController
                 $returnMessage = 'Migrations table missing.';
             }
 
-            // log real error message
-            $this->get('logger')->error($e->getMessage());
+            $this->logger->error($e->getMessage());
 
             return [false, $returnMessage];
         }

--- a/api/src/AppBundle/Controller/NoteController.php
+++ b/api/src/AppBundle/Controller/NoteController.php
@@ -3,6 +3,9 @@
 namespace AppBundle\Controller;
 
 use AppBundle\Entity as EntityDir;
+use AppBundle\Service\Formatter\RestFormatter;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
@@ -12,6 +15,15 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class NoteController extends RestController
 {
+    private EntityManagerInterface $em;
+    private RestFormatter $formatter;
+
+    public function __construct(EntityManagerInterface $em, RestFormatter $formatter)
+    {
+        $this->em = $em;
+        $this->formatter = $formatter;
+    }
+
     /**
      * @Route("{clientId}", requirements={"clientId":"\d+"}, methods={"POST"})
      * @Security("has_role('ROLE_ORG')")
@@ -22,14 +34,16 @@ class NoteController extends RestController
         $this->denyAccessIfClientDoesNotBelongToUser($client);
 
         // hydrate and persist
-        $data = $this->deserializeBodyContent($request, [
+        $data = $this->formatter->deserializeBodyContent($request, [
             'title' => 'notEmpty',
             'category' => 'mustExist',
             'content' => 'mustExist',
         ]);
         $note = new EntityDir\Note($client, $data['category'], $data['title'], $data['content']);
         $note->setCreatedBy($this->getUser());
-        $this->persistAndFlush($note);
+
+        $this->em->persist($note);
+        $this->em->flush();
 
         return ['id' => $note->getId()];
     }
@@ -47,7 +61,7 @@ class NoteController extends RestController
     {
         $serialisedGroups = $request->query->has('groups')
             ? (array) $request->query->get('groups') : ['notes', 'user'];
-        $this->setJmsSerialiserGroups($serialisedGroups);
+        $this->formatter->setJmsSerialiserGroups($serialisedGroups);
 
         $note = $this->findEntityBy(EntityDir\Note::class, $id); /* @var $note EntityDir\Note */
         $this->denyAccessIfClientDoesNotBelongToUser($note->getClient());
@@ -69,7 +83,7 @@ class NoteController extends RestController
         // enable if the check above is removed and the note is available for editing for the whole team
         $this->denyAccessIfClientDoesNotBelongToUser($note->getClient());
 
-        $data = $this->deserializeBodyContent($request);
+        $data = $this->formatter->deserializeBodyContent($request);
         $this->hydrateEntityWithArrayData($note, $data, [
             'category' => 'setCategory',
             'title' => 'setTitle',
@@ -78,7 +92,7 @@ class NoteController extends RestController
 
         $note->setLastModifiedBy($this->getUser());
 
-        $this->getEntityManager()->flush($note);
+        $this->em->flush($note);
 
         return $note->getId();
     }
@@ -91,9 +105,10 @@ class NoteController extends RestController
      *
      * @param int $id
      *
+     * @param LoggerInterface $logger
      * @return array
      */
-    public function delete($id)
+    public function delete($id, LoggerInterface $logger)
     {
         try {
             /** @var $note EntityDir\Note $note */
@@ -102,11 +117,11 @@ class NoteController extends RestController
             // enable if the check above is removed and the note is available for editing for the whole team
             $this->denyAccessIfClientDoesNotBelongToUser($note->getClient());
 
-            $this->getEntityManager()->remove($note);
+            $this->em->remove($note);
 
-            $this->getEntityManager()->flush($note);
+            $this->em->flush($note);
         } catch (\Throwable $e) {
-            $this->get('logger')->error('Failed to delete note ID: ' . $id . ' - ' . $e->getMessage());
+            $logger->error('Failed to delete note ID: ' . $id . ' - ' . $e->getMessage());
         }
 
         return [];

--- a/api/src/AppBundle/Controller/Report/DocumentController.php
+++ b/api/src/AppBundle/Controller/Report/DocumentController.php
@@ -6,9 +6,10 @@ use AppBundle\Controller\RestController;
 use AppBundle\Entity as EntityDir;
 use AppBundle\Entity\Report\Document;
 use AppBundle\Exception\UnauthorisedException;
+use AppBundle\Service\Auth\AuthService;
+use AppBundle\Service\Formatter\RestFormatter;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
-use PhpParser\Comment\Doc;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,7 +20,18 @@ class DocumentController extends RestController
     const RETRIES_FAILED_MESSAGE = 'Document failed to sync after 4 attempts';
     const REPORT_PDF_FAILED_MESSAGE = 'Report PDF failed to sync';
 
-    private $sectionIds = [EntityDir\Report\Report::SECTION_DOCUMENTS];
+    private EntityManagerInterface $em;
+    private AuthService $authService;
+    private RestFormatter $formatter;
+
+    private array $sectionIds = [EntityDir\Report\Report::SECTION_DOCUMENTS];
+
+    public function __construct(EntityManagerInterface $em, AuthService $authService, RestFormatter $formatter)
+    {
+        $this->authService = $authService;
+        $this->em = $em;
+        $this->formatter = $formatter;
+    }
 
     /**
      * @Route("/document/{reportType}/{reportId}", requirements={
@@ -39,7 +51,7 @@ class DocumentController extends RestController
         $this->denyAccessIfReportDoesNotBelongToUser($report);
 
         // hydrate and persist
-        $data = $this->deserializeBodyContent($request, [
+        $data = $this->formatter->deserializeBodyContent($request, [
             'file_name' => 'notEmpty',
             'storage_reference' => 'notEmpty'
         ]);
@@ -52,10 +64,10 @@ class DocumentController extends RestController
             // only set flag to yes if document being added is a deputy Document (and not auto-generated)
             $report->setWishToProvideDocumentation('yes');
         }
-        $this->persistAndFlush($document);
 
+        $this->em->persist($document);
         $report->updateSectionsStatusCache($this->sectionIds);
-        $this->getEntityManager()->flush();
+        $this->em->flush();
 
         return ['id' => $document->getId()];
     }
@@ -70,7 +82,7 @@ class DocumentController extends RestController
     {
         $serialisedGroups = $request->query->has('groups')
             ? (array) $request->query->get('groups') : ['documents'];
-        $this->setJmsSerialiserGroups($serialisedGroups);
+        $this->formatter->setJmsSerialiserGroups($serialisedGroups);
 
         /* @var $document EntityDir\Report\Document */
         $document = $this->findEntityBy(EntityDir\Report\Document::class, $id);
@@ -100,8 +112,8 @@ class DocumentController extends RestController
         // enable if the check above is removed and the note is available for editing for the whole team
         $this->denyAccessIfClientDoesNotBelongToUser($document->getReport()->getClient());
 
-        $this->getEntityManager()->remove($document);
-        $this->getEntityManager()->flush();
+        $this->em->remove($document);
+        $this->em->flush();
 
         // update yesno question to null if its the last document to be removed
         if (count($report->getDeputyDocuments()) == 0) {
@@ -109,7 +121,7 @@ class DocumentController extends RestController
         }
 
         $report->updateSectionsStatusCache($this->sectionIds);
-        $this->getEntityManager()->flush();
+        $this->em->flush();
 
         return ['id' => $id];
     }
@@ -123,11 +135,11 @@ class DocumentController extends RestController
      */
     public function getQueuedDocuments(Request $request, EntityManagerInterface $em): string
     {
-        if (!$this->getAuthService()->isSecretValid($request)) {
+        if (!$this->authService->isSecretValid($request)) {
             throw new UnauthorisedException('client secret not accepted.');
         }
 
-        $data = $this->deserializeBodyContent($request);
+        $data = $this->formatter->deserializeBodyContent($request);
 
         $documentRepo = $em->getRepository(Document::class);
 
@@ -143,7 +155,7 @@ class DocumentController extends RestController
      */
     public function updateRelatedDocumentStatuses(Request $request, EntityManagerInterface $em): string
     {
-        if (!$this->getAuthService()->isSecretValid($request)) {
+        if (!$this->authService->isSecretValid($request)) {
             throw new UnauthorisedException('client secret not accepted.');
         }
 
@@ -165,11 +177,11 @@ class DocumentController extends RestController
      */
     public function update(Request $request, int $id, EntityManagerInterface $em): Document
     {
-        if (!$this->getAuthService()->isSecretValid($request)) {
+        if (!$this->authService->isSecretValid($request)) {
             throw new UnauthorisedException('client secret not accepted.');
         }
 
-        $data = $this->deserializeBodyContent($request);
+        $data = $this->formatter->deserializeBodyContent($request);
 
         /** @var Document $document */
         $documentRepository = $em->getRepository(Document::class);
@@ -178,7 +190,7 @@ class DocumentController extends RestController
         $serialisedGroups = $request->query->has('groups')
             ? (array) $request->query->get('groups') : ['synchronisation', 'document-id'];
 
-        $this->setJmsSerialiserGroups($serialisedGroups);
+        $this->formatter->setJmsSerialiserGroups($serialisedGroups);
 
         if (!empty($data['syncStatus'])) {
             $document->setSynchronisationStatus($data['syncStatus']);
@@ -205,7 +217,8 @@ class DocumentController extends RestController
             }
         }
 
-        $this->persistAndFlush($document);
+        $this->em->persist($document);
+        $this->em->flush();
 
         return $document;
     }

--- a/api/src/AppBundle/Controller/Report/ProfServiceFeeController.php
+++ b/api/src/AppBundle/Controller/Report/ProfServiceFeeController.php
@@ -4,13 +4,24 @@ namespace AppBundle\Controller\Report;
 
 use AppBundle\Controller\RestController;
 use AppBundle\Entity as EntityDir;
+use AppBundle\Service\Formatter\RestFormatter;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 
 class ProfServiceFeeController extends RestController
 {
-    private $sectionIds = [EntityDir\Report\Report::SECTION_PROF_CURRENT_FEES];
+    private EntityManagerInterface $em;
+    private RestFormatter $formatter;
+
+    private array $sectionIds = [EntityDir\Report\Report::SECTION_PROF_CURRENT_FEES];
+
+    public function __construct(EntityManagerInterface $em, RestFormatter $formatter)
+    {
+        $this->em = $em;
+        $this->formatter = $formatter;
+    }
 
     /**
      * @Route("/report/{reportId}/prof-service-fee", methods={"POST"})
@@ -18,7 +29,7 @@ class ProfServiceFeeController extends RestController
      */
     public function addAction(Request $request, $reportId)
     {
-        $data = $this->deserializeBodyContent($request);
+        $data = $this->formatter->deserializeBodyContent($request);
 
         /* @var $report EntityDir\Report\Report */
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
@@ -28,10 +39,12 @@ class ProfServiceFeeController extends RestController
         $profServiceFee->setReport($report);
         $this->updateEntity($data, $profServiceFee);
         $report->setCurrentProfPaymentsReceived('yes');
-        $this->persistAndFlush($profServiceFee);
+
+        $this->em->persist($profServiceFee);
+        $this->em->flush();
 
         $report->updateSectionsStatusCache($this->sectionIds);
-        $this->getEntityManager()->flush();
+        $this->em->flush();
 
         return ['id' => $profServiceFee->getId()];
     }
@@ -47,12 +60,12 @@ class ProfServiceFeeController extends RestController
         $report = $profServiceFee->getReport();
         $this->denyAccessIfReportDoesNotBelongToUser($profServiceFee->getReport());
 
-        $data = $this->deserializeBodyContent($request);
+        $data = $this->formatter->deserializeBodyContent($request);
         $this->updateEntity($data, $profServiceFee);
-        $this->getEntityManager()->flush();
+        $this->em->flush();
 
         $report->updateSectionsStatusCache($this->sectionIds);
-        $this->getEntityManager()->flush();
+        $this->em->flush();
 
         return ['id' => $profServiceFee->getId()];
     }
@@ -70,7 +83,7 @@ class ProfServiceFeeController extends RestController
     {
         $serialiseGroups = $request->query->has('groups')
             ? (array) $request->query->get('groups') : ['prof_service_fee'];
-        $this->setJmsSerialiserGroups($serialiseGroups);
+        $this->formatter->setJmsSerialiserGroups($serialiseGroups);
 
         $profServiceFee = $this->findEntityBy(EntityDir\Report\ProfServiceFee::class, $id, 'Prof Service Fee with id:' . $id . ' not found');
         $this->denyAccessIfReportDoesNotBelongToUser($profServiceFee->getReport());
@@ -88,11 +101,11 @@ class ProfServiceFeeController extends RestController
         $report = $profServiceFee->getReport();
         $this->denyAccessIfReportDoesNotBelongToUser($profServiceFee->getReport());
 
-        $this->getEntityManager()->remove($profServiceFee);
-        $this->getEntityManager()->flush();
+        $this->em->remove($profServiceFee);
+        $this->em->flush();
 
         $report->updateSectionsStatusCache($this->sectionIds);
-        $this->getEntityManager()->flush();
+        $this->em->flush();
 
         return [];
     }

--- a/api/src/AppBundle/Controller/Report/ReportController.php
+++ b/api/src/AppBundle/Controller/Report/ReportController.php
@@ -4,16 +4,14 @@ namespace AppBundle\Controller\Report;
 
 use AppBundle\Controller\RestController;
 use AppBundle\Entity as EntityDir;
-use AppBundle\Entity\Organisation;
-use AppBundle\Entity\Report\Checklist;
 use AppBundle\Entity\Report\Report;
 use AppBundle\Entity\Repository\ChecklistRepository;
 use AppBundle\Entity\Repository\ReportRepository;
 use AppBundle\Entity\User;
 use AppBundle\Exception\UnauthorisedException;
+use AppBundle\Service\Auth\AuthService;
+use AppBundle\Service\Formatter\RestFormatter;
 use AppBundle\Service\ReportService;
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -26,19 +24,12 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class ReportController extends RestController
 {
-    /** @var array */
-    private $updateHandlers;
-
-    /** @var EntityDir\Repository\ReportRepository */
-    private $repository;
-
-    /** @var ReportService */
-    private $reportService;
-
-    /**
-     * @var EntityManager
-     */
-    private $em;
+    private array $updateHandlers;
+    private ReportRepository $repository;
+    private ReportService $reportService;
+    private EntityManagerInterface $em;
+    private AuthService $authService;
+    private RestFormatter $formatter;
 
     /** @var array */
     private $checklistGroups = [
@@ -60,17 +51,20 @@ class ReportController extends RestController
         'report-submission-id'
     ];
 
-    /**
-     * @param array $updateHandlers
-     * @param EntityDir\Repository\ReportRepository $repository
-     * @param ReportService $reportService
-     */
-    public function __construct(array $updateHandlers, EntityDir\Repository\ReportRepository $repository, ReportService $reportService, EntityManager $em)
-    {
+    public function __construct(
+        array $updateHandlers,
+        ReportRepository $repository,
+        ReportService $reportService,
+        EntityManagerInterface $em,
+        AuthService $authService,
+        RestFormatter $formatter
+    ) {
         $this->updateHandlers = $updateHandlers;
         $this->repository = $repository;
         $this->reportService = $reportService;
         $this->em = $em;
+        $this->authService = $authService;
+        $this->formatter = $formatter;
     }
 
     /**
@@ -83,7 +77,7 @@ class ReportController extends RestController
      */
     public function addAction(Request $request)
     {
-        $reportData = $this->deserializeBodyContent($request);
+        $reportData = $this->formatter->deserializeBodyContent($request);
 
         if (empty($reportData['client']['id'])) {
             throw new \InvalidArgumentException('Missing client.id');
@@ -91,7 +85,7 @@ class ReportController extends RestController
         $client = $this->findEntityBy(EntityDir\Client::class, $reportData['client']['id']);
         $this->denyAccessIfClientDoesNotBelongToUser($client);
 
-        $this->validateArray($reportData, [
+        $this->formatter->validateArray($reportData, [
             'start_date' => 'notEmpty',
             'end_date' => 'notEmpty',
         ]);
@@ -102,7 +96,9 @@ class ReportController extends RestController
         $report->setReportSeen(true);
 
         $report->updateSectionsStatusCache($report->getAvailableSections());
-        $this->persistAndFlush($report);
+
+        $this->em->persist($report);
+        $this->em->flush();
 
         return ['report' => $report->getId()];
     }
@@ -120,16 +116,16 @@ class ReportController extends RestController
         $groups = $request->query->has('groups')
             ? (array)$request->query->get('groups') : ['report'];
 
-        $this->setJmsSerialiserGroups($groups);
+        $this->formatter->setJmsSerialiserGroups($groups);
 
         /* @var $report Report */
         if ($this->isGranted(EntityDir\User::ROLE_ADMIN)) {
             /** @var SoftDeleteableFilter $filter */
-            $filter = $this->getEntityManager()->getFilters()->getFilter('softdeleteable');
+            $filter = $this->em->getFilters()->getFilter('softdeleteable');
             $filter->disableForEntity(EntityDir\Client::class);
 
             $report = $this->findEntityBy(EntityDir\Report\Report::class, $id);
-            $this->getEntityManager()->getFilters()->enable('softdeleteable');
+            $this->em->getFilters()->enable('softdeleteable');
         } else {
             $report = $this->findEntityBy(EntityDir\Report\Report::class, $id);
             $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -148,7 +144,7 @@ class ReportController extends RestController
         /* @var $currentReport Report */
         $this->denyAccessIfReportDoesNotBelongToUser($currentReport);
 
-        $data = $this->deserializeBodyContent($request);
+        $data = $this->formatter->deserializeBodyContent($request);
 
         if (empty($data['submit_date'])) {
             throw new \InvalidArgumentException('Missing submit_date');
@@ -193,7 +189,7 @@ class ReportController extends RestController
             $this->denyAccessIfReportDoesNotBelongToUser($report);
         }
 
-        $data = $this->deserializeBodyContent($request);
+        $data = $this->formatter->deserializeBodyContent($request);
 
         if (isset($data['type'])) {
             $report->setType($data['type']);
@@ -206,7 +202,7 @@ class ReportController extends RestController
             foreach ($report->getDebts() as $debt) {
                 $debt->setAmount(null);
                 $debt->setMoreDetails(null);
-                $this->getEntityManager()->flush($debt);
+                $this->em->flush($debt);
             }
             // set debts as per "debts" key
             if ($data['has_debts'] == 'yes') {
@@ -216,11 +212,11 @@ class ReportController extends RestController
                         continue; //not clear when that might happen. kept similar to transaction below
                     }
                     $debt->setAmountAndDetails($row['amount'], $row['more_details']);
-                    $this->getEntityManager()->flush($debt);
+                    $this->em->flush($debt);
                 }
             }
-            $this->setJmsSerialiserGroups(['debts']); //returns saved data (AJAX operations)
-            $this->getEntityManager()->flush();
+            $this->formatter->setJmsSerialiserGroups(['debts']); //returns saved data (AJAX operations)
+            $this->em->flush();
             $report->updateSectionsStatusCache([
                 Report::SECTION_DEBTS
             ]);
@@ -253,18 +249,18 @@ class ReportController extends RestController
                         $profDeputyOtherCost->setMoreDetails($postedProfDeputyOtherCostType['more_details']);
                     }
 
-                    $this->getEntityManager()->persist($profDeputyOtherCost);
+                    $this->em->persist($profDeputyOtherCost);
                 }
             }
             $report->updateSectionsStatusCache([
                 Report::SECTION_PROF_DEPUTY_COSTS
             ]);
-            $this->getEntityManager()->flush();
+            $this->em->flush();
         }
 
         if (array_key_exists('debt_management', $data)) {
             $report->setDebtManagement($data['debt_management']);
-            $this->getEntityManager()->flush();
+            $this->em->flush();
             $report->updateSectionsStatusCache([
                 Report::SECTION_DEBTS,
             ]);
@@ -277,7 +273,7 @@ class ReportController extends RestController
                     continue; //not clear when that might happen. kept similar to transaction below
                 }
                 $fee->setAmountAndDetails($row['amount'], $row['more_details']);
-                $this->getEntityManager()->flush($fee);
+                $this->em->flush($fee);
             }
             $report->updateSectionsStatusCache([
                 Report::SECTION_DEPUTY_EXPENSES,
@@ -293,7 +289,7 @@ class ReportController extends RestController
                         ->setMoreDetails(null);
                 }
             }
-            $this->getEntityManager()->flush();
+            $this->em->flush();
             $report->updateSectionsStatusCache([
                 Report::SECTION_DEPUTY_EXPENSES,
                 Report::SECTION_PA_DEPUTY_EXPENSES
@@ -303,11 +299,11 @@ class ReportController extends RestController
         if (array_key_exists('paid_for_anything', $data)) {
             if ($data['paid_for_anything'] === 'no') { // remove existing expenses
                 foreach ($report->getExpenses() as $e) {
-                    $this->getEntityManager()->remove($e);
+                    $this->em->remove($e);
                 }
             }
             $report->setPaidForAnything($data['paid_for_anything']);
-            $this->getEntityManager()->flush();
+            $this->em->flush();
             $report->updateSectionsStatusCache([
                 Report::SECTION_DEPUTY_EXPENSES,
                 Report::SECTION_PA_DEPUTY_EXPENSES
@@ -317,11 +313,11 @@ class ReportController extends RestController
         if (array_key_exists('gifts_exist', $data)) {
             if ($data['gifts_exist'] === 'no') { // remove existing gift
                 foreach ($report->getGifts() as $e) {
-                    $this->getEntityManager()->remove($e);
+                    $this->em->remove($e);
                 }
             }
             $report->setGiftsExist($data['gifts_exist']);
-            $this->getEntityManager()->flush();
+            $this->em->flush();
             $report->updateSectionsStatusCache([
                 Report::SECTION_GIFTS,
             ]);
@@ -359,9 +355,9 @@ class ReportController extends RestController
             $report->setNoAssetToAdd($data['no_asset_to_add']);
             if ($report->getNoAssetToAdd()) {
                 foreach ($report->getAssets() as $asset) {
-                    $this->getEntityManager()->remove($asset);
+                    $this->em->remove($asset);
                 }
-                $this->getEntityManager()->flush();
+                $this->em->flush();
             }
             $report->updateSectionsStatusCache([
                 Report::SECTION_ASSETS,
@@ -372,7 +368,7 @@ class ReportController extends RestController
             if ($data['no_transfers_to_add'] === true) {
                 //true here means "no", so remove existing transfers
                 foreach ($report->getMoneyTransfers() as $e) {
-                    $this->getEntityManager()->remove($e);
+                    $this->em->remove($e);
                 }
             }
             $report->setNoTransfersToAdd($data['no_transfers_to_add']);
@@ -413,10 +409,10 @@ class ReportController extends RestController
                 if ($e instanceof EntityDir\Report\MoneyShortCategory) {
                     $e
                         ->setPresent($row['present']);
-                    $this->getEntityManager()->flush($e);
+                    $this->em->flush($e);
                 }
             }
-            $this->getEntityManager()->flush();
+            $this->em->flush();
             $report->updateSectionsStatusCache([
                 Report::SECTION_MONEY_IN_SHORT,
                 Report::SECTION_MONEY_OUT_SHORT,
@@ -429,10 +425,10 @@ class ReportController extends RestController
                 if ($e instanceof EntityDir\Report\MoneyShortCategory) {
                     $e
                         ->setPresent($row['present']);
-                    $this->getEntityManager()->flush($e);
+                    $this->em->flush($e);
                 }
             }
-            $this->getEntityManager()->flush();
+            $this->em->flush();
             $report->updateSectionsStatusCache([
                 Report::SECTION_MONEY_IN_SHORT,
                 Report::SECTION_MONEY_OUT_SHORT,
@@ -442,11 +438,11 @@ class ReportController extends RestController
         if (array_key_exists('money_transactions_short_in_exist', $data)) {
             if ($data['money_transactions_short_in_exist'] === 'no') { // remove existing
                 foreach ($report->getMoneyTransactionsShortIn() as $e) {
-                    $this->getEntityManager()->remove($e);
+                    $this->em->remove($e);
                 }
             }
             $report->setMoneyTransactionsShortInExist($data['money_transactions_short_in_exist']);
-            $this->getEntityManager()->flush();
+            $this->em->flush();
             $report->updateSectionsStatusCache([
                 Report::SECTION_MONEY_IN_SHORT,
                 Report::SECTION_MONEY_OUT_SHORT,
@@ -456,11 +452,11 @@ class ReportController extends RestController
         if (array_key_exists('money_transactions_short_out_exist', $data)) {
             if ($data['money_transactions_short_out_exist'] === 'no') { // remove existing
                 foreach ($report->getMoneyTransactionsShortOut() as $e) {
-                    $this->getEntityManager()->remove($e);
+                    $this->em->remove($e);
                 }
             }
             $report->setMoneyTransactionsShortOutExist($data['money_transactions_short_out_exist']);
-            $this->getEntityManager()->flush();
+            $this->em->flush();
             $report->updateSectionsStatusCache([
                 Report::SECTION_MONEY_IN_SHORT,
                 Report::SECTION_MONEY_OUT_SHORT,
@@ -472,7 +468,7 @@ class ReportController extends RestController
             if ('no' === $data['wish_to_provide_documentation']) {
                 $report->setWishToProvideDocumentation($data['wish_to_provide_documentation']);
             }
-            $this->getEntityManager()->flush();
+            $this->em->flush();
             $report->updateSectionsStatusCache([
                 Report::SECTION_DOCUMENTS,
             ]);
@@ -486,7 +482,7 @@ class ReportController extends RestController
             } else {
                 $report->setProfFeesEstimateSccoReason($data['prof_fees_estimate_scco_reason']);
             }
-            $this->getEntityManager()->flush();
+            $this->em->flush();
             $report->updateSectionsStatusCache([
                 Report::SECTION_PROF_CURRENT_FEES,
             ]);
@@ -495,13 +491,13 @@ class ReportController extends RestController
         if (array_key_exists('current_prof_payments_received', $data)) {
             if ($data['current_prof_payments_received'] == 'no') { //reset whole section
                 foreach ($report->getCurrentProfServiceFees() as $f) {
-                    $this->getEntityManager()->remove($f);
+                    $this->em->remove($f);
                 }
                 $report->setPreviousProfFeesEstimateGiven(null);
                 $report->setProfFeesEstimateSccoReason(null);
             }
             $report->setCurrentProfPaymentsReceived($data['current_prof_payments_received']);
-            $this->getEntityManager()->flush();
+            $this->em->flush();
             $report->updateSectionsStatusCache([
                 Report::SECTION_PROF_CURRENT_FEES,
             ]);
@@ -519,7 +515,7 @@ class ReportController extends RestController
             $updateHandler->handle($report, $data);
         }
 
-        $this->getEntityManager()->flush();
+        $this->em->flush();
 
         return ['id' => $report->getId()];
     }
@@ -536,7 +532,7 @@ class ReportController extends RestController
             throw new \RuntimeException('Cannot unsubmit an active report');
         }
 
-        $data = $this->deserializeBodyContent($request, [
+        $data = $this->formatter->deserializeBodyContent($request, [
             'un_submit_date' => 'notEmpty',
             'due_date' => 'notEmpty',
             'unsubmitted_sections_list' => 'notEmpty',
@@ -553,7 +549,7 @@ class ReportController extends RestController
             $data['unsubmitted_sections_list']
         );
 
-        $this->getEntityManager()->flush();
+        $this->em->flush();
 
         return ['id' => $report->getId()];
     }
@@ -750,7 +746,7 @@ class ReportController extends RestController
         /** @var Report $report */
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $report_id, 'Report not found');
 
-        $checklistData = $this->deserializeBodyContent($request);
+        $checklistData = $this->formatter->deserializeBodyContent($request);
 
         /** @var EntityDir\Report\Checklist $checklist */
         $checklist = new EntityDir\Report\Checklist($report);
@@ -759,7 +755,7 @@ class ReportController extends RestController
         if (!empty($checklistData['further_information_received'])) {
             $info = new EntityDir\Report\ChecklistInformation($checklist, $checklistData['further_information_received']);
             $info->setCreatedBy($user);
-            $this->getEntityManager()->persist($info);
+            $this->em->persist($info);
         }
 
         if ($checklistData['button_clicked'] == 'submitAndContinue') {
@@ -768,7 +764,8 @@ class ReportController extends RestController
         }
         $checklist->setLastModifiedBy($user);
 
-        $this->persistAndFlush($checklist);
+        $this->em->persist($checklist);
+        $this->em->flush();
 
         return ['checklist' => $checklist->getId()];
     }
@@ -787,7 +784,7 @@ class ReportController extends RestController
         /** @var Report $report */
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $report_id, 'Report not found');
 
-        $checklistData = $this->deserializeBodyContent($request);
+        $checklistData = $this->formatter->deserializeBodyContent($request);
 
         /** @var EntityDir\Report\Checklist $checklist */
         $checklist = $report->getChecklist();
@@ -797,7 +794,7 @@ class ReportController extends RestController
         if (!empty($checklistData['further_information_received'])) {
             $info = new EntityDir\Report\ChecklistInformation($checklist, $checklistData['further_information_received']);
             $info->setCreatedBy($user);
-            $this->getEntityManager()->persist($info);
+            $this->em->persist($info);
         }
 
         if ($checklistData['button_clicked'] == 'submitAndContinue') {
@@ -806,7 +803,9 @@ class ReportController extends RestController
         }
 
         $checklist->setLastModifiedBy($user);
-        $this->persistAndFlush($checklist);
+
+        $this->em->persist($checklist);
+        $this->em->flush();
 
         return ['checklist' => $checklist->getId()];
     }
@@ -853,7 +852,7 @@ class ReportController extends RestController
      */
     public function getChecklist(Request $request, $report_id)
     {
-        $this->setJmsSerialiserGroups(['checklist', 'last-modified', 'user']);
+        $this->formatter->setJmsSerialiserGroups(['checklist', 'last-modified', 'user']);
 
         $checklist = $this
             ->getRepository(EntityDir\Report\ReviewChecklist::class)
@@ -876,7 +875,7 @@ class ReportController extends RestController
         /** @var Report $report */
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $report_id, 'Report not found');
 
-        $checklistData = $this->deserializeBodyContent($request);
+        $checklistData = $this->formatter->deserializeBodyContent($request);
 
         /** @var EntityDir\Report\ReviewChecklist|null $checklist */
         $checklist = $this
@@ -898,7 +897,8 @@ class ReportController extends RestController
 
         $checklist->setLastModifiedBy($user);
 
-        $this->persistAndFlush($checklist);
+        $this->em->persist($checklist);
+        $this->em->flush();
 
         return ['checklist' => $checklist->getId()];
     }
@@ -910,15 +910,15 @@ class ReportController extends RestController
      */
     public function getReportsWithQueuedChecklists(Request $request): array
     {
-        if (!$this->getAuthService()->isSecretValid($request)) {
+        if (!$this->authService->isSecretValid($request)) {
             throw new UnauthorisedException('client secret not accepted.');
         }
 
         /** @var array $data */
-        $data = $this->deserializeBodyContent($request);
+        $data = $this->formatter->deserializeBodyContent($request);
 
         /** @var ReportRepository $reportRepo */
-        $reportRepo = $this->getEntityManager()->getRepository(Report::class);
+        $reportRepo = $this->em->getRepository(Report::class);
         $queuedReportIds = $reportRepo->getReportsIdsWithQueuedChecklistsAndSetChecklistsToInProgress(intval($data['row_limit']));
 
         $reports = [];
@@ -926,7 +926,7 @@ class ReportController extends RestController
             $reports[] = $this->findEntityBy(Report::class, $reportId);
         }
 
-        $this->setJmsSerialiserGroups($this->checklistGroups);
+        $this->formatter->setJmsSerialiserGroups($this->checklistGroups);
 
         return $reports;
     }

--- a/api/src/AppBundle/Controller/Report/ReportSubmissionController.php
+++ b/api/src/AppBundle/Controller/Report/ReportSubmissionController.php
@@ -6,7 +6,10 @@ use AppBundle\Controller\RestController;
 use AppBundle\Entity as EntityDir;
 use AppBundle\Entity\Report\Document;
 use AppBundle\Entity\Report\ReportSubmission;
+use AppBundle\Service\Auth\AuthService;
+use AppBundle\Service\Formatter\RestFormatter;
 use AppBundle\Transformer\ReportSubmission\ReportSubmissionSummaryTransformer;
+use Doctrine\ORM\EntityManagerInterface;
 use InvalidArgumentException;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
@@ -17,13 +20,17 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class ReportSubmissionController extends RestController
 {
+    private EntityManagerInterface $em;
+    private AuthService $authService;
+    private RestFormatter $formatter;
+
     const QUEUEABLE_STATUSES = [
         null,
         Document::SYNC_STATUS_TEMPORARY_ERROR,
         Document::SYNC_STATUS_PERMANENT_ERROR
     ];
 
-    private static $jmsGroups = [
+    private static array $jmsGroups = [
         'report-submission',
         'report-type',
         'report-client',
@@ -41,6 +48,14 @@ class ReportSubmissionController extends RestController
         'synchronisation',
     ];
 
+
+    public function __construct(EntityManagerInterface $em, AuthService $authService, RestFormatter $formatter)
+    {
+        $this->em = $em;
+        $this->authService = $authService;
+        $this->formatter = $formatter;
+    }
+
     /**
      * @Route("", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN')")
@@ -50,16 +65,16 @@ class ReportSubmissionController extends RestController
         $repo = $this->getRepository(EntityDir\Report\ReportSubmission::class); /* @var $repo EntityDir\Repository\ReportSubmissionRepository */
 
         $ret = $repo->findByFiltersWithCounts(
-                $request->get('status'),
-                $request->get('q'),
-                $request->get('created_by_role'),
-                $request->get('offset', 0),
-                $request->get('limit', 15),
-                $request->get('orderBy', 'createdOn'),
-                $request->get('order', 'ASC')
-            );
+            $request->get('status'),
+            $request->get('q'),
+            $request->get('created_by_role'),
+            $request->get('offset', 0),
+            $request->get('limit', 15),
+            $request->get('orderBy', 'createdOn'),
+            $request->get('order', 'ASC')
+        );
 
-        $this->setJmsSerialiserGroups(self::$jmsGroups);
+        $this->formatter->setJmsSerialiserGroups(self::$jmsGroups);
 
         return $ret;
     }
@@ -72,7 +87,7 @@ class ReportSubmissionController extends RestController
     {
         $ret = $this->getRepository(EntityDir\Report\ReportSubmission::class)->findOneByIdUnfiltered($id);
 
-        $this->setJmsSerialiserGroups(array_merge(self::$jmsGroups, ['document-storage-reference']));
+        $this->formatter->setJmsSerialiserGroups(array_merge(self::$jmsGroups, ['document-storage-reference']));
 
         return $ret;
     }
@@ -89,14 +104,14 @@ class ReportSubmissionController extends RestController
         /* @var $reportSubmission EntityDir\Report\ReportSubmission */
         $reportSubmission = $this->findEntityBy(EntityDir\Report\ReportSubmission::class, $reportSubmissionId);
 
-        $data = $this->deserializeBodyContent($request);
+        $data = $this->formatter->deserializeBodyContent($request);
 
         if (!empty($data['archive'])) {
             $reportSubmission->setArchived(true);
             $reportSubmission->setArchivedBy($this->getUser());
         }
 
-        $this->getEntityManager()->flush();
+        $this->em->flush();
 
         return $reportSubmission->getId();
     }
@@ -109,20 +124,20 @@ class ReportSubmissionController extends RestController
      */
     public function updateUuid(Request $request, $reportSubmissionId)
     {
-        if (!$this->getAuthService()->isSecretValid($request)) {
+        if (!$this->authService->isSecretValid($request)) {
             throw new UnauthorisedException('client secret not accepted.');
         }
 
         /* @var $reportSubmission EntityDir\Report\ReportSubmission */
         $reportSubmission = $this->findEntityBy(EntityDir\Report\ReportSubmission::class, $reportSubmissionId);
 
-        $data = $this->deserializeBodyContent($request);
+        $data = $this->formatter->deserializeBodyContent($request);
 
         if (!empty($data['uuid'])) {
             $reportSubmission->setUuid($data['uuid']);
         }
 
-        $this->getEntityManager()->flush();
+        $this->em->flush();
 
         return $reportSubmission->getId();
     }
@@ -135,7 +150,7 @@ class ReportSubmissionController extends RestController
      */
     public function getOld(Request $request)
     {
-        if (!$this->getAuthService()->isSecretValidForRole(EntityDir\User::ROLE_ADMIN, $request)) {
+        if (!$this->authService->isSecretValidForRole(EntityDir\User::ROLE_ADMIN, $request)) {
             throw new \RuntimeException(__METHOD__ . ' only accessible from ADMIN container.', 403);
         }
 
@@ -143,7 +158,7 @@ class ReportSubmissionController extends RestController
 
         $ret = $repo->findDownloadableOlderThan(new \DateTime(EntityDir\Report\ReportSubmission::REMOVE_FILES_WHEN_OLDER_THAN), 100);
 
-        $this->setJmsSerialiserGroups(['report-submission-id', 'report-submission-documents', 'document-storage-reference']);
+        $this->formatter->setJmsSerialiserGroups(['report-submission-id', 'report-submission-documents', 'document-storage-reference']);
 
         return $ret;
     }
@@ -156,7 +171,7 @@ class ReportSubmissionController extends RestController
      */
     public function setUndownloadable($id, Request $request)
     {
-        if (!$this->getAuthService()->isSecretValidForRole(EntityDir\User::ROLE_ADMIN, $request)) {
+        if (!$this->authService->isSecretValidForRole(EntityDir\User::ROLE_ADMIN, $request)) {
             throw new \RuntimeException(__METHOD__ . ' only accessible from ADMIN container.', 403);
         }
 
@@ -167,7 +182,7 @@ class ReportSubmissionController extends RestController
             $document->setStorageReference(null);
         }
 
-        $this->getEntityManager()->flush();
+        $this->em->flush();
 
         return true;
     }
@@ -195,7 +210,7 @@ class ReportSubmissionController extends RestController
             }
         }
 
-        $this->getEntityManager()->flush();
+        $this->em->flush();
 
         return true;
     }

--- a/api/src/AppBundle/Controller/SatisfactionController.php
+++ b/api/src/AppBundle/Controller/SatisfactionController.php
@@ -3,6 +3,8 @@
 namespace AppBundle\Controller;
 
 use AppBundle\Entity\Satisfaction;
+use AppBundle\Service\Formatter\RestFormatter;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
@@ -13,13 +15,23 @@ use AppBundle\Entity as EntityDir;
  */
 class SatisfactionController extends RestController
 {
+    private EntityManagerInterface $em;
+    private RestFormatter $formatter;
+
+    public function __construct(EntityManagerInterface $em, RestFormatter $formatter)
+    {
+        $this->em = $em;
+        $this->formatter = $formatter;
+    }
+
     private function addSatisfactionScore($satisfactionLevel, $comments)
     {
         $satisfaction = new Satisfaction();
         $satisfaction->setScore($satisfactionLevel);
         $satisfaction->setComments($comments);
 
-        $this->persistAndFlush($satisfaction);
+        $this->em->persist($satisfaction);
+        $this->em->flush();
 
         return $satisfaction;
     }
@@ -30,7 +42,7 @@ class SatisfactionController extends RestController
      */
     public function add(Request $request)
     {
-        $data = $this->deserializeBodyContent($request, [
+        $data = $this->formatter->deserializeBodyContent($request, [
             'score' => 'notEmpty',
             'comments' => 'mustExist',
             'reportType' => 'notEmpty',
@@ -41,7 +53,8 @@ class SatisfactionController extends RestController
         $satisfaction->setReportType($data['reportType']);
         $satisfaction->setDeputyRole($this->getUser()->getRoleName());
 
-        $this->persistAndFlush($satisfaction);
+        $this->em->persist($satisfaction);
+        $this->em->flush();
 
         return $satisfaction->getId();
     }
@@ -68,7 +81,7 @@ class SatisfactionController extends RestController
      */
     public function publicAdd(Request $request)
     {
-        $data = $this->deserializeBodyContent($request, [
+        $data = $this->formatter->deserializeBodyContent($request, [
             'score' => 'notEmpty',
             'comments' => 'notEmpty'
         ]);

--- a/api/src/AppBundle/Controller/SettingController.php
+++ b/api/src/AppBundle/Controller/SettingController.php
@@ -3,6 +3,8 @@
 namespace AppBundle\Controller;
 
 use AppBundle\Entity as EntityDir;
+use AppBundle\Service\Formatter\RestFormatter;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
@@ -12,6 +14,15 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class SettingController extends RestController
 {
+    private EntityManagerInterface $em;
+    private RestFormatter $formatter;
+
+    public function __construct(EntityManagerInterface $em, RestFormatter $formatter)
+    {
+        $this->em = $em;
+        $this->formatter = $formatter;
+    }
+
     /**
      * @Route("/{id}", methods={"GET"})
      */
@@ -19,7 +30,7 @@ class SettingController extends RestController
     {
         $setting = $this->getRepository(EntityDir\Setting::class)->find($id);/* @var $setting EntityDir\Setting */
 
-        $this->setJmsSerialiserGroups(['setting']);
+        $this->formatter->setJmsSerialiserGroups(['setting']);
 
         return $setting ?: [];
     }
@@ -30,7 +41,7 @@ class SettingController extends RestController
      */
     public function upsertSetting(Request $request, $id)
     {
-        $data = $this->deserializeBodyContent($request, [
+        $data = $this->formatter->deserializeBodyContent($request, [
             'content' => 'notEmpty',
             'enabled' => 'mustExist',
         ]);
@@ -41,10 +52,10 @@ class SettingController extends RestController
             $setting->setEnabled($data['enabled']);
         } else { //create new one
             $setting = new EntityDir\Setting($id, $data['content'], $data['enabled']);
-            $this->getEntityManager()->persist($setting);
+            $this->em->persist($setting);
         }
 
-        $this->getEntityManager()->flush($setting);
+        $this->em->flush($setting);
 
         return $setting->getId();
     }

--- a/api/src/AppBundle/Controller/StatsController.php
+++ b/api/src/AppBundle/Controller/StatsController.php
@@ -10,10 +10,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class StatsController extends RestController
 {
-    /**
-     * @var QueryFactory
-     */
-    private $QueryFactory;
+    private QueryFactory $QueryFactory;
 
     public function __construct(QueryFactory $QueryFactory)
     {

--- a/api/src/AppBundle/Controller/TeamController.php
+++ b/api/src/AppBundle/Controller/TeamController.php
@@ -2,8 +2,8 @@
 
 namespace AppBundle\Controller;
 
-use AppBundle\Entity as EntityDir;
 use AppBundle\Entity\User;
+use AppBundle\Service\Formatter\RestFormatter;
 use AppBundle\Service\OrgService;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
@@ -14,6 +14,13 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class TeamController extends RestController
 {
+    private RestFormatter $formatter;
+
+    public function __construct(RestFormatter $formatter)
+    {
+        $this->formatter = $formatter;
+    }
+
     /**
      * @Route("/members", methods={"GET"})
      * @Security("has_role('ROLE_ORG')")
@@ -24,7 +31,7 @@ class TeamController extends RestController
             (array) $request->query->get('groups') :
             ['team', 'team-users', 'user', 'team-names'];
 
-        $this->setJmsSerialiserGroups($groups);
+        $this->formatter->setJmsSerialiserGroups($groups);
 
         /** @var User $user */
         $user = $this->getUser();
@@ -38,7 +45,7 @@ class TeamController extends RestController
      */
     public function getMemberById($id, OrgService $orgService)
     {
-        $this->setJmsSerialiserGroups(['team', 'team-users', 'user', 'team-names']);
+        $this->formatter->setJmsSerialiserGroups(['team', 'team-users', 'user', 'team-names']);
 
         /** @var User $user */
         $user = $this->getUser();

--- a/api/src/AppBundle/Controller/UserController.php
+++ b/api/src/AppBundle/Controller/UserController.php
@@ -7,13 +7,13 @@ use AppBundle\Entity\Repository\ClientRepository;
 use AppBundle\Entity\Repository\UserRepository;
 use AppBundle\Entity\User;
 use AppBundle\Security\UserVoter;
-use AppBundle\Service\Audit\AuditEvents;
-use AppBundle\Service\Time\DateTimeProvider;
+use AppBundle\Service\Auth\AuthService;
+use AppBundle\Service\Formatter\RestFormatter;
 use AppBundle\Service\UserService;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
-use Psr\Log\LoggerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -29,35 +29,15 @@ use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
  */
 class UserController extends RestController
 {
-    /**
-     * @var UserService
-     */
-    private $userService;
-
-    /**
-     * @var EncoderFactoryInterface
-     */
-    private $encoderFactory;
-
-    /**
-     * @var UserRepository
-     */
-    private $userRepository;
-
-    /**
-     * @var ClientRepository
-     */
-    private $clientRepository;
-
-    /**
-     * @var UserVoter
-     */
-    private $userVoter;
-
-    /**
-     * @var SecurityHelper
-     */
-    private $securityHelper;
+    private UserService $userService;
+    private EncoderFactoryInterface $encoderFactory;
+    private UserRepository $userRepository;
+    private ClientRepository $clientRepository;
+    private UserVoter $userVoter;
+    private SecurityHelper $securityHelper;
+    private EntityManagerInterface $em;
+    private AuthService $authService;
+    private RestFormatter $formatter;
 
     public function __construct(
         UserService $userService,
@@ -65,7 +45,10 @@ class UserController extends RestController
         UserRepository $userRepository,
         ClientRepository $clientRepository,
         UserVoter $userVoter,
-        SecurityHelper $securityHelper
+        SecurityHelper $securityHelper,
+        EntityManagerInterface $em,
+        AuthService $authService,
+        RestFormatter $formatter
     ) {
         $this->userService = $userService;
         $this->encoderFactory = $encoderFactory;
@@ -73,6 +56,9 @@ class UserController extends RestController
         $this->clientRepository = $clientRepository;
         $this->userVoter = $userVoter;
         $this->securityHelper = $securityHelper;
+        $this->em = $em;
+        $this->authService = $authService;
+        $this->formatter = $formatter;
     }
 
     /**
@@ -81,7 +67,7 @@ class UserController extends RestController
      */
     public function add(Request $request)
     {
-        $data = $this->deserializeBodyContent($request, [
+        $data = $this->formatter->deserializeBodyContent($request, [
             'role_name' => 'notEmpty',
             'email' => 'notEmpty',
             'firstname' => 'mustExist',
@@ -98,7 +84,7 @@ class UserController extends RestController
 
         $groups = $request->query->has('groups') ?
             $request->query->get('groups') : ['user', 'user-teams', 'team'];
-        $this->setJmsSerialiserGroups($groups);
+        $this->formatter->setJmsSerialiserGroups($groups);
 
         return $newUser;
     }
@@ -126,7 +112,7 @@ class UserController extends RestController
         /** @var User $originalUser */
         $originalUser = clone $requestedUser;
 
-        $data = $this->deserializeBodyContent($request);
+        $data = $this->formatter->deserializeBodyContent($request);
         $this->populateUser($requestedUser, $data);
 
         // check if rolename in data - if so add audit log
@@ -150,7 +136,7 @@ class UserController extends RestController
             throw $this->createAccessDeniedException("Not authorised to check other user's password");
         }
 
-        $data = $this->deserializeBodyContent($request, [
+        $data = $this->formatter->deserializeBodyContent($request, [
             'password' => 'notEmpty',
         ]);
 
@@ -176,7 +162,7 @@ class UserController extends RestController
             throw $this->createAccessDeniedException("Not authorised to change other user's data");
         }
 
-        $data = $this->deserializeBodyContent($request, [
+        $data = $this->formatter->deserializeBodyContent($request, [
             'password_plain' => 'notEmpty',
         ]);
 
@@ -188,7 +174,7 @@ class UserController extends RestController
             $requestedUser->setActive($data['set_active']);
         }
 
-        $this->getEntityManager()->flush();
+        $this->em->flush();
 
         return $requestedUser->getId();
     }
@@ -240,7 +226,7 @@ class UserController extends RestController
         $groups = $request->query->has('groups') ?
             $request->query->get('groups') : ['user'];
 
-        $this->setJmsSerialiserGroups($groups);
+        $this->formatter->setJmsSerialiserGroups($groups);
 
         if ($loggedInUser->isCoDeputyWith($user)) {
             return $user;
@@ -270,7 +256,7 @@ class UserController extends RestController
     {
         $user = $this->userRepository->findOneBy(['email' => $email]);
 
-        $this->setJmsSerialiserGroups(['user-id', 'team-names']);
+        $this->formatter->setJmsSerialiserGroups(['user-id', 'team-names']);
 
         return $user;
     }
@@ -303,11 +289,11 @@ class UserController extends RestController
 
         if ($deletee->getFirstClient()) {
             $clients = $deletee->getClients();
-            $this->getEntityManager()->remove($clients[0]);
+            $this->em->remove($clients[0]);
         }
 
-        $this->getEntityManager()->remove($deletee);
-        $this->getEntityManager()->flush();
+        $this->em->remove($deletee);
+        $this->em->flush();
 
         return [];
     }
@@ -318,7 +304,7 @@ class UserController extends RestController
      */
     public function getAll(Request $request)
     {
-        $this->setJmsSerialiserGroups(['user']);
+        $this->formatter->setJmsSerialiserGroups(['user']);
         return $this->userRepository->findUsersByQueryParameters($request);
     }
 
@@ -329,13 +315,13 @@ class UserController extends RestController
      */
     public function recreateToken(Request $request, $email)
     {
-        if (!$this->getAuthService()->isSecretValid($request)) {
+        if (!$this->authService->isSecretValid($request)) {
             throw new \RuntimeException('client secret not accepted.', 403);
         }
 
         /** @var User $user */
         $user = $this->findEntityBy(User::class, ['email' => strtolower($email)]);
-        $hasAdminSecret = $this->getAuthService()->isSecretValidForRole(User::ROLE_ADMIN, $request);
+        $hasAdminSecret = $this->authService->isSecretValidForRole(User::ROLE_ADMIN, $request);
 
         if (!$hasAdminSecret && $user->getRoleName() == User::ROLE_ADMIN) {
             throw new \RuntimeException('Admin emails not accepted.', 403);
@@ -343,9 +329,9 @@ class UserController extends RestController
 
         $user->recreateRegistrationToken();
 
-        $this->getEntityManager()->flush($user);
+        $this->em->flush($user);
 
-        $this->setJmsSerialiserGroups(['user']);
+        $this->formatter->setJmsSerialiserGroups(['user']);
 
         return $user;
     }
@@ -355,7 +341,7 @@ class UserController extends RestController
      */
     public function getByToken(Request $request, $token)
     {
-        if (!$this->getAuthService()->isSecretValid($request)) {
+        if (!$this->authService->isSecretValid($request)) {
             throw new \RuntimeException('client secret not accepted.', 403);
         }
 
@@ -363,12 +349,12 @@ class UserController extends RestController
         $user = $this->findEntityBy(User::class, ['registrationToken' => $token], 'User not found');
 
 
-        if (!$this->getAuthService()->isSecretValidForRole($user->getRoleName(), $request)) {
+        if (!$this->authService->isSecretValidForRole($user->getRoleName(), $request)) {
             throw new \RuntimeException($user->getRoleName() . ' user role not allowed from this client.', 403);
         }
 
         // `user-login` contains number of clients and reports, needed to properly redirect the user to the right page after activation
-        $this->setJmsSerialiserGroups(['user', 'user-login']);
+        $this->formatter->setJmsSerialiserGroups(['user', 'user-login']);
 
         return $user;
     }
@@ -378,20 +364,20 @@ class UserController extends RestController
      */
     public function agreeTermsUSe(Request $request, $token)
     {
-        if (!$this->getAuthService()->isSecretValid($request)) {
+        if (!$this->authService->isSecretValid($request)) {
             throw new \RuntimeException('client secret not accepted.', 403);
         }
 
         $user = $this->findEntityBy(User::class, ['registrationToken' => $token], 'User not found');
         /* @var $user User */
 
-        if (!$this->getAuthService()->isSecretValidForRole($user->getRoleName(), $request)) {
+        if (!$this->authService->isSecretValidForRole($user->getRoleName(), $request)) {
             throw new \RuntimeException($user->getRoleName() . ' user role not allowed from this client.', 403);
         }
 
         $user->setAgreeTermsUse(true);
-        $this->getEntityManager()->persist($user);
-        $this->getEntityManager()->flush($user);
+        $this->em->persist($user);
+        $this->em->flush($user);
 
         return $user->getId();
     }
@@ -477,7 +463,7 @@ class UserController extends RestController
             (array) $request->query->get('groups') :
             ['team', 'team-users', 'user'];
 
-        $this->setJmsSerialiserGroups($groups);
+        $this->formatter->setJmsSerialiserGroups($groups);
 
         return $requestedUserTeams->first();
     }

--- a/api/src/AppBundle/Service/Formatter/RestFormatter.php
+++ b/api/src/AppBundle/Service/Formatter/RestFormatter.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+
+namespace AppBundle\Service\Formatter;
+
+use AppBundle\EventListener\RestInputOuputFormatter;
+use AppBundle\Service\Validator\RestArrayValidator;
+use Symfony\Component\HttpFoundation\Request;
+
+class RestFormatter
+{
+    private RestInputOuputFormatter $formatter;
+    private RestArrayValidator $validator;
+
+    public function __construct(RestInputOuputFormatter $formatter, RestArrayValidator $validator)
+    {
+        $this->formatter = $formatter;
+        $this->validator = $validator;
+    }
+
+    /**
+     * @param Request $request
+     * @param array $assertions
+     * @return array|null
+     */
+    public function deserializeBodyContent(Request $request, array $assertions = [])
+    {
+        $return = $this->formatter->requestContentToArray($request);
+        $this->validator->validateArray($return, $assertions);
+
+        return $return;
+    }
+
+    /**
+     * Set serialise group used by JMS serialiser to composer ouput response
+     * Attach setting to REquest as header, to be read by REstInputOuputFormatter kernel listener.
+     *
+     * @param string $groups user
+     */
+    public function setJmsSerialiserGroups(array $groups)
+    {
+        $this->formatter->addContextModifier(function ($context) use ($groups) {
+            $context->setGroups($groups);
+        });
+    }
+
+    public function validateArray($data, array $assertions = [])
+    {
+        $this->validator->validateArray($data, $assertions);
+    }
+}

--- a/api/src/AppBundle/Service/Validator/RestArrayValidator.php
+++ b/api/src/AppBundle/Service/Validator/RestArrayValidator.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+
+namespace AppBundle\Service\Validator;
+
+class RestArrayValidator
+{
+    /**
+     * @param array $data
+     * @param array $assertions key=>rule
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function validateArray(array $data, array $assertions = [])
+    {
+        $errors = [];
+
+        foreach ($assertions as $requiredKey => $validation) {
+            switch ($validation) {
+                case 'notEmpty':
+                    if (empty($data[$requiredKey])) {
+                        $errors[] = "Expected value for '$requiredKey' key";
+                    }
+                    break;
+
+                case 'mustExist':
+                    if (!array_key_exists($requiredKey, $data)) {
+                        $errors[] = "Missing '$requiredKey' key";
+                    }
+                    break;
+
+                default:
+                    throw new \InvalidArgumentException(__METHOD__ . ": {$validation} not recognised.");
+            }
+        }
+
+        if (!empty($errors)) {
+            throw new \InvalidArgumentException('Errors(' . count($errors) . '): ' . implode(', ', $errors));
+        }
+    }
+}

--- a/api/tests/AppBundle/Controller/AbstractTestController.php
+++ b/api/tests/AppBundle/Controller/AbstractTestController.php
@@ -2,7 +2,6 @@
 
 namespace Tests\AppBundle\Controller;
 
-
 use AppBundle\Service\BruteForce\AttemptsIncrementalWaitingChecker;
 use AppBundle\Service\BruteForce\AttemptsInTimeChecker;
 use Doctrine\ORM\EntityManager;
@@ -48,9 +47,8 @@ abstract class AbstractTestController extends WebTestCase
         /** @var EntityManager $em */
         $em = $container->get('em');
 
-        $t = $container->getParameter('fixtures');
-
         self::$fixtures = new Fixtures($em);
+
         $em->clear();
 
         self::$deputySecret = getenv('SECRETS_FRONT_KEY');
@@ -108,7 +106,8 @@ abstract class AbstractTestController extends WebTestCase
         self::$frameworkBundleClient->request(
             $method,
             $uri,
-            [], [],
+            [],
+            [],
             $headers,
             $rawData
         );

--- a/api/tests/AppBundle/Controller/SelfRegisterControllerTest.php
+++ b/api/tests/AppBundle/Controller/SelfRegisterControllerTest.php
@@ -2,73 +2,12 @@
 
 namespace Tests\AppBundle\Controller;
 
-use AppBundle\Controller\SelfRegisterController;
 use AppBundle\Entity\CasRec;
 use AppBundle\Entity\User;
-use AppBundle\Model\SelfRegisterData;
 use Mockery as m;
 
 class SelfRegisterControllerTest extends AbstractTestController
 {
-    /** @var SelfRegisterController */
-    private $selfRegisterController;
-
-    public function setUp(): void
-    {
-        $this->selfRegisterController = new SelfRegisterController();
-        parent::setUp();
-    }
-
-    public function tearDown(): void
-    {
-        m::close();
-        parent::tearDown();
-    }
-
-    /** @test */
-    public function populateUser()
-    {
-        $data = [
-            'firstname' => 'Zac',
-            'lastname' => 'Tolley',
-            'email' => 'behat-test@gov.uk',
-            'postcode' => 'SW1',
-            'client_firstname' => 'John',
-            'client_lastname' => 'Cross-Tolley',
-            'case_number' => '12345678',
-        ];
-
-        $selfRegisterData = new SelfRegisterData();
-
-        $this->selfRegisterController->populateSelfReg($selfRegisterData, $data);
-
-        $this->assertEquals('Zac', $selfRegisterData->getFirstname());
-        $this->assertEquals('Tolley', $selfRegisterData->getLastname());
-        $this->assertEquals('behat-test@gov.uk', $selfRegisterData->getEmail());
-        $this->assertEquals('SW1', $selfRegisterData->getPostcode());
-        $this->assertEquals('John', $selfRegisterData->getClientFirstname());
-        $this->assertEquals('Cross-Tolley', $selfRegisterData->getClientLastname());
-        $this->assertEquals('12345678', $selfRegisterData->getCaseNumber());
-    }
-
-    /** @test */
-    public function populatePartialData()
-    {
-        $data = [
-            'firstname' => 'Zac',
-            'lastname' => 'Tolley',
-            'email' => 'zac@thetolleys.com',
-        ];
-
-        $selfRegisterData = new SelfRegisterData();
-
-        $this->selfRegisterController->populateSelfReg($selfRegisterData, $data);
-
-        $this->assertEquals('Zac', $selfRegisterData->getFirstname());
-        $this->assertEquals('Tolley', $selfRegisterData->getLastname());
-        $this->assertEquals('zac@thetolleys.com', $selfRegisterData->getEmail());
-    }
-
     /** @test */
     public function failsWhenMissingData()
     {

--- a/api/tests/AppBundle/ControllerReport/AccountControllerTest.php
+++ b/api/tests/AppBundle/ControllerReport/AccountControllerTest.php
@@ -118,6 +118,7 @@ class AccountControllerTest extends AbstractTestController
             'mustSucceed' => true,
             'AuthToken' => self::$tokenDeputy,
         ])['data']['bank_accounts'];
+
         $this->assertCount(3, $data);
         $this->assertTrue($data[0]['id'] != $data[1]['id']);
         $this->assertArrayHasKey('bank', $data[0]);

--- a/api/tests/AppBundle/Service/Formatter/RestFormatterTest.php
+++ b/api/tests/AppBundle/Service/Formatter/RestFormatterTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+
+namespace Tests\AppBundle\Service\Formatter;
+
+use AppBundle\EventListener\RestInputOuputFormatter;
+use AppBundle\Service\Formatter\RestFormatter;
+use AppBundle\Service\Validator\RestArrayValidator;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\Request;
+
+class RestFormatterTest extends TestCase
+{
+    private \Prophecy\Prophecy\ObjectProphecy $inputOutputFormatter;
+    private \Prophecy\Prophecy\ObjectProphecy $validator;
+    private RestFormatter $sut;
+
+    public function setUp(): void
+    {
+        $this->inputOutputFormatter = self::prophesize(RestInputOuputFormatter::class);
+        $this->validator = self::prophesize(RestArrayValidator::class);
+
+        $this->sut = new RestFormatter(
+            $this->inputOutputFormatter->reveal(),
+            $this->validator->reveal()
+        );
+    }
+
+    /** @test */
+    public function deserializeBodyContent()
+    {
+        $incomingRequest = new Request();
+        $expectedContentArray = ['aKey' => 'some data'];
+        $this->inputOutputFormatter
+            ->requestContentToArray($incomingRequest)
+            ->shouldBeCalled()
+            ->willReturn($expectedContentArray);
+
+        $assertions = ['aDataKey' => 'someAssertion'];
+
+        $this->validator->validateArray($expectedContentArray, $assertions)->shouldBeCalled();
+
+        $actualContentArray = $this->sut->deserializeBodyContent($incomingRequest, $assertions);
+
+        self::assertEquals($expectedContentArray, $actualContentArray);
+    }
+
+    /** @test */
+    public function setJmsSerialiserGroups()
+    {
+        $serialiserGroups = ['group1', 'group2'];
+
+        $this->inputOutputFormatter
+            ->addContextModifier(Argument::type('Callable'))
+            ->shouldBeCalled();
+
+        $this->sut->setJmsSerialiserGroups($serialiserGroups);
+    }
+
+    /** @test */
+    public function validateArray()
+    {
+        $data = ['some' => 'data'];
+        $assertions = ['some' => 'assertions'];
+        $this->validator->validateArray($data, $assertions)->shouldBeCalled();
+
+        $this->sut->validateArray($data, $assertions);
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,7 +148,7 @@ services:
         restart: always
 
     file-scanner-server:
-        image: mkodockx/docker-clamav
+        image: mkodockx/docker-clamav:alpine
         environment:
             CLAMD_CONF_SelfCheck: 0
             FRESHCLAM_CONF_NotifyClamd: 'no'


### PR DESCRIPTION
Following other refactors this change removes any remaining instances of accessing services directly in controllers or other services and instead replaces with DI.

This is one of two PRs for the client and API apps - split up to make the review (hopefully) easier.

Fixes DDPB-3668

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes