### PR TITLE
DDPB-3555 add password validation for pwned passwords

### DIFF
--- a/behat/tests/features-v2/deputy-management/deputy/edit-myself.feature
+++ b/behat/tests/features-v2/deputy-management/deputy/edit-myself.feature
@@ -162,7 +162,15 @@ Feature: A deputy user edits their details
     And I press "change_password_save"
     Then the following fields should have an error:
       | change_password_plain_password_first |
-        # valid new password
+      #too common password
+    When I fill in the following:
+      | change_password_current_password | Abcd1234 |
+      | change_password_plain_password_first | Password123 |
+      | change_password_plain_password_second | Password123 |
+    And I press "change_password_save"
+    Then the following fields should have an error:
+      | change_password_plain_password_first |
+      # valid new password
     When I fill in the following:
       | change_password_current_password | Abcd1234 |
       | change_password_plain_password_first | Abcd12345 |

--- a/behat/tests/features/admin/01-admin.feature
+++ b/behat/tests/features/admin/01-admin.feature
@@ -156,8 +156,8 @@ Feature: admin / admin
     And I click on "user-account, password-edit"
     And I fill in the following:
       | change_password_current_password      | Abcd12345 |
-      | change_password_plain_password_first  | Abcd1234  |
-      | change_password_plain_password_second | Abcd1234  |
+      | change_password_plain_password_first  | Abcd1234! |
+      | change_password_plain_password_second | Abcd1234! |
     And I press "change_password_save"
     Then the form should be valid
 

--- a/behat/tests/features/admin/01-admin.feature
+++ b/behat/tests/features/admin/01-admin.feature
@@ -104,13 +104,13 @@ Feature: admin / admin
     Then the response status code should be 200
     And I click on "password-edit"
     Then the response status code should be 200
-      # wrong old password
+    # wrong old password
     When I fill in "change_password_current_password" with "this.is.the.wrong.password"
     And I press "change_password_save"
     Then the following fields should have an error:
       | change_password_current_password     |
       | change_password_plain_password_first |
-      # invalid new password
+    # invalid new password
     When I fill in the following:
       | change_password_current_password      | Abcd1234 |
       | change_password_plain_password_first  | 1        |
@@ -118,7 +118,7 @@ Feature: admin / admin
     And I press "change_password_save"
     Then the following fields should have an error:
       | change_password_plain_password_first |
-      # unmatching new passwords
+    # unmatching new passwords
     When I fill in the following:
       | change_password_current_password      | Abcd1234  |
       | change_password_plain_password_first  | Abcd1234  |
@@ -126,7 +126,7 @@ Feature: admin / admin
     And I press "change_password_save"
     Then the following fields should have an error:
       | change_password_plain_password_first |
-      #empty password
+    #empty password
     When I fill in the following:
       | change_password_current_password      | Abcd1234 |
       | change_password_plain_password_first  |          |
@@ -134,7 +134,15 @@ Feature: admin / admin
     And I press "change_password_save"
     Then the following fields should have an error:
       | change_password_plain_password_first |
-      # valid new password
+    # too common password
+    When I fill in the following:
+      | change_password_current_password      | Abcd1234 |
+      | change_password_plain_password_first  | Password123 |
+      | change_password_plain_password_second | Password123 |
+    And I press "change_password_save"
+    Then the following fields should have an error:
+      | change_password_plain_password_first |
+    # valid new password
     When I fill in the following:
       | change_password_current_password      | Abcd1234  |
       | change_password_plain_password_first  | Abcd12345 |

--- a/behat/tests/features/admin/02-cross-checks.feature
+++ b/behat/tests/features/admin/02-cross-checks.feature
@@ -2,15 +2,15 @@ Feature: admin / acl
 
 
     Scenario: An admin user cannot login into deputy area
-        # check admin can login into admin site
-        Given I am logged in to admin as "behat-admin-user@publicguardian.gov.uk" with password "Abcd1234"
+        # check admin can login into admin site. Password previously changed.
+        Given I am logged in to admin as "behat-admin-user@publicguardian.gov.uk" with password "Abcd1234!"
         #Then the response status code should be 200
         # check admin CANNOT login into DEPUTY site
         Given I go to "/logout"
         And  I go to "/login"
         When I fill in the following:
             | login_email     | behat-admin-user@publicguardian.gov.uk |
-            | login_password  | Abcd1234 |
+            | login_password  | Abcd1234! |
         And I click on "login"
         Then I should see an "#error-summary" element
         And I should be on "/login"

--- a/behat/tests/features/pa/04-dashboard-client-profile/13-settings.feature
+++ b/behat/tests/features/pa/04-dashboard-client-profile/13-settings.feature
@@ -154,6 +154,14 @@ Feature: PA settings
     When I press "change_password_save"
     Then the following fields should have an error:
       | change_password_plain_password_first   |
+      # too common password
+    When I fill in the following:
+      | change_password_current_password       | Abcd1234  |
+      | change_password_plain_password_first   | Password123  |
+      | change_password_plain_password_second  | Password123  |
+    When I press "change_password_save"
+    Then the following fields should have an error:
+      | change_password_plain_password_first   |
     # Finally a valid one
     When I fill in the following:
       | change_password_current_password       | Abcd1234  |

--- a/behat/tests/features/prof/04-dashboard-client-profile/13-settings.feature
+++ b/behat/tests/features/prof/04-dashboard-client-profile/13-settings.feature
@@ -155,6 +155,13 @@ Feature: PROF settings
     When I press "change_password_save"
     Then the following fields should have an error:
       | change_password_plain_password_first   |
+    When I fill in the following:
+      | change_password_current_password       | Abcd1234  |
+      | change_password_plain_password_first   | Password123  |
+      | change_password_plain_password_second  | Password123  |
+    When I press "change_password_save"
+    Then the following fields should have an error:
+      | change_password_plain_password_first   |
     # Finally a valid one
     When I fill in the following:
       | change_password_current_password       | Abcd1234  |

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -97,6 +97,10 @@ COPY docker/confd /etc/confd
 
 RUN chown -R www-data scripts
 
+# Add common passwords file
+RUN wget -q -O /tmp/commonpasswords.txt "https://www.ncsc.gov.uk/static-assets/documents/PwnedPasswordsTop100k.txt" \
+    && chown www-data /tmp/commonpasswords.txt
+
 # Prebuild cache
 RUN su-exec www-data php -d memory_limit=-1 app/console cache:warmup
 

--- a/client/src/AppBundle/Form/ChangePasswordType.php
+++ b/client/src/AppBundle/Form/ChangePasswordType.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Form;
 
 use AppBundle\Validator\Constraints\DUserPassword;
+use AppBundle\Validator\Constraints\CommonPassword;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type as FormTypes;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -32,6 +33,7 @@ class ChangePasswordType extends AbstractType
                         new Assert\Regex(['pattern' => '/[a-z]/', 'message' => 'user.password.noLowerCaseChars', 'groups' => self::VALIDATION_GROUP]),
                         new Assert\Regex(['pattern' => '/[A-Z]/', 'message' => 'user.password.noUpperCaseChars', 'groups' => self::VALIDATION_GROUP]),
                         new Assert\Regex(['pattern' => '/[0-9]/', 'message' => 'user.password.noNumber', 'groups' => self::VALIDATION_GROUP]),
+                        new CommonPassword(['message' => 'user.password.notCommonPassword', 'groups' => self::VALIDATION_GROUP]),
                     ],
                 ])
                 ->add('id', FormTypes\HiddenType::class)

--- a/client/src/AppBundle/Resources/translations/validators.en.yml
+++ b/client/src/AppBundle/Resources/translations/validators.en.yml
@@ -27,6 +27,7 @@ user:
       maxLength: The password cannot be longer than {{ limit }} letters
       noLowerCaseChars: The password must have at least one lowercase letter
       noUpperCaseChars: The password must have at least one capital letter
+      notCommonPassword: Your password is too easy for someone to guess. Please choose a different password.
       noNumber: The password must have at least one number
       existing:
         notBlank: Please enter your correct current password

--- a/client/src/AppBundle/Validator/Constraints/CommonPassword.php
+++ b/client/src/AppBundle/Validator/Constraints/CommonPassword.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace AppBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+class CommonPassword extends Constraint
+{
+    public $message = 'Your password is too easy for someone to guess. Please choose a different password.';
+}

--- a/client/src/AppBundle/Validator/Constraints/CommonPasswordValidator.php
+++ b/client/src/AppBundle/Validator/Constraints/CommonPasswordValidator.php
@@ -1,0 +1,78 @@
+<?php
+namespace AppBundle\Validator\Constraints;
+
+use RuntimeException;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class CommonPasswordValidator extends ConstraintValidator
+{
+    const TMP_ROOT_PATH = '/tmp/';
+    const PWNED_PW_URL = 'https://www.ncsc.gov.uk/static-assets/documents/PwnedPasswordsTop100k.txt';
+
+    /**
+     * @var string
+     */
+    private string $filePathCommonPasswords;
+    /**
+     * @var string
+     */
+    private string $pwnedPasswordsUrl;
+
+    public function __construct()
+    {
+        $this->filePathCommonPasswords = self::TMP_ROOT_PATH . 'commonpasswords.txt';
+        $this->pwnedPasswordsUrl = self::PWNED_PW_URL;
+    }
+    /**
+     * Validates a password is not in list of pwned passwords
+     *
+     * @param string $password
+     * @param Constraint $constraint
+     */
+    public function validate($password, Constraint $constraint)
+    {
+        $this->checkCommonPasswordsFileExists($this->filePathCommonPasswords);
+
+        if ($this->passwordMatchesCommonPasswords($password, $this->filePathCommonPasswords)) {
+            $this->context->buildViolation($constraint->message)->addViolation();
+        }
+    }
+
+    protected function passwordMatchesCommonPasswords(string $searchTerm, string $filePath)
+    {
+        $matches = array();
+
+        $handle = @fopen($filePath, "r");
+        if ($handle) {
+            while (!feof($handle)) {
+                $buffer = fgets($handle);
+                if (strpos($buffer, $searchTerm) !== false) {
+                    $matches[] = $buffer;
+                }
+            }
+            fclose($handle);
+        }
+        //show results:
+        if (count($matches) > 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    protected function checkCommonPasswordsFileExists(string $filePath)
+    {
+        if (file_exists($filePath) & (time()-filemtime($filePath) < 24 * 3600)) {
+            return;
+        } else {
+            $written = file_put_contents(
+                "$filePath",
+                fopen($this->pwnedPasswordsUrl, 'r')
+            );
+            if ($written === false) {
+                throw new RuntimeException(sprintf('Unable to download or write common password file to disk'));
+            }
+        }
+    }
+}

--- a/client/src/AppBundle/Validator/Constraints/CommonPasswordValidator.php
+++ b/client/src/AppBundle/Validator/Constraints/CommonPasswordValidator.php
@@ -27,15 +27,17 @@ class CommonPasswordValidator extends ConstraintValidator
     /**
      * Validates a password is not in list of pwned passwords
      *
-     * @param string $password
+     * @param mixed $password
      * @param Constraint $constraint
      */
     public function validate($password, Constraint $constraint)
     {
-        $this->checkCommonPasswordsFileExists($this->filePathCommonPasswords);
+        if (isset($password)) {
+            $this->checkCommonPasswordsFileExists($this->filePathCommonPasswords);
 
-        if ($this->passwordMatchesCommonPasswords($password, $this->filePathCommonPasswords)) {
-            $this->context->buildViolation($constraint->message)->addViolation();
+            if ($this->passwordMatchesCommonPasswords($password, $this->filePathCommonPasswords)) {
+                $this->context->buildViolation($constraint->message)->addViolation();
+            }
         }
     }
 

--- a/client/src/AppBundle/Validator/Constraints/CommonPasswordValidator.php
+++ b/client/src/AppBundle/Validator/Constraints/CommonPasswordValidator.php
@@ -68,12 +68,15 @@ class CommonPasswordValidator extends ConstraintValidator
         if (file_exists($filePath) & (time()-filemtime($filePath) < 24 * 3600)) {
             return;
         } else {
-            $written = file_put_contents(
-                "$filePath",
-                fopen($this->pwnedPasswordsUrl, 'r')
-            );
-            if ($written === false) {
-                throw new RuntimeException(sprintf('Unable to download or write common password file to disk'));
+            $fp = fopen($this->pwnedPasswordsUrl, "r");
+            if ($fp !== false) {
+                $written = file_put_contents(
+                    "$filePath",
+                    $fp
+                );
+                if ($written === false) {
+                    throw new RuntimeException(sprintf('Unable to download or write common password file to disk'));
+                }
             }
         }
     }

--- a/client/tests/phpunit/Validator/Constraints/CommonPasswordValidatorTest.php
+++ b/client/tests/phpunit/Validator/Constraints/CommonPasswordValidatorTest.php
@@ -8,6 +8,17 @@ use PHPUnit\Framework\TestCase;
 
 class CommonPasswordValidatorTest extends TestCase
 {
+    const PW_FILE_PATH = '/tmp/commonpasswords.txt';
+    const PWNED_PW_URL = 'https://www.ncsc.gov.uk/static-assets/documents/PwnedPasswordsTop100k.txt';
+
+    public function setUp(): void
+    {
+        file_put_contents(
+            self::PW_FILE_PATH,
+            fopen(self::PWNED_PW_URL, 'r')
+        );
+    }
+
     /**
      * @param string $expectedMessage The expected message on a validation violation, if any.
      * @return CommonPasswordValidator

--- a/client/tests/phpunit/Validator/Constraints/CommonPasswordValidatorTest.php
+++ b/client/tests/phpunit/Validator/Constraints/CommonPasswordValidatorTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace AppBundle\Validator\Constraints;
+
+use AppBundle\Validator\Constraints\CommonPassword;
+use AppBundle\Validator\Constraints\CommonPasswordValidator;
+use PHPUnit\Framework\TestCase;
+
+class CommonPasswordValidatorTest extends TestCase
+{
+    /**
+     * @param string $expectedMessage The expected message on a validation violation, if any.
+     * @return CommonPasswordValidator
+     */
+    public function configureValidator($expectedMessage = null)
+    {
+        // mock the violation builder
+        $builder = $this->getMockBuilder('Symfony\Component\Validator\Violation\ConstraintViolationBuilder')
+            ->disableOriginalConstructor()
+            ->setMethods(array('addViolation'))
+            ->getMock();
+
+        // mock the validator context
+        $context = $this->getMockBuilder('Symfony\Component\Validator\Context\ExecutionContext')
+            ->disableOriginalConstructor()
+            ->setMethods(array('buildViolation'))
+            ->getMock();
+
+        if ($expectedMessage) {
+            $builder->expects($this->once())
+                ->method('addViolation');
+
+            $context->expects($this->once())
+                ->method('buildViolation')
+                ->with($this->equalTo($expectedMessage))
+                ->will($this->returnValue($builder));
+        } else {
+            $context->expects($this->never())
+                ->method('buildViolation');
+        }
+
+        // initialize the validator with the mocked context
+        $validator = new CommonPasswordValidator();
+        $validator->initialize($context);
+
+        // return the SomeConstraintValidator
+        return $validator;
+    }
+
+    /**
+     * Verify a constraint message is triggered when value is invalid.
+     */
+    public function testValidateOnInvalid()
+    {
+        $constraint = new CommonPassword();
+        $validator = $this->configureValidator($constraint->message);
+
+        $validator->validate('Password123', $constraint);
+    }
+
+    /**
+     * Verify no constraint message is triggered when value is valid.
+     */
+    public function testValidateOnValid()
+    {
+        $constraint = new CommonPassword();
+        $validator = $this->configureValidator();
+
+        $validator->validate('Aformidablepw876!', $constraint);
+    }
+}


### PR DESCRIPTION
## Purpose
Stop users from using passwords that are too common by taking the top 100k known pwned passwords and making sure password is not in the list.

When we move to symfony 4 we should use the constraint that does this check automatically! It's cleverer than what we are doing.

Fixes DDPB-3555

## Approach
Went back and forth on approach a bit. Initially I wanted the list in the database but in the end after realising the size of the list (tiny) I went for a hybrid approach of DLing file locally where it doesn't already exist or if it's older than 24 hours and using that for the comparison. The check takes milliseconds so seems fine doing it this way.

I created a new bespoke constraint and added some unit tests and behat tests to check it.

## Learning
Constraints, unit testing constraints, (although not in the code, I learned quite a bit more about doctrine!)

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
