### PR TITLE
DDPB-3786: Handle larger text in the feedback form and prevent spam

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ up-app: ## Brings the app up
 
 up-app-debug: up-app enable-debug ## Brings the app up in dev mode with debugging enabled
 
-up-app-no-debug: up-app	disable-debug ## Brings the app up in dev mode with debugging disabled
+up-app-no-debug: up-app disable-debug ## Brings the app up in dev mode with debugging disabled
 
 up-app-build: ## Brings the app up and rebuilds containers
 	COMPOSE_HTTP_TIMEOUT=90 docker-compose up -d --build --remove-orphans

--- a/api/app/DoctrineMigrations/Version247.php
+++ b/api/app/DoctrineMigrations/Version247.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version247 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+        $this->addSql('ALTER TABLE satisfaction ALTER COLUMN comments TYPE TEXT');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+        $this->addSql('ALTER TABLE satisfaction ALTER COLUMN comments TYPE VARCHAR(1200)');
+    }
+}

--- a/client/src/AppBundle/Form/FeedbackType.php
+++ b/client/src/AppBundle/Form/FeedbackType.php
@@ -6,11 +6,19 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type as FormTypes;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Validator\Constraints as Constraints;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class FeedbackType extends AbstractType
 {
-    use Traits\HasTranslatorTrait;
+    /**
+     * @var TranslatorInterface
+     */
+    private TranslatorInterface $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
 
     public const HONEYPOT_FIELD_NAME = 'old_question';
 
@@ -18,7 +26,7 @@ class FeedbackType extends AbstractType
     {
         $satisfactionScores = range(5, 1);
         $satisfactionLabels = array_map(function($score) {
-            return $this->translate('form.satisfactionLevel.choices.' . $score, [], 'feedback');
+            return $this->translator->trans('form.satisfactionLevel.choices.' . $score, [], 'feedback');
         }, $satisfactionScores);
 
         $builder
@@ -39,9 +47,6 @@ class FeedbackType extends AbstractType
             ])
             ->add('email', FormTypes\EmailType::class, [
                 'required' => false,
-                'constraints' => [
-                    new Constraints\Email(['message' => 'login.email.inValid'])
-                ]
             ])
             ->add('phone', FormTypes\TextType::class, [
                 'required' => false,

--- a/client/src/AppBundle/Form/FeedbackType.php
+++ b/client/src/AppBundle/Form/FeedbackType.php
@@ -12,6 +12,8 @@ class FeedbackType extends AbstractType
 {
     use Traits\HasTranslatorTrait;
 
+    public const HONEYPOT_FIELD_NAME = 'question';
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $satisfactionScores = range(5, 1);
@@ -51,6 +53,7 @@ class FeedbackType extends AbstractType
                 'required' => false,
                 'placeholder' => false,
             ])
+            ->add(self::HONEYPOT_FIELD_NAME, FormTypes\TextType::class, ['required' => false])
             ->add('save', FormTypes\SubmitType::class);
     }
 

--- a/client/src/AppBundle/Form/FeedbackType.php
+++ b/client/src/AppBundle/Form/FeedbackType.php
@@ -12,7 +12,7 @@ class FeedbackType extends AbstractType
 {
     use Traits\HasTranslatorTrait;
 
-    public const HONEYPOT_FIELD_NAME = 'question';
+    public const HONEYPOT_FIELD_NAME = 'old_question';
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {

--- a/client/src/AppBundle/Form/Traits/HasTranslatorTrait.php
+++ b/client/src/AppBundle/Form/Traits/HasTranslatorTrait.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Form\Traits;
 
+use Symfony\Component\Translation\Translator;
 use Symfony\Component\Translation\TranslatorInterface;
 
 trait HasTranslatorTrait
@@ -12,6 +13,7 @@ trait HasTranslatorTrait
     private $translator;
 
     /**
+     * @param TranslatorInterface $translator
      * @required
      */
     public function setTranslator(TranslatorInterface $translator)
@@ -19,7 +21,7 @@ trait HasTranslatorTrait
         $this->translator = $translator;
     }
 
-    private function translate($id, $options, $domain)
+    private function translate($id, $options, $domain): string
     {
         return $this->translator->trans($id, $options, $domain);
     }

--- a/client/src/AppBundle/Resources/assets/javascripts/main.js
+++ b/client/src/AppBundle/Resources/assets/javascripts/main.js
@@ -103,6 +103,10 @@ $(document).ready(function () {
       $el.addEventListener('click', function ($e) {
         this.classList.add('opg-submit-link--disabled', 'govuk-button--disabled')
       })
+
+      setTimeout(function () {
+        this.classList.remove('opg-submit-link--disabled', 'govuk-button--disabled')
+      }, 3000)
     })
   }
 

--- a/client/src/AppBundle/Resources/assets/javascripts/main.js
+++ b/client/src/AppBundle/Resources/assets/javascripts/main.js
@@ -101,12 +101,12 @@ $(document).ready(function () {
   if ($submitButtons !== null) {
     $submitButtons.forEach(function ($el) {
       $el.addEventListener('click', function ($e) {
-        this.classList.add('opg-submit-link--disabled', 'govuk-button--disabled')
-      })
+        $e.target.classList.add('opg-submit-link--disabled', 'govuk-button--disabled')
 
-      setTimeout(function () {
-        this.classList.remove('opg-submit-link--disabled', 'govuk-button--disabled')
-      }, 3000)
+        setTimeout(function () {
+          $e.target.classList.remove('opg-submit-link--disabled', 'govuk-button--disabled')
+        }, 3000)
+      })
     })
   }
 

--- a/client/src/AppBundle/Resources/translations/feedback.en.yml
+++ b/client/src/AppBundle/Resources/translations/feedback.en.yml
@@ -8,6 +8,7 @@ collectionPage:
         title: Do you want a reply?
         explanation: If you'd like us to get back to you, please leave your details below.
     confirmation: Thank you for your feedback
+    spamError: Spam detected!
 
 form:
     specificPage:

--- a/client/src/AppBundle/Resources/views/Feedback/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Feedback/index.html.twig
@@ -40,9 +40,12 @@
             {{ form_input(form.email, 'form.email') }}
             {{ form_input(form.phone, 'form.phone') }}
 
+            {{ form_widget(form.question, {'attr': {'style': 'display:none!important', 'tabindex': '-1', 'autocomplete': 'off'}}) }}
+
             {{ form_checkbox_group(form.satisfactionLevel, 'form.satisfactionLevel', {
                 legendClass: 'govuk-label--m'
             }) }}
+
             <div style="clear:both;display:inline-block;height:0px;" data-module="opg-toggleable-submit">
                 {{ form_submit(form.save, 'form.send') }}
             </div>

--- a/client/src/AppBundle/Resources/views/Feedback/index.html.twig
+++ b/client/src/AppBundle/Resources/views/Feedback/index.html.twig
@@ -40,7 +40,8 @@
             {{ form_input(form.email, 'form.email') }}
             {{ form_input(form.phone, 'form.phone') }}
 
-            {{ form_widget(form.question, {'attr': {'style': 'display:none!important', 'tabindex': '-1', 'autocomplete': 'off'}}) }}
+            {{ form_widget(form.old_question, {'attr': {'style': 'display:none!important', 'tabindex': '-1',
+                'autocomplete': 'off'}}) }}
 
             {{ form_checkbox_group(form.satisfactionLevel, 'form.satisfactionLevel', {
                 legendClass: 'govuk-label--m'

--- a/client/tests/phpunit/Form/FeedbackTypeTest.php
+++ b/client/tests/phpunit/Form/FeedbackTypeTest.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+use AppBundle\Form\FeedbackType;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class FeedbackTypeTest extends TypeTestCase {
+
+    /**
+     * Test the form submit fails if the honey pot field
+     * is filled in
+     */
+    public function testSubmitInvalidData()
+    {
+        $form = $this->factory->create(FeedbackType::class);
+
+        $formData = [
+            'old_question' => 'some value', // honeypot field
+            'specificPage' => 'whole site',
+            'comments' => 'Lorem ipsum Iure ad veritatis quidem non.',
+        ];
+
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSubmitted());
+        $this->assertFalse($form->isValid());
+    }
+}

--- a/client/tests/phpunit/Form/FeedbackTypeTest.php
+++ b/client/tests/phpunit/Form/FeedbackTypeTest.php
@@ -1,28 +1,57 @@
 <?php declare(strict_types=1);
 
 use AppBundle\Form\FeedbackType;
+use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
+use Mockery as m;
 
-class FeedbackTypeTest extends TypeTestCase {
+class FeedbackTypeTest extends TypeTestCase
+{
+    private $translator;
+
+    public function setUp(): void
+    {
+        $this->translator = m::mock('Symfony\Component\Translation\TranslatorInterface');
+        $this->translator->shouldReceive('trans')->with(m::any(), [], 'feedback')->andReturnUsing(function ($a) {
+            return range(5, 1);
+        });
+
+        parent::setUp();
+    }
+
+    protected function getExtensions()
+    {
+        // create a type instance with the mocked dependencies
+        $feedbackType = new FeedbackType($this->translator);
+
+        return [
+            // register the type instances with the PreloadedExtension
+            new PreloadedExtension([$feedbackType], []),
+        ];
+    }
 
     /**
      * Test the form submit fails if the honey pot field
      * is filled in
+     *
      */
     public function testSubmitInvalidData()
     {
-        $feedback = new FeedbackType();
-        $form = $this->factory->create(FeedbackType::class, $feedback);
-
         $formData = [
             'old_question' => 'some value', // honeypot field
             'specificPage' => 'whole site',
             'comments' => 'Lorem ipsum Iure ad veritatis quidem non.',
         ];
+        $form = $this->factory->create(FeedbackType::class, $formDataconstraints);
 
         $form->submit($formData);
 
         $this->assertTrue($form->isSubmitted());
         $this->assertFalse($form->isValid());
+    }
+
+    public function tearDown(): void
+    {
+        m::close();
     }
 }

--- a/client/tests/phpunit/Form/FeedbackTypeTest.php
+++ b/client/tests/phpunit/Form/FeedbackTypeTest.php
@@ -11,7 +11,8 @@ class FeedbackTypeTest extends TypeTestCase {
      */
     public function testSubmitInvalidData()
     {
-        $form = $this->factory->create(FeedbackType::class);
+        $feedback = new FeedbackType();
+        $form = $this->factory->create(FeedbackType::class, $feedback);
 
         $formData = [
             'old_question' => 'some value', // honeypot field


### PR DESCRIPTION
We had a limit of 1200 characters at the DB level for the feedback form
but did not apply the limit to the frontend. We now just increased the
DB character count to a lot more by changing the field to a TEXT field.

Also we added a honeypot method to the feedback form to try and stop
random (non-targeted) spam.

Issue DDPB-3786

## Approach
For the honeypot trick basically we have a hidden field on the form that to a spambot would look like a normal field to fill in. If this field is filled in then we reject the submission and it could be potential spam.

## Learning
Honeypot field in Symfony: https://www.strangebuzz.com/en/blog/implementing-a-honeypot-in-a-symfony-form

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes