### PR TITLE
DDPB-3733 do not fail healthcheck on sirius down

### DIFF
--- a/client/src/AppBundle/Controller/ManageController.php
+++ b/client/src/AppBundle/Controller/ManageController.php
@@ -18,7 +18,9 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
  */
 class ManageController extends AbstractController
 {
-    public function __construct(){}
+    public function __construct()
+    {
+    }
 
     /**
      * @Route("/availability", methods={"GET"})
@@ -35,9 +37,7 @@ class ManageController extends AbstractController
         ApiAvailability $apiAvailability,
         NotifyAvailability $notifyAvailability,
         RedisAvailability $redisAvailability
-    )
-    {
-
+    ) {
         $services = [
             $apiAvailability,
             $redisAvailability,
@@ -76,8 +76,7 @@ class ManageController extends AbstractController
         ApiAvailability $apiAvailability,
         NotifyAvailability $notifyAvailability,
         RedisAvailability $redisAvailability
-    )
-    {
+    ) {
         $services = [
             $apiAvailability,
             $redisAvailability,
@@ -116,7 +115,9 @@ class ManageController extends AbstractController
 
         foreach ($services as $service) {
             if (!$service->isHealthy()) {
-                $healthy = false;
+                if ($service->getName() != 'Sirius') {
+                    $healthy = false;
+                }
                 $errors[] = $service->getErrors();
             }
         }


### PR DESCRIPTION
## Purpose
We should keep the status in manage availability but we don't want the healthcheck to affect our uptime stats as it's not a vital part of our service and docs will just remain queued if it's down.

Fixes DDPB-3733

## Approach
Don't return unhealthy status if it's just sirius that's down.

## Learning
NA
## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
