### PR TITLE
DDPB-3816: Fix failing lay CSV upload

### DIFF
--- a/client/src/AppBundle/Controller/Admin/AjaxController.php
+++ b/client/src/AppBundle/Controller/Admin/AjaxController.php
@@ -4,7 +4,7 @@ namespace AppBundle\Controller\Admin;
 
 use AppBundle\Controller\AbstractController;
 use AppBundle\Service\Client\RestClient;
-use Predis\Client;
+use Predis\ClientInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -52,10 +52,10 @@ class AjaxController extends AbstractController
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
      *
      * @param Request $request
-     * @param Client $redisClient
+     * @param ClientInterface $redisClient
      * @return JsonResponse
      */
-    public function uploadUsersAjaxAction(Request $request, Client $redisClient)
+    public function uploadUsersAjaxAction(Request $request, ClientInterface $redisClient)
     {
         $chunkId = 'chunk' . $request->get('chunk');
 


### PR DESCRIPTION
## Purpose
Fixes the broken CSV upload.

Fixes DDPB-3816

## Approach
We had reports that the CSV upload process was hanging in production. Looking in cloudwatch there was an error related to the Ajaxcontroller that gets called when splitting the CSV into chunks of 2000 rows - a class wasn't being injected into the controller function that required it. 

I've fixed the typehint now but the reason our tests didn't pick this up is all of the CSVs we upload are under 2000 rows long. As chunks are set at 2000 rows the Ajaxcontroller was never called in tests. I'm looking into writing a JS enabled test in behat to cover this off but want to get the fix out now so the Lay team can get the most recent lays added to the system.
