### PR TITLE
DDPB-3645 scheduled workspace cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,16 +90,10 @@ workflows:
           task_name: restore
 
       - cleanup:
-          name: approve destroy environment
+          name: destroy environment
           type: approval
           requires: [ restore environment ]
           filters: { branches: { ignore: [ main ] } }
-
-      - terraform-command:
-          name: destroy environment
-          requires: [ approve destroy environment ]
-          filters: { branches: { ignore: [ main ] } }
-          tf_command: destroy
 
   integration:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,11 @@ workflows:
           filters: { branches: { ignore: [ main ] } }
           tf_command: apply
 
+      - protect-workspace:
+          name: protect branch workspace
+          requires: [ apply environment ]
+          filters: { branches: { ignore: [ main ] } }
+
       - client-unit-test:
           name: client unit test
           requires: [ build pr ]
@@ -55,7 +60,7 @@ workflows:
       - approve:
           name: approval for further testing
           type: approval
-          requires: [ api unit test, client unit test, apply environment ]
+          requires: [ api unit test, client unit test, protect branch workspace ]
           filters: { branches: { ignore: [ master ] } }
 
       - run-task:
@@ -291,6 +296,16 @@ workflows:
           notify_slack: true
           timeout: 3000
 
+  nightly_workspace_deletion:
+    triggers:
+      - schedule:
+          cron: "00 00 * * *"
+          filters: { branches: { only: [ DDPB-3645 ] } }
+    jobs:
+      - destroy-workspaces:
+          name: destroy non protected workspaces
+          filters: { branches: { only: [ DDPB-3645 ] } }
+
 orbs:
   aws-cli: circleci/aws-cli@0.1.13
   slack: circleci/slack@3.4.2
@@ -356,6 +371,14 @@ orbs:
           - run:
               name: Install Terraform
               command: sudo unzip terraform_${TF_VERSION}_linux_amd64.zip -d /bin
+      install_workspace_manager:
+        steps:
+          - run:
+              name: install workspace manager
+              command: |
+                wget https://github.com/TomTucka/terraform-workspace-manager/releases/download/v0.3.0/terraform-workspace-manager_Linux_x86_64.tar.gz -O $HOME/terraform-workspace-manager.tar.gz
+                sudo tar -xvf $HOME/terraform-workspace-manager.tar.gz -C /usr/local/bin
+                sudo chmod +x /usr/local/bin/terraform-workspace-manager
 
 jobs:
   lint:
@@ -435,6 +458,42 @@ jobs:
             - run:
                 name: tag pact commit with v<x>_production
                 command: pact_tags
+
+  protect-workspace:
+    executor: terraform/terraform
+    resource_class: small
+    working_directory: ~/project/environment
+    steps:
+      - checkout:
+          path: ~/project
+      - terraform/install
+      - terraform/install_workspace_manager
+      - run:
+          name: Set environment
+          command: ~/project/.circleci/set_env.sh >> $BASH_ENV
+      - run:
+          name: Add workspace to protected list
+          command: terraform-workspace-manager -register-workspace="${TF_WORKSPACE}" -time-to-protect=24 -aws-account-id=248804316466 -aws-iam-role=digideps-ci
+
+  destroy-workspaces:
+    executor: terraform/terraform
+    resource_class: small
+    working_directory: ~/project/environment
+    steps:
+      - checkout:
+          path: ~/project
+      - terraform/install
+      - terraform/install_workspace_manager
+      - attach_workspace: { at: ~/project }
+      - run:
+          name: destroy unprotected workspaces
+          command: |
+            unset TF_WORKSPACE
+            ./scripts/workspace_cleanup.sh $(terraform-workspace-manager -protected-workspaces=true -aws-account-id=248804316466 -aws-iam-role=digideps-ci)
+      - slack/status:
+          channel: opg-digideps-devs
+          failure_message: nightly destroy workspaces has failed.
+          success_message: nightly destroy workspaces has succeeded.
 
   build:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,11 +300,11 @@ workflows:
     triggers:
       - schedule:
           cron: "00 00 * * *"
-          filters: { branches: { only: [ DDPB-3645 ] } }
+          filters: { branches: { only: [ main ] } }
     jobs:
       - destroy-workspaces:
           name: destroy non protected workspaces
-          filters: { branches: { only: [ DDPB-3645 ] } }
+          filters: { branches: { only: [ main ] } }
 
 orbs:
   aws-cli: circleci/aws-cli@0.1.13

--- a/docs/runbooks/PULL-REQUEST-PROCEDURE.md
+++ b/docs/runbooks/PULL-REQUEST-PROCEDURE.md
@@ -17,7 +17,7 @@ starts with the branch name. Example `git commit -m 'DDPB-1234 add scheduling of
 that will build your environment in AWS and run all unit and integration tests.
 
 - If all the tests pass and it is ready for approval then fill in the pull request template giving all relevant details.
-If not then you can continue submmitting commits to the branch which will kick off the rebuild process.
+If not then you can continue submitting commits to the branch which will kick off the rebuild process.
 
 - Put a link to your jira ticket in the Dev channel `opg-digideps-devs`. This should have automatically linked
 through to your ticket so your colleagues can go and review your code.
@@ -28,7 +28,7 @@ at by a project manager (internal infrastructure change for example) then procee
 
 - Move your ticket across the board to `ready to merge` in jira.
 
-- Run the destroy environment workflow approval from CircleCi which can be accessed through github on your PR.
+- Your environment will be destroyed asynchronously, not on the current night but the subsequent night (via the circle workflow).
 
 - Once this process has finished then you are able to merge your PR. You will perform a 'squash and merge' on your PR
 and at this point you should tidy up your PR to adhere to the following guidelines:

--- a/environment/scripts/workspace_cleanup.sh
+++ b/environment/scripts/workspace_cleanup.sh
@@ -22,7 +22,7 @@ do
       echo "protected workspace: $workspace"
       ;;
     *)
-      if [[ $workspace == *"prod"* ]] || [[ $workspace == *"dependabot"* ]]
+      if [[ $workspace == *"prod"* ]]
       then
         echo "check on this workspace: $workspace as it has reserved word fragment in the title..."
       else

--- a/environment/scripts/workspace_cleanup.sh
+++ b/environment/scripts/workspace_cleanup.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env sh
+
+if [ $# -eq 0 ]
+  then
+    echo "Please provide workspaces to be removed."
+fi
+
+function getWorkspaces {
+  terraform workspace list
+}
+
+in_use_workspaces="$@"
+reserved_workspaces="default production preproduction development develop integration training production02"
+
+protected_workspaces="$in_use_workspaces $reserved_workspaces"
+all_workspaces=$(terraform workspace list|sed 's/*//g')
+
+unset TF_WORKSPACE
+export TF_VAR_OPG_DOCKER_TAG=""
+
+for workspace in $all_workspaces
+do
+  case "$protected_workspaces" in
+    *$workspace*)
+      echo "protected workspace: $workspace"
+      ;;
+    *)
+      if [[ $workspace == *"prod"* ]]
+      then
+        echo "check on this workspace: $workspace as it has prod in the title..."
+      else
+        echo "cleaning up workspace $workspace..."
+#        terraform workspace select $workspace
+#        terraform destroy -auto-approve
+#        if [ $? != 0 ]; then
+#          local TF_EXIT_CODE = 1
+#        fi
+#        terraform workspace select default
+#        terraform workspace delete $workspace
+      fi
+      ;;
+  esac
+done
+
+if [TF_EXIT_CODE == 1]; then
+  exit 1
+fi

--- a/environment/workspace_cleanup.tf
+++ b/environment/workspace_cleanup.tf
@@ -1,0 +1,4 @@
+module "workspace-cleanup" {
+  source  = "github.com/TomTucka/terraform-workspace-manager/terraform/workspace_cleanup"
+  enabled = true
+}

--- a/shared/workspace-cleanup.tf
+++ b/shared/workspace-cleanup.tf
@@ -1,4 +1,4 @@
 module "workspace-cleanup" {
   source  = "github.com/TomTucka/terraform-workspace-manager/terraform/workspace_cleanup"
-  enabled = true
+  enabled = local.account.name == "development" ? true : false
 }


### PR DESCRIPTION
## Purpose

So we don't have to destroy environments as part of the pipeline and get left with random environments and loads of empty workspaces, we need a script that runs through them and destroys them.

Fixes DDPB-3645

## Approach

Went for an approach of locking them for 24 hours. Although it says 24 hours this basically means that they will remain for this working day and the next as the job runs at midnight each night. If you want to extend the duration you can either rerun the whole pipeline, change the expiry in dynamo or probably the quickest is just rerun the protect bit of the pipeline again. 

The bulk of the work here was actually clearing up all our old workspaces. Manually went through them with the script to make sure everything was in a fit state... took ages..

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
