### PR TITLE
DDPB-3818: Respect the to date when choosing a date period for DAT reports

### DIFF
--- a/api/app/config/parameters.yml
+++ b/api/app/config/parameters.yml
@@ -1,0 +1,30 @@
+# This file is auto-generated during the composer install
+
+
+# This file is a "template" of what your parameters.yml file should look like
+parameters:
+    cloudwatch_logs_client_params:
+       version: 'latest'
+       region: 'eu-west-1'
+
+       endpoint: 'http://localstack:4586'
+       validate: false
+       credentials:
+           key: 'FAKE_ID'
+           secret: 'FAKE_KEY'
+
+    database_driver: pdo_pgsql
+    database_host: postgres
+    database_port: 5432
+    database_name: api
+    database_user: api
+    database_password: api
+    locale: en
+    secret: foobar
+    redis_dsn: 'redis://redisapi'
+
+    fixtures:
+        account_password: Abcd1234
+
+    log_level: warning
+    log_path: /var/log/app/application.log

--- a/api/src/AppBundle/Controller/Report/ReportSubmissionController.php
+++ b/api/src/AppBundle/Controller/Report/ReportSubmissionController.php
@@ -225,12 +225,12 @@ class ReportSubmissionController extends RestController
         /* @var $repo EntityDir\Repository\ReportSubmissionRepository */
         $repo = $this->getRepository(EntityDir\Report\ReportSubmission::class);
 
-        $fromDate = $request->get('fromDate', null) ? new DateTime($request->get('fromDate')) : null;
-        $toDate = $request->get('toDate', null) ? new DateTime($request->get('toDate')) : null;
+        $fromDate = $request->get('fromDate') ? new DateTime($request->get('fromDate')) : null;
+        $toDate = $request->get('toDate') ? new DateTime($request->get('toDate')) : null;
 
         $ret = $repo->findAllReportSubmissions(
-            $fromDate,
-            $toDate,
+            $fromDate->setTime(0, 0),
+            $toDate->setTime(23, 59, 59),
             $request->get('orderBy', 'createdOn'),
             $request->get('order', 'ASC')
         );

--- a/api/src/AppBundle/Controller/Report/ReportSubmissionController.php
+++ b/api/src/AppBundle/Controller/Report/ReportSubmissionController.php
@@ -219,8 +219,14 @@ class ReportSubmissionController extends RestController
     /**
      * @Route("/casrec_data", name="casrec_data", methods={"GET"})
      * @Security("has_role('ROLE_ADMIN')")
+     * 
+     * @param Request $request
+     * @param ReportSubmissionSummaryTransformer $reportSubmissionSummaryTransformer
+     * 
+     * @return array
+     * @throws \Exception
      */
-    public function getCasrecData(Request $request, ReportSubmissionSummaryTransformer $reportSubmissionSummaryTransformer)
+    public function getCasrecData(Request $request, ReportSubmissionSummaryTransformer $reportSubmissionSummaryTransformer): array
     {
         /* @var $repo EntityDir\Repository\ReportSubmissionRepository */
         $repo = $this->getRepository(EntityDir\Report\ReportSubmission::class);

--- a/api/src/AppBundle/Controller/Report/ReportSubmissionController.php
+++ b/api/src/AppBundle/Controller/Report/ReportSubmissionController.php
@@ -233,10 +233,13 @@ class ReportSubmissionController extends RestController
 
         $fromDate = $request->get('fromDate') ? new DateTime($request->get('fromDate')) : null;
         $toDate = $request->get('toDate') ? new DateTime($request->get('toDate')) : null;
+        
+        $fromDateTime = $fromDate ? $fromDate->setTime(0, 0) : null;
+        $toDateTime = $toDate ? $toDate->setTime(23, 59, 59) : null;
 
         $ret = $repo->findAllReportSubmissions(
-            $fromDate->setTime(0, 0),
-            $toDate->setTime(23, 59, 59),
+            $fromDateTime,
+            $toDateTime,
             $request->get('orderBy', 'createdOn'),
             $request->get('order', 'ASC')
         );

--- a/api/src/AppBundle/Service/Stats/Query/Query.php
+++ b/api/src/AppBundle/Service/Stats/Query/Query.php
@@ -46,11 +46,11 @@ abstract class Query
         $query = $this->em->createNativeQuery($this->constructQuery($sq), $rsm);
 
         if ($sq->queryHasDateConstraint()) {
-            $startDate = (clone $sq->getStartDate());
-            $endDate = (clone $sq->getEndDate());
+            $startDate = (clone $sq->getStartDate())->setTime(0, 0, 0);
+            $endDate = (clone $sq->getEndDate())->setTime(23, 59, 59);
 
-            $query->setParameter('startDate', $startDate->format('Y-m-d'));
-            $query->setParameter('endDate', $endDate->format('Y-m-d'));
+            $query->setParameter('startDate', $startDate->format('Y-m-d H:i:s'));
+            $query->setParameter('endDate', $endDate->format('Y-m-d H:i:s'));
         }
 
         return $query->getResult();

--- a/api/src/AppBundle/Service/Stats/Query/Query.php
+++ b/api/src/AppBundle/Service/Stats/Query/Query.php
@@ -46,11 +46,11 @@ abstract class Query
         $query = $this->em->createNativeQuery($this->constructQuery($sq), $rsm);
 
         if ($sq->queryHasDateConstraint()) {
-            $startDate = (clone $sq->getStartDate())->setTime(0, 0, 0);
-            $endDate = (clone $sq->getEndDate())->setTime(23, 59, 59);
+            $startDate = (clone $sq->getStartDate());
+            $endDate = (clone $sq->getEndDate());
 
-            $query->setParameter('startDate', $startDate->format('Y-m-d H:i:s'));
-            $query->setParameter('endDate', $endDate->format('Y-m-d H:i:s'));
+            $query->setParameter('startDate', $startDate->format('Y-m-d'));
+            $query->setParameter('endDate', $endDate->format('Y-m-d'));
         }
 
         return $query->getResult();

--- a/api/src/AppBundle/Service/Stats/StatsQueryParameters.php
+++ b/api/src/AppBundle/Service/Stats/StatsQueryParameters.php
@@ -2,6 +2,9 @@
 
 namespace AppBundle\Service\Stats;
 
+use DateInterval;
+use DateTime;
+
 class StatsQueryParameters
 {
     private $metric;
@@ -50,19 +53,19 @@ class StatsQueryParameters
         $this->endDate = $parameters['endDate'];
 
         if ($this->startDate === null && $this->endDate === null) {
-            $this->endDate = new \DateTime();
-            $this->startDate = new \DateTime('-30 days');
+            $this->endDate = new DateTime();
+            $this->startDate = new DateTime('-30 days');
         } elseif ($this->startDate === null) {
-            $this->endDate = new \DateTime($this->endDate);
+            $this->endDate = new DateTime($this->endDate);
             $this->startDate = clone $this->endDate;
-            $this->startDate->sub(new \DateInterval('P30D'));
+            $this->startDate->sub(new DateInterval('P30D'));
         } elseif ($this->endDate === null) {
-            $this->startDate = new \DateTime($this->startDate);
+            $this->startDate = new DateTime($this->startDate);
             $this->endDate = clone $this->startDate;
-            $this->endDate->add(new \DateInterval('P30D'));
+            $this->endDate->add(new DateInterval('P30D'));
         } else {
-            $this->startDate = new \DateTime($this->startDate);
-            $this->endDate = new \DateTime($this->endDate);
+            $this->startDate = new DateTime($this->startDate);
+            $this->endDate = new DateTime($this->endDate);
         }
     }
 

--- a/api/tests/AppBundle/ControllerReport/ReportSubmissionControllerTest.php
+++ b/api/tests/AppBundle/ControllerReport/ReportSubmissionControllerTest.php
@@ -182,8 +182,8 @@ class ReportSubmissionControllerTest extends AbstractTestController
      */
     public function testGetCaserecDataRetrievesWithinGivenDateRangesInclusive(string $fromDate, string $toDate, array $expectedOutcomes)
     {
-        $this->updateReportSubmissionByIdWithNewDateTime(1, '2018-01-01 12:00:00');
-        $this->updateReportSubmissionByIdWithNewDateTime(2, '2018-01-31 12:00:00');
+        $this->updateReportSubmissionByIdWithNewDateTime(1, '2018-01-01');
+        $this->updateReportSubmissionByIdWithNewDateTime(2, '2018-01-31');
         self::fixtures()->flush();
 
         $data = $this->makeRequestAndReturnResults(

--- a/api/tests/AppBundle/ControllerReport/ReportSubmissionControllerTest.php
+++ b/api/tests/AppBundle/ControllerReport/ReportSubmissionControllerTest.php
@@ -4,6 +4,7 @@ namespace Tests\AppBundle\ControllerReport;
 
 use AppBundle\Entity\Report\Document;
 use AppBundle\Entity\Report\ReportSubmission;
+use DateTime;
 use Doctrine\ORM\EntityManager;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\AppBundle\Controller\AbstractTestController;
@@ -34,11 +35,11 @@ class ReportSubmissionControllerTest extends AbstractTestController
                 ['setFirstname' => "c{$i}", 'setLastname' => "l{$i}", 'setCaseNumber' => "100000{$i}"]
             );
             $report = self::fixtures()->createReport($client, [
-                'setStartDate'   => new \DateTime('2014-01-01'),
-                'setEndDate'     => new \DateTime('2014-12-31'),
+                'setStartDate'   => new DateTime('2014-01-01'),
+                'setEndDate'     => new DateTime('2014-12-31'),
                 'setSubmitted'   => true,
                 'setSubmittedBy' => self::$pa1, //irrelevant for assertions
-                'setSubmitDate'  => new \DateTime('2015-01-01')
+                'setSubmitDate'  => new DateTime('2015-01-01')
             ]);
             // create submission
             $submission = new ReportSubmission($report, ($i<3) ? self::$pa2 : self::$deputy1);
@@ -182,8 +183,8 @@ class ReportSubmissionControllerTest extends AbstractTestController
      */
     public function testGetCaserecDataRetrievesWithinGivenDateRangesInclusive(string $fromDate, string $toDate, array $expectedOutcomes)
     {
-        $this->updateReportSubmissionByIdWithNewDateTime(1, '2018-01-01');
-        $this->updateReportSubmissionByIdWithNewDateTime(2, '2018-01-31');
+        $this->updateReportSubmissionByIdWithNewDateTime(1, '2018-01-01 12:00:00');
+        $this->updateReportSubmissionByIdWithNewDateTime(2, '2018-01-31 12:00:00');
         self::fixtures()->flush();
 
         $data = $this->makeRequestAndReturnResults(
@@ -191,7 +192,7 @@ class ReportSubmissionControllerTest extends AbstractTestController
             ['fromDate' => $fromDate, 'toDate' => $toDate]
         );
 
-        $this->assertEquals($expectedOutcomes['count'], count($data));
+        $this->assertCount($expectedOutcomes['count'], $data);
 
         foreach ($expectedOutcomes['caseNumbers'] as $expectedCaseNumber) {
             $this->assertResponseIncludesReportWithCaseNumber($data, $expectedCaseNumber);
@@ -205,32 +206,32 @@ class ReportSubmissionControllerTest extends AbstractTestController
     {
         return [
             [
-                'fromDate' => '2018-01-01 12:00:00',
-                'toDate' => '2018-01-31 12:00:00',
+                'fromDate' => '2018-01-01',
+                'toDate' => '2018-01-31',
                 'expectedOutcomes' => [
                     'count' => 2,
                     'caseNumbers' => ['1000000', '1000001']
                 ]
             ],
             [
-                'fromDate' => '2017-12-31 23:59:59',
-                'toDate' => '2018-02-01 00:00:00',
+                'fromDate' => '2017-12-31',
+                'toDate' => '2018-02-01',
                 'expectedOutcomes' => [
                     'count' => 2,
                     'caseNumbers' => ['1000000', '1000001']
                 ]
             ],
             [
-                'fromDate' => '2018-01-01 12:00:01',
-                'toDate' => '2018-01-31 12:00:00',
+                'fromDate' => '2018-01-02',
+                'toDate' => '2018-01-31',
                 'expectedOutcomes' => [
                     'count' => 1,
                     'caseNumbers' => ['1000001']
                 ]
             ],
             [
-                'fromDate' => '2018-01-01 12:00:00',
-                'toDate' => '2018-01-31 09:59:59',
+                'fromDate' => '2018-01-01',
+                'toDate' => '2018-01-30',
                 'expectedOutcomes' => [
                     'count' => 1,
                     'caseNumbers' => ['1000000']
@@ -280,7 +281,7 @@ class ReportSubmissionControllerTest extends AbstractTestController
     private function updateReportSubmissionByIdWithNewDateTime(int $id, string $date)
     {
         $entity = self::fixtures()->getRepo('Report\ReportSubmission')->findOneById($id);
-        $entity->setCreatedOn(new \DateTime($date));
+        $entity->setCreatedOn(new DateTime($date));
 
         self::fixtures()->persist($entity);
     }

--- a/client/app/config/parameters.yml
+++ b/client/app/config/parameters.yml
@@ -1,0 +1,62 @@
+# This file is auto-generated during the composer install
+parameters:
+    locale: en
+    secret: setme
+    api_base_url: 'http://api.digideps.local/'
+    api_client_secret: setme
+    env: setme
+    redis_dsn: 'redis://setme'
+    non_admin_host: 'https://digideps.local'
+    admin_host: 'https://admin.digideps.local'
+    client_base_urls:
+        front: 'https://digideps.local'
+        admin: 'https://admin.digideps.local'
+    session_expire_seconds: 3900
+    session_popup_show_after: 3600
+    session_cookie_secure: false
+    session_prefix: application_session
+    ga:
+        default: null
+        gds: null
+    opg_docker_tag: 0.0.0
+    log_level: warning
+    log_path: /var/log/app/application.log
+    email_params:
+        from_email: noreply-opgdeputyservice@digideps.dsd.io
+        report_submit_to_address: digideps+noop@digital.justice.gov.uk
+        feedback_send_to_address: digideps+noop@digital.justice.gov.uk
+        update_send_to_address: digideps+noop@digital.justice.gov.uk
+    email_send:
+        from_email: no-reply@digideps.dsd.io
+    email_report_submit:
+        from_email: no-reply@digideps.dsd.io
+        to_email: behat-digideps@digital.justice.gov.uk
+    email_feedback_send:
+        from_email: no-reply@digideps.dsd.io
+        to_email: behat-digideps@digital.justice.gov.uk
+    email:
+        base_url:
+            frontend: 'https://digideps.local'
+            admin: 'https://admin.digideps.local'
+            routes:
+                user_activate: '/user/activate/{token}'
+                password_reset: '/user/password-reset/{token}'
+                homepage: /
+                report_overview: '/report/{reportId|}/overview'
+                client_home: /client/show
+    s3_bucket_name: pa-uploads-local
+    s3_client_params:
+        version: latest
+        region: eu-west-1
+        validate: true
+    ssm_client_params:
+        version: latest
+        region: eu-west-1
+        validate: true
+    file_scanner_url: 'http://file-scanner-rest:8080'
+    file_scanner_sslverify: false
+    wkhtmltopdf_address: 'http://wkhtmltopdf:80'
+    cloudwatch_logs_client_params:
+        version: latest
+        region: eu-west-1
+        validate: true

--- a/client/src/AppBundle/Form/Admin/ReportSubmissionDownloadFilterType.php
+++ b/client/src/AppBundle/Form/Admin/ReportSubmissionDownloadFilterType.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Form\Admin;
 
+use DateTime;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type as FormTypes;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -36,19 +37,6 @@ class ReportSubmissionDownloadFilterType extends AbstractType
             ->addEventListener(FormEvents::POST_SUBMIT, [$this, 'onPostSubmit']);
     }
 
-    /**
-     * @param FormEvent $event
-     */
-    public function onPostSubmit(FormEvent $event)
-    {
-        $entity = $event->getData();
-
-        if ($entity->getEndDate() instanceof \DateTime) {
-            $endDate = $entity->getEndDate();
-            $entity->setEndDate($endDate->setTime(23, 59, 59));
-        }
-    }
-
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
@@ -56,7 +44,7 @@ class ReportSubmissionDownloadFilterType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'admin';
     }

--- a/client/src/AppBundle/Form/Admin/ReportSubmissionDownloadFilterType.php
+++ b/client/src/AppBundle/Form/Admin/ReportSubmissionDownloadFilterType.php
@@ -37,6 +37,19 @@ class ReportSubmissionDownloadFilterType extends AbstractType
             ->addEventListener(FormEvents::POST_SUBMIT, [$this, 'onPostSubmit']);
     }
 
+    /**
+     * @param FormEvent $event
+     */
+    public function onPostSubmit(FormEvent $event)
+    {
+        $entity = $event->getData();
+
+        if ($entity->getEndDate() instanceof DateTime) {
+            $endDate = $entity->getEndDate();
+            $entity->setEndDate($endDate->setTime(23, 59, 59));
+        }
+    }
+
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([


### PR DESCRIPTION
There was a bug where the DAT download was only the dates 1 day before
the endDate that was send in the form submission. This hopefully fixes
that

Issue DDPB-3818

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
