### PR TITLE
DDPB-3750: Success banner on deputy report submission

### DIFF
--- a/behat/tests/features/pa/03-report/04-submit-report.feature
+++ b/behat/tests/features/pa/03-report/04-submit-report.feature
@@ -45,7 +45,7 @@ Feature: Report submit (client 02100014)
         And the URL should match "/report/\d+/submitted"
         And I should not see the "report-submit-submitted" link
         # assert report display page is not broken
-        When I click on "return-to-org-dashboard"
+        When I click on "return-to-reports-page"
         Then the URL should match "/org"
         And the response status code should be 200
 

--- a/behat/tests/features/prof/03-report/07-submit-report.feature
+++ b/behat/tests/features/prof/03-report/07-submit-report.feature
@@ -62,7 +62,7 @@ Feature: Report submit (client 31000010)
         And the URL should match "/report/\d+/submitted"
         And I should not see the "report-submit-submitted" link
         # assert report display page is not broken
-        When I click on "return-to-org-dashboard"
+        When I click on "return-to-reports-page"
         Then the URL should match "/org"
         And the response status code should be 200
 

--- a/client/src/AppBundle/Controller/Report/ReportController.php
+++ b/client/src/AppBundle/Controller/Report/ReportController.php
@@ -444,7 +444,7 @@ class ReportController extends AbstractController
         return [
             'report' => $report,
             'form' => $form->createView(),
-            'homePathName' => $this->getUser()->isDeputy() ? 'lay_home' : "org_dashboard"
+            'homePathName' => $this->getUser()->isLayDeputy() ? 'lay_home' : "org_dashboard"
         ];
     }
 

--- a/client/src/AppBundle/Controller/Report/ReportController.php
+++ b/client/src/AppBundle/Controller/Report/ReportController.php
@@ -444,6 +444,7 @@ class ReportController extends AbstractController
         return [
             'report' => $report,
             'form' => $form->createView(),
+            'homePathName' => $this->getUser()->isDeputy() ? 'lay_home' : "org_dashboard"
         ];
     }
 

--- a/client/src/AppBundle/Resources/translations/report-submitted.en.yml
+++ b/client/src/AppBundle/Resources/translations/report-submitted.en.yml
@@ -1,10 +1,11 @@
 page:
   htmlTitle: "Report submitted - Complete the deputy report | GOV.UK"
   pageTitle: "Report submitted"
-  thankYouForsubmitting: Thank you for submitting your %reportName% report
-  yourReportWillBeSent: "Your report has been sent to OPG. You'll get an email shortly to let you know we've received it."
-  weWillSendReminder: "We'll send you a reminder when it's time for you to complete the next report. You can make a start on it at any time from now on."
-  downloadLink: View %reportName% report
+  successBannerTitle: Report submitted
+  successBannerBody: Your report has been sent to OPG
+  weHaveSentEmail: We’ve sent you an email to confirm we’ve got your report. It may take a few minutes to arrive. We’ll write to you again once we’ve reviewed your report.
+  yourNextReport: Your next report has been added to your account. You can add information to it as you go throughout the year. We’ll send you a reminder before it’s due.
+  yourReportsButton: Your reports
   returnToHomepage: Return to reports page
   returnToClientProfile: Return to client profile
   returnToDashboard: Return to dashboard

--- a/client/src/AppBundle/Resources/views/Ndr/Ndr/submitConfirmation.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Ndr/submitConfirmation.html.twig
@@ -24,7 +24,7 @@
         <p class="govuk-body">{{ 'page.yourNextReport' | trans }}</p>
     </div>
 
-    <a href="{{ path('ndr_index') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary govuk-!-margin-bottom-7" data-module="govuk-button">
+    <a href="{{ path('ndr_index') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary govuk-!-margin-bottom-7 behat-link-return-to-reports-page" data-module="govuk-button">
         {{ 'page.yourReportsButton' | trans }}
     </a>
 
@@ -49,11 +49,5 @@
 
     {{ form_end(form) }}
     {# end feedback form #}
-
-    {% if app.user.isDeputyOrg() %}
-        <a href="{{path('org_dashboard')}}" class="behat-link-return-to-org-dashboard">{{ 'page.returnToDashboard' | trans }}</a>
-    {% else %}
-        <a href="{{ path('lay_home')}}" class="behat-link-return-to-reports-page">{{ 'page.returnToHomepage' | trans }}</a>
-    {% endif %}
 
 {% endblock %}

--- a/client/src/AppBundle/Resources/views/Ndr/Ndr/submitConfirmation.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Ndr/submitConfirmation.html.twig
@@ -10,15 +10,22 @@
 
 {% block pageContent %}
 
-    {{ macros.notification('success', 'page.thankYouForsubmitting' | trans({'%reportName%': ''})) }}
-
-    <div class="text push--top">
-        <p class="govuk-body">{{ 'page.yourReportWillBeSent' | trans }}</p>
-        <p class="govuk-body">{{ 'page.weWillSendReminder' | trans }}</p>
+    <div class="govuk-panel govuk-panel--confirmation">
+        <h1 class="govuk-panel__title">
+            {{ 'page.successBannerTitle' | trans }}
+        </h1>
+        <div class="govuk-panel__body">
+            {{ 'page.successBannerBody' | trans }}
+        </div>
     </div>
 
-    <a href="{{ path('ndr_review', {'ndrId': ndr.id}) }}" class="behat-link-download-report">
-        {{ 'page.downloadLink' | trans({'%reportName%': ''}) }}
+    <div class="text push--top">
+        <p class="govuk-body">{{ 'page.weHaveSentEmail' | trans }}</p>
+        <p class="govuk-body">{{ 'page.yourNextReport' | trans }}</p>
+    </div>
+
+    <a href="{{ path('ndr_index') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary govuk-!-margin-bottom-7" data-module="govuk-button">
+        {{ 'page.yourReportsButton' | trans }}
     </a>
 
     {# feedback form #}

--- a/client/src/AppBundle/Resources/views/Report/Report/submitConfirmation.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Report/submitConfirmation.html.twig
@@ -27,7 +27,7 @@
         <p class="govuk-body">{{ 'page.yourNextReport' | trans }}</p>
     </div>
 
-    <a href="{{ path( homePathName ) }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary govuk-!-margin-bottom-7" data-module="govuk-button">
+    <a href="{{ path( homePathName ) }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary govuk-!-margin-bottom-7 behat-link-return-to-reports-page" data-module="govuk-button">
         {{ 'page.yourReportsButton' | trans }}
     </a>
 
@@ -60,11 +60,5 @@
 
     {{ form_end(form) }}
     {# end feedback form #}
-
-    {% if app.user.isDeputyOrg() %}
-        <a href="{{path('org_dashboard')}}" class="behat-link-return-to-org-dashboard">{{ 'page.returnToDashboard' | trans }}</a>
-    {% else %}
-        <a href="{{ path('lay_home')}}" class="behat-link-return-to-reports-page">{{ 'page.returnToHomepage' | trans }}</a>
-    {% endif %}
 
 {% endblock %}

--- a/client/src/AppBundle/Resources/views/Report/Report/submitConfirmation.html.twig
+++ b/client/src/AppBundle/Resources/views/Report/Report/submitConfirmation.html.twig
@@ -13,15 +13,22 @@
 
 {% block pageContent %}
 
-    {{ macros.notification('success', 'page.thankYouForsubmitting' | trans(transOptions)) }}
-
-    <div class="text push--top">
-        <p class="govuk-body">{{ 'page.yourReportWillBeSent' | trans }}</p>
-        <p class="govuk-body">{{ 'page.weWillSendReminder' | trans }}</p>
+    <div class="govuk-panel govuk-panel--confirmation">
+        <h1 class="govuk-panel__title">
+            {{ 'page.successBannerTitle' | trans }}
+        </h1>
+        <div class="govuk-panel__body">
+            {{ 'page.successBannerBody' | trans }}
+        </div>
     </div>
 
-    <a href="{{ path('report_review', {'reportId': report.id}) }}" class="behat-link-download-report">
-        {{ 'page.downloadLink' | trans(transOptions) }}
+    <div class="text push--top">
+        <p class="govuk-body">{{ 'page.weHaveSentEmail' | trans }}</p>
+        <p class="govuk-body">{{ 'page.yourNextReport' | trans }}</p>
+    </div>
+
+    <a href="{{ path( homePathName ) }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary govuk-!-margin-bottom-7" data-module="govuk-button">
+        {{ 'page.yourReportsButton' | trans }}
     </a>
 
     {% if report.hasSection('profDeputyCosts') %}


### PR DESCRIPTION
## Purpose
Changes the notification element to a banner element when submitting Reports and NDRs for all deputy types. Also removes the link at the bottom of the page to return to reports and replaces with a button link underneath the banner.

Fixes DDPB-3750

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
