### PR TITLE
Ddpb 3428

### DIFF
--- a/client/src/AppBundle/Controller/Admin/Client/ReportController.php
+++ b/client/src/AppBundle/Controller/Admin/Client/ReportController.php
@@ -443,7 +443,7 @@ class ReportController extends AbstractController
             if ($form->has('confirm') && $form['confirm']->getData() === 'yes' && $report->isSubmitted()) {
                 $this->reportApi->unsubmit(
                     $report,
-                    $this->get('security.token_storage')->getToken()->getUser(),
+                    $this->getUser(),
                     AuditEvents::TRIGGER_UNSUBMIT_REPORT
                 );
                 $this->upsertChecklistInformation($report);

--- a/client/src/AppBundle/Controller/Admin/Client/ReportController.php
+++ b/client/src/AppBundle/Controller/Admin/Client/ReportController.php
@@ -5,7 +5,6 @@ namespace AppBundle\Controller\Admin\Client;
 use AppBundle\Controller\AbstractController;
 use AppBundle\Entity\Report\Checklist;
 use AppBundle\Entity\Report\Report;
-use AppBundle\Entity\User;
 use AppBundle\Exception\ReportNotSubmittedException;
 use AppBundle\Form\Admin\CloseReportConfirmType;
 use AppBundle\Form\Admin\CloseReportType;
@@ -16,7 +15,6 @@ use AppBundle\Form\Admin\ManageSubmittedReportType;
 use AppBundle\Form\Admin\ManageReportConfirmType;
 use AppBundle\Service\Client\Internal\ReportApi;
 use AppBundle\Service\Client\RestClient;
-use AppBundle\Service\Client\Internal\OrganisationApi;
 use AppBundle\Service\Audit\AuditEvents;
 use AppBundle\Service\ParameterStoreService;
 use AppBundle\Service\ReportSubmissionService;
@@ -97,9 +95,6 @@ class ReportController extends AbstractController
 
     /** @var ReportApi */
     private $reportApi;
-
-    /** @var OrganisationApi */
-    private OrganisationApi $organisationApi;
 
     private LoggerInterface $logger;
 
@@ -531,19 +526,6 @@ class ReportController extends AbstractController
             'form' => $form->createView()
         ];
     }
-
-//    /**
-//     * @param Report $report
-//     * @throws \Exception
-//     */
-//    private function unsubmitReport(Report $report): void
-//    {
-//        $report->setUnSubmitDate(new \DateTime());
-//
-//        $this->restClient->put('report/' . $report->getId() . '/unsubmit', $report, [
-//            'submitted', 'unsubmit_date', 'report_unsubmitted_sections_list', 'startEndDates', 'report_due_date'
-//        ]);
-//    }
 
     /**
      * @param Report $report

--- a/client/src/AppBundle/Controller/Admin/Client/ReportController.php
+++ b/client/src/AppBundle/Controller/Admin/Client/ReportController.php
@@ -5,6 +5,7 @@ namespace AppBundle\Controller\Admin\Client;
 use AppBundle\Controller\AbstractController;
 use AppBundle\Entity\Report\Checklist;
 use AppBundle\Entity\Report\Report;
+use AppBundle\Entity\User;
 use AppBundle\Exception\ReportNotSubmittedException;
 use AppBundle\Form\Admin\CloseReportConfirmType;
 use AppBundle\Form\Admin\CloseReportType;
@@ -15,8 +16,11 @@ use AppBundle\Form\Admin\ManageSubmittedReportType;
 use AppBundle\Form\Admin\ManageReportConfirmType;
 use AppBundle\Service\Client\Internal\ReportApi;
 use AppBundle\Service\Client\RestClient;
+use AppBundle\Service\Client\Internal\OrganisationApi;
+use AppBundle\Service\Audit\AuditEvents;
 use AppBundle\Service\ParameterStoreService;
 use AppBundle\Service\ReportSubmissionService;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
@@ -94,12 +98,19 @@ class ReportController extends AbstractController
     /** @var ReportApi */
     private $reportApi;
 
+    /** @var OrganisationApi */
+    private OrganisationApi $organisationApi;
+
+    private LoggerInterface $logger;
+
     public function __construct(
         RestClient $restClient,
-        ReportApi $reportApi
+        ReportApi $reportApi,
+        LoggerInterface $logger
     ) {
         $this->restClient = $restClient;
         $this->reportApi = $reportApi;
+        $this->logger = $logger;
     }
 
     /**
@@ -410,9 +421,8 @@ class ReportController extends AbstractController
      *
      * @param $id
      * @return array|Response|RedirectResponse
-     * @Template("AppBundle:Admin/Client/Report:manageConfirm.html.twig")
-     *
      * @throws \Exception
+     * @Template("AppBundle:Admin/Client/Report:manageConfirm.html.twig")
      */
     public function manageConfirmAction(Request $request, $id)
     {
@@ -436,7 +446,11 @@ class ReportController extends AbstractController
             $this->restClient->put('report/' . $report->getId(), $report, ['report_type', 'report_due_date']);
 
             if ($form->has('confirm') && $form['confirm']->getData() === 'yes' && $report->isSubmitted()) {
-                $this->unsubmitReport($report);
+                $this->reportApi->unsubmit(
+                    $report,
+                    $this->get('security.token_storage')->getToken()->getUser(),
+                    AuditEvents::TRIGGER_UNSUBMIT_REPORT
+                );
                 $this->upsertChecklistInformation($report);
                 $this->addFlash('notice', 'Report marked as incomplete');
             }
@@ -518,18 +532,18 @@ class ReportController extends AbstractController
         ];
     }
 
-    /**
-     * @param Report $report
-     * @throws \Exception
-     */
-    private function unsubmitReport(Report $report): void
-    {
-        $report->setUnSubmitDate(new \DateTime());
-
-        $this->restClient->put('report/' . $report->getId() . '/unsubmit', $report, [
-            'submitted', 'unsubmit_date', 'report_unsubmitted_sections_list', 'startEndDates', 'report_due_date'
-        ]);
-    }
+//    /**
+//     * @param Report $report
+//     * @throws \Exception
+//     */
+//    private function unsubmitReport(Report $report): void
+//    {
+//        $report->setUnSubmitDate(new \DateTime());
+//
+//        $this->restClient->put('report/' . $report->getId() . '/unsubmit', $report, [
+//            'submitted', 'unsubmit_date', 'report_unsubmitted_sections_list', 'startEndDates', 'report_due_date'
+//        ]);
+//    }
 
     /**
      * @param Report $report

--- a/client/src/AppBundle/Controller/Report/ReportController.php
+++ b/client/src/AppBundle/Controller/Report/ReportController.php
@@ -14,7 +14,6 @@ use AppBundle\Form\FeedbackReportType;
 use AppBundle\Form\Report\ReportDeclarationType;
 use AppBundle\Form\Report\ReportType;
 use AppBundle\Model\FeedbackReport;
-use AppBundle\Service\Audit\AuditEvents;
 use AppBundle\Service\Client\Internal\CasrecApi;
 use AppBundle\Service\Client\Internal\ClientApi;
 use AppBundle\Service\Client\Internal\ReportApi;
@@ -377,9 +376,6 @@ class ReportController extends AbstractController
     {
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$reportGroupsAll);
 
-        file_put_contents('php://stderr', print_r("BEFORE", true));
-        file_put_contents('php://stderr', print_r($report->getUnSubmitDate(), true));
-        file_put_contents('php://stderr', print_r("BOOOOOOOM", true));
         // check status
         $status = $report->getStatus();
         if (!$report->isDue() || !$status->getIsReadyToSubmit()) {
@@ -396,15 +392,11 @@ class ReportController extends AbstractController
         $form = $this->createForm(ReportDeclarationType::class, $report);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
-
             /** @var User $currentUser */
             $currentUser = $this->getUser();
 
             $report->setSubmitted(true)->setSubmitDate(new DateTime());
             $reportSubmissionService->generateReportDocuments($report);
-            file_put_contents('php://stderr', print_r("AFTER", true));
-            file_put_contents('php://stderr', print_r($report->getUnSubmitDate(), true));
-            file_put_contents('php://stderr', print_r("BOOOOOOOM", true));
 
             $this->reportApi->submit($report, $currentUser);
 

--- a/client/src/AppBundle/Controller/Report/ReportController.php
+++ b/client/src/AppBundle/Controller/Report/ReportController.php
@@ -14,6 +14,7 @@ use AppBundle\Form\FeedbackReportType;
 use AppBundle\Form\Report\ReportDeclarationType;
 use AppBundle\Form\Report\ReportType;
 use AppBundle\Model\FeedbackReport;
+use AppBundle\Service\Audit\AuditEvents;
 use AppBundle\Service\Client\Internal\CasrecApi;
 use AppBundle\Service\Client\Internal\ClientApi;
 use AppBundle\Service\Client\Internal\ReportApi;
@@ -376,6 +377,9 @@ class ReportController extends AbstractController
     {
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$reportGroupsAll);
 
+        file_put_contents('php://stderr', print_r("BEFORE", true));
+        file_put_contents('php://stderr', print_r($report->getUnSubmitDate(), true));
+        file_put_contents('php://stderr', print_r("BOOOOOOOM", true));
         // check status
         $status = $report->getStatus();
         if (!$report->isDue() || !$status->getIsReadyToSubmit()) {
@@ -392,11 +396,15 @@ class ReportController extends AbstractController
         $form = $this->createForm(ReportDeclarationType::class, $report);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
+
             /** @var User $currentUser */
             $currentUser = $this->getUser();
 
             $report->setSubmitted(true)->setSubmitDate(new DateTime());
             $reportSubmissionService->generateReportDocuments($report);
+            file_put_contents('php://stderr', print_r("AFTER", true));
+            file_put_contents('php://stderr', print_r($report->getUnSubmitDate(), true));
+            file_put_contents('php://stderr', print_r("BOOOOOOOM", true));
 
             $this->reportApi->submit($report, $currentUser);
 

--- a/client/src/AppBundle/Event/ReportUnsubmittedEvent.php
+++ b/client/src/AppBundle/Event/ReportUnsubmittedEvent.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+
+namespace AppBundle\Event;
+
+use AppBundle\Entity\Report\Report;
+use AppBundle\Entity\User;
+use Symfony\Component\EventDispatcher\Event;
+
+class ReportUnsubmittedEvent extends Event
+{
+    public const NAME = 'report.unsubmitted';
+
+    /** @var Report */
+    private $unsubmittedReport;
+
+
+    /** @var User */
+    private $unsubmittedBy;
+
+    /** @var string|int|null */
+    private $newYearReportId;
+
+    /**
+     * @var string
+     */
+    private string $trigger;
+
+    public function __construct(Report $unsubmittedReport, User $unsubmittedBy, $newYearReportId, string $trigger)
+    {
+        $this->unsubmittedReport = $unsubmittedReport;
+        $this->submittedBy = $unsubmittedBy;
+        $this->newYearReportId = $newYearReportId;
+        $this->trigger = $trigger;
+    }
+
+    public function getTrigger()
+    {
+        return $this->trigger;
+    }
+
+    /**
+     * @return Report
+     */
+    public function getUnsubmittedReport(): Report
+    {
+        return $this->unsubmittedReport;
+    }
+
+    /**
+     * @param Report $unsubmittedReport
+     * @return ReportUnsubmittedEvent
+     */
+    public function setUnsubmittedReport(Report $unsubmittedReport): ReportUnsubmittedEvent
+    {
+        $this->unsubmittedReport = $unsubmittedReport;
+        return $this;
+    }
+
+    /**
+     * @return User
+     */
+    public function getUnsubmittedBy(): User
+    {
+        return $this->unsubmittedBy;
+    }
+
+    /**
+     * @param User $unsubmittedBy
+     * @return ReportUnsubmittedEvent
+     */
+    public function setUnsubmittedBy(User $unsubmittedBy): ReportUnsubmittedEvent
+    {
+        $this->unsubmittedBy = $unsubmittedBy;
+        return $this;
+    }
+
+    /**
+     * @return string|int|null
+     */
+    public function getNewYearReportId()
+    {
+        return $this->newYearReportId;
+    }
+
+    /**
+     * @param string|int|null $newYearReportId
+     * @return ReportUnsubmittedEvent
+     */
+    public function setNewYearReportId($newYearReportId): ReportUnsubmittedEvent
+    {
+        $this->newYearReportId = $newYearReportId;
+        return $this;
+    }
+}

--- a/client/src/AppBundle/Event/ReportUnsubmittedEvent.php
+++ b/client/src/AppBundle/Event/ReportUnsubmittedEvent.php
@@ -18,19 +18,15 @@ class ReportUnsubmittedEvent extends Event
     /** @var User */
     private $unsubmittedBy;
 
-    /** @var string|int|null */
-    private $newYearReportId;
-
     /**
      * @var string
      */
     private string $trigger;
 
-    public function __construct(Report $unsubmittedReport, User $unsubmittedBy, $newYearReportId, string $trigger)
+    public function __construct(Report $unsubmittedReport, User $unsubmittedBy, string $trigger)
     {
         $this->unsubmittedReport = $unsubmittedReport;
-        $this->submittedBy = $unsubmittedBy;
-        $this->newYearReportId = $newYearReportId;
+        $this->unsubmittedBy = $unsubmittedBy;
         $this->trigger = $trigger;
     }
 
@@ -72,24 +68,6 @@ class ReportUnsubmittedEvent extends Event
     public function setUnsubmittedBy(User $unsubmittedBy): ReportUnsubmittedEvent
     {
         $this->unsubmittedBy = $unsubmittedBy;
-        return $this;
-    }
-
-    /**
-     * @return string|int|null
-     */
-    public function getNewYearReportId()
-    {
-        return $this->newYearReportId;
-    }
-
-    /**
-     * @param string|int|null $newYearReportId
-     * @return ReportUnsubmittedEvent
-     */
-    public function setNewYearReportId($newYearReportId): ReportUnsubmittedEvent
-    {
-        $this->newYearReportId = $newYearReportId;
         return $this;
     }
 }

--- a/client/src/AppBundle/EventSubscriber/ReportSubmittedSubscriber.php
+++ b/client/src/AppBundle/EventSubscriber/ReportSubmittedSubscriber.php
@@ -37,7 +37,7 @@ class ReportSubmittedSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            ReportSubmittedEvent::NAME => 'log',
+            ReportSubmittedEvent::NAME => 'logResubmittedReport',
             ReportSubmittedEvent::NAME => 'sendEmail'
         ];
     }
@@ -50,7 +50,7 @@ class ReportSubmittedSubscriber implements EventSubscriberInterface
         }
     }
 
-    public function log(ReportSubmittedEvent $event)
+    public function logResubmittedReport(ReportSubmittedEvent $event)
     {
         if ($event->getSubmittedReport()->getUnSubmitDate() !== null) {
             $auditEvent = (new AuditEvents($this->dateTimeProvider))

--- a/client/src/AppBundle/EventSubscriber/ReportSubmittedSubscriber.php
+++ b/client/src/AppBundle/EventSubscriber/ReportSubmittedSubscriber.php
@@ -37,19 +37,9 @@ class ReportSubmittedSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            ReportSubmittedEvent::NAME => 'submitReportEvent'
+            ReportSubmittedEvent::NAME => 'log',
+            ReportSubmittedEvent::NAME => 'sendEmail'
         ];
-    }
-
-    public function submitReportEvent(ReportSubmittedEvent $event)
-    {
-        if ($event->getSubmittedReport()->getUnSubmitDate() !== null) {
-            try {
-                $this->logReportSubmittedEvent($event);
-            } catch (\Exception $e) {
-            }
-        }
-        $this->sendEmail($event);
     }
 
     public function sendEmail(ReportSubmittedEvent $event)
@@ -60,18 +50,16 @@ class ReportSubmittedSubscriber implements EventSubscriberInterface
         }
     }
 
-    /**
-     * @param ReportSubmittedEvent $event
-     * @throws \Exception
-     */
-    public function logReportSubmittedEvent(ReportSubmittedEvent $event)
+    public function log(ReportSubmittedEvent $event)
     {
-        $auditEvent = (new AuditEvents($this->dateTimeProvider))
-            ->reportResubmitted(
-                $event->getSubmittedReport(),
-                $event->getSubmittedBy()
-            );
+        if ($event->getSubmittedReport()->getUnSubmitDate() !== null) {
+            $auditEvent = (new AuditEvents($this->dateTimeProvider))
+                ->reportResubmitted(
+                    $event->getSubmittedReport(),
+                    $event->getSubmittedBy()
+                );
 
-        $this->logger->notice('', $auditEvent);
+            $this->logger->notice('', $auditEvent);
+        }
     }
 }

--- a/client/src/AppBundle/EventSubscriber/ReportUnsubmittedSubscriber.php
+++ b/client/src/AppBundle/EventSubscriber/ReportUnsubmittedSubscriber.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+
+namespace AppBundle\EventSubscriber;
+
+use AppBundle\Event\ReportUnsubmittedEvent;
+use AppBundle\Service\Client\Internal\ReportApi;
+use AppBundle\Service\Mailer\Mailer;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use AppBundle\Event\UserAddedToOrganisationEvent;
+use AppBundle\Event\UserRemovedFromOrganisationEvent;
+use AppBundle\Service\Audit\AuditEvents;
+use AppBundle\Service\Time\DateTimeProvider;
+use Psr\Log\LoggerInterface;
+
+class ReportUnsubmittedSubscriber implements EventSubscriberInterface
+{
+    /** @var ReportApi */
+    private $reportApi;
+
+    private LoggerInterface $logger;
+
+    private DateTimeProvider $dateTimeProvider;
+
+    public function __construct(LoggerInterface $logger, DateTimeProvider $dateTimeProvider, ReportApi $reportApi)
+    {
+        $this->reportApi = $reportApi;
+        $this->logger = $logger;
+        $this->dateTimeProvider = $dateTimeProvider;
+    }
+
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            ReportUnsubmittedEvent::NAME => 'logReportUnsubmittedEvent'
+        ];
+    }
+
+    /**
+     * @param ReportUnsubmittedEvent $event
+     * @throws \Exception
+     */
+    public function logUserAddedEvent(ReportUnsubmittedEvent $event)
+    {
+        $auditEvent = (new AuditEvents($this->dateTimeProvider))
+            ->reportUnsubmitted(
+                $event->getTrigger(),
+                $event->getUnsubmittedReport(),
+                $event->getUnsubmittedBy()
+            );
+
+        $this->logger->notice('', $auditEvent);
+    }
+}

--- a/client/src/AppBundle/EventSubscriber/ReportUnsubmittedSubscriber.php
+++ b/client/src/AppBundle/EventSubscriber/ReportUnsubmittedSubscriber.php
@@ -4,27 +4,19 @@
 namespace AppBundle\EventSubscriber;
 
 use AppBundle\Event\ReportUnsubmittedEvent;
-use AppBundle\Service\Client\Internal\ReportApi;
-use AppBundle\Service\Mailer\Mailer;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use AppBundle\Event\UserAddedToOrganisationEvent;
-use AppBundle\Event\UserRemovedFromOrganisationEvent;
 use AppBundle\Service\Audit\AuditEvents;
 use AppBundle\Service\Time\DateTimeProvider;
 use Psr\Log\LoggerInterface;
 
 class ReportUnsubmittedSubscriber implements EventSubscriberInterface
 {
-    /** @var ReportApi */
-    private $reportApi;
-
     private LoggerInterface $logger;
 
     private DateTimeProvider $dateTimeProvider;
 
-    public function __construct(LoggerInterface $logger, DateTimeProvider $dateTimeProvider, ReportApi $reportApi)
+    public function __construct(LoggerInterface $logger, DateTimeProvider $dateTimeProvider)
     {
-        $this->reportApi = $reportApi;
         $this->logger = $logger;
         $this->dateTimeProvider = $dateTimeProvider;
     }
@@ -41,13 +33,13 @@ class ReportUnsubmittedSubscriber implements EventSubscriberInterface
      * @param ReportUnsubmittedEvent $event
      * @throws \Exception
      */
-    public function logUserAddedEvent(ReportUnsubmittedEvent $event)
+    public function logReportUnsubmittedEvent(ReportUnsubmittedEvent $event)
     {
         $auditEvent = (new AuditEvents($this->dateTimeProvider))
             ->reportUnsubmitted(
-                $event->getTrigger(),
                 $event->getUnsubmittedReport(),
-                $event->getUnsubmittedBy()
+                $event->getUnsubmittedBy(),
+                $event->getTrigger(),
             );
 
         $this->logger->notice('', $auditEvent);

--- a/client/src/AppBundle/Service/Audit/AuditEvents.php
+++ b/client/src/AppBundle/Service/Audit/AuditEvents.php
@@ -5,6 +5,7 @@ namespace AppBundle\Service\Audit;
 use AppBundle\Entity\Organisation;
 use AppBundle\Entity\User;
 use AppBundle\Service\Time\DateTimeProvider;
+use AppBundle\Entity\Report\Report;
 use DateTime;
 
 final class AuditEvents
@@ -15,6 +16,7 @@ final class AuditEvents
     const EVENT_CLIENT_DELETED = 'CLIENT_DELETED';
     const EVENT_DEPUTY_DELETED = 'DEPUTY_DELETED';
     const EVENT_ADMIN_DELETED = 'ADMIN_DELETED';
+    const EVENT_REPORT_UNSUBMITTED = 'REPORT_UNSUBMITTED';
     const EVENT_USER_ADDED_TO_ORG = 'USER_ADDED_TO_ORG';
     const EVENT_USER_REMOVED_FROM_ORG = 'USER_REMOVED_FROM_ORG';
 
@@ -199,6 +201,25 @@ final class AuditEvents
         ];
 
         return $event + $this->baseEvent(AuditEvents::EVENT_USER_REMOVED_FROM_ORG);
+    }
+
+    /**
+     * @param string $trigger, what caused the event
+     * @param User $deputyOnReport,
+     * @param Report $unsubmittedReport
+     * @return array|string[]
+     * @throws \Exception
+     */
+    public function reportUnsubmitted(string $trigger, Report $unsubmittedReport, User $deputyOnReport)
+    {
+        $event = [
+            'trigger' => $trigger,
+            'deputy_user' => $deputyOnReport->getId(),
+            'report_id' => $unsubmittedReport->getId(),
+            'date_unsubmitted' => $unsubmittedReport->getUnSubmitDate(),
+        ];
+
+        return $event + $this->baseEvent(AuditEvents::EVENT_REPORT_UNSUBMITTED);
     }
 
     /**

--- a/client/src/AppBundle/Service/Audit/AuditEvents.php
+++ b/client/src/AppBundle/Service/Audit/AuditEvents.php
@@ -17,6 +17,7 @@ final class AuditEvents
     const EVENT_DEPUTY_DELETED = 'DEPUTY_DELETED';
     const EVENT_ADMIN_DELETED = 'ADMIN_DELETED';
     const EVENT_REPORT_UNSUBMITTED = 'REPORT_UNSUBMITTED';
+    const EVENT_REPORT_RESUBMITTED = 'REPORT_RESUBMITTED';
     const EVENT_USER_ADDED_TO_ORG = 'USER_ADDED_TO_ORG';
     const EVENT_USER_REMOVED_FROM_ORG = 'USER_REMOVED_FROM_ORG';
 
@@ -28,6 +29,8 @@ final class AuditEvents
     const TRIGGER_CODEPUTY_CREATED = 'CODEPUTY_CREATED';
     const TRIGGER_ORG_USER_MANAGE_ORG_MEMBER = 'ORG_USER_MANAGE_ORG_MEMBER';
     const TRIGGER_ADMIN_USER_MANAGE_ORG_MEMBER = 'ADMIN_USER_MANAGE_ORG_USER';
+    const TRIGGER_UNSUBMIT_REPORT = 'UNSUBMIT_REPORT';
+    const TRIGGER_RESUBMIT_REPORT = 'RESUBMIT_REPORT';
 
     /**
      * @var DateTimeProvider
@@ -205,21 +208,38 @@ final class AuditEvents
 
     /**
      * @param string $trigger, what caused the event
-     * @param User $deputyOnReport,
+     * @param User $reportUnsubmittedBy,
      * @param Report $unsubmittedReport
      * @return array|string[]
      * @throws \Exception
      */
-    public function reportUnsubmitted(string $trigger, Report $unsubmittedReport, User $deputyOnReport)
+    public function reportUnsubmitted(Report $unsubmittedReport, User $reportUnsubmittedBy, string $trigger)
     {
         $event = [
             'trigger' => $trigger,
-            'deputy_user' => $deputyOnReport->getId(),
+            'deputy_user' => $reportUnsubmittedBy->getId(),
             'report_id' => $unsubmittedReport->getId(),
             'date_unsubmitted' => $unsubmittedReport->getUnSubmitDate(),
         ];
 
         return $event + $this->baseEvent(AuditEvents::EVENT_REPORT_UNSUBMITTED);
+    }
+
+    /**
+     * @param Report $resubmittedReport
+     * @param User $reportSubmittedBy
+     * @return array|string[]
+     */
+    public function reportResubmitted(Report $resubmittedReport, User $reportSubmittedBy)
+    {
+        $event = [
+            'trigger' => AuditEvents::TRIGGER_RESUBMIT_REPORT,
+            'deputy_user' => $reportSubmittedBy->getId(),
+            'report_id' => $resubmittedReport->getId(),
+            'date_resubmitted' => $resubmittedReport->getSubmitDate(),
+        ];
+
+        return $event + $this->baseEvent(AuditEvents::EVENT_REPORT_RESUBMITTED);
     }
 
     /**

--- a/client/src/AppBundle/Service/Client/Internal/ReportApi.php
+++ b/client/src/AppBundle/Service/Client/Internal/ReportApi.php
@@ -8,7 +8,6 @@ use AppBundle\Entity\Report\Report;
 use AppBundle\Entity\User;
 use AppBundle\Event\ReportSubmittedEvent;
 use AppBundle\Event\ReportUnsubmittedEvent;
-use AppBundle\Event\ReportResubmittedEvent;
 use AppBundle\EventDispatcher\ObservableEventDispatcher;
 use AppBundle\Exception\DisplayableException;
 use AppBundle\Exception\ReportSubmittedException;

--- a/client/src/AppBundle/Service/Client/Internal/ReportApi.php
+++ b/client/src/AppBundle/Service/Client/Internal/ReportApi.php
@@ -7,6 +7,8 @@ use AppBundle\Entity\Ndr\Ndr;
 use AppBundle\Entity\Report\Report;
 use AppBundle\Entity\User;
 use AppBundle\Event\ReportSubmittedEvent;
+use AppBundle\Event\ReportUnsubmittedEvent;
+use AppBundle\Event\ReportResubmittedEvent;
 use AppBundle\EventDispatcher\ObservableEventDispatcher;
 use AppBundle\Exception\DisplayableException;
 use AppBundle\Exception\ReportSubmittedException;
@@ -153,5 +155,22 @@ class ReportApi
 
         $event = new ReportSubmittedEvent($reportToSubmit, $submittedBy, $newYearReportId);
         $this->eventDispatcher->dispatch(ReportSubmittedEvent::NAME, $event);
+    }
+
+    public function unsubmit(Report $report, User $user, string $trigger): void
+    {
+        $report->setUnSubmitDate(new \DateTime());
+
+        $this->restClient->put('report/' . $report->getId() . '/unsubmit', $report, [
+            'submitted', 'unsubmit_date', 'report_unsubmitted_sections_list', 'startEndDates', 'report_due_date'
+        ]);
+
+        $event = new ReportUnsubmittedEvent(
+            $report,
+            $user,
+            $trigger
+        );
+
+        $this->eventDispatcher->dispatch(ReportUnsubmittedEvent::NAME, $event);
     }
 }

--- a/client/tests/phpunit/EventSubscriber/ReportSubmittedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/ReportSubmittedSubscriberTest.php
@@ -24,7 +24,7 @@ class ReportSubmittedSubscriberTest extends TestCase
     public function getSubscribedEvents()
     {
         self::assertEquals(
-            [ReportSubmittedEvent::NAME => 'submitReportEvent'],
+            [ReportSubmittedEvent::NAME => 'log', ReportSubmittedEvent::NAME => 'sendEmail'],
             ReportSubmittedSubscriber::getSubscribedEvents()
         );
     }
@@ -88,7 +88,7 @@ class ReportSubmittedSubscriberTest extends TestCase
     /**
      * @test
      */
-    public function logReportSubmittedEvent()
+    public function log()
     {
         $logger = self::prophesize(LoggerInterface::class);
         $dateTimeProvider = self::prophesize(DateTimeProvider::class);
@@ -116,6 +116,6 @@ class ReportSubmittedSubscriberTest extends TestCase
         ];
 
         $logger->notice('', $expectedEvent)->shouldBeCalled();
-        $sut->logReportSubmittedEvent($reportResubmittedEvent);
+        $sut->log($reportResubmittedEvent);
     }
 }

--- a/client/tests/phpunit/EventSubscriber/ReportSubmittedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/ReportSubmittedSubscriberTest.php
@@ -5,29 +5,39 @@ namespace Tests\AppBundle\EventListener;
 
 use AppBundle\Event\ReportSubmittedEvent;
 use AppBundle\EventSubscriber\ReportSubmittedSubscriber;
+use AppBundle\Service\Audit\AuditEvents;
 use AppBundle\Service\Client\Internal\ReportApi;
+use AppBundle\Service\Time\DateTimeProvider;
 use AppBundle\Service\Mailer\Mailer;
 use AppBundle\TestHelpers\ReportHelpers;
 use AppBundle\TestHelpers\UserHelpers;
+use DateTime;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Prophecy\Argument;
 
 class ReportSubmittedSubscriberTest extends TestCase
 {
-    /** @test */
+    /**
+     * @test
+     */
     public function getSubscribedEvents()
     {
         self::assertEquals(
-            [ReportSubmittedEvent::NAME => 'sendEmail'],
+            [ReportSubmittedEvent::NAME => 'submitReportEvent'],
             ReportSubmittedSubscriber::getSubscribedEvents()
         );
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function sendEmail()
     {
         $reportApi = self::prophesize(ReportApi::class);
         $mailer = self::prophesize(Mailer::class);
+        $logger = self::prophesize(LoggerInterface::class);
+        $dateTimeProvider = self::prophesize(DateTimeProvider::class);
         $submittedBy = UserHelpers::createUser();
         $submittedReport = ReportHelpers::createReport();
         $nextYearReport = ReportHelpers::createReport();
@@ -42,17 +52,21 @@ class ReportSubmittedSubscriberTest extends TestCase
             ->sendReportSubmissionConfirmationEmail($submittedBy, $submittedReport, $nextYearReport)
             ->shouldBeCalled();
 
-        $sut = new ReportSubmittedSubscriber($reportApi->reveal(), $mailer->reveal());
+        $sut = new ReportSubmittedSubscriber($reportApi->reveal(), $mailer->reveal(), $logger->reveal(), $dateTimeProvider->reveal());
         $event = new ReportSubmittedEvent($submittedReport, $submittedBy, $nextYearReportId);
 
         $sut->sendEmail($event);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function sendEmail_email_not_sent_for_resubmissions()
     {
         $reportApi = self::prophesize(ReportApi::class);
         $mailer = self::prophesize(Mailer::class);
+        $logger = self::prophesize(LoggerInterface::class);
+        $dateTimeProvider = self::prophesize(DateTimeProvider::class);
         $submittedBy = UserHelpers::createUser();
         $submittedReport = ReportHelpers::createReport();
         $nextYearReportId = null;
@@ -65,9 +79,43 @@ class ReportSubmittedSubscriberTest extends TestCase
             ->sendReportSubmissionConfirmationEmail(Argument::cetera())
             ->shouldNotBeCalled();
 
-        $sut = new ReportSubmittedSubscriber($reportApi->reveal(), $mailer->reveal());
+        $sut = new ReportSubmittedSubscriber($reportApi->reveal(), $mailer->reveal(), $logger->reveal(), $dateTimeProvider->reveal());
         $event = new ReportSubmittedEvent($submittedReport, $submittedBy, $nextYearReportId);
 
         $sut->sendEmail($event);
+    }
+
+    /**
+     * @test
+     */
+    public function logReportSubmittedEvent()
+    {
+        $logger = self::prophesize(LoggerInterface::class);
+        $dateTimeProvider = self::prophesize(DateTimeProvider::class);
+        $reportApi = self::prophesize(ReportApi::class);
+        $mailer = self::prophesize(Mailer::class);
+        $submittedReport = ReportHelpers::createReport();
+        $nextYearReport = ReportHelpers::createReport();
+
+        $now = new DateTime();
+        $dateTimeProvider->getDateTime()->willReturn($now);
+        $submittedBy = UserHelpers::createUser();
+        $trigger = 'RESUBMIT_REPORT';
+
+        $sut = new ReportSubmittedSubscriber($reportApi->reveal(), $mailer->reveal(), $logger->reveal(), $dateTimeProvider->reveal());
+
+        $reportResubmittedEvent = new ReportSubmittedEvent($submittedReport, $submittedBy, $nextYearReport);
+
+        $expectedEvent = [
+            'trigger' => $trigger,
+            'deputy_user' => $submittedBy->getId(),
+            'report_id' => $submittedReport->getId(),
+            'date_resubmitted' => $submittedReport->getSubmitDate(),
+            'event' => AuditEvents::EVENT_REPORT_RESUBMITTED,
+            'type' => 'audit'
+        ];
+
+        $logger->notice('', $expectedEvent)->shouldBeCalled();
+        $sut->logReportSubmittedEvent($reportResubmittedEvent);
     }
 }

--- a/client/tests/phpunit/EventSubscriber/ReportSubmittedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/ReportSubmittedSubscriberTest.php
@@ -116,6 +116,6 @@ class ReportSubmittedSubscriberTest extends TestCase
         ];
 
         $logger->notice('', $expectedEvent)->shouldBeCalled();
-        $sut->log($reportResubmittedEvent);
+        $sut->logResubmittedReport($reportResubmittedEvent);
     }
 }

--- a/client/tests/phpunit/EventSubscriber/ReportUnsubmittedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/ReportUnsubmittedSubscriberTest.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+
+namespace Tests\AppBundle\EventListener;
+
+use AppBundle\Event\ReportUnsubmittedEvent;
+use AppBundle\EventSubscriber\ReportUnsubmittedSubscriber;
+use AppBundle\Service\Audit\AuditEvents;
+use AppBundle\Service\Time\DateTimeProvider;
+use AppBundle\TestHelpers\ReportHelpers;
+use AppBundle\TestHelpers\UserHelpers;
+use DateTime;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class ReportUnsubmittedSubscriberTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function getSubscribedEvents()
+    {
+        self::assertEquals(
+            [
+                ReportUnsubmittedEvent::NAME => 'logReportUnsubmittedEvent',
+            ],
+            ReportUnsubmittedSubscriber::getSubscribedEvents()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function logReportUnsubmittedEvent()
+    {
+        $logger = self::prophesize(LoggerInterface::class);
+        $dateTimeProvider = self::prophesize(DateTimeProvider::class);
+
+        $now = new DateTime();
+        $dateTimeProvider->getDateTime()->willReturn($now);
+        $currentUser = UserHelpers::createUser();
+        $trigger = 'UNSUBMIT_REPORT';
+
+
+        $submittedReport = ReportHelpers::createSubmittedReport();
+
+        $sut = new ReportUnsubmittedSubscriber($logger->reveal(), $dateTimeProvider->reveal());
+
+        $reportUnsubmittedEvent = new ReportUnsubmittedEvent($submittedReport, $currentUser, $trigger);
+
+        $expectedEvent = [
+            'trigger' => $trigger,
+            'deputy_user' => $currentUser->getId(),
+            'report_id' => $submittedReport->getId(),
+            'date_unsubmitted' => $submittedReport->getUnSubmitDate(),
+            'event' => AuditEvents::EVENT_REPORT_UNSUBMITTED,
+            'type' => 'audit'
+        ];
+
+        $logger->notice('', $expectedEvent)->shouldBeCalled();
+        $sut->logReportUnsubmittedEvent($reportUnsubmittedEvent);
+    }
+}

--- a/client/tests/phpunit/Service/Client/Internal/ReportApiTest.php
+++ b/client/tests/phpunit/Service/Client/Internal/ReportApiTest.php
@@ -9,33 +9,70 @@ use AppBundle\Service\Client\RestClient;
 use AppBundle\TestHelpers\ReportHelpers;
 use AppBundle\TestHelpers\UserHelpers;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
+use AppBundle\Event\ReportUnsubmittedEvent;
 
 class ReportApiTest extends TestCase
 {
+    private ObjectProphecy $restClient;
+    private ObjectProphecy $eventDispatcher;
+    private ReportApi $sut;
+
+    public function setUp(): void
+    {
+        $this->restClient = self::prophesize(RestClient::class);
+        $this->eventDispatcher = self::prophesize(ObservableEventDispatcher::class);
+
+        $this->sut = new ReportApi(
+            $this->restClient->reveal(),
+            $this->eventDispatcher->reveal()
+        );
+    }
+
     /**
      * @dataProvider reportIdProvider
      * @test
      */
     public function submit(?string $reportId)
     {
-        $restClient = self::prophesize(RestClient::class);
-        $eventDispatcher = self::prophesize(ObservableEventDispatcher::class);
-
         $reportToBeSubmitted = ReportHelpers::createReport();
         $submittedBy = UserHelpers::createUser();
         $event = new ReportSubmittedEvent($reportToBeSubmitted, $submittedBy, $reportId);
 
-        $restClient
+        $this->restClient
             ->put(sprintf('report/%s/submit', $reportToBeSubmitted->getId()), $reportToBeSubmitted, ['submit'])
             ->shouldBeCalled()
             ->willReturn($reportId);
 
-        $eventDispatcher
+        $this->eventDispatcher
             ->dispatch('report.submitted', $event)
             ->shouldBeCalled();
 
-        $sut = new ReportApi($restClient->reveal(), $eventDispatcher->reveal());
-        $sut->submit($reportToBeSubmitted, $submittedBy);
+        $this->sut->submit($reportToBeSubmitted, $submittedBy);
+    }
+
+    /** @test */
+    public function unsubmit()
+    {
+        $trigger = 'A_TRIGGER';
+        $currentUser = UserHelpers::createUser();
+        $submittedReport = ReportHelpers::createSubmittedReport();
+
+        $this->restClient
+            ->put('report/' . $submittedReport->getId() . '/unsubmit', $submittedReport, ['submitted', 'unsubmit_date', 'report_unsubmitted_sections_list', 'startEndDates', 'report_due_date'])
+            ->shouldBeCalled();
+
+        $reportUnsubmittedEvent = new ReportUnsubmittedEvent(
+            $submittedReport,
+            $currentUser,
+            $trigger
+        );
+
+        $this->eventDispatcher
+            ->dispatch('report.unsubmitted', $reportUnsubmittedEvent)
+            ->shouldBeCalled();
+
+        $this->sut->unsubmit($submittedReport, $currentUser, $trigger);
     }
 
     public function reportIdProvider()


### PR DESCRIPTION
## Purpose
Add audit logging for unsubmit and resubmit events.

Fixes DDPB-3428

## Approach
Followed the patterns from previous jobs. Feel in hindsight it may have been better to split the send email and log for the submit into different events rather than have them as one submit event however it seemed easier to code and made sense that way at the time (EDIT: got picked up on this in code review and wasn't tricky to change in the end).

I also promised some tests based on actual log events. Whilst I can see how to do this (as it's all set up nicely for it already), by the time I got it all working as is I didn't have time. Will do it for the next one.

## Learning
Here's a tip which used up about 2 hours of head scratching!! You need to completely rebuild the containers for subscribers to recognise different numbers of params as it seems it registers this kind of thing on startup.. spend ages trying to work out where it was getting the values from... you live and learn!

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
