### PR TITLE
DDPB-3130 add logging bucket

### DIFF
--- a/environment/s3.tf
+++ b/environment/s3.tf
@@ -3,6 +3,7 @@ locals {
   bucket_replication_status  = contains(local.non-replication_workspaces, local.environment) ? "Disabled" : "Enabled"
   long_expiry_workspaces     = ["production02", "development", "training"]
   expiration_days            = contains(local.long_expiry_workspaces, local.environment) ? 490 : 14
+  noncurrent_expiration_days = contains(local.long_expiry_workspaces, local.environment) ? 365 : 7
 }
 
 data "aws_s3_bucket" "replication_bucket" {
@@ -19,6 +20,11 @@ resource "aws_s3_bucket" "pa_uploads" {
     enabled = true
   }
 
+  logging {
+    target_bucket = aws_s3_bucket.s3_access_logs.id
+    target_prefix = "pa_uploads/"
+  }
+
   lifecycle_rule {
     enabled = true
 
@@ -27,7 +33,7 @@ resource "aws_s3_bucket" "pa_uploads" {
     }
 
     noncurrent_version_expiration {
-      days = 10
+      days = local.noncurrent_expiration_days
     }
   }
 
@@ -156,4 +162,54 @@ POLICY
 resource "aws_iam_role_policy_attachment" "replication" {
   role       = aws_iam_role.replication.name
   policy_arn = aws_iam_policy.replication.arn
+}
+
+resource "aws_s3_bucket" "s3_access_logs" {
+  bucket        = "s3-access-logs.${local.environment}"
+  acl           = "log-delivery-write"
+  force_destroy = local.account["force_destroy_bucket"]
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    transition {
+      days          = 30
+      storage_class = "GLACIER"
+    }
+
+    noncurrent_version_transition {
+      days          = 30
+      storage_class = "GLACIER"
+    }
+
+    noncurrent_version_expiration {
+      days = 180
+    }
+
+    expiration {
+      days                         = 180
+      expired_object_delete_marker = true
+    }
+
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "s3_access_logs" {
+  bucket = aws_s3_bucket.s3_access_logs.bucket
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }


### PR DESCRIPTION
## Purpose

We only have the main bucket that is of interest here. It already had versioning but needed logging

Fixes DDPB-3130

## Approach
added logging and made versioning have better expiration rules

## Learning

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
