### PR TITLE
DDPB-3852: Fix self register

### DIFF
--- a/api/src/Service/UserRegistrationService.php
+++ b/api/src/Service/UserRegistrationService.php
@@ -62,14 +62,6 @@ class UserRegistrationService
             if ($existingClient->hasDeputies() || $existingClient->getOrganisation() instanceof Organisation) {
                 throw new \RuntimeException('User registration: Case number already used', 425);
             } else {
-                foreach ($existingClient->getCourtOrders() as $order) {
-                    foreach ($order->getDeputies() as $deputy) {
-                        if (!is_null($deputy->getUser()) || !is_null($deputy->getOrganisation())) {
-                            throw new \RuntimeException('User registration: Case number already used', 425);
-                        }
-                    }
-                }
-
                 // soft delete client
                 $this->em->remove($existingClient);
                 $this->em->flush();

--- a/client/src/EventSubscriber/DeputySelfRegisteredSubscriber.php
+++ b/client/src/EventSubscriber/DeputySelfRegisteredSubscriber.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+
+namespace App\EventSubscriber;
+
+use App\Event\DeputySelfRegisteredEvent;
+use App\Service\Mailer\Mailer;
+
+class DeputySelfRegisteredSubscriber
+{
+    /** @var Mailer */
+    private $mailer;
+
+    public function __construct(Mailer $mailer)
+    {
+        $this->mailer = $mailer;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            DeputySelfRegisteredEvent::NAME => 'sendEmail'
+        ];
+    }
+
+    public function sendEmail(DeputySelfRegisteredEvent $event)
+    {
+        $this->mailer->sendActivationEmail($event->getRegisteredDeputy());
+    }
+}

--- a/client/templates/Manage/api-collector.html.twig
+++ b/client/templates/Manage/api-collector.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle/Profiler/layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {# icon at http://www.flaticon.com/free-icon/computers-network-interface-symbol_36181  #}
 

--- a/client/tests/phpunit/EventSubscriber/DeputySelfRegisteredSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/DeputySelfRegisteredSubscriberTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+
+namespace Tests\App\EventListener;
+
+use App\Event\DeputySelfRegisteredEvent;
+use App\EventSubscriber\DeputySelfRegisteredSubscriber;
+use App\Service\Mailer\Mailer;
+use App\TestHelpers\UserHelpers;
+use PHPUnit\Framework\TestCase;
+
+class DeputySelfRegisteredSubscriberTest extends TestCase
+{
+    /** @test */
+    public function getSubscribedEvents()
+    {
+        self::assertEquals(
+            [DeputySelfRegisteredEvent::NAME => 'sendEmail'],
+            DeputySelfRegisteredSubscriber::getSubscribedEvents()
+        );
+    }
+
+    /** @test */
+    public function sendEmail()
+    {
+        $selfRegisteredDeputy = UserHelpers::createUser();
+        $deputyRegisteredEvent = new DeputySelfRegisteredEvent($selfRegisteredDeputy);
+
+        $mailer = self::prophesize(Mailer::class);
+        $mailer->sendActivationEmail($selfRegisteredDeputy)->shouldBeCalled();
+
+        $sut = new DeputySelfRegisteredSubscriber($mailer->reveal());
+
+        $sut->sendEmail($deputyRegisteredEvent);
+    }
+}


### PR DESCRIPTION
## Purpose
Removing some old court order code that was leftover that resulted in some registrations not completing and adding a missing send email listener for self-registration events.

Fixes DDPB-3852.

## Learning
We clearly have some holes in our behat tests. The sooner we get on the rewrite the better.

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
