### PR TITLE
DDPB-3805b: Implement success message for file upload

### DIFF
--- a/client/src/Controller/Report/DocumentController.php
+++ b/client/src/Controller/Report/DocumentController.php
@@ -193,8 +193,7 @@ class DocumentController extends AbstractController
                 if ($verified) {
                     try {
                         $this->fileUploader->uploadSupportingFilesAndPersistDocuments($uploadedFiles, $report);
-                        $this->addFlash('notice', 'Files uploaded');
-                        return $this->redirectToRoute('report_documents', ['reportId' => $reportId]);
+                        return $this->redirectToRoute('report_documents', ['reportId' => $reportId, 'successUploaded' => 'true']);
                     } catch (\Throwable $e) {
                         $logger->warning('Error uploading file: ' . $e->getMessage());
                         $form->get('files')->addError(new FormError('Cannot upload file, please try again later'));
@@ -208,6 +207,7 @@ class DocumentController extends AbstractController
             'step'     => $request->get('step'), // if step is set, this is used to show the save and continue button
             'backLink' => $backLink,
             'nextLink' => $nextLink,
+            'successUploaded' => $request->get('successUploaded'),
             'form'     => $form->createView(),
         ];
     }

--- a/client/templates/Report/Document/step2.html.twig
+++ b/client/templates/Report/Document/step2.html.twig
@@ -18,6 +18,10 @@
 
 {% block pageContent %}
 
+    {% if successUploaded == "true" %}
+        {{ macros.successBanner(page ~ '.successUploaded', translationDomain, page ~ '.successUploadedHeader') }}
+    {% endif %}
+
     <h2 class="govuk-heading-m">{{ (page ~ '.selectHeading') | trans }}</h2>
 
     <p class="govuk-body">{{ (page ~ '.selectHelp') | trans }}</p>

--- a/client/translations/report-documents.en.yml
+++ b/client/translations/report-documents.en.yml
@@ -38,6 +38,8 @@ attachPage:
   deleteDocument: Remove
   continueToSubmit: Continue to send documents
   pleaseWait: The file is being uploaded.
+  successUploadedHeader: Files uploaded
+  successUploaded: Your uploaded files are now attached to this report and listed below
   uploadHint: |
     If the file takes more than 5 minutes to upload, please refresh the page and try again.
     To stop uploading the file, just refresh the page.


### PR DESCRIPTION
## Purpose
When a user adds a file successfully as a document on the document upload page, they will see a green confirmation banner.

Fixes DDPB-3805


## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
