### PR TITLE
DDPB-3871 fix out of date sec checker

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -95,7 +95,9 @@ COPY phpstan.neon .
 RUN su-exec www-data php -d memory_limit=-1 app/console cache:warmup
 
 # Check for security issues
-RUN su-exec www-data php app/console security:check
+RUN wget -q -O local-php-security-checker https://github.com/fabpot/local-php-security-checker/releases/download/v1.0.0/local-php-security-checker_1.0.0_linux_arm64 \
+  && chmod +x local-php-security-checker \
+  && su-exec local-php-security-checker
 
 CMD confd -onetime -backend env \
   && waitforit -address=tcp://$DATABASE_HOSTNAME:$DATABASE_PORT -timeout=$TIMEOUT \

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -115,7 +115,9 @@ RUN wget -q -O /tmp/commonpasswords.txt "https://www.ncsc.gov.uk/static-assets/d
     && chown www-data /tmp/commonpasswords.txt
 
 #Check for security issues
-RUN su-exec www-data php app/console security:check
+RUN wget -q -O local-php-security-checker https://github.com/fabpot/local-php-security-checker/releases/download/v1.0.0/local-php-security-checker_1.0.0_linux_arm64 \
+  && chmod +x local-php-security-checker \
+  && su-exec local-php-security-checker
 
 # Prebuild cache
 RUN su-exec www-data php -d memory_limit=-1 app/console cache:warmup


### PR DESCRIPTION
## Purpose
Security checks using the existing symfony security check have ended at end of Jan for 3.x. Using suggested package instead until we upgrade to 4.x

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
