### PR TITLE
DDPB-3852: Implement EventSubscriber for DeputySelfRegisteredSubscriber

### DIFF
--- a/client/src/EventSubscriber/DeputySelfRegisteredSubscriber.php
+++ b/client/src/EventSubscriber/DeputySelfRegisteredSubscriber.php
@@ -5,11 +5,11 @@ namespace App\EventSubscriber;
 
 use App\Event\DeputySelfRegisteredEvent;
 use App\Service\Mailer\Mailer;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class DeputySelfRegisteredSubscriber
+class DeputySelfRegisteredSubscriber implements EventSubscriberInterface
 {
-    /** @var Mailer */
-    private $mailer;
+    private Mailer $mailer;
 
     public function __construct(Mailer $mailer)
     {


### PR DESCRIPTION
## Purpose
Registration emails were still not being sent in dev and prod - turned out there was a missing class implementation on the event subscriber so the service was never tagged to be a subscriber.

Fixes DDPB-3852