### PR TITLE
DDPB-3886: Fix active lay report

### DIFF
--- a/api/src/Controller/StatsController.php
+++ b/api/src/Controller/StatsController.php
@@ -35,7 +35,7 @@ class StatsController extends RestController
     }
 
     /**
-     * @Route("stats/activeLays", methods={"GET"})
+     * @Route("stats/deputies/lay/active", methods={"GET"})
      * @Security("has_role('ROLE_SUPER_ADMIN')")
      */
     public function getActiveLays()

--- a/api/src/Controller/StatsController.php
+++ b/api/src/Controller/StatsController.php
@@ -14,8 +14,10 @@ class StatsController extends RestController
     private QueryFactory $QueryFactory;
     private UserRepository $userRepository;
 
-    public function __construct(QueryFactory $QueryFactory, UserRepository $userRepository)
-    {
+    public function __construct(
+        QueryFactory $QueryFactory,
+        UserRepository $userRepository
+    ) {
         $this->QueryFactory = $QueryFactory;
         $this->userRepository = $userRepository;
     }
@@ -30,5 +32,14 @@ class StatsController extends RestController
         $query = $this->QueryFactory->create($params);
 
         return $query->execute($params);
+    }
+
+    /**
+     * @Route("stats/activeLays", methods={"GET"})
+     * @Security("has_role('ROLE_SUPER_ADMIN')")
+     */
+    public function getActiveLays()
+    {
+        return $this->userRepository->findActiveLaysInLastYear();
     }
 }

--- a/api/src/Controller/UserController.php
+++ b/api/src/Controller/UserController.php
@@ -467,14 +467,4 @@ class UserController extends RestController
 
         return $requestedUserTeams->first();
     }
-
-    /**
-     * @Route("/activeLays", methods={"GET"})
-     * @Security("has_role('ROLE_SUPER_ADMIN')")
-     */
-    public function getActiveLays()
-    {
-        $this->formatter->setJmsSerialiserGroups(['user', 'user-clients', 'client-name']);
-        return $this->userRepository->findActiveLaysInLastYear();
-    }
 }

--- a/api/src/Entity/Repository/UserRepository.php
+++ b/api/src/Entity/Repository/UserRepository.php
@@ -229,7 +229,7 @@ FROM dd_user as u
 LEFT JOIN deputy_case as dc on u.id = dc.user_id
 LEFT JOIN client as c on dc.client_id = c.id
 LEFT JOIN report as r on c.id = r.client_id
-WHERE r.submit_date is not null AND u.role_name = 'ROLE_LAY_DEPUTY' AND u.last_logged_in > :oneYearAgo
+WHERE r.submit_date is not null AND u.role_name = 'ROLE_LAY_DEPUTY' AND u.last_logged_in >= :oneYearAgo
 GROUP BY u.id, u.firstname, u.lastname, u.email, u.registration_date, u.last_logged_in, c.firstname, c.lastname
 SQL;
 

--- a/api/src/Entity/Repository/UserRepository.php
+++ b/api/src/Entity/Repository/UserRepository.php
@@ -206,20 +206,36 @@ class UserRepository extends AbstractEntityRepository
     }
 
     /**
-     * @return User[]
+     * @return array
      */
     public function findActiveLaysInLastYear()
     {
-        $oneYearAgo = (new DateTime())->modify('-1 Year');
+        $oneYearAgo = (new DateTime())->modify('-1 Year')->format('Y-m-d');
 
-        $qb = $this->createQueryBuilder('u');
-        $qb
-            ->select()
-            ->where('u.lastLoggedIn > :login_cutoff')
-            ->andWhere('u.roleName = :lay_deputy_role')
-            ->setParameter('login_cutoff', $oneYearAgo)
-            ->setParameter('lay_deputy_role', User::ROLE_LAY_DEPUTY);
+        $conn = $this->getEntityManager()->getConnection();
 
-        return $qb->getQuery()->getResult();
+        $sql = <<<SQL
+SELECT u.id,
+u.firstname as user_first_name,
+u.lastname as user_last_name,
+u.email as user_email,
+u.phone_main as user_phone_number,
+u.registration_date,
+u.last_logged_in,
+c.firstname as client_first_name,
+c.lastname as client_last_name,
+COUNT(r.id) as submitted_reports
+FROM dd_user as u
+LEFT JOIN deputy_case as dc on u.id = dc.user_id
+LEFT JOIN client as c on dc.client_id = c.id
+LEFT JOIN report as r on c.id = r.client_id
+WHERE r.submit_date is not null AND u.role_name = 'ROLE_LAY_DEPUTY' AND u.last_logged_in > :oneYearAgo
+GROUP BY u.id, u.firstname, u.lastname, u.email, u.registration_date, u.last_logged_in, c.firstname, c.lastname
+SQL;
+
+        $stmt = $conn->prepare($sql);
+        $stmt->execute(['oneYearAgo' => $oneYearAgo]);
+
+        return $stmt->fetchAllAssociative();
     }
 }

--- a/api/src/FixtureFactory/LoadTestFactory.php
+++ b/api/src/FixtureFactory/LoadTestFactory.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+
+namespace App\FixtureFactory;
+
+use App\TestHelpers\ClientTestHelper;
+use App\TestHelpers\ReportTestHelper;
+use App\TestHelpers\UserTestHelper;
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+
+class LoadTestFactory
+{
+    private EntityManagerInterface $em;
+
+    public function __construct(EntityManagerInterface $em)
+    {
+        $this->em = $em;
+    }
+
+    /**
+     * Use to persist entities to simulate a prod like databases in size (run in a test for a hacky way to fill the DB)
+     *
+     * @param int $recordsToMake
+     */
+    public function createUsersClientsReports(int $recordsToMake)
+    {
+        $oneYearAgo = (new \DateTimeImmutable())->modify('-1 Year');
+
+        $userTestHelper = new UserTestHelper();
+        $reportTestHelper = new ReportTestHelper();
+        $clientTestHelper = new ClientTestHelper();
+
+        foreach (range(1, $recordsToMake) as $index) {
+            $user = ($userTestHelper->createUser(null))
+                ->setLastLoggedIn(
+                    DateTime::createFromImmutable($oneYearAgo->modify('+1 day'))
+                );
+
+            $user->setEmail($user->getEmail() . rand(1, 100000));
+
+            $client = $clientTestHelper->createClient($this->em, $user);
+            $user->addClient($client);
+
+            $report = $reportTestHelper->generateReport($this->em, $user->getFirstClient());
+            $report->setSubmitDate(new DateTime());
+
+            $client->addReport($report);
+
+            $this->em->persist($user);
+            $this->em->persist($client);
+            $this->em->persist($report);
+        }
+
+        $this->em->flush();
+    }
+}

--- a/api/src/TestHelpers/ClientTestHelper.php
+++ b/api/src/TestHelpers/ClientTestHelper.php
@@ -5,6 +5,9 @@ namespace App\TestHelpers;
 
 use App\Entity\Client;
 use App\Entity\Report\Report;
+use App\Entity\User;
+use Doctrine\ORM\EntityManager;
+use Faker\Factory;
 use PHPUnit\Framework\TestCase;
 
 class ClientTestHelper extends TestCase
@@ -18,5 +21,42 @@ class ClientTestHelper extends TestCase
         $client->getId()->willReturn($id);
 
         return $client->reveal();
+    }
+
+    public function createClient(EntityManager $em, ?User $user = null)
+    {
+        $faker = Factory::create('en_GB');
+
+        return (new Client())
+            ->addUser($user ? $user : (new UserTestHelper())->createAndPersistUser($em))
+            ->setFirstname($faker->firstName)
+            ->setLastname($faker->lastName)
+            ->setCaseNumber(self::createValidCaseNumber())
+            ->setEmail($faker->safeEmail . rand(1, 100000))
+            ->setCourtDate(new \DateTime());
+    }
+
+    /**
+     * Sirius has a modulus 11 validation check on case references (because casrec.) which we should adhere to
+     * to make sure integration tests create data that is in the correct format.
+     */
+    public static function createValidCaseNumber()
+    {
+        $ref = '';
+        $sum = 0;
+
+        foreach ([3, 4, 7, 5, 8, 2, 4] as $constant) {
+            $value = mt_rand(0, 9);
+            $ref .= $value;
+            $sum += $value * $constant;
+        }
+
+        $checkbit = (11 - ($sum % 11)) % 11;
+
+        if ($checkbit === 10) {
+            $checkbit = 'T';
+        }
+
+        return $ref . $checkbit;
     }
 }

--- a/api/src/TestHelpers/ReportSubmissionHelper.php
+++ b/api/src/TestHelpers/ReportSubmissionHelper.php
@@ -22,7 +22,7 @@ class ReportSubmissionHelper extends KernelTestCase
     public function generateAndPersistReportSubmission(EntityManager $em)
     {
         $client = new Client();
-        $report = (new ReportTestHelper())->generateReport($client);
+        $report = (new ReportTestHelper())->generateReport($em, $client);
         $client->addReport($report);
         $user = (new UserTestHelper())->createAndPersistUser($em, $client);
         $reportSubmission = new ReportSubmission($report, $user);
@@ -56,6 +56,7 @@ class ReportSubmissionHelper extends KernelTestCase
         $client = $lastSubmission->getReport()->getClient();
 
         $report = (new ReportTestHelper())->generateReport(
+            $em,
             $client,
             $lastSubmission->getReport()->getType(),
             $lastSubmission->getReport()->getSubmitDate()->modify('+366 days')

--- a/api/src/TestHelpers/ReportTestHelper.php
+++ b/api/src/TestHelpers/ReportTestHelper.php
@@ -7,20 +7,21 @@ use App\Entity\Client;
 use App\Entity\Report\Report;
 use DateInterval;
 use DateTime;
+use Doctrine\ORM\EntityManager;
 
 class ReportTestHelper
 {
     /**
+     * @param EntityManager $em
      * @param Client|null $client
      * @param string|null $type
      * @param DateTime|null $startDate
      * @param DateTime|null $endDate
      * @return Report
-     * @throws \Exception
      */
-    public function generateReport(?Client $client=null, ?string $type=null, ?DateTime $startDate=null, ?DateTime $endDate=null)
+    public function generateReport(EntityManager $em, ?Client $client=null, ?string $type=null, ?DateTime $startDate=null, ?DateTime $endDate=null)
     {
-        $client = $client ? $client : (new ClientTestHelper())->generateClient();
+        $client = $client ? $client : (new ClientTestHelper())->createClient($em);
         $type = $type ? $type : Report::TYPE_102;
         $startDate = $startDate ? $startDate : new \DateTime();
         $endDate = $endDate ? $endDate : (clone $startDate)->add(new DateInterval('P1Y'));

--- a/api/src/TestHelpers/UserTestHelper.php
+++ b/api/src/TestHelpers/UserTestHelper.php
@@ -9,6 +9,7 @@ use DateTime;
 use Doctrine\ORM\EntityManager;
 use Faker\Factory;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
 class UserTestHelper extends TestCase
 {
@@ -27,7 +28,7 @@ class UserTestHelper extends TestCase
         return $user->reveal();
     }
 
-    public function createAndPersistUser(EntityManager $em, ?Client $client = null, ?string $roleName = User::ROLE_LAY_DEPUTY)
+    public function createUser(?Client $client = null, ?string $roleName = User::ROLE_LAY_DEPUTY)
     {
         $faker = Factory::create('en_GB');
 
@@ -41,8 +42,18 @@ class UserTestHelper extends TestCase
             ->setLastLoggedIn(new DateTime());
 
         if (!is_null($client)) {
-            $em->persist($client);
             $user->addClient($client);
+        }
+
+        return $user;
+    }
+
+    public function createAndPersistUser(EntityManager $em, ?Client $client = null, ?string $roleName = User::ROLE_LAY_DEPUTY)
+    {
+        $user = $this->createUser($client, $roleName);
+
+        if (!is_null($client)) {
+            $em->persist($client);
         }
 
         $em->persist($user);

--- a/api/tests/App/Controller/StatsControllerTest.php
+++ b/api/tests/App/Controller/StatsControllerTest.php
@@ -34,4 +34,26 @@ class StatsControllerTest extends AbstractTestController
 
         self::assertIsArray($response);
     }
+
+    /** @test */
+    public function activeLayDeputies_only_super_admins_can_access()
+    {
+        $unauthorisedUserTokens = [
+            $this->loginAsAdmin(),
+            $this->loginAsDeputy(),
+            $this->loginAsProf(),
+            $this->loginAsPa()
+        ];
+
+        foreach ($unauthorisedUserTokens as $token) {
+            $this->assertJsonRequest(
+                'GET',
+                '/stats/activeLays',
+                [
+                    'mustFail' => true,
+                    'AuthToken' => $token,
+                ]
+            );
+        }
+    }
 }

--- a/api/tests/App/Controller/StatsControllerTest.php
+++ b/api/tests/App/Controller/StatsControllerTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+
+namespace Tests\App\Controller;
+
+use App\TestHelpers\ClientTestHelper;
+use App\TestHelpers\ReportTestHelper;
+use App\TestHelpers\UserTestHelper;
+use DateTime;
+
+class StatsControllerTest extends AbstractTestController
+{
+    private $entityManager;
+
+    public function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+    }
+
+    /** @test */
+    public function activeLayDeputies()
+    {
+        $response = $this->assertJsonRequest(
+            'GET',
+            '/stats/activeLays',
+            [
+                'mustSucceed' => true,
+                'AuthToken' => $this->loginAsSuperAdmin(),
+            ]
+        );
+
+        self::assertIsArray($response);
+    }
+}

--- a/api/tests/App/Controller/StatsControllerTest.php
+++ b/api/tests/App/Controller/StatsControllerTest.php
@@ -25,7 +25,7 @@ class StatsControllerTest extends AbstractTestController
     {
         $response = $this->assertJsonRequest(
             'GET',
-            '/stats/activeLays',
+            '/stats/deputies/lay/active',
             [
                 'mustSucceed' => true,
                 'AuthToken' => $this->loginAsSuperAdmin(),
@@ -48,7 +48,7 @@ class StatsControllerTest extends AbstractTestController
         foreach ($unauthorisedUserTokens as $token) {
             $this->assertJsonRequest(
                 'GET',
-                '/stats/activeLays',
+                '/stats/deputies/lay/active',
                 [
                     'mustFail' => true,
                     'AuthToken' => $token,

--- a/api/tests/App/Controller/UserControllerTest.php
+++ b/api/tests/App/Controller/UserControllerTest.php
@@ -1,15 +1,10 @@
 <?php declare(strict_types=1);
 
+
 namespace Tests\App\Controller;
 
-use App\Entity\Report\Report;
 use App\Entity\Role;
 use App\Entity\User;
-use App\TestHelpers\ReportSubmissionHelper;
-use App\TestHelpers\UserHelpers;
-use App\TestHelpers\UserTestHelper;
-use DateTime;
-use Doctrine\ORM\EntityManagerInterface;
 
 class UserControllerTest extends AbstractTestController
 {
@@ -19,10 +14,6 @@ class UserControllerTest extends AbstractTestController
     private static $tokenAdmin = null;
     private static $tokenSuperAdmin = null;
     private static $tokenDeputy = null;
-    /** @var EntityManagerInterface */
-    private $entityManager;
-    /** @var ReportSubmissionHelper */
-    private $submissionHelper;
 
     public static function setUpBeforeClass(): void
     {
@@ -52,13 +43,6 @@ class UserControllerTest extends AbstractTestController
             self::$tokenAdmin = $this->loginAsAdmin();
             self::$tokenDeputy = $this->loginAsDeputy();
         }
-
-        $kernel = self::bootKernel();
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')
-            ->getManager();
-
-        $this->submissionHelper = new ReportSubmissionHelper();
     }
 
     public function testAddAuth()
@@ -543,33 +527,5 @@ class UserControllerTest extends AbstractTestController
         $deputy = self::fixtures()->clear()->getRepo('User')->findOneByEmail('deputy@example.org');
         $this->assertTrue($deputy->getAgreeTermsUse());
         $this->assertEquals(date('Y-m-d'), $deputy->getAgreeTermsUseDate()->format('Y-m-d'));
-    }
-
-    /** @test */
-    public function activeLayDeputies()
-    {
-        $userHelper = new UserTestHelper();
-
-        $activeUserOne = $userHelper->createAndPersistUser($this->entityManager);
-        $activeUserTwo = $userHelper->createAndPersistUser($this->entityManager);
-
-        $inactiveUser = $userHelper->createAndPersistUser($this->entityManager);
-        $inactiveUser->setLastLoggedIn(new DateTime('-380 days'));
-        $this->entityManager->persist($inactiveUser);
-        $this->entityManager->flush();
-
-        $url = sprintf('%s?%s', '/user/activeLays', http_build_query(['groups' => ['user']]));
-        $response = $this->assertJsonRequest(
-            'GET',
-            $url,
-            [
-                'mustSucceed' => true,
-                'AuthToken' => $this->loginAsSuperAdmin(),
-            ]
-        );
-
-        self::assertStringContainsString($activeUserOne->getEmail(), json_encode($response['data']));
-        self::assertStringContainsString($activeUserTwo->getEmail(), json_encode($response['data']));
-        self::assertStringNotContainsString($inactiveUser->getEmail(), json_encode($response['data']));
     }
 }

--- a/api/tests/App/Entity/Repository/ReportRepositoryTest.php
+++ b/api/tests/App/Entity/Repository/ReportRepositoryTest.php
@@ -195,7 +195,7 @@ class ReportRepositoryTest extends ApiBaseTestCase
         $user = (new User())
             ->setFirstname('firstname')
             ->setLastname('lastname')
-            ->setEmail(sprintf('email%s@test.com', rand(1, 1000)))
+            ->setEmail(sprintf('email%s@test.com', rand(1, 100000)))
             ->setPassword('password');
 
         $reportSubmission = new ReportSubmission($report, $user);

--- a/api/tests/App/Entity/Repository/UserRepositoryTest.php
+++ b/api/tests/App/Entity/Repository/UserRepositoryTest.php
@@ -4,6 +4,8 @@ namespace Tests\App\Entity\Repository;
 
 use App\Entity\Repository\UserRepository;
 use App\Entity\User;
+use App\TestHelpers\ClientTestHelper;
+use App\TestHelpers\ReportTestHelper;
 use App\TestHelpers\UserTestHelper;
 use DateTime;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
@@ -81,40 +83,51 @@ class UserRepositoryTest extends WebTestCase
     /** @test */
     public function findActiveLaysInLastYear()
     {
-        $oneYearAgo = (new \DateTimeImmutable())->modify('-1 Year');
+        $userHelper = new UserTestHelper();
+        $reportHelper = new ReportTestHelper();
+        $clientHelper = new ClientTestHelper();
 
-        $userTestHelper = new UserTestHelper();
+        $clientOne = $clientHelper->createClient($this->em) ;
+        $activeUserOne = ($userHelper->createAndPersistUser($this->em, $clientOne));
+        $reportOne = ($reportHelper->generateReport($this->em, $clientOne))->setSubmitDate(new DateTime());
 
-        $activeLay = ($userTestHelper->createAndPersistUser($this->em, null))
-            ->setLastLoggedIn(
-                DateTime::createFromImmutable($oneYearAgo->modify('+1 day'))
-            );
+        $clientTwo = $clientHelper->createClient($this->em) ;
+        $activeUserTwo = $userHelper->createAndPersistUser($this->em, $clientTwo);
+        $reportTwo = ($reportHelper->generateReport($this->em, $clientTwo))->setSubmitDate(new DateTime());
 
-        $activeLay2 = ($userTestHelper->createAndPersistUser($this->em, null))
-            ->setLastLoggedIn(
-                DateTime::createFromImmutable($oneYearAgo->modify('+1 minute'))
-            );
+        $clientThree = $clientHelper->createClient($this->em) ;
+        $reportThree = ($reportHelper->generateReport($this->em, $clientThree))->setSubmitDate(new DateTime());
+        $inactiveUserOne = $userHelper->createAndPersistUser($this->em, $clientThree);
+        $inactiveUserOne->setLastLoggedIn(new DateTime('-380 days'));
 
-        $inactiveLay = ($userTestHelper->createAndPersistUser($this->em, null))
-            ->setLastLoggedIn(
-                DateTime::createFromImmutable($oneYearAgo->modify('-5 second'))
-            );
+        $clientFour = $clientHelper->createClient($this->em) ;
+        $reportFour = $reportHelper->generateReport($this->em, $clientFour);
+        $inactiveUserTwo = $userHelper->createAndPersistUser($this->em, $clientFour);
+        $inactiveUserTwo->setLastLoggedIn(new DateTime());
 
-        $this->em->persist($activeLay);
-        $this->em->persist($activeLay2);
-        $this->em->persist($inactiveLay);
+        $this->em->persist($inactiveUserOne);
+        $this->em->persist($inactiveUserTwo);
+        $this->em->persist($reportOne);
+        $this->em->persist($reportTwo);
+        $this->em->persist($reportThree);
+        $this->em->persist($reportFour);
+        $this->em->persist($clientOne);
+        $this->em->persist($clientTwo);
+        $this->em->persist($clientThree);
+        $this->em->persist($clientFour);
         $this->em->flush();
 
         $results = $this->sut->findActiveLaysInLastYear();
         $resultsUserIds = [];
 
-        foreach ($results as $user) {
-            $resultsUserIds[] = $user->getId();
+        foreach ($results as $userData) {
+            $resultsUserIds[] = $userData['id'];
         }
 
-        self::assertContains($activeLay->getId(), $resultsUserIds);
-        self::assertContains($activeLay2->getId(), $resultsUserIds);
-        self::assertNotContains($inactiveLay->getId(), $resultsUserIds);
+        self::assertContains($activeUserOne->getId(), $resultsUserIds);
+        self::assertContains($activeUserTwo->getId(), $resultsUserIds);
+        self::assertNotContains($inactiveUserOne->getId(), $resultsUserIds);
+        self::assertNotContains($inactiveUserTwo->getId(), $resultsUserIds);
     }
 
     protected function tearDown(): void

--- a/api/tests/App/Entity/Repository/UserRepositoryTest.php
+++ b/api/tests/App/Entity/Repository/UserRepositoryTest.php
@@ -4,8 +4,6 @@ namespace Tests\App\Entity\Repository;
 
 use App\Entity\Repository\UserRepository;
 use App\Entity\User;
-
-
 use App\TestHelpers\UserTestHelper;
 use DateTime;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;

--- a/api/tests/App/Entity/UserTest.php
+++ b/api/tests/App/Entity/UserTest.php
@@ -5,15 +5,17 @@ namespace Tests\App\Entity;
 use App\TestHelpers\ReportSubmissionHelper;
 use DateTime;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\ApiBaseTestCase;
 
 /**
  * User Entity test
  */
-class UserTest extends KernelTestCase
+class UserTest extends ApiBaseTestCase
 {
     /** @test */
     public function getNumberOfSubmittedReports()
     {
+        $this->purgeDatabase();
         $kernel = self::bootKernel();
         $em = $kernel->getContainer()
             ->get('doctrine')

--- a/client/src/Controller/Admin/StatsController.php
+++ b/client/src/Controller/Admin/StatsController.php
@@ -11,6 +11,7 @@ use App\Mapper\ReportSatisfaction\ReportSatisfactionSummaryMapper;
 use App\Mapper\ReportSatisfaction\ReportSatisfactionSummaryQuery;
 use App\Mapper\ReportSubmission\ReportSubmissionSummaryMapper;
 use App\Mapper\ReportSubmission\ReportSubmissionSummaryQuery;
+use App\Service\Client\Internal\StatsApi;
 use App\Service\Client\Internal\UserApi;
 use App\Service\Client\RestClient;
 use App\Service\Csv\ActiveLaysCsvGenerator;
@@ -30,14 +31,18 @@ class StatsController extends AbstractController
 {
     private RestClient $restClient;
     private SatisfactionCsvGenerator $csvGenerator;
-    private UserApi $userApi;
+    private StatsApi $statsApi;
     private ActiveLaysCsvGenerator $activeLaysCsvGenerator;
 
-    public function __construct(RestClient $restClient, SatisfactionCsvGenerator $csvGenerator, UserApi $userApi, ActiveLaysCsvGenerator $activeLaysCsvGenerator)
-    {
+    public function __construct(
+        RestClient $restClient,
+        SatisfactionCsvGenerator $csvGenerator,
+        StatsApi $statsApi,
+        ActiveLaysCsvGenerator $activeLaysCsvGenerator
+    ) {
         $this->restClient = $restClient;
         $this->csvGenerator = $csvGenerator;
-        $this->userApi = $userApi;
+        $this->statsApi = $statsApi;
         $this->activeLaysCsvGenerator = $activeLaysCsvGenerator;
     }
 
@@ -192,8 +197,8 @@ class StatsController extends AbstractController
      */
     public function downloadActiveLayCsv()
     {
-        $activeLays = $this->userApi->getActiveLays();
-        $csv = $this->activeLaysCsvGenerator->generateActiveLaysCsv($activeLays);
+        $activeLaysData = $this->statsApi->getActiveLayReportData();
+        $csv = $this->activeLaysCsvGenerator->generateActiveLaysCsv($activeLaysData);
 
         $response = new Response($csv);
 

--- a/client/src/Service/Client/Internal/StatsApi.php
+++ b/client/src/Service/Client/Internal/StatsApi.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+
+namespace App\Service\Client\Internal;
+
+use App\Service\Client\RestClientInterface;
+
+class StatsApi
+{
+    protected const GET_ACTIVE_LAY_REPORT_DATA_ENDPOINT = 'stats/activeLays';
+
+    private RestClientInterface $restClient;
+
+    public function __construct(RestClientInterface $restClient)
+    {
+        $this->restClient = $restClient;
+    }
+
+    /**
+     * @return array
+     */
+    public function getActiveLayReportData()
+    {
+        return $this->restClient->get(
+            self::GET_ACTIVE_LAY_REPORT_DATA_ENDPOINT,
+            'array',
+            ['active-users']
+        );
+    }
+}

--- a/client/src/Service/Client/Internal/StatsApi.php
+++ b/client/src/Service/Client/Internal/StatsApi.php
@@ -7,7 +7,7 @@ use App\Service\Client\RestClientInterface;
 
 class StatsApi
 {
-    protected const GET_ACTIVE_LAY_REPORT_DATA_ENDPOINT = 'stats/activeLays';
+    protected const GET_ACTIVE_LAY_REPORT_DATA_ENDPOINT = 'stats/deputies/lay/active';
 
     private RestClientInterface $restClient;
 

--- a/client/src/Service/Client/Internal/UserApi.php
+++ b/client/src/Service/Client/Internal/UserApi.php
@@ -28,7 +28,6 @@ class UserApi
     protected const RECREATE_USER_TOKEN_ENDPOINT = 'user/recreate-token/%s';
     protected const DEPUTY_SELF_REGISTER_ENDPOINT = 'selfregister';
     protected const CREATE_CODEPUTY_ENDPOINT = 'codeputy/add';
-    protected const GET_ACTIVE_LAYS = 'user/activeLays';
 
     /**  @var RestClientInterface */
     protected $restClient;

--- a/client/src/Service/Csv/ActiveLaysCsvGenerator.php
+++ b/client/src/Service/Csv/ActiveLaysCsvGenerator.php
@@ -3,8 +3,6 @@
 
 namespace App\Service\Csv;
 
-use App\Entity\User;
-
 class ActiveLaysCsvGenerator
 {
     /**
@@ -18,7 +16,7 @@ class ActiveLaysCsvGenerator
     }
 
     /**
-     * @param User[] $lays
+     * @param array $lays
      * @return string
      */
     public function generateActiveLaysCsv(array $lays)
@@ -37,13 +35,13 @@ class ActiveLaysCsvGenerator
 
         foreach ($lays as $lay) {
             $rows[] = [
-                $lay->getId(),
-                $lay->getFullName(),
-                $lay->getEmail(),
-                $lay->getPhoneMain(),
-                $lay->getNumberOfSubmittedReports(),
-                $lay->getRegistrationDate()->format('j F Y'),
-                $lay->getFirstClient()->getFullName()
+                $lay['id'],
+                sprintf('%s %s', $lay['user_first_name'], $lay['user_last_name']),
+                $lay['user_email'],
+                $lay['user_phone_number'],
+                $lay['submitted_reports'],
+                $lay['registration_date'],
+                sprintf('%s %s', $lay['client_first_name'], $lay['client_last_name']),
             ];
         }
 

--- a/client/tests/phpunit/Service/Csv/ActiveLaysCsvGeneratorTest.php
+++ b/client/tests/phpunit/Service/Csv/ActiveLaysCsvGeneratorTest.php
@@ -1,13 +1,8 @@
-<?php
+<?php declare(strict_types=1);
 
 
 namespace App\Service\Csv;
 
-use App\Entity\Client;
-use App\Entity\User;
-use App\TestHelpers\ClientHelpers;
-use App\TestHelpers\ReportHelpers;
-use DateTime;
 use PHPUnit\Framework\TestCase;
 
 class ActiveLaysCsvGeneratorTest extends TestCase
@@ -15,35 +10,39 @@ class ActiveLaysCsvGeneratorTest extends TestCase
     /** @test */
     public function generateActiveLaysCsv()
     {
-        $lays = [
-            (new User())
-                ->setId(10)
-                ->setFirstname('Rosa')
-                ->setLastname('Walton')
-                ->setEmail('r.walton@example.com')
-                ->setPhoneMain('01212324545')
-                ->setClients([(new Client())->setFirstname('Sophie')->setLastname('Xeon')])
-                ->setNumberOfSubmittedReports(1)
-                ->setRegistrationDate(new DateTime('2020-11-28')),
-            (new User())
-                ->setId(457)
-                ->setFirstname('Jenny')
-                ->setLastname('Hollingworth')
-                ->setEmail('j.hollingworth@example.com')
-                ->setPhoneMain('01216861212')
-                ->setClients([(new Client())->setFirstname('Charlotte')->setLastname('Aitchison')])
-                ->setNumberOfSubmittedReports(3)
-                ->setRegistrationDate(new DateTime('2020-09-15'))
+        $laysData = [
+            [
+                'id' => 10,
+                'user_first_name' => 'Rosa',
+                'user_last_name' => 'Walton',
+                'user_email' => 'r.walton@example.com',
+                'user_phone_number' => '01212324545',
+                'submitted_reports' => '1',
+                'registration_date' => '2021-02-05 17:26:19',
+                'client_first_name' => 'Sophie',
+                'client_last_name' => 'Xeon',
+            ],
+            [
+                'id' => 457,
+                'user_first_name' => 'Jenny',
+                'user_last_name' => 'Hollingworth',
+                'user_email' => 'j.hollingworth@example.com',
+                'user_phone_number' => '01216861212',
+                'submitted_reports' => '3',
+                'registration_date' => '2020-09-15 18:01:47',
+                'client_first_name' => 'Charlotte',
+                'client_last_name' => 'Aitchison',
+            ],
         ];
 
         $expectedCsv = <<<CSV
 Id,"Deputy Full Name","Deputy Email","Deputy Phone Number","Reports Submitted","Registered On","Client Full Name"
-10,"Rosa Walton",r.walton@example.com,01212324545,1,"28 November 2020","Sophie Xeon"
-457,"Jenny Hollingworth",j.hollingworth@example.com,01216861212,3,"15 September 2020","Charlotte Aitchison"
+10,"Rosa Walton",r.walton@example.com,01212324545,1,"2021-02-05 17:26:19","Sophie Xeon"
+457,"Jenny Hollingworth",j.hollingworth@example.com,01216861212,3,"2020-09-15 18:01:47","Charlotte Aitchison"
 
 CSV;
 
         $sut = new ActiveLaysCsvGenerator(new CsvBuilder());
-        self::assertEquals($expectedCsv, $sut->generateActiveLaysCsv($lays));
+        self::assertEquals($expectedCsv, $sut->generateActiveLaysCsv($laysData));
     }
 }


### PR DESCRIPTION
## Purpose
The active lay report was timing out on prod as there were approximately 23K Users being returned. This change streamlines the process to allow the full dataset to be returned.

Fixes DDPB-3886

## Approach
I replicated creating a large dataset using a factory locally and running in a test multiple times. I backed up the test database and restored to the API database. We could look at building this functionality into our fixtures so we have a representative DB size to work with when we need to test anything with high loads. 

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
