### PR TITLE
DDPB-3908: Set fixtures password env var in api service

### DIFF
--- a/api/config/services.yml
+++ b/api/config/services.yml
@@ -9,6 +9,10 @@ imports:
     - { resource: services/security.yml }
     - { resource: services/transformers.yml }
 
+parameters:
+    fixtures:
+        account_password: '%env(FIXTURES_ACCOUNTPASSWORD)%'
+
 services:
     em:
         alias: doctrine.orm.entity_manager

--- a/api/docker/confd/templates/parameters.yml.tmpl
+++ b/api/docker/confd/templates/parameters.yml.tmpl
@@ -24,7 +24,5 @@ parameters:
     locale: en
     secret: {{ getv "/secret" }}
     redis_dsn: '{{getv "/redis/dsn" }}'
-    fixtures:
-        account_password: {{ getv "/fixtures/accountpassword" }}
     log_level: warning
     log_path: /var/log/app/application.log

--- a/api/docker/confd/templates/parameters.yml.tmpl
+++ b/api/docker/confd/templates/parameters.yml.tmpl
@@ -24,9 +24,7 @@ parameters:
     locale: en
     secret: {{ getv "/secret" }}
     redis_dsn: '{{getv "/redis/dsn" }}'
-{{ if ls "/fixtures" }}
     fixtures:
         account_password: {{ getv "/fixtures/accountpassword" }}
-{{ end }}
     log_level: warning
     log_path: /var/log/app/application.log

--- a/environment/api_service.tf
+++ b/environment/api_service.tf
@@ -101,6 +101,7 @@ locals {
       { "name": "DATABASE_NAME", "value": "${local.db.name}" },
       { "name": "DATABASE_PORT", "value": "${local.db.port}" },
       { "name": "DATABASE_USERNAME", "value": "${local.db.username}" },
+      { "name": "FIXTURES_ACCOUNTPASSWORD", "value": "Abcd1234" },
       { "name": "NGINX_APP_NAME", "value": "api" },
       { "name": "OPG_DOCKER_TAG", "value": "${var.OPG_DOCKER_TAG}" },
       { "name": "REDIS_DSN", "value": "redis://${aws_route53_record.api_redis.fqdn}" }


### PR DESCRIPTION
Development is currently broken due to a missing env var from API. I'd somehow managed to get #595 through the pipeline despite the fact the env var `FIXTURES_ACCOUNTPASSWORD` didn't exists in the API service. 

I thought about adding some logic to determining which system environment to add this to but that seems overly complex considering the risk of having the env var there is pretty low. 

Fixes DDPB-3908.