### PR TITLE
DDPB-2914 add bucket backup replication

### DIFF
--- a/environment/disaster_recovery/kms.tf
+++ b/environment/disaster_recovery/kms.tf
@@ -1,3 +1,10 @@
+resource "aws_kms_alias" "backup_kms_alias" {
+  name          = "alias/digideps-ca-db-backup"
+  target_key_id = aws_kms_key.db_backup.id
+
+  depends_on = [aws_kms_key.db_backup]
+}
+
 resource "aws_kms_key" "db_backup" {
   description             = "KMS DB secondary backup"
   deletion_window_in_days = 10

--- a/environment/s3_access_logs.tf
+++ b/environment/s3_access_logs.tf
@@ -1,0 +1,49 @@
+resource "aws_s3_bucket" "s3_access_logs" {
+  bucket        = "s3-access-logs.${local.environment}"
+  acl           = "log-delivery-write"
+  force_destroy = local.account["force_destroy_bucket"]
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    transition {
+      days          = 30
+      storage_class = "GLACIER"
+    }
+
+    noncurrent_version_transition {
+      days          = 30
+      storage_class = "GLACIER"
+    }
+
+    noncurrent_version_expiration {
+      days = 180
+    }
+
+    expiration {
+      days                         = 180
+      expired_object_delete_marker = true
+    }
+
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "s3_access_logs" {
+  bucket = aws_s3_bucket.s3_access_logs.bucket
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -36,7 +36,9 @@
       "aurora_instance_count": 3,
       "aurora_serverless": false,
       "deletion_protection": true,
-      "aurora_enabled": true
+      "aurora_enabled": true,
+      "s3_backup_replication": "Enabled",
+      "s3_backup_kms_arn": "8d42ba9a-321c-43ac-a911-5f452d336da5"
     },
     "preproduction": {
       "name": "preproduction",
@@ -72,7 +74,9 @@
       "aurora_instance_count": 2,
       "aurora_serverless": false,
       "deletion_protection": true,
-      "aurora_enabled": true
+      "aurora_enabled": true,
+      "s3_backup_replication": "Enabled",
+      "s3_backup_kms_arn": "5875b77a-043c-41e3-a3c6-84bdd865fedf"
     },
     "training": {
       "name": "production",
@@ -108,7 +112,9 @@
       "aurora_instance_count": 2,
       "aurora_serverless": false,
       "deletion_protection": true,
-      "aurora_enabled": true
+      "aurora_enabled": true,
+      "s3_backup_replication": "Disabled",
+      "s3_backup_kms_arn": "8d42ba9a-321c-43ac-a911-5f452d336da5"
     },
     "integration": {
       "name": "preproduction",
@@ -144,7 +150,9 @@
       "aurora_instance_count": 1,
       "aurora_serverless": false,
       "deletion_protection": false,
-      "aurora_enabled": true
+      "aurora_enabled": true,
+      "s3_backup_replication": "Disabled",
+      "s3_backup_kms_arn": "5875b77a-043c-41e3-a3c6-84bdd865fedf"
     },
     "development": {
       "name": "development",
@@ -183,7 +191,9 @@
       "aurora_instance_count": 0,
       "aurora_serverless": true,
       "deletion_protection": false,
-      "aurora_enabled": true
+      "aurora_enabled": true,
+      "s3_backup_replication": "Enabled",
+      "s3_backup_kms_arn": "f4dd7602-251f-48f8-accb-6d1bec57436f"
     },
     "default": {
       "name": "development",
@@ -220,7 +230,9 @@
       "aurora_instance_count": 0,
       "aurora_serverless": true,
       "deletion_protection": false,
-      "aurora_enabled": true
+      "aurora_enabled": true,
+      "s3_backup_replication": "Disabled",
+      "s3_backup_kms_arn": "f4dd7602-251f-48f8-accb-6d1bec57436f"
     }
   }
 }

--- a/environment/variables.tf
+++ b/environment/variables.tf
@@ -43,6 +43,8 @@ variable "accounts" {
       aurora_serverless       = bool
       deletion_protection     = bool
       aurora_enabled          = bool
+      s3_backup_replication   = string
+      s3_backup_kms_arn       = string
     })
   )
 }


### PR DESCRIPTION
## Purpose
Added all the digideps side for bucket replication to a backup account. The org infra side has already been merged in.

Fixes DDPB-2914

## Approach

Tried the full setup in a PR on our side first to check everything lined up then pulled out the backup account stuff and opened a PR in org infra with it. 

## Learning

Couple of things.. you need a filter setting to have two replication setups even if you don't use it. That was a bit of a gotcha. Also the whole dynamic for_each setup of all the vars to do per env setup on the org infra side (not in this PR) was a bit of learning to get it working as I wanted. We may want to remove dev or even preprod from the replication in the future but it's nice to have the option to replicate and proves it works through real envs before hitting prod.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
