### PR TITLE
DDPB-3876: Update password length to 14 chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,4 +94,4 @@ The OPG Digideps Client is released under the MIT license, a copy of which can b
 
 ## Runbook
 
-Our runbook, incident response process and other OPG technical guidance can be found [here](https://ministryofjustice.github.io/opg-technical-guidance/#opg-technical-guidance)
+Our runbook, incident response process and other OPG technical guidance can be found [here](https://ministryofjustice.github.io/opg-technical-guidance/#opg-technical-guidance).

--- a/api/api.env
+++ b/api/api.env
@@ -8,7 +8,7 @@ SECRET=foobar
 
 REDIS_DSN=redis://redis-api
 
-FIXTURES_ACCOUNTPASSWORD=Abcd1234
+FIXTURES_ACCOUNTPASSWORD=DigidepsPass1234
 
 SECRETS_FRONT_KEY=api-frontend-key
 

--- a/api/config/parameters.yml.dist
+++ b/api/config/parameters.yml.dist
@@ -15,7 +15,7 @@ parameters:
         ad@publicguardian.gsi.gov.uk:
             firstname: "AD user"
             lastname: "AD surname"
-            password: Abcd1234
+            password: DigidepsPass1234
             roleName: ROLE_AD
             activated: true
             ndrEnabled: false
@@ -29,7 +29,7 @@ parameters:
         admin@publicguardian.gsi.gov.uk:
             firstname: Admin
             lastname: User
-            password: Abcd1234
+            password: DigidepsPass1234
             roleName: ROLE_ADMIN
             activated: true
             ndrEnabled: false
@@ -37,7 +37,7 @@ parameters:
         laydeputy@publicguardian.gsi.gov.uk:
             firstname: "Lay Deputy"
             lastname: User
-            password: Abcd1234
+            password: DigidepsPass1234
             roleName: ROLE_LAY_DEPUTY
             activated: true
             ndrEnabled: false
@@ -51,7 +51,7 @@ parameters:
         laydeputyndr@publicguardian.gsi.gov.uk:
             firstname: "Lay Deputy NDR"
             lastname: User
-            password: Abcd1234
+            password: DigidepsPass1234
             roleName: ROLE_LAY_DEPUTY
             activated: true
             ndrEnabled: true
@@ -65,7 +65,7 @@ parameters:
         laydeputy102@publicguardian.gsi.gov.uk:
             firstname: "Lay Deputy 102"
             lastname: User
-            password: Abcd1234
+            password: DigidepsPass1234
             roleName: ROLE_LAY_DEPUTY
             activated: true
             ndrEnabled: false
@@ -79,7 +79,7 @@ parameters:
         laydeputy103@publicguardian.gsi.gov.uk:
             firstname: "Lay Deputy 103"
             lastname: User
-            password: Abcd1234
+            password: DigidepsPass1234
             roleName: ROLE_LAY_DEPUTY
             activated: true
             ndrEnabled: false
@@ -93,7 +93,7 @@ parameters:
         laydeputy104@publicguardian.gsi.gov.uk:
             firstname: "Lay Deputy 104"
             lastname: User
-            password: Abcd1234
+            password: DigidepsPass1234
             roleName: ROLE_LAY_DEPUTY
             activated: true
             ndrEnabled: false
@@ -107,7 +107,7 @@ parameters:
         laydeputy102-4@publicguardian.gsi.gov.uk:
             firstname: "Lay Deputy 102-4"
             lastname: User
-            password: Abcd1234
+            password: DigidepsPass1234
             roleName: ROLE_LAY_DEPUTY
             activated: true
             ndrEnabled: false
@@ -121,7 +121,7 @@ parameters:
         laydeputy103-4@publicguardian.gsi.gov.uk:
             firstname: "Lay Deputy 103-4"
             lastname: User
-            password: Abcd1234
+            password: DigidepsPass1234
             roleName: ROLE_LAY_DEPUTY
             activated: true
             ndrEnabled: false

--- a/api/config/services.yml
+++ b/api/config/services.yml
@@ -9,6 +9,10 @@ imports:
     - { resource: services/security.yml }
     - { resource: services/transformers.yml }
 
+parameters:
+    fixtures:
+        account_password: '%env(FIXTURES_ACCOUNTPASSWORD)%'
+
 services:
     em:
         alias: doctrine.orm.entity_manager

--- a/api/docker/confd/templates/parameters.yml.tmpl
+++ b/api/docker/confd/templates/parameters.yml.tmpl
@@ -24,9 +24,5 @@ parameters:
     locale: en
     secret: {{ getv "/secret" }}
     redis_dsn: '{{getv "/redis/dsn" }}'
-{{ if ls "/fixtures" }}
-    fixtures:
-        account_password: {{ getv "/fixtures/accountpassword" }}
-{{ end }}
     log_level: warning
     log_path: /var/log/app/application.log

--- a/api/src/FixtureFactory/UserFactory.php
+++ b/api/src/FixtureFactory/UserFactory.php
@@ -45,7 +45,7 @@ class UserFactory
             ->setRoleName($roleName);
 
         if ($data['activated'] === 'true' || $data['activated'] === true) {
-            $user->setPassword($this->encoder->encodePassword($user, 'Abcd1234'));
+            $user->setPassword($this->encoder->encodePassword($user, 'DigidepsPass1234'));
         } else {
             $user->setActive(false);
         }
@@ -68,7 +68,7 @@ class UserFactory
             ->setRoleName($data['adminType']);
 
         if ($data['activated'] === 'true') {
-            $user->setPassword($this->encoder->encodePassword($user, 'Abcd1234'))->setActive(true);
+            $user->setPassword($this->encoder->encodePassword($user, 'DigidepsPass1234'))->setActive(true);
         }
 
         return $user;
@@ -95,7 +95,7 @@ class UserFactory
             ->setAddressCountry('GB')
             ->setRoleName('ROLE_PROF_TEAM_MEMBER');
 
-        $user->setPassword($this->encoder->encodePassword($user, 'Abcd1234'));
+        $user->setPassword($this->encoder->encodePassword($user, 'DigidepsPass1234'));
 
         return $user;
     }
@@ -140,7 +140,7 @@ class UserFactory
             ->setActive(true);
 
         if ($data['activated'] === 'true' || $data['activated'] === true) {
-            $user2->setPassword($this->encoder->encodePassword($user2, 'Abcd1234'));
+            $user2->setPassword($this->encoder->encodePassword($user2, 'DigidepsPass1234'));
         } else {
             $user2->setActive(false);
         }

--- a/api/tests/App/Controller/AbstractTestController.php
+++ b/api/tests/App/Controller/AbstractTestController.php
@@ -216,7 +216,7 @@ abstract class AbstractTestController extends WebTestCase
      */
     protected function loginAsDeputy()
     {
-        return $this->login('deputy@example.org', 'Abcd1234', self::$deputySecret);
+        return $this->login('deputy@example.org', 'DigidepsPass1234', self::$deputySecret);
     }
 
     /**
@@ -224,7 +224,7 @@ abstract class AbstractTestController extends WebTestCase
      */
     protected function loginAsPa()
     {
-        return $this->login('pa@example.org', 'Abcd1234', self::$deputySecret);
+        return $this->login('pa@example.org', 'DigidepsPass1234', self::$deputySecret);
     }
 
     /**
@@ -232,7 +232,7 @@ abstract class AbstractTestController extends WebTestCase
      */
     protected function loginAsPaAdmin()
     {
-        return $this->login('pa_admin@example.org', 'Abcd1234', self::$deputySecret);
+        return $this->login('pa_admin@example.org', 'DigidepsPass1234', self::$deputySecret);
     }
 
     /**
@@ -240,7 +240,7 @@ abstract class AbstractTestController extends WebTestCase
      */
     protected function loginAsPaTeamMember()
     {
-        return $this->login('pa_team_member@example.org', 'Abcd1234', self::$deputySecret);
+        return $this->login('pa_team_member@example.org', 'DigidepsPass1234', self::$deputySecret);
     }
 
     /**
@@ -248,7 +248,7 @@ abstract class AbstractTestController extends WebTestCase
      */
     protected function loginAsProf()
     {
-        return $this->login('prof@example.org', 'Abcd1234', self::$deputySecret);
+        return $this->login('prof@example.org', 'DigidepsPass1234', self::$deputySecret);
     }
 
     /**
@@ -256,7 +256,7 @@ abstract class AbstractTestController extends WebTestCase
      */
     protected function loginAsAdmin()
     {
-        return $this->login('admin@example.org', 'Abcd1234', self::$adminSecret);
+        return $this->login('admin@example.org', 'DigidepsPass1234', self::$adminSecret);
     }
 
     /**
@@ -264,7 +264,7 @@ abstract class AbstractTestController extends WebTestCase
      */
     protected function loginAsSuperAdmin()
     {
-        return $this->login('super_admin@example.org', 'Abcd1234', self::$adminSecret);
+        return $this->login('super_admin@example.org', 'DigidepsPass1234', self::$adminSecret);
     }
 
     protected function tearDown(): void

--- a/api/tests/App/Controller/AuthControllerTest.php
+++ b/api/tests/App/Controller/AuthControllerTest.php
@@ -76,7 +76,7 @@ class AuthControllerTest extends AbstractTestController
             'mustFail' => true,
             'data' => [
                 'email' => 'admin@example.org',
-                'password' => 'Abcd1234',
+                'password' => 'DigidepsPass1234',
             ],
             'ClientSecret' => API_TOKEN_DEPUTY,
             'assertCode' => 403,
@@ -92,7 +92,7 @@ class AuthControllerTest extends AbstractTestController
 
     public function testFailWrongAuthToken()
     {
-        $authToken = $this->login('deputy@example.org', 'Abcd1234', API_TOKEN_DEPUTY);
+        $authToken = $this->login('deputy@example.org', 'DigidepsPass1234', API_TOKEN_DEPUTY);
 
         $this->assertTrue(strlen($authToken) > 5, "Token $authToken not valid");
 
@@ -114,7 +114,7 @@ class AuthControllerTest extends AbstractTestController
 
     public function testLoginSuccess()
     {
-        $authToken = $this->login('deputy@example.org', 'Abcd1234', API_TOKEN_DEPUTY);
+        $authToken = $this->login('deputy@example.org', 'DigidepsPass1234', API_TOKEN_DEPUTY);
 
         // assert succeed with token
         $data = $this->assertJsonRequest('GET', '/auth/get-logged-user', [
@@ -150,8 +150,8 @@ class AuthControllerTest extends AbstractTestController
         $this->resetAttempts('email' . 'deputy@example.org');
         $this->resetAttempts('email' . 'admin@example.org');
 
-        $authTokenDeputy = $this->login('deputy@example.org', 'Abcd1234', API_TOKEN_DEPUTY);
-        $authTokenAdmin = $this->login('admin@example.org', 'Abcd1234', API_TOKEN_ADMIN);
+        $authTokenDeputy = $this->login('deputy@example.org', 'DigidepsPass1234', API_TOKEN_DEPUTY);
+        $authTokenAdmin = $this->login('admin@example.org', 'DigidepsPass1234', API_TOKEN_ADMIN);
 
         // assert deputy can access
         $data = $this->assertJsonRequest('GET', '/auth/get-logged-user', [
@@ -185,7 +185,7 @@ class AuthControllerTest extends AbstractTestController
 
     public function testLoginTimeout()
     {
-        $authToken = $this->login('deputy@example.org', 'Abcd1234', API_TOKEN_DEPUTY);
+        $authToken = $this->login('deputy@example.org', 'DigidepsPass1234', API_TOKEN_DEPUTY);
 
         // manually expire token in REDIS
         self::$frameworkBundleClient->getContainer()->get('snc_redis.default')->expire($authToken, 0);
@@ -230,7 +230,7 @@ class AuthControllerTest extends AbstractTestController
             'mustFail' => false,
             'data' => [
                 'email' => 'deputy@example.org',
-                'password' => 'Abcd1234',
+                'password' => 'DigidepsPass1234',
             ],
             'ClientSecret' => API_TOKEN_DEPUTY,
             'assertResponseCode' => 200,
@@ -263,7 +263,7 @@ class AuthControllerTest extends AbstractTestController
                 'mustFail' => true,
                 'data' => [
                     'email' => 'deputy@example.org',
-                    'password' => 'Abcd1234',
+                    'password' => 'DigidepsPass1234',
                 ],
                 'ClientSecret' => API_TOKEN_DEPUTY,
                 'assertCode' => 423,

--- a/api/tests/App/Controller/SelfRegisterControllerTest.php
+++ b/api/tests/App/Controller/SelfRegisterControllerTest.php
@@ -25,7 +25,7 @@ class SelfRegisterControllerTest extends AbstractTestController
     /** @test */
     public function dontSaveUnvalidUserToDB()
     {
-        $token = $this->login('deputy@example.org', 'Abcd1234', API_TOKEN_DEPUTY);
+        $token = $this->login('deputy@example.org', 'DigidepsPass1234', API_TOKEN_DEPUTY);
 
         $this->assertJsonRequest('POST', '/selfregister', [
             'mustFail' => true,
@@ -63,7 +63,7 @@ class SelfRegisterControllerTest extends AbstractTestController
         $this->fixtures()->persist($casRec);
         $this->fixtures()->flush($casRec);
 
-        $token = $this->login('deputy@example.org', 'Abcd1234', API_TOKEN_DEPUTY);
+        $token = $this->login('deputy@example.org', 'DigidepsPass1234', API_TOKEN_DEPUTY);
 
         $responseArray = $this->assertJsonRequest('POST', '/selfregister', [
             'mustSucceed' => true,
@@ -103,7 +103,7 @@ class SelfRegisterControllerTest extends AbstractTestController
      */
     public function userNotFoundinCasRec()
     {
-        $token = $this->login('deputy@example.org', 'Abcd1234', API_TOKEN_DEPUTY);
+        $token = $this->login('deputy@example.org', 'DigidepsPass1234', API_TOKEN_DEPUTY);
 
         $responseArray = $this->assertJsonRequest('POST', '/selfregister', [
             'mustFail' => true,
@@ -129,7 +129,7 @@ class SelfRegisterControllerTest extends AbstractTestController
      */
     public function throwErrorForDuplicate()
     {
-        $token = $this->login('deputy@example.org', 'Abcd1234', API_TOKEN_DEPUTY);
+        $token = $this->login('deputy@example.org', 'DigidepsPass1234', API_TOKEN_DEPUTY);
 
         $this->assertJsonRequest('POST', '/selfregister', [
             'mustFail' => true,

--- a/api/tests/App/Controller/UserControllerTest.php
+++ b/api/tests/App/Controller/UserControllerTest.php
@@ -215,11 +215,11 @@ class UserControllerTest extends AbstractTestController
             'mustSucceed' => true,
             'AuthToken' => self::$tokenDeputy,
             'data' => [
-                'password_plain' => 'Abcd1234ne',
+                'password_plain' => 'DigidepsPass1234ne',
             ],
         ]);
 
-        $this->login('deputy@example.org', 'Abcd1234ne', API_TOKEN_DEPUTY);
+        $this->login('deputy@example.org', 'DigidepsPass1234ne', API_TOKEN_DEPUTY);
     }
 
     /**
@@ -233,13 +233,13 @@ class UserControllerTest extends AbstractTestController
             'mustSucceed' => true,
             'AuthToken' => self::$tokenDeputy,
             'data' => [
-                'password_plain' => 'Abcd1234pa',
+                'password_plain' => 'DigidepsPass1234pa',
                 'send_email' => 'activate',
 
             ],
         ]);
 
-        $this->login('deputy@example.org', 'Abcd1234pa', API_TOKEN_DEPUTY);
+        $this->login('deputy@example.org', 'DigidepsPass1234pa', API_TOKEN_DEPUTY);
     }
 
     /**
@@ -253,7 +253,7 @@ class UserControllerTest extends AbstractTestController
             'mustSucceed' => true,
             'AuthToken' => self::$tokenDeputy,
             'data' => [
-                'password_plain' => 'Abcd1234', //restore password for subsequent logins
+                'password_plain' => 'DigidepsPass1234', //restore password for subsequent logins
                 'send_email' => 'password-reset',
             ],
         ]);

--- a/behat/tests/bootstrap/Common/AuthenticationTrait.php
+++ b/behat/tests/bootstrap/Common/AuthenticationTrait.php
@@ -47,7 +47,7 @@ trait AuthenticationTrait
     public function openActivationOrPasswordResetPage($admin, $pageType, $email)
     {
         $url = sprintf('/admin/fixtures/user-registration-token?email=%s', $email);
-        $this->iAmLoggedInToAdminAsWithPassword('admin@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('admin@publicguardian.gov.uk', 'DigidepsPass1234');
         $this->visitAdminPath($url);
         $token = $this->getSession()->getPage()->getContent();
         $this->visitAdminPath('/logout');

--- a/behat/tests/bootstrap/Common/CourtOrderTrait.php
+++ b/behat/tests/bootstrap/Common/CourtOrderTrait.php
@@ -13,7 +13,7 @@ trait CourtOrderTrait
      */
     public function theFollowingCourtOrdersExist(TableNode $table)
     {
-        $this->iAmLoggedInToAdminAsWithPassword('super-admin@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('super-admin@publicguardian.gov.uk', 'DigidepsPass1234');
 
         foreach ($table as $row) {
             $queryString = http_build_query([

--- a/behat/tests/bootstrap/Common/ReportTrait.php
+++ b/behat/tests/bootstrap/Common/ReportTrait.php
@@ -132,7 +132,7 @@ trait ReportTrait
      */
     public function iHaveTheReportBetweenDeputyAndClient($startDate, $endDate, $deputy, $client)
     {
-        $this->iAmLoggedInAsWithPassword($deputy.'@behat-test.com', 'Abcd1234');
+        $this->iAmLoggedInAsWithPassword($deputy.'@behat-test.com', 'DigidepsPass1234');
         $this->enterReport($client, $startDate, $endDate);
         preg_match('/\/(ndr|report)\/(\d+)\//', $this->getSession()->getCurrentUrl(), $match);
 
@@ -218,7 +218,7 @@ trait ReportTrait
      */
     public function theReportHasBeenUnsubmitted()
     {
-        $this->iAmLoggedInToAdminAsWithPassword('admin@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('admin@publicguardian.gov.uk', 'DigidepsPass1234');
 
         $reportId = self::$currentReportCache['reportId'];
         $this->visitAdminPath("/admin/fixtures/unsubmit-report/$reportId");
@@ -229,7 +229,7 @@ trait ReportTrait
      */
     public function theReportShouldBeUnsubmitted()
     {
-        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'DigidepsPass1234');
 
         $client = self::$currentReportCache['client'];
         $startDate = self::$currentReportCache['startDate'];
@@ -353,7 +353,7 @@ trait ReportTrait
 
     private function completeSections(string $sections, string $reportType='report')
     {
-        $this->iAmLoggedInToAdminAsWithPassword('admin@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('admin@publicguardian.gov.uk', 'DigidepsPass1234');
 
         $reportId = self::$currentReportCache['reportId'];
         $url = sprintf('/admin/fixtures/complete-sections/%s/%s?sections=%s', $reportType, $reportId, $sections);
@@ -381,7 +381,7 @@ trait ReportTrait
 
     private function logInAndEnterReport(): void
     {
-        $this->iAmLoggedInAsWithPassword(self::$currentReportCache['deputy'] . '@behat-test.com', 'Abcd1234');
+        $this->iAmLoggedInAsWithPassword(self::$currentReportCache['deputy'] . '@behat-test.com', 'DigidepsPass1234');
         $reportId = self::$currentReportCache['reportId'];
         $reportType = self::$currentReportCache['reportType'];
         $this->visit("$reportType/$reportId/overview");

--- a/behat/tests/bootstrap/CourtOrderManagement/CourtOrderManagementTrait.php
+++ b/behat/tests/bootstrap/CourtOrderManagement/CourtOrderManagementTrait.php
@@ -9,7 +9,7 @@ trait CourtOrderManagementTrait
      */
     public function aSuperAdminDischargesDeputyFromClient($caseNumber)
     {
-        $this->iAmLoggedInToAdminAsWithPassword('super-admin@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('super-admin@publicguardian.gov.uk', 'DigidepsPass1234');
         $this->visitAdminPath("/admin/client/case-number/$caseNumber/details");
         $this->clickLink('Discharge deputy');
         $this->clickLink('Discharge deputy');
@@ -23,8 +23,8 @@ trait CourtOrderManagementTrait
         $result = null;
 
         $query = "
-SELECT count(co.id) 
-FROM court_order co 
+SELECT count(co.id)
+FROM court_order co
 JOIN court_order_deputy cod on cod.court_order_id = co.id
 WHERE cod.email = '$deputy'
 AND co.case_number = '$caseNumber'
@@ -37,5 +37,4 @@ AND co.case_number = '$caseNumber'
             throw new \Exception('Expected court order to exist but it does not');
         }
     }
-
 }

--- a/behat/tests/bootstrap/OrganisationManagement/OrganisationManagementTrait.php
+++ b/behat/tests/bootstrap/OrganisationManagement/OrganisationManagementTrait.php
@@ -11,7 +11,7 @@ trait OrganisationManagementTrait
      */
     public function organisationsExist(TableNode $table)
     {
-        $this->iAmLoggedInToAdminAsWithPassword('admin@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('admin@publicguardian.gov.uk', 'DigidepsPass1234');
 
         foreach ($table as $inputs) {
             $this->visitAdminPath('/admin/organisations/add');
@@ -38,7 +38,7 @@ trait OrganisationManagementTrait
      */
     public function usersAreInOrgs(TableNode $table)
     {
-        $this->iAmLoggedInToAdminAsWithPassword('admin@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('admin@publicguardian.gov.uk', 'DigidepsPass1234');
 
         foreach ($table as $inputs) {
             $this->visitAdminPath('/admin/organisations');
@@ -59,7 +59,7 @@ trait OrganisationManagementTrait
      */
     public function usersClientsAreInUsersOrg(TableNode $table)
     {
-        $this->iAmLoggedInToAdminAsWithPassword('admin@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('admin@publicguardian.gov.uk', 'DigidepsPass1234');
 
         foreach ($table as $inputs) {
             $this->visitAdminPath(sprintf("/admin/fixtures/move-users-clients-to-users-org/%s", $inputs['userEmail']));
@@ -75,7 +75,7 @@ trait OrganisationManagementTrait
      */
     public function theOrgIsActivated(string $orgName)
     {
-        $this->iAmLoggedInToAdminAsWithPassword('admin@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('admin@publicguardian.gov.uk', 'DigidepsPass1234');
 
         $this->visitAdminPath(sprintf("/admin/fixtures/activateOrg/%s", $orgName));
 

--- a/behat/tests/bootstrap/Registration/RegistrationFeatureContext.php
+++ b/behat/tests/bootstrap/Registration/RegistrationFeatureContext.php
@@ -25,7 +25,7 @@ class RegistrationFeatureContext extends BaseFeatureContext
      */
     public function anAdminUserUploadsTheFileIntoTheLayCsvUploader($file)
     {
-        $this->iAmLoggedInToAdminAsWithPassword('admin@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('admin@publicguardian.gov.uk', 'DigidepsPass1234');
         $this->visitAdminPath("/admin/casrec-upload");
         $this->attachFileToField("admin_upload_file", $file);
         $this->pressButton("admin_upload_upload");
@@ -49,14 +49,14 @@ class RegistrationFeatureContext extends BaseFeatureContext
             $this->pressButton('self_registration_save');
 
             $this->openActivationOrPasswordResetPage('', 'activation', $courtOrder['deputyEmail']);
-            $this->fillField('set_password_password_first', 'Abcd1234');
-            $this->fillField('set_password_password_second', 'Abcd1234');
+            $this->fillField('set_password_password_first', 'DigidepsPass1234');
+            $this->fillField('set_password_password_second', 'DigidepsPass1234');
             $this->checkOption('set_password_showTermsAndConditions');
             $this->pressButton('set_password_save');
 
             $this->assertPageContainsText('Sign in to your new account');
             $this->fillField('login_email', $courtOrder['deputyEmail']);
-            $this->fillField('login_password', 'Abcd1234');
+            $this->fillField('login_password', 'DigidepsPass1234');
             $this->pressButton('login_login');
 
             $this->fillField('user_details_address1', '102 Petty France');

--- a/behat/tests/bootstrap/ReportManagement/ReportManagementTrait.php
+++ b/behat/tests/bootstrap/ReportManagement/ReportManagementTrait.php
@@ -19,7 +19,7 @@ trait ReportManagementTrait
 
         $reportId = self::$currentReportCache['reportId'];
 
-        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'DigidepsPass1234');
         $this->visitAdminPath("/admin/report/$reportId/manage");
         $this->selectOption('manage_report[type]', $type);
         $this->selectOption('manage_report[dueDateChoice]', 'keep');
@@ -40,7 +40,7 @@ trait ReportManagementTrait
 
         $reportId = self::$currentReportCache['reportId'];
 
-        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'DigidepsPass1234');
         $this->visitAdminPath("/admin/report/$reportId/manage");
         $this->selectOption('manage_report[type]', $type);
         $this->selectOption('manage_report[dueDateChoice]', 'keep');
@@ -62,7 +62,6 @@ trait ReportManagementTrait
         try {
             $this->selectOption('manage_report_confirm[confirm]', 'yes');
         } catch (ElementNotFoundException $e) {
-
         }
 
         $this->pressButton('manage_report_confirm[save]');
@@ -78,12 +77,11 @@ trait ReportManagementTrait
         // Only log in and reload the session if we're not already on the management page.
         $currentUrl = $this->getSession()->getCurrentUrl();
         if (strpos($currentUrl, "/admin/report/$reportId/manage") === false) {
-            $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'Abcd1234');
+            $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'DigidepsPass1234');
             $this->visitAdminPath("/admin/report/$reportId/manage");
         }
 
         foreach ($table as $inputs) {
-
             if (isset($inputs['type'])) {
                 $this->selectOption('manage_report[type]', $inputs['type']);
             }
@@ -125,7 +123,7 @@ trait ReportManagementTrait
         $adjustment = intval($adjustment);
         $reportId = self::$currentReportCache['reportId'];
 
-        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'DigidepsPass1234');
         $this->visitAdminPath("/admin/report/$reportId/manage");
         $this->selectOption('manage_report[dueDateChoice]', $adjustment);
         $this->pressButton('manage_report[save]');
@@ -140,7 +138,7 @@ trait ReportManagementTrait
         $reportId = self::$currentReportCache['reportId'];
         $adjustment = explode('-', $adjustment);
 
-        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'DigidepsPass1234');
         $this->visitAdminPath("/admin/report/$reportId/manage");
         $this->selectOption('manage_report[dueDateChoice]', 'custom');
         $this->fillField('manage_report_dueDateCustom_day', $adjustment[2]);
@@ -159,7 +157,7 @@ trait ReportManagementTrait
         $startDate = self::$currentReportCache['startDate'];
         $endDate = self::$currentReportCache['endDate'];
 
-        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'DigidepsPass1234');
         $this->visitAdminPath("/admin/client/case-number/$client/details");
 
         $adjustment = intval($adjustment);
@@ -176,7 +174,7 @@ trait ReportManagementTrait
         $startDate = self::$currentReportCache['startDate'];
         $endDate = self::$currentReportCache['endDate'];
 
-        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'DigidepsPass1234');
         $this->visitAdminPath("/admin/client/case-number/$client/details");
 
         $expectedDueDate = new \DateTime($adjustment);
@@ -199,7 +197,7 @@ trait ReportManagementTrait
     {
         $reportId = self::$currentReportCache['reportId'];
 
-        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'DigidepsPass1234');
         $this->visitAdminPath("/admin/report/$reportId/manage");
     }
 
@@ -210,7 +208,7 @@ trait ReportManagementTrait
     {
         $reportId = self::$currentReportCache['reportId'];
 
-        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'Abcd1234');
+        $this->iAmLoggedInToAdminAsWithPassword('casemanager@publicguardian.gov.uk', 'DigidepsPass1234');
         $this->visitAdminPath("/admin/report/$reportId/manage");
         $this->checkOption('manage_report_close[agreeCloseReport]');
         $this->pressButton('manage_report_close[save]');

--- a/behat/tests/bootstrap/UserTrait.php
+++ b/behat/tests/bootstrap/UserTrait.php
@@ -229,6 +229,15 @@ trait UserTrait
     }
 
     /**
+     * @When I fill in the reset password fields with :password
+     */
+    public function iFillTheResetPasswordFieldsWith($password)
+    {
+        $this->fillField('reset_password_password_first', $password);
+        $this->fillField('reset_password_password_second', $password);
+    }
+
+    /**
      * @When I set the user details to:
      */
     public function iSetTheUserDetailsTo(TableNode $table)

--- a/behat/tests/bootstrap/v2/BaseFeatureContext.php
+++ b/behat/tests/bootstrap/v2/BaseFeatureContext.php
@@ -77,7 +77,7 @@ class BaseFeatureContext extends MinkContext
         $this->visitPath('/logout');
         $this->visitPath('/login');
         $this->fillField('login_email', $email);
-        $this->fillField('login_password', 'Abcd1234');
+        $this->fillField('login_password', 'DigidepsPass1234');
         $this->pressButton('login_login');
 
         $this->visitPath(sprintf(self::BEHAT_FRONT_USER_DETAILS, $email));
@@ -97,7 +97,7 @@ class BaseFeatureContext extends MinkContext
         $this->visitAdminPath('/logout');
         $this->visitAdminPath('/login');
         $this->fillField('login_email', $email);
-        $this->fillField('login_password', 'Abcd1234');
+        $this->fillField('login_password', 'DigidepsPass1234');
         $this->pressButton('login_login');
     }
 

--- a/behat/tests/features-v2/acl/admin/super-admin-only.feature
+++ b/behat/tests/features-v2/acl/admin/super-admin-only.feature
@@ -4,21 +4,21 @@ Feature: Limiting access to sections of the app to super admins
   I need to limit access to certain areas of the app to Super Admins
 
   Scenario: Super admin can access satisfaction and active lay reports
-    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I am on admin page "/admin/stats/metrics"
     And I should see "Download DAT file"
     And I should see "Download satisfaction report"
     And I should see "Download active lays report"
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I am on admin page "/admin/stats/metrics"
     And I should see "Download DAT file"
     And I should not see "Download satisfaction report"
     And I should not see "Download active lays report"
 
   Scenario: Super admin can access fixture endpoints in navigation bar
-    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should see "Fixtures" in the "navbar" region
     When I follow "Fixtures"
     Then I should be on "/admin/fixtures/"
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should not see "Fixtures" in the "navbar" region

--- a/behat/tests/features-v2/contact-details/contact-details.feature
+++ b/behat/tests/features-v2/contact-details/contact-details.feature
@@ -1,7 +1,7 @@
 Feature: Contact details
 
   Scenario: Create users for scenarios
-    Given I am logged in to admin as 'super-admin@publicguardian.gov.uk' with password 'Abcd1234'
+    Given I am logged in to admin as 'super-admin@publicguardian.gov.uk' with password 'DigidepsPass1234'
 
     And the following users exist:
       | ndr      | deputyType | firstName | lastName | email                          | postCode | activated |
@@ -18,31 +18,31 @@ Feature: Contact details
   Scenario: Admin should not show any helpline
     Given I go to admin page "/"
     Then I should not see the "contact-details" region
-    When I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    When I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should not see the "contact-details" region
 
   Scenario: NDR should see lay email
-    Given I am logged in as "ndr1234@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "ndr1234@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should see the "contact-details" region
     And I should see "laydeputysupport@publicguardian.gov.uk" in the "contact-details" region
 
   Scenario: Lay deputy should see lay email
-    Given I am logged in as "lay1234@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "lay1234@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should see the "contact-details" region
     And I should see "laydeputysupport@publicguardian.gov.uk" in the "contact-details" region
 
   Scenario: Professional deputy should see professional helpline
-    Given I am logged in as "prof1234@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "prof1234@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should see the "contact-details" region
     And I should see "opg.pro@publicguardian.gov.uk" in the "contact-details" region
 
   Scenario: Public authority deputy should see professional helpline
-    Given I am logged in as "pa1234@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "pa1234@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should see the "contact-details" region
     And I should see "opg.publicauthorityteam@publicguardian.gov.uk" in the "contact-details" region
 
   Scenario: Cleanup users
-    Given I am logged in to admin as 'super-admin@publicguardian.gov.uk' with password 'Abcd1234'
+    Given I am logged in to admin as 'super-admin@publicguardian.gov.uk' with password 'DigidepsPass1234'
     And I delete the following users:
       | email                          |
       | ndr1234@publicguardian.gov.uk  |

--- a/behat/tests/features-v2/cross-browser/cross-browser.feature
+++ b/behat/tests/features-v2/cross-browser/cross-browser.feature
@@ -13,18 +13,18 @@ Feature: Preview a summary of the report
 
   @mink:browser_stack @chrome
   Scenario: Accessing the report preview for an active report
-    Given I am logged in as "deputy127@behat-test.com" with password "Abcd1234"
+    Given I am logged in as "deputy127@behat-test.com" with password "DigidepsPass1234"
     And I am viewing the "2018" to "2019" report for "48520098"
     When I click on "edit-report-review"
 
   @mink:browser_stack @ie11
   Scenario: Accessing the report preview for an active report
-    Given I am logged in as "deputy128@behat-test.com" with password "Abcd1234"
+    Given I am logged in as "deputy128@behat-test.com" with password "DigidepsPass1234"
     And I am viewing the "2018" to "2019" report for "48520099"
     When I click on "edit-report-review"
 
   @mink:browser_stack @android-chrome
   Scenario: Accessing the report preview for an active report
-    Given I am logged in as "deputy129@behat-test.com" with password "Abcd1234"
+    Given I am logged in as "deputy129@behat-test.com" with password "DigidepsPass1234"
     And I am viewing the "2018" to "2019" report for "48520100"
     When I click on "edit-report-review"

--- a/behat/tests/features-v2/deputy-management/deputy/edit-myself.feature
+++ b/behat/tests/features-v2/deputy-management/deputy/edit-myself.feature
@@ -4,7 +4,7 @@ Feature: A deputy user edits their details
   I need to be able to update my user details
 
   Scenario: Creating users to edit
-    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "DigidepsPass1234"
 
     Given the following users exist:
       | ndr      | deputyType | firstName | lastName       | email                 | postCode | activated |
@@ -14,7 +14,7 @@ Feature: A deputy user edits their details
       | disabled | LAY        | Billy     | Butcherson     | b.butcherson@test.com | HA4      | true      |
 
   Scenario: A lay deputy edits their details
-    Given I am logged in as "w.sanderson@test.com" with password "Abcd1234"
+    Given I am logged in as "w.sanderson@test.com" with password "DigidepsPass1234"
     And I view the lay deputy edit your details page
     And the following fields should have the corresponding values:
       | profile_firstname        | Winifred             |
@@ -71,7 +71,7 @@ Feature: A deputy user edits their details
       | profile_email            | m.dennison@test.com |
 
   Scenario Outline: A deputy that belongs to an Organisation edits their details
-    Given I am logged in as "<email>" with password "Abcd1234"
+    Given I am logged in as "<email>" with password "DigidepsPass1234"
     And I view the org deputy edit your details page
     And the following fields should have the corresponding values:
       | profile_firstname        | <first_name>         |
@@ -111,7 +111,7 @@ Feature: A deputy user edits their details
       | profile_email            | <new_email>    |
     And I press "profile_save"
     Then the form should be valid
-    When I am logged in as "<new_email>" with password "Abcd1234"
+    When I am logged in as "<new_email>" with password "DigidepsPass1234"
     And I view the org deputy edit your details page
     And the following fields should have the corresponding values:
       | profile_firstname        | Max            |
@@ -130,55 +130,55 @@ Feature: A deputy user edits their details
       | m.sanderson@test.com | e.binx@test.com | Mary       | Sanderson |
 
   Scenario: A deputy changes their password
-    Given I am logged in as "b.butcherson@test.com" with password "Abcd1234"
+    Given I am logged in as "b.butcherson@test.com" with password "DigidepsPass1234"
     And I view the lay deputy change password page
         # wrong old password
     When I fill in "change_password_current_password" with "this.is.the.wrong.password"
     And I press "change_password_save"
     Then the following fields should have an error:
       | change_password_current_password |
-      | change_password_plain_password_first |
+      | change_password_password_first |
         # invalid new password
     When I fill in the following:
-      | change_password_current_password | Abcd1234 |
-      | change_password_plain_password_first | 1 |
-      | change_password_plain_password_second | 2 |
+      | change_password_current_password | DigidepsPass1234 |
+      | change_password_password_first | 1 |
+      | change_password_password_second | 2 |
     And I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first |
+      | change_password_password_first |
         # unmatching new passwords
     When I fill in the following:
-      | change_password_current_password | Abcd1234 |
-      | change_password_plain_password_first | Abcd1234 |
-      | change_password_plain_password_second | Abcd12345 |
+      | change_password_current_password | DigidepsPass1234 |
+      | change_password_password_first | DigidepsPass1234 |
+      | change_password_password_second | DigidepsPass12345 |
     And I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first |
+      | change_password_password_first |
         #empty password
     When I fill in the following:
-      | change_password_current_password | Abcd1234 |
-      | change_password_plain_password_first | |
-      | change_password_plain_password_second | |
+      | change_password_current_password | DigidepsPass1234 |
+      | change_password_password_first | |
+      | change_password_password_second | |
     And I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first |
+      | change_password_password_first |
       #too common password
     When I fill in the following:
-      | change_password_current_password | Abcd1234 |
-      | change_password_plain_password_first | Password123 |
-      | change_password_plain_password_second | Password123 |
+      | change_password_current_password | DigidepsPass1234 |
+      | change_password_password_first | Password123 |
+      | change_password_password_second | Password123 |
     And I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first |
+      | change_password_password_first |
       # valid new password
     When I fill in the following:
-      | change_password_current_password | Abcd1234 |
-      | change_password_plain_password_first | Abcd12345 |
-      | change_password_plain_password_second | Abcd12345 |
+      | change_password_current_password | DigidepsPass1234 |
+      | change_password_password_first | DigidepsPass12345 |
+      | change_password_password_second | DigidepsPass12345 |
     And I press "change_password_save"
     Then the form should be valid
     And I should be on "/login"
     And I should see "Sign in with your new password"
         # restore old password (and assert the current password can be used as old password)
-    When I am logged in as "b.butcherson@test.com" with password "Abcd12345"
+    When I am logged in as "b.butcherson@test.com" with password "DigidepsPass12345"
     Then the response status code should be 200

--- a/behat/tests/features-v2/report-syncing/document-synchronisation.feature
+++ b/behat/tests/features-v2/report-syncing/document-synchronisation.feature
@@ -20,7 +20,7 @@ Feature: Synchronising Documents with Sirius
     And the report has been completed
     And I attached a supporting document "test-image.png" to the completed report
     And I submit the report
-    And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I view the submissions page
     And I click on "tab-pending"
     Then I should see "<case_number>"
@@ -39,7 +39,7 @@ Feature: Synchronising Documents with Sirius
     Given I have the "2018" to "2019" report between "DeputyDocsC" and "34343434"
     And the report has been completed
     And I submit the report
-    And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I view the submissions page
     And I click on "tab-pending"
     Then I should see "34343434"
@@ -47,9 +47,9 @@ Feature: Synchronising Documents with Sirius
 
     Scenario Outline: Submitting supporting documents after a report submission sets the synchronisation status to queued
       Given I have the "2018" to "2019" report between "<deputy>" and "<case_number>"
-      Given I am logged in as "<emailAddress>" with password "Abcd1234"
+      Given I am logged in as "<emailAddress>" with password "DigidepsPass1234"
       And I attached a supporting document "test-image.png" to the submitted report
-      And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+      And I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
       When I view the submissions page
       And I click on "tab-pending"
       Then I should see "<case_number>"
@@ -64,7 +64,7 @@ Feature: Synchronising Documents with Sirius
         | 78787878    | DeputyDocsG@behat-test.com | DeputyDocsG |
 
   Scenario: Running the document-sync command syncs queued Report PDF documents with Sirius
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I run the document-sync command
     When I view the submissions page
     And I click on "tab-pending"
@@ -73,7 +73,7 @@ Feature: Synchronising Documents with Sirius
     And the document "test-image.png" should be queued
 
   Scenario: Running the document-sync command syncs queued supporting documents with Sirius when the related report PDF document has been synced
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I run the document-sync command
     When I view the submissions page
     And I click on "tab-archived"

--- a/behat/tests/features-v2/reporting/preview/preview-report.feature
+++ b/behat/tests/features-v2/reporting/preview/preview-report.feature
@@ -9,7 +9,7 @@ Feature: Preview a summary of the report
       | 48520098 | Deputy127 | LAY         | Property and Financial Affairs High Assets | 2018-01-30 |
 
   Scenario: Accessing the report preview for an active report
-    Given I am logged in as "deputy127@behat-test.com" with password "Abcd1234"
+    Given I am logged in as "deputy127@behat-test.com" with password "DigidepsPass1234"
     And I am viewing the "2018" to "2019" report for "48520098"
     When I follow "edit-report-preview"
     Then the response status code should be 200
@@ -20,9 +20,8 @@ Feature: Preview a summary of the report
     And a case manager makes the following changes to the report:
       | incompleteSection     |
       | Any other information |
-    When I am logged in as "deputy127@behat-test.com" with password "Abcd1234"
+    When I am logged in as "deputy127@behat-test.com" with password "DigidepsPass1234"
     And I am viewing the "2018" to "2019" report for "48520098"
     When I check "confirmReview"
     And I follow "edit-report-review"
     Then the response status code should be 200
-

--- a/behat/tests/features/UserManagement/editingUserDetails.admin.feature
+++ b/behat/tests/features/UserManagement/editingUserDetails.admin.feature
@@ -4,14 +4,14 @@ Feature: Editing Deputy details as an admin user
   I need to view and edit details about each deputy
 
   Scenario: Create user for editing
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And the following users exist:
       | ndr      | deputyType | firstName | lastName    | email                   | postCode | activated |
       | disabled | LAY        | Jenny     | Ferguson    | jenny.ferguson@test.com | HA4      | true      |
       | disabled | LAY        | Tom       | Aikens      | tom.aikens@test.com     | HA9      | true      |
 
   Scenario: Super admin user edits a deputy
-    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "user-jennyfergusontestcom"
     Then the following fields should have the corresponding values:
       | admin_firstname       | Jenny                   |
@@ -44,7 +44,7 @@ Feature: Editing Deputy details as an admin user
       | admin_addressPostcode | LN3                  |
 
   Scenario: Regular admin user edits a deputy
-    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "user-tomaikenstestcom"
     Then I should not see "tom.aikens@test.com"
     And the following fields should have the corresponding values:
@@ -71,5 +71,3 @@ Feature: Editing Deputy details as an admin user
       | admin_firstname       | Paula                |
       | admin_lastname        | Jones                |
       | admin_addressPostcode | LN3                  |
-
-

--- a/behat/tests/features/admin/01-admin.feature
+++ b/behat/tests/features/admin/01-admin.feature
@@ -1,13 +1,13 @@
 Feature: admin / admin
   @infra
   Scenario: login as admin
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should be on "/admin/"
 
   Scenario: login and add admin user
     Given I am on admin page "/"
     Then I should be on "/login"
-    And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     Given I am on admin page "/"
     Then I should be on "/admin/"
     And I create a new "NDR-disabled" "Admin" user "John" "Doe" with email "behat-admin-user@publicguardian.gov.uk" and postcode "AB12CD"
@@ -15,27 +15,27 @@ Feature: admin / admin
     And the response status code should be 200
 
   Scenario: login and add user (admin)
-    When I activate the admin user "behat-admin-user@publicguardian.gov.uk" with password "Abcd1234"
+    When I activate the admin user "behat-admin-user@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should not see an "#error-summary" element
     And I should be on "/login"
     And I should see "Sign in to your new account"
 
   Scenario: Admins cannot add super admins
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I follow "Add new user"
     And I fill in "admin_roleType_1" with "staff"
     Then I should see "Admin"
     And I should not see "Super admin"
 
   Scenario: Super admins can add super admins
-    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I follow "Add new user"
     And I fill in "admin_roleType_1" with "staff"
     Then I should see "Admin"
     And I should see "Super admin"
 
   Scenario: login and add NDR enabled lay user with co-deputy
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I create a new "NDR-enabled" "Lay Deputy" user "Joe" "Bloggs" with email "joe.bloggs@publicguardian.gov.uk" and postcode "SW1"
     Then I should see "joe.bloggs@publicguardian.gov.uk" in the "users" region
     And the response status code should be 200
@@ -43,9 +43,9 @@ Feature: admin / admin
       | Case     | Surname | Deputy No | Dep Surname | Dep Postcode | Typeofrep |
       | 12345XYZ | Smith   | D003      | Bloggs      | SW1          | OPG102    |
       | 12345XYZ | Smith   | D004      | Doe         | SW1          | OPG102    |
-    When I activate the user "joe.bloggs@publicguardian.gov.uk" with password "Abcd1234"
+    When I activate the user "joe.bloggs@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I go to "logout"
-    Given I am logged in as "joe.bloggs@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "joe.bloggs@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then the url should match "/user/details"
     When I fill in the following:
       | user_details_firstname       | Joe                              |
@@ -72,7 +72,7 @@ Feature: admin / admin
     And I should see the "invite-codeputy-button" link
 
   Scenario: Can follow links to lay upload page
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I am on admin page "/admin"
     And I follow "Upload users"
     And I fill in "form_type_0" with "lay"
@@ -80,7 +80,7 @@ Feature: admin / admin
     Then I should be on "/admin/casrec-upload"
 
   Scenario: Can follow links to org upload page
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I am on admin page "/admin"
     And I follow "Upload users"
     And I fill in "form_type_1" with "org"
@@ -88,7 +88,7 @@ Feature: admin / admin
     Then I should be on "/admin/org-csv-upload"
 
   Scenario: Report submissions CSV download No dates
-    Given I am logged in to admin as "behat-admin-user@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "behat-admin-user@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I go to admin page "/admin/stats"
     And I click on "submit-and-download"
     And the response status code should be 200
@@ -97,7 +97,7 @@ Feature: admin / admin
     And the response should have the "Content-Disposition" header containing ".dat"
 
   Scenario Outline: Downloading Report Submissions with start and end dates
-    Given I am logged in to admin as "behat-admin-user@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "behat-admin-user@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I go to admin page "/admin/stats"
     And I fill in "admin_startDate_day" with "<from_day>"
     And I fill in "admin_startDate_month" with "<from_month>"
@@ -115,7 +115,7 @@ Feature: admin / admin
       | 12       | 12         | 2018      | 13     | 12       | 2018    |
 
   Scenario: Attempting to download Report Submissions with an end date earlier than the start date
-    Given I am logged in to admin as "behat-admin-user@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "behat-admin-user@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I go to admin page "/admin/stats"
     And I fill in "admin_startDate_day" with "12"
     And I fill in "admin_startDate_month" with "12"
@@ -127,7 +127,7 @@ Feature: admin / admin
     Then I should see "Check the end date: it cannot be before the start date"
 
   Scenario: Can access metrics and set a period
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I go to admin page "/admin/stats/metrics"
     Then the response status code should be 200
     When I fill in "admin_period_1" with "this-year"
@@ -135,7 +135,7 @@ Feature: admin / admin
     Then the response status code should be 200
 
   Scenario: change user password on admin area
-    Given I am logged in to admin as "behat-admin-user@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "behat-admin-user@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "user-account"
     Then the response status code should be 200
     And I click on "password-edit"
@@ -145,55 +145,55 @@ Feature: admin / admin
     And I press "change_password_save"
     Then the following fields should have an error:
       | change_password_current_password     |
-      | change_password_plain_password_first |
+      | change_password_password_first |
     # invalid new password
     When I fill in the following:
-      | change_password_current_password      | Abcd1234 |
-      | change_password_plain_password_first  | 1        |
-      | change_password_plain_password_second | 2        |
+      | change_password_current_password      | DigidepsPass1234 |
+      | change_password_password_first  | 1        |
+      | change_password_password_second | 2        |
     And I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first |
+      | change_password_password_first |
     # unmatching new passwords
     When I fill in the following:
-      | change_password_current_password      | Abcd1234  |
-      | change_password_plain_password_first  | Abcd1234  |
-      | change_password_plain_password_second | Abcd12345 |
+      | change_password_current_password      | DigidepsPass1234  |
+      | change_password_password_first  | DigidepsPass1234  |
+      | change_password_password_second | DigidepsPass12345 |
     And I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first |
+      | change_password_password_first |
     #empty password
     When I fill in the following:
-      | change_password_current_password      | Abcd1234 |
-      | change_password_plain_password_first  |          |
-      | change_password_plain_password_second |          |
+      | change_password_current_password      | DigidepsPass1234 |
+      | change_password_password_first  |          |
+      | change_password_password_second |          |
     And I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first |
+      | change_password_password_first |
     # too common password
     When I fill in the following:
-      | change_password_current_password      | Abcd1234 |
-      | change_password_plain_password_first  | Password123 |
-      | change_password_plain_password_second | Password123 |
+      | change_password_current_password      | DigidepsPass1234 |
+      | change_password_password_first  | Password123 |
+      | change_password_password_second | Password123 |
     And I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first |
+      | change_password_password_first |
     # valid new password
     When I fill in the following:
-      | change_password_current_password      | Abcd1234  |
-      | change_password_plain_password_first  | Abcd12345 |
-      | change_password_plain_password_second | Abcd12345 |
+      | change_password_current_password      | DigidepsPass1234  |
+      | change_password_password_first  | DigidepsPass12345 |
+      | change_password_password_second | DigidepsPass12345 |
     And I press "change_password_save"
     Then the form should be valid
     And I should be on "/login"
     And I should see "Sign in with your new password"
       # restore old password (and assert the current password can be used as old password)
-    When I am logged in to admin as "behat-admin-user@publicguardian.gov.uk" with password "Abcd12345"
+    When I am logged in to admin as "behat-admin-user@publicguardian.gov.uk" with password "DigidepsPass12345"
     And I click on "user-account, password-edit"
     And I fill in the following:
-      | change_password_current_password      | Abcd12345 |
-      | change_password_plain_password_first  | Abcd1234! |
-      | change_password_plain_password_second | Abcd1234! |
+      | change_password_current_password      | DigidepsPass12345 |
+      | change_password_password_first  | DigidepsPass1234! |
+      | change_password_password_second | DigidepsPass1234! |
     And I press "change_password_save"
     Then the form should be valid
 
@@ -203,7 +203,7 @@ Feature: admin / admin
     And I go to "/login"
     Then I should not see the "service-notification-behat" region
     # go to admin page
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I am on admin page "/admin/settings/service-notification"
     Then the following fields should have the corresponding values:
       | setting_content   |  |

--- a/behat/tests/features/admin/02-cross-checks.feature
+++ b/behat/tests/features/admin/02-cross-checks.feature
@@ -3,14 +3,14 @@ Feature: admin / acl
 
     Scenario: An admin user cannot login into deputy area
         # check admin can login into admin site. Password previously changed.
-        Given I am logged in to admin as "behat-admin-user@publicguardian.gov.uk" with password "Abcd1234!"
+        Given I am logged in to admin as "behat-admin-user@publicguardian.gov.uk" with password "DigidepsPass1234!"
         #Then the response status code should be 200
         # check admin CANNOT login into DEPUTY site
         Given I go to "/logout"
         And  I go to "/login"
         When I fill in the following:
             | login_email     | behat-admin-user@publicguardian.gov.uk |
-            | login_password  | Abcd1234! |
+            | login_password  | DigidepsPass1234! |
         And I click on "login"
         Then I should see an "#error-summary" element
         And I should be on "/login"

--- a/behat/tests/features/admin/03-ad.feature
+++ b/behat/tests/features/admin/03-ad.feature
@@ -2,7 +2,7 @@ Feature: admin / AD
 
   @ad
   Scenario: Add new assisted Lay and login on behalf
-    Given I am logged in to admin as "behat-ad@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "behat-ad@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should be on "/ad/"
     # add assisted Lay
     When I press "ad_save"
@@ -27,11 +27,11 @@ Feature: admin / AD
 
   @ad
   Scenario: Login on behalf of a newly created (not activated) Lay deputy
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And the following users exist:
       | ndr | deputyType | firstName | lastName | email | postCode | activated |
       | enabled | LAY | Assis | Ted | behat-lay-assisted@publicguardian.gov.uk | HA4 | false |
-    Given I am logged in to admin as "behat-ad@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "behat-ad@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I am on admin page "/admin"
     And I click on "view" in the "user-behat-lay-assistedpublicguardiangovuk" region
     And I click on "login-as"

--- a/behat/tests/features/admin/04-client-details.feature
+++ b/behat/tests/features/admin/04-client-details.feature
@@ -2,12 +2,12 @@
 Feature: Client details
 
   Scenario: Client information contains report type
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I visit the client page for "102-4-6"
     Then I should see "OPG102-4-6" in the "report-2016-to-2017" region
 
   Scenario: Client details contain named deputy information
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I visit the client page for "102-4-6"
     Then I should see "Named Deputy 102-4-6"
     And I should see "Victoria Road" in the "deputy-details" region
@@ -17,7 +17,7 @@ Feature: Client details
     And I should see "behat-nd-102-4-6@publicguardian.gov.uk" in the "deputy-details" region
 
   Scenario: Lay client details contain named deputy information
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I visit the client page for "103"
     Then I should see "Lay Deputy 103"
     And I should see "Victoria Road" in the "deputy-details" region

--- a/behat/tests/features/admin/05-ndr-enablement.feature
+++ b/behat/tests/features/admin/05-ndr-enablement.feature
@@ -1,13 +1,13 @@
 Feature: Enabling and disabling NDR for Lay deputies
 
   Scenario: Enabling and disabling NDR from admin toggles the availability of the NDR and Report accordingly
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    And there is an activated "Lay Deputy" user with NDR "disabled" and email "red-squirrel@publicguardian.gov.uk" and password "Abcd1234"
-    And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
+    And there is an activated "Lay Deputy" user with NDR "disabled" and email "red-squirrel@publicguardian.gov.uk" and password "DigidepsPass1234"
+    And I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
 
     # Enabling NDR makes NDR available and disables the Report
     When I "enable" NDR for user "red-squirrelpublicguardiangovuk"
-    And I am logged in as "red-squirrel@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "red-squirrel@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should see "Start now" in the "ndr-card" region
     And I should see "Not available" in the "report-card" region
     # (Store the NDR URL to retrieve for upcoming test)
@@ -15,15 +15,15 @@ Feature: Enabling and disabling NDR for Lay deputies
     Then I save the report as "red-squirrel-ndr"
 
     # Disabling NDR makes NDR unavailable and enables the Report
-    When I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    When I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I "disable" NDR for user "red-squirrelpublicguardiangovuk"
-    And I am logged in as "red-squirrel@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "red-squirrel@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should see "Start now" in the "report-active" region
 
     # Re-enabling NDR retrieves the previous NDR (instead of creating a new one)
-    When I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    When I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I "enable" NDR for user "red-squirrelpublicguardiangovuk"
-    And I am logged in as "red-squirrel@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "red-squirrel@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should see "Start now" in the "ndr-card" region
     And I should see "Not available" in the "report-card" region
     When I go to the report URL "overview" for "red-squirrel-ndr"

--- a/behat/tests/features/admin/06-organisations.feature
+++ b/behat/tests/features/admin/06-organisations.feature
@@ -2,14 +2,14 @@ Feature: Administration of organisations
 
   @admin
   Scenario: Navbar works
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should see "Organisations" in the "navbar" region
     When I click on "admin-organisations" in the "navbar" region
     Then I should be on "/admin/organisations/"
 
   @admin
   Scenario: Admin can create organisation
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I am on admin page "/admin/organisations"
     When I follow "Add a new organisation"
     Then I should be on "/admin/organisations/add"
@@ -32,7 +32,7 @@ Feature: Administration of organisations
 
   @admin
   Scenario: Admin can choose email identifier when creating an organisation
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I am on admin page "/admin/organisations/add"
     # Check domain value is not carried across
     When I fill in "organisation_emailIdentifierType_0" with "domain"
@@ -52,7 +52,7 @@ Feature: Administration of organisations
 
   @admin
   Scenario: API errors are reported back to user
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I am on admin page "/admin/organisations/add"
     And I fill in "organisation_name" with "Duplicate organisation"
     And I fill in "organisation_isActivated_0" with "0"
@@ -63,7 +63,7 @@ Feature: Administration of organisations
 
   @admin
   Scenario: Organisations cannot be created as known public email domains
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I am on admin page "/admin/organisations/add"
     And I fill in "organisation_name" with "Gmail organisation"
     And I fill in "organisation_isActivated_0" with "0"
@@ -77,7 +77,7 @@ Feature: Administration of organisations
 
   @admin
   Scenario: Admin can edit an organisation's name and activate them
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I am on admin page "/admin/organisations"
     When I click on "edit" in the "org-email-address-owning-organisation" region
     # Data should be prefilled
@@ -95,13 +95,13 @@ Feature: Administration of organisations
 
   @admin
   Scenario: Admin cannot delete an organisation
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I am on admin page "/admin/organisations"
     Then I should not see "Remove" in the "org-somesolicitorsorg" region
 
   @admin
   Scenario: Super admin can delete an organisation
-    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I am on admin page "/admin/organisations"
     When I click on "delete" in the "org-somesolicitorsorg" region
     Then I should see "Are you sure you want to remove this organisation?"

--- a/behat/tests/features/admin/07-organisation-membership.feature
+++ b/behat/tests/features/admin/07-organisation-membership.feature
@@ -1,7 +1,7 @@
 Feature: Organisation membership
 
   Scenario: Set up organisation fixture
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And the following users exist:
       | ndr | deputyType | firstName | lastName | email | postCode |
       | disabled | PROF | Main | ERZ Contact | main.contact@erz.example | HA4 |
@@ -16,7 +16,7 @@ Feature: Organisation membership
 
   @admin
   Scenario: Admin can add members to an organisation
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I am on admin page "/admin/organisations"
     And I follow "ERZ Solicitors"
     When I follow "Add user"
@@ -31,7 +31,7 @@ Feature: Organisation membership
 
   @admin
   Scenario: Admin cannot add non-registered users to an organisation
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I am on admin page "/admin/organisations"
     And I follow "ERZ Solicitors"
     And I follow "Add user"
@@ -41,7 +41,7 @@ Feature: Organisation membership
 
   @admin
   Scenario: Admin cannot add lay or admin users to an organisation
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I am on admin page "/admin/organisations"
     And I follow "ERZ Solicitors"
     And I follow "Add user"
@@ -51,7 +51,7 @@ Feature: Organisation membership
 
   @admin
   Scenario: Admin cannot add duplicate users to an organisation
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I am on admin page "/admin/organisations"
     And I follow "ERZ Solicitors"
     And I follow "Add user"
@@ -64,7 +64,7 @@ Feature: Organisation membership
 
   @admin
   Scenario: Public domains: Admin can add users from different domains
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And the following users exist:
       | ndr | deputyType | firstName | lastName | email | postCode |
       | disabled | PROF | Rana | Kossak | rana.kossak@example.com | HA4 |
@@ -79,7 +79,7 @@ Feature: Organisation membership
 
   @admin
   Scenario: Public domains: Admin can add initial user to a public domain organisation
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I am on admin page "/admin/organisations"
     And I follow "jo.brown@example.com"
     And I follow "Add user"
@@ -94,7 +94,7 @@ Feature: Organisation membership
 
   @admin
   Scenario: Public domains: Admin can add additional users to a public domain organisation
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I am on admin page "/admin/organisations"
     And I follow "jo.brown@example.com"
     And I follow "Add user"
@@ -106,7 +106,7 @@ Feature: Organisation membership
 
   @admin
   Scenario: Admin can remove users from an organisation
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I am on admin page "/admin/organisations"
     And I follow "ERZ Solicitors"
     When I click on "delete" in the "org-main-erz-contact" region

--- a/behat/tests/features/admin/08-deputy-search.feature
+++ b/behat/tests/features/admin/08-deputy-search.feature
@@ -1,14 +1,14 @@
 Feature: Deputy search
   @admin @admin-search @deputy-search
   Scenario: Search broadly across all deputy roles, excluding clients
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I search in admin for a deputy with the term "User-2"
     Then I should see "User-2"
     And I should see "Found 1 users"
 
   @admin @admin-search @deputy-search
   Scenario: Search broadly across deputy by a role, excluding clients
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I search in admin for a deputy with the term "Manager1" and filter role by "Public Authority deputies (named)"
     Then I should see "Found 0 users"
     When I search in admin for a deputy with the term "Manager1" and filter role by "Admin"
@@ -17,7 +17,7 @@ Feature: Deputy search
 
   @admin @admin-search @deputy-search
   Scenario: Search broadly across all deputy roles, including clients
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I search in admin for a deputy with the term "103-client"
     Then I should see "Found 0 users"
     And I should not see "LAY Deputy 103 User"
@@ -27,20 +27,20 @@ Feature: Deputy search
 
   @admin@admin-search  @deputy-search
   Scenario: Search broadly across deputy by a role, including clients
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I search in admin for a deputy with the term "103-6-client" and filter role by "Public Authority deputies (named)" and include clients
     Then I should see "Found 1 users"
 
   @admin @admin-search @deputy-search
   Scenario: Search exact name match across all deputy roles, excluding clients
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I search in admin for a deputy with the term "Admin User"
     Then I should see "admin user"
     And I should see "Found 1 users"
 
   @admin @admin-search @deputy-search
   Scenario: Search exact name match across all deputy roles, including clients
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I search in admin for a deputy with the term "john 104-client"
     Then I should see "Found 0 users"
     When I search in admin for a deputy with the term "john 104-client" and include clients
@@ -49,7 +49,7 @@ Feature: Deputy search
 
   @admin @admin-search @deputy-search
   Scenario: Search exact name match across a specific deputy role
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I search in admin for a deputy with the term "Admin User" and filter role by "Public Authority deputies (named)"
     Then I should see "Found 0 users"
     When I search in admin for a deputy with the term "Admin User" and filter role by "Admin"

--- a/behat/tests/features/admin/09-client-search.feature
+++ b/behat/tests/features/admin/09-client-search.feature
@@ -1,7 +1,7 @@
 Feature: Client search
   @admin @admin-search @client-search
   Scenario: Search broadly across clients by firstname or lastname
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I search in admin for a client with the term "Johnny"
     Then I should see "Found 0 clients"
     When I search in admin for a client with the term "Joh"
@@ -13,9 +13,8 @@ Feature: Client search
 
   @admin @admin-search @client-search
   Scenario: Search exact name match across clients
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I search in admin for a client with the term "John 102-4-"
     Then I should see "Found 0 clients"
     And I search in admin for a client with the term "John 102-4-client"
     Then I should see "Found 1 clients"
-

--- a/behat/tests/features/admin/10-user-management.feature
+++ b/behat/tests/features/admin/10-user-management.feature
@@ -2,14 +2,14 @@ Feature: User management
 
   @admin @user-management
   Scenario: Admin user views the edit page of a Lay Deputy
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "user-behat-lay-deputy-102publicguardiangovuk"
     Then the response status code should be 200
     And I should see "Clients and reports"
 
   @admin @user-management
   Scenario: Admin user views the edit page of a Deputy in an organisation
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And "behat-pa-deputy-103-4-6@publicguardian.gov.uk" has been added to the "abc-solicitors.example.com" organisation
     And "behat-pa-deputy-103-4-6@publicguardian.gov.uk" has been added to the "some.example.com" organisation
     And the organisation "abc-solicitors.example.com" is active
@@ -27,7 +27,7 @@ Feature: User management
 
   @admin @user-management
   Scenario: Admin user views the edit page of a non lay Deputy who is not in an organisation
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And "behat-pa-deputy-103-4-6@publicguardian.gov.uk" has been removed from the "abc-solicitors.example.com" organisation
     And "behat-pa-deputy-103-4-6@publicguardian.gov.uk" has been removed from the "some.example.com" organisation
     And I click on "user-behat-pa-deputy-103-4-6publicguardiangovuk"

--- a/behat/tests/features/deputy/01-registration-steps/01-create-users.feature
+++ b/behat/tests/features/deputy/01-registration-steps/01-create-users.feature
@@ -13,14 +13,14 @@ Feature: deputy / user / add user
       # test user email in caps
     When I fill in the following:
       | login_email    | admin@publicguardian.gov.uk |
-      | login_password | Abcd1234                        |
+      | login_password | DigidepsPass1234                        |
     And I click on "login"
     Then I should see "admin@publicguardian.gov.uk" in the "users" region
     Given I go to "/logout"
       # test right credentials
     When I fill in the following:
       | login_email    | admin@publicguardian.gov.uk |
-      | login_password | Abcd1234                        |
+      | login_password | DigidepsPass1234                        |
     And I click on "login"
       #When I go to "/admin"
     Then I am on admin page "/admin"
@@ -45,7 +45,7 @@ Feature: deputy / user / add user
 
   @ndr
   Scenario: add deputy user (ndr)
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
       # assert form OK
     When I create a new "NDR-enabled" "Lay Deputy" user "John NDR" "Doe NDR" with email "behat-user-ndr@publicguardian.gov.uk" and postcode "AB12CD"
     Then I should see "behat-user-ndr@publicguardian.gov.uk" in the "users" region

--- a/behat/tests/features/deputy/01-registration-steps/02-set-password.feature
+++ b/behat/tests/features/deputy/01-registration-steps/02-set-password.feature
@@ -11,33 +11,43 @@ Feature: deputy / user / set password
         Then the form should be invalid
         #password mismatch
         When I fill in the following:
-            | set_password_password_first   | Abcd1234 |
-            | set_password_password_second  | Abcd12345 |
+            | set_password_password_first   | DigidepsPass1234 |
+            | set_password_password_second  | DigidepsPass12345 |
+        And I check "set_password_showTermsAndConditions"
+        And I press "set_password_save"
+        Then the form should be invalid
+        # not long enough
+        When I fill in the password fields with "Digideps1234"
         And I check "set_password_showTermsAndConditions"
         And I press "set_password_save"
         Then the form should be invalid
         # nolowercase
-        When I fill in the password fields with "ABCD1234"
+        When I fill in the password fields with "DIGIDEPSPASS1234"
         And I check "set_password_showTermsAndConditions"
         And I press "set_password_save"
         Then the form should be invalid
         # nouppercase
-        When I fill in the password fields with "abcd1234"
+        When I fill in the password fields with "digidepspass1234"
         And I check "set_password_showTermsAndConditions"
         And I press "set_password_save"
         Then the form should be invalid
         # no number
-        When I fill in the password fields with "Abcdefgh"
+        When I fill in the password fields with "DigidepsPassword"
         And I check "set_password_showTermsAndConditions"
         And I press "set_password_save"
         Then the form should be invalid
         # not agreed on TC
-        When I fill in the password fields with "Abcd1234"
+        When I fill in the password fields with "DigidepsPass1234"
         And I uncheck "set_password_showTermsAndConditions"
         And I press "set_password_save"
         Then the form should be invalid
+        # too common password
+        When I fill in the password fields with "Password123"
+        And I check "set_password_showTermsAndConditions"
+        And I press "set_password_save"
+        Then the form should be invalid
         # correct !!
-        When I fill in the password fields with "Abcd1234"
+        When I fill in the password fields with "DigidepsPass1234"
         And I check "set_password_showTermsAndConditions"
         And I press "set_password_save"
         Then the form should be valid
@@ -45,18 +55,18 @@ Feature: deputy / user / set password
         And I should see "Sign in to your new account"
         When I fill in the following:
             | login_email     | behat-user@publicguardian.gov.uk |
-            | login_password  | Abcd1234 |
+            | login_password  | DigidepsPass1234 |
         And I press "login_login"
         Then I should not see an "#error-summary" element
 
     @ndr
     Scenario: login and add user (deputy ndr)
-        When I activate the user "behat-user-ndr@publicguardian.gov.uk" with password "Abcd1234"
+        When I activate the user "behat-user-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
         # test login
         And I go to "logout"
         And I go to "/login"
         And I fill in the following:
             | login_email     | behat-user-ndr@publicguardian.gov.uk |
-            | login_password  | Abcd1234 |
+            | login_password  | DigidepsPass1234 |
         And I press "login_login"
         Then I should not see an "#error-summary" element

--- a/behat/tests/features/deputy/01-registration-steps/03-add-user-details.feature
+++ b/behat/tests/features/deputy/01-registration-steps/03-add-user-details.feature
@@ -2,7 +2,7 @@ Feature: deputy / user / add details
 
   @deputy
   Scenario: add user details (deputy)
-    Given I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-user@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should be on "/user/details"
       # wrong form
     Then the following hidden fields should have the corresponding values:
@@ -50,7 +50,7 @@ Feature: deputy / user / add details
 
   @ndr
   Scenario: add user details (deputy ndr)
-    Given I am logged in as "behat-user-ndr@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-user-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should be on "/user/details"
     When I set the user details to:
       | name    | John NDR         | Doe NDR       |        |          |    |
@@ -68,6 +68,3 @@ Feature: deputy / user / add details
       | user_details_addressCountry   | GB               |
       | user_details_phoneMain        | 020 3334 3555    |
       | user_details_phoneAlternative | 020 1234 5678    |
-
-    
-        

--- a/behat/tests/features/deputy/01-registration-steps/04-add-client-and-report.feature
+++ b/behat/tests/features/deputy/01-registration-steps/04-add-client-and-report.feature
@@ -2,7 +2,7 @@ Feature: deputy / user / add client and report
 
   @deputy
   Scenario: update client (client name/case number/postcode already set)
-    Given I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-user@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should be on "client/add"
     # submit empty form and check errors
     Then the following hidden fields should have the corresponding values:
@@ -62,7 +62,7 @@ Feature: deputy / user / add client and report
 
   @ndr
   Scenario: add client (ndr) with no casrec record
-    Given I am logged in as "behat-user-ndr@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-user-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should be on "client/add"
       # right values
     When I set the client details with:
@@ -80,7 +80,7 @@ Feature: deputy / user / add client and report
     Given I add the following users to CASREC:
       | Case     | Surname       | Deputy No | Dep Surname  | Dep Postcode | Typeofrep |
       | 33333333 | Hent3          | D003      | Doe NDR      | p0stc0d3      | OPG102    |
-    And I am logged in as "behat-user-ndr@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-user-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should be on "client/add"
       # right values
     When I set the client details with:
@@ -94,14 +94,14 @@ Feature: deputy / user / add client and report
 
   @ndr
   Scenario: New NDR report shown in admin panel
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I visit the client page for "33333333"
     Then the URL should match "/admin/client/\d+/details"
     And I should see the "report-ndr" region in the "report-group-active" region
 
   @deputy
   Scenario: create report
-    Given I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-user@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then the URL should match "report/create/\d+"
       # missing D,M,Y
     When I fill in the following:
@@ -161,13 +161,13 @@ Feature: deputy / user / add client and report
 
   @deputy
   Scenario: report-overview
-    Given I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-user@publicguardian.gov.uk" with password "DigidepsPass1234"
     Given I click on "report-start"
     Then the URL should match "report/\d+/overview"
 
   @deputy
   Scenario: report-overview links
-    Given I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-user@publicguardian.gov.uk" with password "DigidepsPass1234"
     #Lay deputy links
     Then I should see the "user-account" link
     And I should see the "reports" link

--- a/behat/tests/features/deputy/02-ndr/01-visits-care.feature
+++ b/behat/tests/features/deputy/02-ndr/01-visits-care.feature
@@ -2,13 +2,13 @@ Feature: NDR visits care
 
   @ndr
   Scenario: absence of co-deputies section for a client without multiple assigned deputies
-    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then the URL should match "/ndr"
     And I should not see the "codeputies" region
 
   @ndr
   Scenario: NDR visits care
-    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "ndr-start, edit-visits_care, start"
       # step 1 empty
     And the step cannot be submitted without making a selection

--- a/behat/tests/features/deputy/02-ndr/02-expenses.feature
+++ b/behat/tests/features/deputy/02-ndr/02-expenses.feature
@@ -2,7 +2,7 @@ Feature: NDR expenses
 
   @ndr
   Scenario: NDR expenses
-    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "ndr-start, edit-deputy_expenses, start"
     # chose "no records"
     Given the step cannot be submitted without making a selection

--- a/behat/tests/features/deputy/02-ndr/03-income-benefits.feature
+++ b/behat/tests/features/deputy/02-ndr/03-income-benefits.feature
@@ -2,7 +2,7 @@ Feature: NDR income benefits
 
   @ndr
   Scenario: NDR income and benefits
-    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "ndr-start, edit-income_benefits, start"
     # State benefits: tick Housing benefit, Universal Credit
     And the step with the following values CANNOT be submitted:

--- a/behat/tests/features/deputy/02-ndr/04-account.feature
+++ b/behat/tests/features/deputy/02-ndr/04-account.feature
@@ -2,7 +2,7 @@ Feature: NDR/ account
 
   @ndr
   Scenario: NDR accounts
-    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "ndr-start, edit-bank_accounts, start"
   # step 1
     Then the step cannot be submitted without making a selection

--- a/behat/tests/features/deputy/02-ndr/05-assets.feature
+++ b/behat/tests/features/deputy/02-ndr/05-assets.feature
@@ -2,7 +2,7 @@ Feature: NDR assets
 
   @ndr
   Scenario: NDR assets
-    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "ndr-start, edit-assets, start"
       # chose "no records"
     Then the step cannot be submitted without making a selection
@@ -95,7 +95,7 @@ Feature: NDR assets
 
   @ndr
   Scenario: NDR asset property
-    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "ndr-start, edit-assets, add"
     And the step with the following values CAN be submitted:
       | ndr_asset_title_title_0 | Property |

--- a/behat/tests/features/deputy/02-ndr/06-debts.feature
+++ b/behat/tests/features/deputy/02-ndr/06-debts.feature
@@ -2,7 +2,7 @@ Feature: NDR debts
 
   @ndr
   Scenario: NDR debts
-    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "ndr-start, edit-debts, start"
     # chose "no records"
     Given the step cannot be submitted without making a selection
@@ -80,4 +80,3 @@ Feature: NDR debts
         # check record in summary page
     And each text should be present in the corresponding region:
       | 200 per month payment plan    | debt-management-details |
-

--- a/behat/tests/features/deputy/02-ndr/07-actions.feature
+++ b/behat/tests/features/deputy/02-ndr/07-actions.feature
@@ -2,7 +2,7 @@ Feature: NDR actions
 
   @ndr
   Scenario: NDR actions gifts
-    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "ndr-start, edit-actions, start"
        # gifts
     And the step cannot be submitted without making a selection

--- a/behat/tests/features/deputy/02-ndr/08-any-other-info.feature
+++ b/behat/tests/features/deputy/02-ndr/08-any-other-info.feature
@@ -2,7 +2,7 @@ Feature: NDR any other info
 
   @ndr
   Scenario: NDR any other info
-    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "ndr-start, edit-other_info, start"
      # step 1
     And the step cannot be submitted without making a selection

--- a/behat/tests/features/deputy/02-ndr/10-submit.feature
+++ b/behat/tests/features/deputy/02-ndr/10-submit.feature
@@ -2,7 +2,7 @@ Feature: ndr / report submit
 
     @ndr
     Scenario: NDR review page
-        Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
         # go to review page
         When I click on "ndr-start, ndr-submit"
         Then the URL should match "/ndr/\d+/review"
@@ -18,7 +18,7 @@ Feature: ndr / report submit
 
     @ndr
     Scenario: NDR declaration and submission
-        Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "ndr-start, ndr-submit, ndr-declaration-page"
         Then the URL should match "/ndr/\d+/declaration"
         #
@@ -63,7 +63,7 @@ Feature: ndr / report submit
 
     @ndr
     Scenario: admin area check submission ZIP file
-        Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "admin-documents"
         Then I should be on "/admin/documents/list"
         And I click on "tab-pending"
@@ -87,7 +87,7 @@ Feature: ndr / report submit
 
     @ndr
     Scenario: assert 2nd year report has been created
-        Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "report-start"
         Then I should see a "#edit-contacts" element
         And I should see a "#edit-decisions" element
@@ -115,7 +115,7 @@ Feature: ndr / report submit
 
     @ndr
     Scenario: NDR homepage and create new report
-        Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
         Then I should be on "/ndr"
         And I should see the "reports-history" region
         # edit report period

--- a/behat/tests/features/deputy/02-ndr/11-report-submission.feature
+++ b/behat/tests/features/deputy/02-ndr/11-report-submission.feature
@@ -2,7 +2,7 @@ Feature: Admin NDR submitted
 
   @ndr
   Scenario: Admin client search returns NDR client
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "admin-client-search, search_clients_search"
     Then each text should be present in the corresponding region:
     | Cly3 Hent3 | client-33333333 |
@@ -26,7 +26,7 @@ Feature: Admin NDR submitted
 
   @ndr
   Scenario: Admin client page shows NDR report complete
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I visit the client page for "ndr"
     Then I should see the "report-ndr" region in the "report-group-submitted" region
     And I should see "NDR" in the "report-ndr" region

--- a/behat/tests/features/deputy/03-report/01-102/01-report.feature
+++ b/behat/tests/features/deputy/03-report/01-102/01-report.feature
@@ -2,7 +2,7 @@ Feature: Report edit and test tabs
 
     @deputy
     Scenario: Initialise report
-        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     # valid values
         When I fill in the following:
             | report_startDate_day | 01 |
@@ -16,7 +16,7 @@ Feature: Report edit and test tabs
 
     @deputy
     Scenario: edit report dates
-        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "report-edit-period"
         Then the following fields should have the corresponding values:
             | report_edit_startDate_day | 01 |
@@ -48,7 +48,7 @@ Feature: Report edit and test tabs
             | report_edit_startDate_year | 2016 |
             | report_edit_endDate_day | 31 |
             | report_edit_endDate_month | 12 |
-            | report_edit_endDate_year | 2016 |    
+            | report_edit_endDate_year | 2016 |
         And I press "report_edit_save"
         Then the form should be valid
         # check values
@@ -64,7 +64,7 @@ Feature: Report edit and test tabs
 
     @deputy
     Scenario: test tabs for "Property and Affairs" report
-        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "report-start"
         Then I should see the "edit-decisions" link
         Then I should see the "edit-contacts" link
@@ -78,7 +78,7 @@ Feature: Report edit and test tabs
 
     @deputy
     Scenario: Check 102, 103 sections presence on overview page
-        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "report-start"
         # assert tabs
         And I should see the "edit-decisions" link

--- a/behat/tests/features/deputy/03-report/01-102/02-decisions.feature
+++ b/behat/tests/features/deputy/03-report/01-102/02-decisions.feature
@@ -2,7 +2,7 @@ Feature: Report decisions
 
     @deputy
     Scenario: decisions
-        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "report-start, edit-decisions, start"
         # step  mental capacity
         Then the step cannot be submitted without making a selection

--- a/behat/tests/features/deputy/03-report/01-102/03-contacts.feature
+++ b/behat/tests/features/deputy/03-report/01-102/03-contacts.feature
@@ -2,7 +2,7 @@ Feature: Report contacts
 
     @deputy
     Scenario: contacts
-        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "report-start, edit-contacts, start"
         # chose "no records"
         Given the step cannot be submitted without making a selection
@@ -86,5 +86,3 @@ Feature: Report contacts
             | France | contact-n2-aw2 |
             | my GP | contact-n2-aw2 |
             | he takes care of my health | contact-n2-aw2 |
-
-

--- a/behat/tests/features/deputy/03-report/01-102/06-visits-care.feature
+++ b/behat/tests/features/deputy/03-report/01-102/06-visits-care.feature
@@ -2,7 +2,7 @@ Feature: Report visits and care
 
   @deputy
   Scenario: visits and care steps
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start, edit-visits_care, start"
       # step 1 empty
     And the step cannot be submitted without making a selection

--- a/behat/tests/features/deputy/03-report/01-102/07-actions.feature
+++ b/behat/tests/features/deputy/03-report/01-102/07-actions.feature
@@ -2,7 +2,7 @@ Feature: Report actions
 
   @deputy
   Scenario: report actions
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start, edit-actions, start"
       # step 1
     And the step cannot be submitted without making a selection

--- a/behat/tests/features/deputy/03-report/01-102/08-documents.feature
+++ b/behat/tests/features/deputy/03-report/01-102/08-documents.feature
@@ -2,7 +2,7 @@ Feature: Report documents
 
   @deputy
   Scenario: No documents to attach
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start, edit-documents, start"
     # chose "no documents"
     Then the URL should match "report/\d+/documents/step/1"
@@ -16,7 +16,7 @@ Feature: Report documents
 
   @deputy
   Scenario: Upload PDF documents
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start, edit-documents"
     Then the URL should match "report/\d+/documents/summary"
     And I should see "Edit" in the "provided-documentation" region
@@ -65,7 +65,7 @@ Feature: Report documents
 
   @deputy
   Scenario: Delete document
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start, edit-documents"
     # chose "yes documents"
     Then the URL should match "report/\d+/documents/summary"
@@ -90,7 +90,7 @@ Feature: Report documents
 
   @deputy
   Scenario: Upload image documents
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "reports, report-start, edit-documents"
     Then the URL should match "report/\d+/documents/summary"
     And I should see "Edit" in the "provided-documentation" region
@@ -122,7 +122,7 @@ Feature: Report documents
 
   @deputy
     Scenario: Upload file1.pdf
-      Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+      Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
       And I click on "report-start, edit-documents"
       Then the URL should match "report/\d+/documents/summary"
       When I click on "edit" in the "provided-documentation" region
@@ -143,7 +143,7 @@ Feature: Report documents
 
   @deputy
   Scenario: Deleting one of many files doesn't restart process
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "reports, report-start, edit-documents"
     When I click on "add"
     And I attach the file "file2.pdf" to "report_document_upload_files"

--- a/behat/tests/features/deputy/03-report/01-102/09-any-other-info.feature
+++ b/behat/tests/features/deputy/03-report/01-102/09-any-other-info.feature
@@ -2,7 +2,7 @@ Feature: Report any other info
 
   @deputy
   Scenario: any other info
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start, edit-other_info, start"
      # step 1
     And the step cannot be submitted without making a selection

--- a/behat/tests/features/deputy/03-report/01-102/10-account.feature
+++ b/behat/tests/features/deputy/03-report/01-102/10-account.feature
@@ -2,7 +2,7 @@ Feature: Report accounts
 
   @deputy
   Scenario: add account
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start, edit-bank_accounts, start"
     # step 1
     Then the step cannot be submitted without making a selection
@@ -114,7 +114,7 @@ Feature: Report accounts
 
   @deputy
   Scenario: add a 3rd account (it'll be deleted before submission)
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start, edit-bank_accounts, add"
     And the step with the following values CAN be submitted:
       | account_accountType_0 | current |

--- a/behat/tests/features/deputy/03-report/01-102/11-expenses.feature
+++ b/behat/tests/features/deputy/03-report/01-102/11-expenses.feature
@@ -2,7 +2,7 @@ Feature: Report deputy expenses
 
   @deputy
   Scenario: deputy expenses
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start, edit-deputy_expenses, start"
     # chose "no records"
     Given the step cannot be submitted without making a selection

--- a/behat/tests/features/deputy/03-report/01-102/12-gifts.feature
+++ b/behat/tests/features/deputy/03-report/01-102/12-gifts.feature
@@ -2,7 +2,7 @@ Feature: Report gifts
 
   @deputy
   Scenario: gifts
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start, edit-gifts, start"
     # chose "no records"
     Given the step cannot be submitted without making a selection

--- a/behat/tests/features/deputy/03-report/01-102/13-asset.feature
+++ b/behat/tests/features/deputy/03-report/01-102/13-asset.feature
@@ -2,7 +2,7 @@ Feature: Report asset with variations
 
     @deputy
     Scenario: assets
-        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "report-start, edit-assets, start"
         # chose "no records"
         Then the step cannot be submitted without making a selection
@@ -94,7 +94,7 @@ Feature: Report asset with variations
 
     @deputy
     Scenario: properties
-        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "report-start, edit-assets, add"
         And the step with the following values CAN be submitted:
             | asset_title_title_0 | Property   |

--- a/behat/tests/features/deputy/03-report/01-102/14-debts.feature
+++ b/behat/tests/features/deputy/03-report/01-102/14-debts.feature
@@ -2,7 +2,7 @@ Feature: Report debts
 
     @deputy
     Scenario: debts
-        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "report-start, edit-debts, start"
         # chose "no records"
         Given the step cannot be submitted without making a selection

--- a/behat/tests/features/deputy/03-report/01-102/17-money.feature
+++ b/behat/tests/features/deputy/03-report/01-102/17-money.feature
@@ -2,7 +2,7 @@ Feature: Report money 102
 
   @deputy
   Scenario: money in 102
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start, edit-money_in, start"
     # add transaction n.1 and check validation
     Then the step cannot be submitted without making a selection
@@ -72,7 +72,7 @@ Feature: Report money 102
 
   @deputy
   Scenario: money out
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start"
     #And I should not see "#finances-section .behat-alert-message"
     And I click on "edit-money_out, start"
@@ -147,7 +147,7 @@ Feature: Report money 102
 
   @deputy
   Scenario: Add a 3rd transaction associate to the 3rd bank account
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start, edit-money_out, add"
     And the step with the following values CAN be submitted:
       | account_category_5 | food |
@@ -162,7 +162,6 @@ Feature: Report money 102
 
   @deputy
   Scenario: Assert balance status is "not matching"
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start"
     And I should see the "balance-state-not-matching" region
-

--- a/behat/tests/features/deputy/03-report/01-102/18-bank-account-delete.feature
+++ b/behat/tests/features/deputy/03-report/01-102/18-bank-account-delete.feature
@@ -2,7 +2,7 @@ Feature: bank account delete
 
   @deputy
   Scenario: Remove account with transfers does not delete transactions
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start, edit-bank_accounts"
     And I click on "delete" in the "account-03ta" region
     Then the URL should match "/report/\d+/bank-account/\d+/delete"
@@ -11,10 +11,7 @@ Feature: bank account delete
 
   @deputy
   Scenario: assert transaction associated to the bank account is not deleted
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start, edit-money_out"
     Then I should see "2.00" in the "transaction-coffee" region
     But I should not see "03ta" in the "transaction-coffee" region
-
-
-

--- a/behat/tests/features/deputy/03-report/01-102/19-transfers.feature
+++ b/behat/tests/features/deputy/03-report/01-102/19-transfers.feature
@@ -2,7 +2,7 @@ Feature: Report account transfers
 
   @deputy
   Scenario: transfers
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start, edit-money_transfers, start"
       # chose "no records"
     Given the step cannot be submitted without making a selection
@@ -72,7 +72,7 @@ Feature: Report account transfers
   @deputy
     Scenario: Remove account with transfers
       # navigate to accounts list (that now have transfers)
-      Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+      Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
       And I click on "report-start, edit-bank_accounts"
       And I click on "delete" in the "account-11cf" region
       # Account still visible

--- a/behat/tests/features/deputy/03-report/01-102/20-balance.feature
+++ b/behat/tests/features/deputy/03-report/01-102/20-balance.feature
@@ -2,7 +2,7 @@ Feature: Report balance
 
     @deputy
     Scenario: balance fix
-        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         # assert report not submittable
         And I click on "report-start"
         #And I should see an "#finances-section .behat-alert-message" element
@@ -30,7 +30,7 @@ Feature: Report balance
     Scenario: balance explanation
         # restore previous bad balance, add explanation
         Given I load the application status from "balance-before-adding-explanation"
-        And I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        And I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "report-start, edit-balance"
         And I should see the "balance-bad" region
         # add explanation
@@ -46,7 +46,7 @@ Feature: Report balance
 
     @deputy
     Scenario: Transactions CSV link
-        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         When I click on "report-start, edit-balance"
         And I click on "download-transactions"
         And the response status code should be 200

--- a/behat/tests/features/deputy/03-report/01-102/21-check-and-submit.feature
+++ b/behat/tests/features/deputy/03-report/01-102/21-check-and-submit.feature
@@ -2,7 +2,7 @@ Feature: Report submit
 
     @deputy
     Scenario: report declaration page
-        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "report-start"
         Then I should not see the "report-review" link
         # if not found, it means that the report is not submittable
@@ -14,7 +14,7 @@ Feature: Report submit
 
     @deputy
     Scenario: Can see and edit deputy information
-        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "report-start, report-submit, declaration-page"
         Then each text should be present in the corresponding region:
             | John 102-Client                            | client-contact |
@@ -33,7 +33,7 @@ Feature: Report submit
 
     @deputy
     Scenario: report submission
-        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "report-start"
         And I save the report as "102 report"
         # assert I cannot access the submitted page directly
@@ -94,7 +94,7 @@ Feature: Report submit
     @deputy
     Scenario: deputy gives feedback after submitting report
         Given I load the application status from "report-submit-pre"
-        And I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        And I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "report-start"
         And I click on "report-submit"
         And I click on "declaration-page"
@@ -125,7 +125,7 @@ Feature: Report submit
 
     @deputy
     Scenario: admin area check filters, submission and ZIP file content
-        Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "admin-documents"
         Then I should be on "/admin/documents/list"
         And I save the current URL as "admin-documents-list-new"
@@ -151,7 +151,7 @@ Feature: Report submit
 
     @deputy
     Scenario: admin can download individual report flies
-        Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "admin-documents"
         And I click on "tab-pending"
         When I follow "Download"
@@ -162,7 +162,7 @@ Feature: Report submit
 
     @deputy
     Scenario: admin can download zips of a report's files
-        Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "admin-documents"
         And I click on "tab-pending"
         When I check "Select 102"
@@ -187,7 +187,7 @@ Feature: Report submit
 
     @deputy
     Scenario: assert 2nd year report has been created
-        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "report-start"
         Then I should see a "#edit-contacts" element
         And I should see a "#edit-decisions" element
@@ -203,7 +203,7 @@ Feature: Report submit
 
     @deputy
     Scenario: deputy report download
-        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         When I click on "report-review"
         Then the URL should match "report/\d+/review"
         And the response should contain "102"

--- a/behat/tests/features/deputy/03-report/01-102/22-submit-more-documents.feature
+++ b/behat/tests/features/deputy/03-report/01-102/22-submit-more-documents.feature
@@ -3,7 +3,7 @@ Feature: Add more documents after report has been submitted
   @deputy
   Scenario: Deputy adds documents after submission
     Given I load the application status from "report-submit-reports"
-    And I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I save the current URL as "your-reports"
     And I click on "add-more-documents" in the "submitted-reports" region
     Then the URL should match "report/\d+/documents/step/2"

--- a/behat/tests/features/deputy/03-report/01-102/23-report-resubmission.feature
+++ b/behat/tests/features/deputy/03-report/01-102/23-report-resubmission.feature
@@ -2,7 +2,7 @@ Feature: Admin unsubmit report (from client page)
 
   @deputy
   Scenario: Admin unsubmits report and changes report due date and reporting period
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I visit the client page for "102"
     # reports page
     Then the URL should match "/admin/client/\d+/details"
@@ -70,7 +70,7 @@ Feature: Admin unsubmit report (from client page)
 
   @deputy
   Scenario: Deputy resubmit report
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should see "30 April 2022" in the "report-unsubmitted" region
     And I should see the "report-active" region
     But I should not see the "submitted-reports" region
@@ -98,7 +98,7 @@ Feature: Admin unsubmit report (from client page)
 
   @deputy
   Scenario: admin sees new submission and client page updated
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     # check report being resubmitted
     When I visit the client page for "102"
     Then I should see the "report-2016" region in the "report-group-submitted" region

--- a/behat/tests/features/deputy/03-report/01-102/24-lodging-checklist.feature
+++ b/behat/tests/features/deputy/03-report/01-102/24-lodging-checklist.feature
@@ -2,7 +2,7 @@ Feature: Admin report checklist
 
   @deputy
   Scenario: Case manager submits empty checklist for the report 102
-    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I visit the client page for "102"
     And I click on "checklist" in the "report-2016" region
     Then the URL should match "/admin/report/\d+/checklist"
@@ -88,7 +88,7 @@ Feature: Admin report checklist
 
   @deputy
   Scenario: Case manager saves further information on checklist
-    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I open the "2016" checklist for client "102"
     Then the URL should match "/admin/report/\d+/checklist"
     And each text should be present in the corresponding region:
@@ -120,7 +120,7 @@ Feature: Admin report checklist
 
   @deputy
   Scenario: Admin completes checklist
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     # Navigate to checklist via search
     When I open the "2016" checklist for client "102"
     Then the URL should match "/admin/report/\d+/checklist"
@@ -177,7 +177,7 @@ Feature: Admin report checklist
 
   @deputy
   Scenario: Admin marked as submitted
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     # Navigate to checklist via search
     When I open the "2016" checklist for client "102"
     Then the URL should match "/admin/report/\d+/checklist"

--- a/behat/tests/features/deputy/03-report/01-102/25-review-checklist.feature
+++ b/behat/tests/features/deputy/03-report/01-102/25-review-checklist.feature
@@ -2,7 +2,7 @@ Feature: Full review checklist
 
   @deputy
   Scenario: Full review checklist contains logic summary
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I open the "2016" checklist for client "102"
     Then I should see the "lodging-summary" region
     And I should see "I am not satisfied" in the "lodging-summary" region
@@ -12,7 +12,7 @@ Feature: Full review checklist
 
   @deputy
   Scenario: Full review checklist requires validation on submission
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I open the "2016" checklist for client "102"
     And I click on "submit-and-continue" in the "full-review-checklist" region
     Then the following fields should have an error:
@@ -48,7 +48,7 @@ Feature: Full review checklist
 
   @deputy
   Scenario: Can add details to the full review checklist
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I open the "2016" checklist for client "102"
     And I fill in the following:
         | full-review_answers_fullBankStatementsExist_0 | yes                         |
@@ -77,7 +77,7 @@ Feature: Full review checklist
 
   @deputy
   Scenario: Can submit full review checklist
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I open the "2016" checklist for client "102"
     And I click on "submit-and-continue" in the "full-review-checklist" region
     Then the form should be valid

--- a/behat/tests/features/deputy/03-report/02-103/00-start.feature
+++ b/behat/tests/features/deputy/03-report/02-103/00-start.feature
@@ -2,7 +2,7 @@ Feature: Report 103 start
 
   @deputy @deputy-103
   Scenario: Check 103 report not initially submittable
-    Given I am logged in as "behat-lay-deputy-103@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-103@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I set the report start date to "1/1/2016"
     And I set the report end date to "31/12/2016"
     And I click on "report-start"
@@ -26,7 +26,7 @@ Feature: Report 103 start
 
   @deputy @deputy-103
   Scenario: Complete previously tested report sections
-    Given I am logged in as "behat-lay-deputy-103@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-103@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I click on "report-start"
     # Decisions
     When I click on "edit-decisions, start"
@@ -101,4 +101,3 @@ Feature: Report 103 start
     And I click on "save-and-continue, breadcrumbs-report-overview"
     # Assert that more info is still needed
     Then the lay report should not be submittable
-

--- a/behat/tests/features/deputy/03-report/02-103/01-money-103.feature
+++ b/behat/tests/features/deputy/03-report/02-103/01-money-103.feature
@@ -2,7 +2,7 @@ Feature: Report money 103
 
   @deputy @deputy-103
   Scenario: money in 103
-    Given I am logged in as "behat-lay-deputy-103@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-103@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start, edit-money_in_short, start"
     # categories
     And the step with the following values CAN be submitted:
@@ -70,7 +70,7 @@ Feature: Report money 103
 
   @deputy @deputy-103
   Scenario: money out 103
-    Given I am logged in as "behat-lay-deputy-103@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-103@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start, edit-money_out_short, start"
     # categories
     And the step with the following values CAN be submitted:
@@ -134,11 +134,3 @@ Feature: Report money 103
       | money_short_transaction_amount      | 1,451.00      |
     And each text should be present in the corresponding region:
       | 1,451.00 | transaction-november-rent |
-
-
-
-
-
-
-
-

--- a/behat/tests/features/deputy/03-report/02-103/02-check-and-submit.feature
+++ b/behat/tests/features/deputy/03-report/02-103/02-check-and-submit.feature
@@ -2,6 +2,6 @@ Feature: Report submit
 
     @deputy @deputy-103
     Scenario: report 103 check is complete and submittable
-        Given I am logged in as "behat-lay-deputy-103@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-103@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "report-start"
         Then the lay report should be submittable

--- a/behat/tests/features/deputy/03-report/03-104/00-start.feature
+++ b/behat/tests/features/deputy/03-report/03-104/00-start.feature
@@ -2,7 +2,7 @@ Feature: Report 104 start
 
   @deputy @deputy-104
   Scenario: test tabs for 104
-    Given I am logged in as "behat-lay-deputy-104@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-104@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I set the report start date to "1/1/2016"
     And I set the report end date to "31/12/2016"
     And I click on "report-start"
@@ -27,7 +27,7 @@ Feature: Report 104 start
 
   @deputy @deputy-104
   Scenario: Complete previously tested report sections
-    Given I am logged in as "behat-lay-deputy-104@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-104@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I click on "report-start"
     # Decisions
     When I click on "edit-decisions, start"

--- a/behat/tests/features/deputy/03-report/03-104/01-health-welfare.feature
+++ b/behat/tests/features/deputy/03-report/03-104/01-health-welfare.feature
@@ -2,7 +2,7 @@ Feature: Report 104 health welfare
 
   @deputy @deputy-104
   Scenario: test HW section
-    Given I am logged in as "behat-lay-deputy-104@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-104@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start, edit-lifestyle, start"
     Then the URL should match "report/\d+/lifestyle/step/1"
     Given the step with the following values CANNOT be submitted:
@@ -28,11 +28,3 @@ Feature: Report 104 health welfare
       | care appointments with physio     | care-appointments         |
       | No     | does-client-undertake-social-activities |
       | The client is immobile    | activity-details                     |
-
-
-
-
-
-
-
-

--- a/behat/tests/features/deputy/03-report/03-104/02-check-and-submit.feature
+++ b/behat/tests/features/deputy/03-report/03-104/02-check-and-submit.feature
@@ -2,7 +2,7 @@ Feature: Report submit
 
     @deputy @deputy-104
     Scenario: submit 104
-        Given I am logged in as "behat-lay-deputy-104@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-104@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "report-start, report-submit, declaration-page"
         And I fill in the following:
             | report_declaration_agree | 1 |

--- a/behat/tests/features/deputy/03-report/03-104/03-lodging-checklist.feature
+++ b/behat/tests/features/deputy/03-report/03-104/03-lodging-checklist.feature
@@ -2,7 +2,7 @@ Feature: Admin report checklist
 
   @deputy @deputy-104
   Scenario: Case manager submits empty checklist for the report 104
-    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I open the "2016" checklist for client "104"
     Then the URL should match "/admin/report/\d+/checklist"
     # check default values
@@ -43,7 +43,7 @@ Feature: Admin report checklist
 
   @deputy @deputy-104
   Scenario: Case manager saves further information on 104 checklist
-    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I open the "2016" checklist for client "104"
     Then the URL should match "/admin/report/\d+/checklist"
     And each text should be present in the corresponding region:
@@ -75,7 +75,7 @@ Feature: Admin report checklist
 
   @deputy @deputy-104
   Scenario: Admin completes 104 checklist
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I open the "2016" checklist for client "104"
     Then the URL should match "/admin/report/\d+/checklist"
     And each text should be present in the corresponding region:
@@ -118,7 +118,7 @@ Feature: Admin report checklist
 
   @deputy @deputy-104
   Scenario: 104 Admin marked as submitted
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I open the "2016" checklist for client "104"
     Then the URL should match "/admin/report/\d+/checklist"
     And each text should be present in the corresponding region:

--- a/behat/tests/features/deputy/03-report/04-post-submit/00-report-download-admin.feature
+++ b/behat/tests/features/deputy/03-report/04-post-submit/00-report-download-admin.feature
@@ -2,13 +2,13 @@ Feature: As an admin user, in order to ensure correct report PDFs can always be 
 
   @deputy @download-reports
   Scenario: Non super user cannot download a report that has been submitted
-    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I visit the client page for "102"
     Then I should not see "Download"
 
   @deputy @download-reports
   Scenario: Super user can download a report that has been submitted
-    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I visit the client page for "102"
     And I follow "Download"
     Then the response status code should be 200
@@ -17,6 +17,6 @@ Feature: As an admin user, in order to ensure correct report PDFs can always be 
 
   @deputy @download-reports
   Scenario: Case manager cannot download a non submitted report
-    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I visit the client page for "103-5"
     Then I should not see "Download"

--- a/behat/tests/features/deputy/04-user/00-login-logout.feature
+++ b/behat/tests/features/deputy/04-user/00-login-logout.feature
@@ -1,23 +1,23 @@
 Feature: deputy / login and logout functionalities
     @infra
     Scenario: manual login
-      Given I am logged in as "behat-lay-deputy-103-4@publicguardian.gov.uk" with password "Abcd1234"
+      Given I am logged in as "behat-lay-deputy-103-4@publicguardian.gov.uk" with password "DigidepsPass1234"
       Then the URL should match "report/create/\d+"
       Then I click on "logout"
-      Given I am logged in as "behat-pa-deputy-102-6@publicguardian.gov.uk" with password "Abcd1234"
+      Given I am logged in as "behat-pa-deputy-102-6@publicguardian.gov.uk" with password "DigidepsPass1234"
       Then the URL should match "org"
       Then I click on "logout"
 
   @deputy
     Scenario: manual logout
-      Given I am logged in as "behat-lay-deputy-103@publicguardian.gov.uk" with password "Abcd1234"
+      Given I am logged in as "behat-lay-deputy-103@publicguardian.gov.uk" with password "DigidepsPass1234"
       When I click on "logout"
       Then I should be on "/login"
       And I should see the "manual-logout-message" region
 
     @deputy
     Scenario: no cache
-      Given I am logged in as "behat-lay-deputy-103@publicguardian.gov.uk" with password "Abcd1234"
+      Given I am logged in as "behat-lay-deputy-103@publicguardian.gov.uk" with password "DigidepsPass1234"
       And I go to the homepage
       And I click on "user-account"
       Then the response should have the "Cache-Control" header containing "no-cache"

--- a/behat/tests/features/deputy/04-user/03-userselfregister.feature
+++ b/behat/tests/features/deputy/04-user/03-userselfregister.feature
@@ -99,7 +99,7 @@ Feature: User Self Registration
     Then I am on admin login page
     And I fill in the following:
       | login_email    | admin@publicguardian.gov.uk |
-      | login_password | Abcd1234                        |
+      | login_password | DigidepsPass1234                        |
     Then I click on "login"
     Then I should see "behat-zac.tolley@digital.justice.gov.uk" in the "users" region
 
@@ -164,9 +164,9 @@ Feature: User Self Registration
     And I press "self_registration_save"
     Then I should see "Please check your email"
     And I should see "We've sent you a link to behat-jenny.lens@digital.justice.gov.uk"
-    When I activate the user "behat-jenny.lens@digital.justice.gov.uk" with password "Abcd1234"
+    When I activate the user "behat-jenny.lens@digital.justice.gov.uk" with password "DigidepsPass1234"
     Then the URL should match "/login"
-    When I am logged in as "behat-jenny.lens@digital.justice.gov.uk" with password "Abcd1234"
+    When I am logged in as "behat-jenny.lens@digital.justice.gov.uk" with password "DigidepsPass1234"
     Then the URL should match "/user/details"
     When I fill in the following:
       | user_details_address1       | Address1     |
@@ -189,5 +189,5 @@ Feature: User Self Registration
     And I set the report end date to "1/1/2016"
     Then the URL should match "/lay"
     Then I go to "/logout"
-    And I am logged in as "behat-jenny.lens@digital.justice.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-jenny.lens@digital.justice.gov.uk" with password "DigidepsPass1234"
     Then the URL should match "/lay"

--- a/behat/tests/features/deputy/04-user/05-client-edit.feature
+++ b/behat/tests/features/deputy/04-user/05-client-edit.feature
@@ -3,7 +3,7 @@ Feature: deputy / report / edit client
     @deputy
     Scenario: edit client details
         Given I load the application status from "report-submit-pre"
-        And I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        And I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "user-account, client-show, client-edit"
         Then the following fields should have the corresponding values:
             | client_firstname | John |
@@ -61,7 +61,7 @@ Feature: deputy / report / edit client
     # @deputy
     # Scenario: edit client details
     #     Given emails are sent from "deputy" area
-    #     And I am logged in as "laydeputy@publicguardian.gov.uk" with password "Abcd1234"
+    #     And I am logged in as "laydeputy@publicguardian.gov.uk" with password "DigidepsPass1234"
     #     And I click on "user-account, client-show, client-edit"
     #     When I fill in the following:
     #         | client_firstname | Ulrich |

--- a/behat/tests/features/deputy/04-user/06-codeputies.feature
+++ b/behat/tests/features/deputy/04-user/06-codeputies.feature
@@ -24,8 +24,8 @@ Feature: Codeputy Self Registration
       | self_registration_clientLastname  | Jones                                             |
       | self_registration_caseNumber      | 00000000                                          |
     And I press "self_registration_save"
-    And I activate the user "behat-jack.goodby-noncodep@digital.justice.gov.uk" with password "Abcd1234"
-    And I am logged in as "behat-jack.goodby-noncodep@digital.justice.gov.uk" with password "Abcd1234"
+    And I activate the user "behat-jack.goodby-noncodep@digital.justice.gov.uk" with password "DigidepsPass1234"
+    And I am logged in as "behat-jack.goodby-noncodep@digital.justice.gov.uk" with password "DigidepsPass1234"
     Then the URL should match "/user/details"
     When I fill in the following:
       | user_details_address1       | Address1     |
@@ -45,7 +45,7 @@ Feature: Codeputy Self Registration
     And I set the report end date to "31/12/2016"
     Then the URL should match "/lay"
     Then I go to "/logout"
-    Given I am logged in as "behat-jack.goodby-noncodep@digital.justice.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-jack.goodby-noncodep@digital.justice.gov.uk" with password "DigidepsPass1234"
     Then the URL should match "/lay"
     And I should not see the "codeputies" region
 
@@ -103,8 +103,8 @@ Feature: Codeputy Self Registration
     And I should see "We've sent you a link to behat-jack.goodby-mld1@digital.justice.gov.uk"
 
     # 1st codep registers fully
-    When I activate the user "behat-jack.goodby-mld1@digital.justice.gov.uk" with password "Abcd1234"
-    And I am logged in as "behat-jack.goodby-mld1@digital.justice.gov.uk" with password "Abcd1234"
+    When I activate the user "behat-jack.goodby-mld1@digital.justice.gov.uk" with password "DigidepsPass1234"
+    And I am logged in as "behat-jack.goodby-mld1@digital.justice.gov.uk" with password "DigidepsPass1234"
     Then the URL should match "/user/details"
     When I fill in the following:
       | user_details_address1       | Address1     |
@@ -130,7 +130,7 @@ Feature: Codeputy Self Registration
 
   @deputy
   Scenario: The first co-deputy logs in and sees the deputy area and invites a codeputy
-    Given I am logged in as "behat-jack.goodby-mld1@digital.justice.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-jack.goodby-mld1@digital.justice.gov.uk" with password "DigidepsPass1234"
     Then the URL should match "/lay"
     And I should see the "codeputies" region
     And I click on "invite-codeputy-button"
@@ -144,7 +144,7 @@ Feature: Codeputy Self Registration
 
   @deputy
   Scenario: Admin logs in and sees placeholder text for the nameless invited codeputy
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should see "Invited co-deputy" in the "users" region
 
   @deputy @ndr
@@ -167,11 +167,11 @@ Feature: Codeputy Self Registration
       | self_registration_caseNumber      | 22222222                                   |
     And I press "self_registration_save"
     # Activate the deputy
-    And I activate the user "behat-user-ndr-codep@publicguardian.gov.uk" with password "Abcd1234"
+    And I activate the user "behat-user-ndr-codep@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I go to "/login"
     And I fill in the following:
       | login_email     | behat-user-ndr-codep@publicguardian.gov.uk |
-      | login_password  | Abcd1234 |
+      | login_password  | DigidepsPass1234 |
     And I press "login_login"
     When I set the user details to:
       | name    | Peter         | NDR           |        |         |    |

--- a/behat/tests/features/deputy/05-acl/01-cross-checks.feature
+++ b/behat/tests/features/deputy/05-acl/01-cross-checks.feature
@@ -4,14 +4,14 @@ Feature: deputy / acl / cross domain (admin and deputy) checks
     Scenario: A deputy cannot login into admin area
         # check deputy can login into deputy site
         Given I load the application status from "report-submit-pre"
-        And I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "Abcd1234"
+        And I am logged in as "behat-lay-deputy-ndr@publicguardian.gov.uk" with password "DigidepsPass1234"
         #Then the response status code should be 200
         # check deputy CANNOT login into ADMIN site
         Given I go to "/logout"
         And I am on admin login page
         When I fill in the following:
             | login_email     | behat-lay-deputy-ndr@publicguardian.gov.ukk |
-            | login_password  | Abcd1234 |
+            | login_password  | DigidepsPass1234 |
         And I click on "login"
         Then I should see an "#error-summary" element
         And I should be on "/login"

--- a/behat/tests/features/deputy/05-acl/02-pages-security.feature
+++ b/behat/tests/features/deputy/05-acl/02-pages-security.feature
@@ -7,11 +7,11 @@ Feature: deputy / acl / security on pages
     And I add the following users to CASREC:
       | Case     | Surname | Deputy No | Dep Surname | Dep Postcode | Typeofrep |
       | 12345ABC | Client  | D003      | User        | SW1H 9AJ     | OPG102    |
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And the following users exist:
       | ndr | deputyType | firstName | lastName | email | postCode | activated |
       | disabled | LAY | Malicious | User | behat-malicious@publicguardian.gov.uk | SW1H 9AJ | true |
-    Given I am logged in as "behat-malicious@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-malicious@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I set the user details to:
       | name    | Malicious        | User          |        |          |    |
       | address | 102 Petty France | MOJ           | London | SW1H 9AJ | GB |
@@ -39,7 +39,7 @@ Feature: deputy / acl / security on pages
   @deputy
   Scenario: Malicious User cannot access other's pages
     # behat-lay-deputy-102 can access report n.2
-    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then the following "102 report" report pages should return the following status:
       | overview         | 200 |
       # decisions
@@ -53,7 +53,7 @@ Feature: deputy / acl / security on pages
       # accounts
       | bank-accounts    | 200 |
     # behat-malicious CANNOT access the same URLs
-    Given I am logged in as "behat-malicious@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-malicious@publicguardian.gov.uk" with password "DigidepsPass1234"
     # reload the status (as some URLs calls might have deleted data)
     Then the following "102 report" report pages should return the following status:
       | overview                | 404 |

--- a/behat/tests/features/deputy/06-static-pages/03-terms.feature
+++ b/behat/tests/features/deputy/06-static-pages/03-terms.feature
@@ -12,7 +12,7 @@ Feature: Terms of use
 
     @deputy
     Scenario: The footer provides a link to the terms of use when logged in
-        Given I am logged in as "admin@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
         Then the "Terms of use" link, in the footer, url should contain "/terms"
 
     @deputy

--- a/behat/tests/features/deputy/06-static-pages/04-privacy.feature
+++ b/behat/tests/features/deputy/06-static-pages/04-privacy.feature
@@ -8,7 +8,7 @@ Feature: Privacy
 
     @deputy
     Scenario: The footer provides a link to the privacy page when logged in
-        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "DigidepsPass1234"
         Then the "Privacy notice" link, in the footer, url should contain "/privacy"
         And I go to "/privacy"
         And the response status code should be 200
@@ -21,4 +21,3 @@ Feature: Privacy
         Then I go to "/privacy"
         And the response status code should be 200
         And the "Back" link url should contain "/login"
-

--- a/behat/tests/features/deputy/07-infra-checks/00-documents.feature
+++ b/behat/tests/features/deputy/07-infra-checks/00-documents.feature
@@ -2,7 +2,7 @@ Feature: Infrastructure document tests
 
   @infra
   Scenario: Can upload documents
-    Given I am logged in as "behat-lay-deputy-103-4@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-103-4@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I set the report start date to "1/1/2016"
     And I set the report end date to "31/12/2016"
     And I click on "report-start, edit-documents, start"
@@ -20,7 +20,7 @@ Feature: Infrastructure document tests
 
   @infra
   Scenario: Can generate report PDF
-    Given I am logged in as "behat-lay-deputy-103-4@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-103-4@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I click on "report-start"
     And I follow "Preview and check report"
     And I click on "download-pdf"
@@ -31,7 +31,7 @@ Feature: Infrastructure document tests
 
   @infra
   Scenario: Complete and submit report
-    Given I am logged in as "behat-lay-deputy-103-4@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-103-4@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "report-start"
     # Decisions
     When I click on "edit-decisions, start"
@@ -124,7 +124,7 @@ Feature: Infrastructure document tests
 
   @infra
   Scenario: Can download submitted documents
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I click on "admin-documents"
     And I click on "tab-pending"
     And I check "Select 103-4"

--- a/behat/tests/features/pa/01-registration-steps/01-admin-add-pa-users-and-activate.feature
+++ b/behat/tests/features/pa/01-registration-steps/01-admin-add-pa-users-and-activate.feature
@@ -1,6 +1,6 @@
 Feature: Add PA users and activate PA user (journey)
   Scenario: Activate PA user
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
       # upload PA users
     When I go to admin page "/admin/org-csv-upload"
     When I attach the file "behat-pa.csv" to "admin_upload_file"
@@ -21,13 +21,13 @@ Feature: Add PA users and activate PA user (journey)
     And I press "agree_terms_save"
     Then the form should be valid
     # password step
-    When I fill in the password fields with "Abcd1234"
+    When I fill in the password fields with "DigidepsPass1234"
     And I check "set_password_showTermsAndConditions"
     And I click on "save"
     Then the form should be valid
     And the url should match "/login"
     And I should see "Sign in to your new account"
-    When I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    When I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     # assert pre-fill
     Then the url should match "/user/details"
     And the following fields should have the corresponding values:
@@ -55,11 +55,11 @@ Feature: Add PA users and activate PA user (journey)
     And I should see the "client-02100010" region
 
   Scenario: Activation link is removed
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should not see "send-activation-email" in the "user-behat-pa1publicguardiangovuk" region
 
   Scenario: Register PA2 user
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "send-activation-email" in the "user-behat-pa2publicguardiangovuk" region
     And I go to "/logout"
     When I open the activation page for "behat-pa2@publicguardian.gov.uk"
@@ -68,11 +68,11 @@ Feature: Add PA users and activate PA user (journey)
     And I press "agree_terms_save"
     Then the form should be valid
     # password step
-    When I fill in the password fields with "Abcd1234"
+    When I fill in the password fields with "DigidepsPass1234"
     And I check "set_password_showTermsAndConditions"
     And I click on "save"
     Then the form should be valid
-    When I am logged in as "behat-pa2@publicguardian.gov.uk" with password "Abcd1234"
+    When I am logged in as "behat-pa2@publicguardian.gov.uk" with password "DigidepsPass1234"
     # correct
     And I fill in the following:
       | user_details_firstname  | Pa User     |
@@ -85,7 +85,7 @@ Feature: Add PA users and activate PA user (journey)
     And I should see the "client-02200001" region
 
   Scenario: Register PA3 user
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "send-activation-email" in the "user-behat-pa3publicguardiangovuk" region
     And I go to "/logout"
     When I open the activation page for "behat-pa3@publicguardian.gov.uk"
@@ -94,11 +94,11 @@ Feature: Add PA users and activate PA user (journey)
     And I press "agree_terms_save"
     Then the form should be valid
     # password step
-    When I fill in the password fields with "Abcd1234"
+    When I fill in the password fields with "DigidepsPass1234"
     And I check "set_password_showTermsAndConditions"
     When I click on "save"
     Then the form should be valid
-    When I am logged in as "behat-pa3@publicguardian.gov.uk" with password "Abcd1234"
+    When I am logged in as "behat-pa3@publicguardian.gov.uk" with password "DigidepsPass1234"
     # correct
     And I fill in the following:
       | user_details_firstname  | Pa User     |
@@ -111,7 +111,7 @@ Feature: Add PA users and activate PA user (journey)
     And I should see the "client-02300001" region
 
   Scenario: Edit PA2 user
-    When I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    When I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "user-behat-pa2publicguardiangovuk" in the "user-behat-pa2publicguardiangovuk" region
     And I press "Edit user"
     Then the following fields should have the corresponding values:

--- a/behat/tests/features/pa/03-report/01-report-edit-period.feature
+++ b/behat/tests/features/pa/03-report/01-report-edit-period.feature
@@ -1,7 +1,7 @@
 Feature: PA report
 
   Scenario: Setup data
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     Given the following court orders exist:
       | client   | deputy           | deputy_type | report_type                                | court_date |
       | 78978978 | EmilyHainesNamed | PA          | Property and Financial Affairs High Assets | 2018-01-30 |
@@ -15,7 +15,7 @@ Feature: PA report
   Scenario: PA does not see unsubmitted reports in the submitted reports section
     Given I have the "2018" to "2019" report between "EmilyHainesNamed" and "78978978"
     And the report has been unsubmitted
-    When I am logged in as "EmilyHainesNamed@behat-test.com" with password "Abcd1234"
+    When I am logged in as "EmilyHainesNamed@behat-test.com" with password "DigidepsPass1234"
     And I fill in "search" with "78978978"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-78978978" region
@@ -23,7 +23,7 @@ Feature: PA report
 
   # Logic will evolve differently therefore better to have regression test on this
   Scenario: PA edit 102 report dates
-    And I am logged in as "JamesShawAdmin@behat-test.com" with password "Abcd1234"
+    And I am logged in as "JamesShawAdmin@behat-test.com" with password "DigidepsPass1234"
     And I fill in "search" with "98798798"
     And I press "search_submit"
     When I click on "pa-report-open" in the "client-98798798" region

--- a/behat/tests/features/pa/03-report/02-common-report-sections.feature
+++ b/behat/tests/features/pa/03-report/02-common-report-sections.feature
@@ -1,7 +1,7 @@
 Feature: PA user edits common report sections common to ALL report types
   @102 @103-6 @104
   Scenario: PA 102 user edit decisions section
-    And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-02100014" region
@@ -22,7 +22,7 @@ Feature: PA user edits common report sections common to ALL report types
 
   @102 @103-6 @104
   Scenario: PA 102 saves a contact
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-02100014" region
@@ -35,7 +35,7 @@ Feature: PA user edits common report sections common to ALL report types
 
   @102 @103-6 @104
   Scenario: PA 102 visits and care steps
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-02100014" region
@@ -67,7 +67,7 @@ Feature: PA user edits common report sections common to ALL report types
 
   @102 @103-6 @104
   Scenario: PA 102 report actions
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-02100014" region
@@ -85,7 +85,7 @@ Feature: PA user edits common report sections common to ALL report types
 
   @102 @103-6 @104
   Scenario: PA 102 any other info
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-02100014" region
@@ -98,7 +98,7 @@ Feature: PA user edits common report sections common to ALL report types
 
   @102 @103-6 @104
   Scenario: PA adds documents to 102
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-02100014" region
@@ -134,7 +134,7 @@ Feature: PA user edits common report sections common to ALL report types
 
   @102 @103-6 @104
   Scenario: PA deletes document from 102
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-02100014" region

--- a/behat/tests/features/pa/03-report/03-edit-report-sections.feature
+++ b/behat/tests/features/pa/03-report/03-edit-report-sections.feature
@@ -1,7 +1,7 @@
 Feature: PA user edits report sections
 
   Scenario: PA 102 deputy expenses (with fees)
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-02100014" region
@@ -32,7 +32,7 @@ Feature: PA user edits report sections
       | £14.00                        | expense-some-expense |
 
   Scenario: PA 102 gifts
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-02100014" region
@@ -43,7 +43,7 @@ Feature: PA user edits report sections
       | yes_no_giftsExist_1 | no |
 
   Scenario: PA 102 assets
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-02100014" region
@@ -53,7 +53,7 @@ Feature: PA user edits report sections
       | yes_no_noAssetToAdd_1 | 1 |
 
   Scenario: PA 102 debts
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-02100014" region
@@ -64,7 +64,7 @@ Feature: PA user edits report sections
       | yes_no_hasDebts_1 | no |
 
   Scenario: PA 102 add current account
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-02100014" region
@@ -91,7 +91,7 @@ Feature: PA user edits report sections
     And I choose "no" when asked for adding another record
 
   Scenario: PA 102 add postoffice account (no sort code, no bank name)
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-02100014" region
@@ -114,7 +114,7 @@ Feature: PA user edits report sections
     And I choose "no" when asked for adding another record
 
   Scenario: PA 102 add no sortcode account (still requires bank name)
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-02100014" region
@@ -138,7 +138,7 @@ Feature: PA user edits report sections
     And I choose "no" when asked for adding another record
 
   Scenario: PA 102 deletes bank account
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     When I click on "pa-report-open" in the "client-02100014" region
@@ -151,7 +151,7 @@ Feature: PA user edits report sections
     Then I should see "Bank account deleted"
 
   Scenario: PA 102 money in
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-02100014" region
@@ -170,7 +170,7 @@ Feature: PA user edits report sections
       | HSBC - main account - Current account (****01ca) | transaction-pension-received |
 
   Scenario: PA 102 money out
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-02100014" region
@@ -190,7 +190,7 @@ Feature: PA user edits report sections
 
 
   Scenario: PA 102 Report should be submittable
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-02100014" region

--- a/behat/tests/features/pa/03-report/04-submit-report.feature
+++ b/behat/tests/features/pa/03-report/04-submit-report.feature
@@ -1,7 +1,7 @@
 Feature: Report submit (client 02100014)
 
     Scenario: Setup data
-        Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
         Given the following users exist:
           | ndr      | deputyType     | firstName | lastName | email                              | postCode | activated |
           | disabled | PA_TEAM_MEMBER | Kim       | Petras   | KimPetrasTeamMember@behat-test.com | HA4      | true      |
@@ -10,7 +10,7 @@ Feature: Report submit (client 02100014)
           | KimPetrasTeamMember@behat-test.com   | PA OPG  |
 
     Scenario: 102 report declaration page
-        And I am logged in as "KimPetrasTeamMember@behat-test.com" with password "Abcd1234"
+        And I am logged in as "KimPetrasTeamMember@behat-test.com" with password "DigidepsPass1234"
         And I click on "tab-ready"
         And I fill in "search" with "02100014"
         And I press "search_submit"
@@ -36,7 +36,7 @@ Feature: Report submit (client 02100014)
 
     Scenario: 102 report submission
         # log in as team member to submit the report and test that named deputy details are displayed
-        Given I am logged in as "KimPetrasTeamMember@behat-test.com" with password "Abcd1234"
+        Given I am logged in as "KimPetrasTeamMember@behat-test.com" with password "DigidepsPass1234"
         And I fill in "search" with "02100014"
         And I press "search_submit"
         When I click on "pa-report-open" in the "client-02100014" region
@@ -62,7 +62,7 @@ Feature: Report submit (client 02100014)
         And the response status code should be 200
 
     Scenario: 102 assert submitted report displays correctly in client profile page
-        Given I am logged in as "KimPetrasTeamMember@behat-test.com" with password "Abcd1234"
+        Given I am logged in as "KimPetrasTeamMember@behat-test.com" with password "DigidepsPass1234"
         And I click on "tab-in-progress"
         And I fill in "search" with "02100014"
         And I press "search_submit"
@@ -76,7 +76,7 @@ Feature: Report submit (client 02100014)
         Then the current URL should match with the URL previously saved as "client-02100014-profile"
 
     Scenario: 102 assert 2nd year report has been created and displays correctly
-        Given I am logged in as "KimPetrasTeamMember@behat-test.com" with password "Abcd1234"
+        Given I am logged in as "KimPetrasTeamMember@behat-test.com" with password "DigidepsPass1234"
         And I click on "tab-in-progress"
         And I fill in "search" with "02100014"
         And I press "search_submit"

--- a/behat/tests/features/pa/03-report/05-report-resubmission.feature
+++ b/behat/tests/features/pa/03-report/05-report-resubmission.feature
@@ -3,7 +3,7 @@ Feature: Admin unsubmit and client re-submit
   @deputy
   Scenario: Admin unsubmits report for client 02100014
     Given I load the application status from "pa-report-submitted"
-    And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I visit the client page for "02100014"
     Then I should see the "report-2016-to-2017" region in the "report-group-submitted" region
     And I click on "manage" in the "report-2016-to-2017" region
@@ -19,7 +19,7 @@ Feature: Admin unsubmit and client re-submit
 
   @deputy
   Scenario: PA resubmit report
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100014"
     And I press "search_submit"
     Then I should see the "client" region exactly 2 times
@@ -37,7 +37,7 @@ Feature: Admin unsubmit and client re-submit
 
   @deputy
   Scenario: Admin checks report was re-submitted
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I visit the client page for "02100014"
     Then I should see the "report-2016-to-2017" region in the "report-group-submitted" region
     # restore previous status

--- a/behat/tests/features/pa/03-report/06-lodging-checklist.feature
+++ b/behat/tests/features/pa/03-report/06-lodging-checklist.feature
@@ -3,7 +3,7 @@ Feature: Admin report checklist
 
   Scenario: Case manager submits empty PA checklist for the report
     Given I load the application status from "pa-report-submitted"
-    And I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I open the "2016-to-2017" checklist for client "02100014"
     Then the URL should match "/admin/report/\d+/checklist"
     And I should see the "court-date" region
@@ -73,7 +73,7 @@ Feature: Admin report checklist
     And the URL should match "/admin/report/\d+/checklist"
 
   Scenario: Case manager saves further information on PA checklist
-    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I open the "2016-to-2017" checklist for client "02100014"
     Then each text should be present in the corresponding region:
       | Not saved yet | lodging-last-saved-by |
@@ -103,7 +103,7 @@ Feature: Admin report checklist
 
 
   Scenario: Admin completes PA checklist
-    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I open the "2016-to-2017" checklist for client "02100014"
     Then each text should be present in the corresponding region:
       | Case Manager1, Admin | lodging-last-saved-by |
@@ -153,7 +153,7 @@ Feature: Admin report checklist
     And the form should be valid
 
   Scenario: Admin marked as submitted
-    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I open the "2016-to-2017" checklist for client "02100014"
     Then each text should be present in the corresponding region:
       | Case Manager1, Admin | lodging-last-saved-by     |

--- a/behat/tests/features/pa/04-dashboard-client-profile/02-dashboard.feature
+++ b/behat/tests/features/pa/04-dashboard-client-profile/02-dashboard.feature
@@ -1,7 +1,7 @@
 Feature: PA dashboard
 
   Scenario: PA dashboard check visibility, pagination and search
-    And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     # check pagination
     And I should see the "client" region exactly 15 times
     When I click on "paginator-page-2"
@@ -19,7 +19,7 @@ Feature: PA dashboard
     Then the URL should match "/org"
 
   Scenario: PA links in header
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     #PA links
     Then I should see the "org-dashboard" link
     And I should see the "org-settings" link

--- a/behat/tests/features/pa/04-dashboard-client-profile/10-client-profile.feature
+++ b/behat/tests/features/pa/04-dashboard-client-profile/10-client-profile.feature
@@ -1,7 +1,7 @@
 Feature: PA client profile
 
   Scenario: PA view client details
-    And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "02100010"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-02100010" region

--- a/behat/tests/features/pa/04-dashboard-client-profile/11-client-profile-notes.feature
+++ b/behat/tests/features/pa/04-dashboard-client-profile/11-client-profile-notes.feature
@@ -1,13 +1,13 @@
 Feature: PA client profile Notes
 
   Scenario: PA view client notes
-    And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-02100010" region
     Then each text should be present in the corresponding region:
       | No notes    | client-profile-notes |
 
   Scenario: PA adds client notes
-    And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-02100010" region
     And I click on "add-notes-button" in the "client-profile-notes" region
     # empty form
@@ -40,7 +40,7 @@ Feature: PA client profile Notes
       | test content | client-profile-notes |
 
   Scenario: PA edit client notes
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-02100010" region
     And I click on "edit-notes-button" in the "client-profile-notes" region
     Then the following fields should have the corresponding values:
@@ -61,7 +61,7 @@ Feature: PA client profile Notes
       | test content edit | client-profile-notes |
 
   Scenario: PA delete client notes
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-02100010" region
     And I save the current URL as "report-overview"
     And I click on "delete-notes-button" in the "client-profile-notes" region

--- a/behat/tests/features/pa/04-dashboard-client-profile/12-client-profile-contacts.feature
+++ b/behat/tests/features/pa/04-dashboard-client-profile/12-client-profile-contacts.feature
@@ -1,13 +1,13 @@
 Feature: PA client profile contacts
 
   Scenario: PA view client contacts
-    And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-02100010" region
     Then each text should be present in the corresponding region:
       | No contacts    | client-profile-contacts |
 
   Scenario: PA adds client contact
-    And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-02100010" region
     And I save the current URL as "report-overview"
     And I click on "add-contact-button" in the "client-profile-contacts" region
@@ -79,7 +79,7 @@ Then I fill in the following:
       | doc@brown.com | client-profile-contacts-display-contact-info |
 
   Scenario: PA edits client contact
-  Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+  Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
   And I click on "pa-report-open" in the "client-02100010" region
   And I save the current URL as "report-overview"
   And I click on "edit-contact-button" in the "client-profile-contacts-display-actions" region
@@ -107,7 +107,7 @@ Then I fill in the following:
     | doce@brown.com | client-profile-contacts-display-contact-info |
 
 Scenario: PA delete client contacts
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-02100010" region
     And I save the current URL as "report-overview"
     And I click on "delete-contact-button" in the "client-profile-contacts" region

--- a/behat/tests/features/pa/04-dashboard-client-profile/13-settings.feature
+++ b/behat/tests/features/pa/04-dashboard-client-profile/13-settings.feature
@@ -1,7 +1,7 @@
 Feature: PA settings
 
   Scenario: named PA logs in and views profile page
-    And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I click on "org-settings"
     # settings page
     Then I should see the "org-accounts" link
@@ -16,7 +16,7 @@ Feature: PA settings
     And I should see "10000000001" in the "profile-phone" region
 
   Scenario: named PA logs in and updates profile and does not see removeAdmin field
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I click on "org-settings, profile-show, profile-edit"
     Then I should not see "Give up administrator rights"
     Then I fill in the following:
@@ -38,7 +38,7 @@ Feature: PA settings
     And I should see "United Kingdom" in the "profile-address" region
 
   Scenario: PA Admin logs in and updates profile and sees removeAdmin field but does not
-    Given I am logged in as "JamesShawAdmin@behat-test.com" with password "Abcd1234"
+    Given I am logged in as "JamesShawAdmin@behat-test.com" with password "DigidepsPass1234"
     When I click on "org-settings, profile-show, profile-edit"
     Then I should see "Give up administrator rights"
     Then I fill in the following:
@@ -54,7 +54,7 @@ Feature: PA settings
     And I should see "10000000012" in the "profile-phone" region
 
   Scenario: PA Admin logs in and updates profile and removes admin
-    Given I am logged in as "JamesShawAdmin@behat-test.com" with password "Abcd1234"
+    Given I am logged in as "JamesShawAdmin@behat-test.com" with password "DigidepsPass1234"
     When I click on "org-settings, profile-show, profile-edit"
     Then I should see "Give up administrator rights"
     When I check "Give up administrator rights"
@@ -63,7 +63,7 @@ Feature: PA settings
     And I should be on "/login"
 
   Scenario: PA Admin is no longer admin and tests nav
-    Given I am logged in as "JamesShawAdmin@behat-test.com" with password "Abcd1234"
+    Given I am logged in as "JamesShawAdmin@behat-test.com" with password "DigidepsPass1234"
     When I click on "org-settings, org-accounts"
     And I follow "PA OPG"
     Then I should not see "Edit" in the "team-user-behat-pa1publicguardiangovuk" region
@@ -71,7 +71,7 @@ Feature: PA settings
     But I should not see "Edit" in the "team-user-kimpetrasteammemberbehat-testcom" region
 
   Scenario: PA Team member logs in and edits info
-    Given I am logged in as "KimPetrasTeamMember@behat-test.com" with password "Abcd1234"
+    Given I am logged in as "KimPetrasTeamMember@behat-test.com" with password "DigidepsPass1234"
     When I click on "org-settings, profile-show, profile-edit"
     Then I should not see "Give up administrator rights"
     When I fill in the following:
@@ -102,81 +102,84 @@ Feature: PA settings
     And I should see "United Kingdom" in the "profile-address" region
 
   Scenario: Named PA logs in and changes password
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I click on "org-settings, password-edit"
     Then I should see "Change password"
     When I press "change_password_save"
     Then the following fields should have an error:
       | change_password_current_password     |
-      | change_password_plain_password_first |
+      | change_password_password_first |
     #incorrect password
     When I fill in the following:
       | change_password_current_password       | Moo       |
-      | change_password_plain_password_first   | Abcd2345  |
-      | change_password_plain_password_second  | Abcd2345  |
+      | change_password_password_first   | DigidepsPass12345  |
+      | change_password_password_second  | DigidepsPass12345  |
     When I press "change_password_save"
     Then the following fields should have an error:
       | change_password_current_password     |
     #correct password, unmatching new passwords
     When I fill in the following:
-      | change_password_current_password       | Abcd1234  |
-      | change_password_plain_password_first   | Abcd1111  |
-      | change_password_plain_password_second  | Abcd2222  |
+      | change_password_current_password       | DigidepsPass1234  |
+      | change_password_password_first   | DigidepsPass1111  |
+      | change_password_password_second  | DigidepsPass2222  |
     When I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first   |
-    #various password inadequacies
+      | change_password_password_first   |
+    #not long enough
     When I fill in the following:
-      | change_password_current_password       | Abcd1234 |
-      | change_password_plain_password_first   | Abcd123  |
-      | change_password_plain_password_second  | Abcd123  |
+      | change_password_current_password       | DigidepsPass1234 |
+      | change_password_password_first   | Digideps1234  |
+      | change_password_password_second  | Digideps1234  |
     When I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first   |
+      | change_password_password_first   |
+    #no uppercase
     When I fill in the following:
-      | change_password_current_password       | Abcd1234  |
-      | change_password_plain_password_first   | abcd1234  |
-      | change_password_plain_password_second  | abcd1234  |
+      | change_password_current_password       | DigidepsPass1234  |
+      | change_password_password_first   | digideps1234  |
+      | change_password_password_second  | digideps1234  |
     When I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first   |
+      | change_password_password_first   |
+    #no numbers
     When I fill in the following:
-      | change_password_current_password       | Abcd1234  |
-      | change_password_plain_password_first   | Abcdefgh  |
-      | change_password_plain_password_second  | Abcdefgh  |
+      | change_password_current_password       | DigidepsPass1234  |
+      | change_password_password_first   | DigidepsPassword  |
+      | change_password_password_second  | DigidepsPassword  |
     When I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first   |
+      | change_password_password_first   |
+    #no lowercase
     When I fill in the following:
-      | change_password_current_password       | Abcd1234  |
-      | change_password_plain_password_first   | ABCD1234  |
-      | change_password_plain_password_second  | ABCD1234  |
+      | change_password_current_password       | DigidepsPass1234  |
+      | change_password_password_first   | DIGIDEPSPASS1234  |
+      | change_password_password_second  | DIGIDEPSPASS1234  |
     When I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first   |
-      # too common password
+      | change_password_password_first   |
+    # too common password
     When I fill in the following:
-      | change_password_current_password       | Abcd1234  |
-      | change_password_plain_password_first   | Password123  |
-      | change_password_plain_password_second  | Password123  |
+      | change_password_current_password       | DigidepsPass1234  |
+      | change_password_password_first   | Password123  |
+      | change_password_password_second  | Password123  |
     When I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first   |
+      | change_password_password_first   |
     # Finally a valid one
     When I fill in the following:
-      | change_password_current_password       | Abcd1234  |
-      | change_password_plain_password_first   | Abcd2345  |
-      | change_password_plain_password_second  | Abcd2345  |
+      | change_password_current_password       | DigidepsPass1234  |
+      | change_password_password_first   | DigidepsPass2345  |
+      | change_password_password_second  | DigidepsPass2345  |
     When I press "change_password_save"
     Then the form should be valid
     And the url should match "/login"
     And I should see "Sign in with your new password"
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd2345"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass2345"
     When I click on "org-settings, password-edit"
     When I fill in the following:
-      | change_password_current_password       | Abcd2345   |
-      | change_password_plain_password_first   | Abcd1234!! |
-      | change_password_plain_password_second  | Abcd1234!! |
+      | change_password_current_password       | DigidepsPass2345   |
+      | change_password_password_first   | DigidepsPass1234!! |
+      | change_password_password_second  | DigidepsPass1234!! |
     When I press "change_password_save"
     Then the form should be valid
     And the url should match "/login"

--- a/behat/tests/features/pa/04-dashboard-client-profile/14-client-archive.feature
+++ b/behat/tests/features/pa/04-dashboard-client-profile/14-client-archive.feature
@@ -1,7 +1,7 @@
 Feature: PA client archive
 
   Scenario: PA archives a client
-    And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234!!"
+    And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234!!"
     And I fill in "search" with "00900009"
     And I press "search_submit"
     When I click on "pa-report-open" in the "client-00900009" region
@@ -27,14 +27,14 @@ Feature: PA client archive
     But I should not see the "client-00900009" region
 
   Scenario: CSV re-upload
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
       # upload PA users
     When I go to admin page "/admin/org-csv-upload"
     And I attach the file "behat-pa.csv" to "admin_upload_file"
     And I press "admin_upload_upload"
     Then the form should be valid
       # assert archived is shown in PA dashboard
-    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234!!"
+    Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "DigidepsPass1234!!"
     And I fill in "search" with "00900009"
     And I press "search_submit"
     Then I should not see the "client-00900009" region

--- a/behat/tests/features/pa/07-acl.feature
+++ b/behat/tests/features/pa/07-acl.feature
@@ -2,7 +2,7 @@ Feature: PA cannot access other's PA's reports and clients
 # team1 = team with client 2100010
 # team2 = team with client 2000003
   Scenario: CSV org-upload
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     # upload PA users
     When I go to admin page "/admin/org-csv-upload"
     And I attach the file "behat-pa-orgs.csv" to "admin_upload_file"
@@ -10,7 +10,7 @@ Feature: PA cannot access other's PA's reports and clients
     Then the form should be valid
 
   Scenario: Admin activates PA Org 1 deputy
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And the following users exist:
       | ndr | deputyType | firstName | lastName | email | postCode | activated |
       | disabled | PA | Org1 Case | Worker | behat-pa-org1@pa-org1.gov.uk | SW1 | true |
@@ -18,7 +18,7 @@ Feature: PA cannot access other's PA's reports and clients
     And I add the client with case number "40000041" to be deputised by email "behat-pa-org1@pa-org1.gov.uk"
 
   Scenario: Admin activates PA Org 2 deputy
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And the following users exist:
       | ndr | deputyType | firstName | lastName | email | postCode | activated |
       | disabled | PA | Org2 Case | Worker | behat-pa-org2@pa-org2.gov.uk | SW1 | true |
@@ -26,7 +26,7 @@ Feature: PA cannot access other's PA's reports and clients
     And I add the client with case number "40000042" to be deputised by email "behat-pa-org2@pa-org2.gov.uk"
 
   Scenario: PA Org 1 can access own reports and clients
-    Given I am logged in as "behat-pa-org1@pa-org1.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa-org1@pa-org1.gov.uk" with password "DigidepsPass1234"
     # access report and save for future feature tests
     Then I click on "pa-report-open" in the "client-40000041" region
     And I save the report as "40000041-report"
@@ -36,7 +36,7 @@ Feature: PA cannot access other's PA's reports and clients
     Then I go to "/logout"
 
   Scenario: PA Org 2 can access own reports and clients
-    Given I am logged in as "behat-pa-org2@pa-org2.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa-org2@pa-org2.gov.uk" with password "DigidepsPass1234"
     Then I click on "pa-report-open" in the "client-40000042" region
     And I save the report as "40000042-report"
     And I click on "client-edit"
@@ -45,7 +45,7 @@ Feature: PA cannot access other's PA's reports and clients
     Then I go to "/logout"
 
   Scenario: PA Org 1 user logs in and should only see their clients and reports (from the existing team structure)
-    Given I am logged in as "behat-pa-org1@pa-org1.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-pa-org1@pa-org1.gov.uk" with password "DigidepsPass1234"
     And I should see the "client-40000041" region
     And I should not see the "client-40000042" region
     Then I go to the report URL "overview" for "40000042-report"
@@ -56,7 +56,7 @@ Feature: PA cannot access other's PA's reports and clients
   Scenario: User in an active organisation attempting to access clients inside and outside of the organisation
     Given the organisation "pa-org1.gov.uk" is active
     And "behat-pa-org1@pa-org1.gov.uk" has been added to the "pa-org1.gov.uk" organisation
-    When I am logged in as "behat-pa-org1@pa-org1.gov.uk" with password "Abcd1234"
+    When I am logged in as "behat-pa-org1@pa-org1.gov.uk" with password "DigidepsPass1234"
     Then I should see the "client-40000041" region
     And I should not see the "client-40000042" region
     Then I go to the report URL "overview" for "40000041-report"
@@ -67,13 +67,13 @@ Feature: PA cannot access other's PA's reports and clients
   Scenario: User not in an organisation attempting to access their client who is in an active organisation
     Given the organisation "pa-org1.gov.uk" is active
     And "behat-pa-org1@pa-org1.gov.uk" has been removed from their organisation
-    When I am logged in as "behat-pa-org1@pa-org1.gov.uk" with password "Abcd1234"
+    When I am logged in as "behat-pa-org1@pa-org1.gov.uk" with password "DigidepsPass1234"
     And I go to the report URL "overview" for "40000041-report"
     And the response status code should be 404
 
   Scenario: User not in an organisation attempting to access their client who is in an inactive organisation
     Given the organisation "pa-org1.gov.uk" is inactive
     And "behat-pa-org1@pa-org1.gov.uk" has been removed from their organisation
-    When I am logged in as "behat-pa-org1@pa-org1.gov.uk" with password "Abcd1234"
+    When I am logged in as "behat-pa-org1@pa-org1.gov.uk" with password "DigidepsPass1234"
     And I go to the report URL "overview" for "40000041-report"
     And the response status code should be 200

--- a/behat/tests/features/prof/01-registration-steps/01-admin-add-pa-users-and-activate.feature
+++ b/behat/tests/features/prof/01-registration-steps/01-admin-add-pa-users-and-activate.feature
@@ -1,7 +1,7 @@
 Feature: Add PROF users and activate PROF user (journey)
 
   Scenario: Activate Prof user
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
        # upload PROF users
     When I go to admin page "/admin/org-csv-upload"
     When I attach the file "behat-prof.csv" to "admin_upload_file"
@@ -24,13 +24,13 @@ Feature: Add PROF users and activate PROF user (journey)
     And I press "agree_terms_save"
     Then the form should be valid
     # password step
-    When I fill in the password fields with "Abcd1234"
+    When I fill in the password fields with "DigidepsPass1234"
     And I check "set_password_showTermsAndConditions"
     And I click on "save"
     Then the form should be valid
     And the url should match "/login"
     And I should see "Sign in to your new account"
-    When I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    When I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     # assert pre-fill
     Then the following fields should have the corresponding values:
       | user_details_firstname | DEP1     |
@@ -48,11 +48,11 @@ Feature: Add PROF users and activate PROF user (journey)
     And I should see the "client-31000010" region
 
   Scenario: Activation link is removed
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should not see "send-activation-email" in the "user-behat-prof1publicguardiangovuk" region
 
   Scenario: Register PROF2 user
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "send-activation-email" in the "user-behat-prof2publicguardiangovuk" region
     And I go to "/logout"
     When I open the activation page for "behat-prof2@publicguardian.gov.uk"
@@ -61,11 +61,11 @@ Feature: Add PROF users and activate PROF user (journey)
     And I press "agree_terms_save"
     Then the form should be valid
     # password step
-    When I fill in the password fields with "Abcd1234"
+    When I fill in the password fields with "DigidepsPass1234"
     And I check "set_password_showTermsAndConditions"
     And I click on "save"
     Then the form should be valid
-    When I am logged in as "behat-prof2@publicguardian.gov.uk" with password "Abcd1234"
+    When I am logged in as "behat-prof2@publicguardian.gov.uk" with password "DigidepsPass1234"
     # correct
     When I fill in the following:
       | user_details_firstname  | Pa User     |
@@ -78,7 +78,7 @@ Feature: Add PROF users and activate PROF user (journey)
     And I should see the "client-32000001" region
 
   Scenario: Register PROF3 user
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "send-activation-email" in the "user-behat-prof3publicguardiangovuk" region
     And I go to "/logout"
     When I open the activation page for "behat-prof3@publicguardian.gov.uk"
@@ -87,11 +87,11 @@ Feature: Add PROF users and activate PROF user (journey)
     And I press "agree_terms_save"
     Then the form should be valid
     # password step
-    When I fill in the password fields with "Abcd1234"
+    When I fill in the password fields with "DigidepsPass1234"
     And I check "set_password_showTermsAndConditions"
     When I click on "save"
     Then the form should be valid
-    When I am logged in as "behat-prof3@publicguardian.gov.uk" with password "Abcd1234"
+    When I am logged in as "behat-prof3@publicguardian.gov.uk" with password "DigidepsPass1234"
     # correct
     And I fill in the following:
       | user_details_firstname  | Pa User     |
@@ -104,7 +104,7 @@ Feature: Add PROF users and activate PROF user (journey)
     And I should see the "client-33000001" region
 
   Scenario: Register PROF4 user
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I create a new "NDR-disabled" "Prof Named" user "ABC org" "Administrator" with email "behat-prof-org-1@org-1.co.uk" and postcode "SW1"
     And "behat-prof-org-1@org-1.co.uk" has been added to the "org-1.co.uk" organisation
     And I add the client with case number "03000025" to be deputised by email "behat-prof-org-1@org-1.co.uk"
@@ -113,11 +113,11 @@ Feature: Add PROF users and activate PROF user (journey)
     When I check "agree_terms_agreeTermsUse"
     And I press "agree_terms_save"
     Then the form should be valid
-    When I fill in the password fields with "Abcd1234"
+    When I fill in the password fields with "DigidepsPass1234"
     And I check "set_password_showTermsAndConditions"
     When I click on "save"
     Then the form should be valid
-    When I am logged in as "behat-prof-org-1@org-1.co.uk" with password "Abcd1234"
+    When I am logged in as "behat-prof-org-1@org-1.co.uk" with password "DigidepsPass1234"
     And I fill in the following:
       | user_details_firstname  | Prof User   |
       | user_details_lastname   | Three       |
@@ -127,7 +127,7 @@ Feature: Add PROF users and activate PROF user (journey)
     Then the form should be valid
 
   Scenario: Register PROF5 user
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I create a new "NDR-disabled" "Prof Named" user "ABC org" "Administrator" with email "behat-prof-org-2@org-1.co.uk" and postcode "SW1"
     And I add the client with case number "03000026" to be deputised by email "behat-prof-org-2@org-1.co.uk"
     And I click on "send-activation-email" in the "user-behat-prof-org-2org-1couk" region
@@ -136,11 +136,11 @@ Feature: Add PROF users and activate PROF user (journey)
     And I check "agree_terms_agreeTermsUse"
     And I press "agree_terms_save"
     Then the form should be valid
-    When I fill in the password fields with "Abcd1234"
+    When I fill in the password fields with "DigidepsPass1234"
     And I check "set_password_showTermsAndConditions"
     When I click on "save"
     Then the form should be valid
-    When I am logged in as "behat-prof-org-2@org-1.co.uk" with password "Abcd1234"
+    When I am logged in as "behat-prof-org-2@org-1.co.uk" with password "DigidepsPass1234"
     And I fill in the following:
       | user_details_firstname  | Prof User   |
       | user_details_lastname   | Three       |
@@ -150,7 +150,7 @@ Feature: Add PROF users and activate PROF user (journey)
     Then the form should be valid
 
   Scenario: Register PROF6 user
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I create a new "NDR-disabled" "Prof Named" user "ABC org" "Administrator" with email "behat-prof-org-3@org-2.co.uk" and postcode "SW1"
     And I add the client with case number "03000027" to be deputised by email "behat-prof-org-3@org-2.co.uk"
     And I add the client with case number "03000028" to be deputised by email "behat-prof-org-3@org-2.co.uk"
@@ -160,11 +160,11 @@ Feature: Add PROF users and activate PROF user (journey)
     And I check "agree_terms_agreeTermsUse"
     And I press "agree_terms_save"
     Then the form should be valid
-    When I fill in the password fields with "Abcd1234"
+    When I fill in the password fields with "DigidepsPass1234"
     And I check "set_password_showTermsAndConditions"
     When I click on "save"
     Then the form should be valid
-    When I am logged in as "behat-prof-org-3@org-2.co.uk" with password "Abcd1234"
+    When I am logged in as "behat-prof-org-3@org-2.co.uk" with password "DigidepsPass1234"
     And I fill in the following:
       | user_details_firstname  | Prof User   |
       | user_details_lastname   | Three       |
@@ -175,7 +175,7 @@ Feature: Add PROF users and activate PROF user (journey)
 
   Scenario: Edit PROF2 user
     Given I save the application status into "prof-users-uploaded"
-    When I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    When I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "user-behat-prof2publicguardiangovuk" in the "user-behat-prof2publicguardiangovuk" region
     And I press "Edit user"
     Then the following fields should have the corresponding values:

--- a/behat/tests/features/prof/03-report/01-report-edit-period.feature
+++ b/behat/tests/features/prof/03-report/01-report-edit-period.feature
@@ -1,7 +1,7 @@
 Feature: PROF report 102-5
 
   Scenario: Setup data
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     Given the following users exist:
       | ndr      | deputyType       | firstName | lastName | email                               | postCode | activated |
       | disabled | PROF_TEAM_MEMBER | Caroline  | Polachek | CarolinePolachekTeamMember@prof.opg | HA4      | true      |
@@ -13,7 +13,7 @@ Feature: PROF report 102-5
 
   @102-5
   Scenario: PROF does not see unsubmitted reports in the submitted reports section
-    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "31000010"
     And I press "search_submit"
     When I click on "pa-report-open" in the "client-31000010" region
@@ -23,7 +23,7 @@ Feature: PROF report 102-5
   # Logic will evolve differently therefore better to have regression test on this
   @102-5
   Scenario: PROF edit 102-5 report dates
-    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "31000010"
     And I press "search_submit"
     When I click on "pa-report-open" in the "client-31000010" region
@@ -75,7 +75,7 @@ Feature: PROF report 102-5
 
   @102-5
   Scenario: PROF admin has access to edit 102-5 report dates
-    And I am logged in as "CarolinePolachekTeamMember@prof.opg" with password "Abcd1234"
+    And I am logged in as "CarolinePolachekTeamMember@prof.opg" with password "DigidepsPass1234"
     And I fill in "search" with "31000014"
     And I press "search_submit"
     When I click on "pa-report-open" in the "client-31000014" region

--- a/behat/tests/features/prof/03-report/02-common-report-sections.feature
+++ b/behat/tests/features/prof/03-report/02-common-report-sections.feature
@@ -1,7 +1,7 @@
 Feature: PROF user edits 102-5 report sections common to ALL report types
 
   Scenario: PROF-102-5 sections check
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000010" region
     Then I should see a "#edit-contacts" element
     And I should see a "#edit-decisions" element
@@ -20,7 +20,7 @@ Feature: PROF user edits 102-5 report sections common to ALL report types
     And I should see a "#edit-documents" element
 
   Scenario: PROF 102-5 user edit decisions section
-    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000010" region
     Then the response status code should be 200
     And the URL should match "report/\d+/overview"
@@ -38,7 +38,7 @@ Feature: PROF user edits 102-5 report sections common to ALL report types
       | decision_exist_reasonForNoDecisions | rfnd |
 
   Scenario: PROF 102-5 saves a contact
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000010" region
     And I click on "edit-contacts, start"
         # chose "no records"
@@ -49,7 +49,7 @@ Feature: PROF user edits 102-5 report sections common to ALL report types
 
 
   Scenario: PROF 102-5 visits and care steps
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000010" region
     And I click on "edit-visits_care, start"
     # step 1 empty
@@ -78,7 +78,7 @@ Feature: PROF user edits 102-5 report sections common to ALL report types
       | visits_care_whenWasCarePlanLastReviewed_year  | 2015 |
 
   Scenario: PROF 102-5 report actions
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000010" region
     And I click on "edit-actions, start"
       # step 1
@@ -93,7 +93,7 @@ Feature: PROF user edits 102-5 report sections common to ALL report types
       | action_doYouHaveConcernsDetails | dyhcd |
 
   Scenario: PROF 102-5 any other info
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000010" region
     And I click on "edit-other_info, start"
      # step 1
@@ -103,7 +103,7 @@ Feature: PROF user edits 102-5 report sections common to ALL report types
       | more_info_actionMoreInfoDetails | amid |
 
   Scenario: PROF adds documents to 102-5
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000010" region
     # Check report is not submittable until documents section complete
     And the PROF report should not be submittable
@@ -135,7 +135,7 @@ Feature: PROF user edits 102-5 report sections common to ALL report types
       | report_document_upload_files   |
 
   Scenario: PROF deletes document from 102-5
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000010" region
     And I click on "edit-documents"
     # chose "yes documents"

--- a/behat/tests/features/prof/03-report/04-edit-report-sections.feature
+++ b/behat/tests/features/prof/03-report/04-edit-report-sections.feature
@@ -1,7 +1,7 @@
 Feature: PROF user edits 102-5 report sections
 
   Scenario: PROF 102-5 gifts
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "31000010"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-31000010" region
@@ -12,7 +12,7 @@ Feature: PROF user edits 102-5 report sections
       | yes_no_giftsExist_1 | no |
 
   Scenario: PROF 102-5 assets
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "31000010"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-31000010" region
@@ -22,7 +22,7 @@ Feature: PROF user edits 102-5 report sections
       | yes_no_noAssetToAdd_1 | 1 |
 
   Scenario: PROF 102-5  debts
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "31000010"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-31000010" region
@@ -33,7 +33,7 @@ Feature: PROF user edits 102-5 report sections
       | yes_no_hasDebts_1 | no |
 
   Scenario: PROF 102-5 add current account
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "31000010"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-31000010" region
@@ -60,7 +60,7 @@ Feature: PROF user edits 102-5 report sections
     And I choose "no" when asked for adding another record
 
   Scenario: PROF 102-5 add postoffice account (no sort code, no bank name)
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "31000010"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-31000010" region
@@ -83,7 +83,7 @@ Feature: PROF user edits 102-5 report sections
     And I choose "no" when asked for adding another record
 
   Scenario: PROF 102-5 add no sortcode account (still requires bank name)
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "31000010"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-31000010" region
@@ -107,7 +107,7 @@ Feature: PROF user edits 102-5 report sections
     And I choose "no" when asked for adding another record
 
   Scenario: PROF 102-5 deletes bank account
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "31000010"
     And I press "search_submit"
     When I click on "pa-report-open" in the "client-31000010" region
@@ -120,7 +120,7 @@ Feature: PROF user edits 102-5 report sections
     Then I should see "Bank account deleted"
 
   Scenario: PROF 102-5 money in
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "31000010"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-31000010" region
@@ -139,7 +139,7 @@ Feature: PROF user edits 102-5 report sections
       | HSBC - main account - Current account (****01ca) | transaction-pension-received |
 
   Scenario: PROF 102-5 money out
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "31000010"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-31000010" region

--- a/behat/tests/features/prof/03-report/05-deputy-costs.feature
+++ b/behat/tests/features/prof/03-report/05-deputy-costs.feature
@@ -1,7 +1,7 @@
 Feature: PROF deputy costs
 
   Scenario: add cost fixed, no previous, no interim, other 2 items
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "31000010"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-31000010" region
@@ -36,7 +36,7 @@ Feature: PROF deputy costs
       | 1,030.03    | total-cost-taken-from-client |
 
   Scenario: all ticked, no previous, no interim, empty breakdown
-    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "3138393T"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-3138393T" region
@@ -74,7 +74,7 @@ Feature: PROF deputy costs
 
   # Entering the section at the correct subsection
   Scenario: Entering partially completed sections with Fixed costs
-    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "31498120"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-31498120" region
@@ -101,7 +101,7 @@ Feature: PROF deputy costs
     Then the url should match "/report/\d+/prof-deputy-costs/summary"
 
   Scenario: Entering partially completed sections with non Fixed costs and has interim
-    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "32000002"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-32000002" region
@@ -141,7 +141,7 @@ Feature: PROF deputy costs
     Then the url should match "/report/\d+/prof-deputy-costs/summary"
 
   Scenario: Entering partially completed sections with non Fixed costs and not interim
-    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "32000003"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-32000003" region
@@ -178,7 +178,7 @@ Feature: PROF deputy costs
     Then the url should match "/report/\d+/prof-deputy-costs/summary"
 
   Scenario: all ticked, previous, interim, 2 breakdown
-    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I fill in "search" with "33000002"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-33000002" region

--- a/behat/tests/features/prof/03-report/06-deputy-code-estimates.feature
+++ b/behat/tests/features/prof/03-report/06-deputy-code-estimates.feature
@@ -3,13 +3,13 @@ Feature: Prof deputy costs estimate
 
   # Happy paths and Overview status checks
   Scenario: Status of section is reported on Report overview when section is not started
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000010" region
     Then I should see a "#edit-prof_deputy_costs_estimate" element
     And I should see the "prof_deputy_costs_estimate-state-not-started" region
 
   Scenario: Completing the Fixed Costs route and viewing the status overview
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000010" region
     And I click on "edit-prof_deputy_costs_estimate"
     Then the URL should match "/report/\d+/prof-deputy-costs-estimate"
@@ -38,7 +38,7 @@ Feature: Prof deputy costs estimate
     Then I should see the "prof_deputy_costs_estimate-state-done" region
 
   Scenario: Partially completed Assessed Costs route
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000011" region
     And I click on "edit-prof_deputy_costs_estimate"
     When I click on "start"
@@ -48,7 +48,7 @@ Feature: Prof deputy costs estimate
     Then I should see the "prof_deputy_costs_estimate-state-incomplete" region
 
   Scenario: Partially completed Both Costs route
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000012" region
     And I click on "edit-prof_deputy_costs_estimate"
     When I click on "start"
@@ -58,7 +58,7 @@ Feature: Prof deputy costs estimate
     Then I should see the "prof_deputy_costs_estimate-state-incomplete" region
 
   Scenario: Completing the Assessed Costs route with only management cost and viewing the status overview
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000013" region
     And I click on "edit-prof_deputy_costs_estimate"
     When I click on "start"
@@ -87,7 +87,7 @@ Feature: Prof deputy costs estimate
     Then I should see the "prof_deputy_costs_estimate-state-done" region
 
   Scenario: Completing the Assessed Costs route with costs and more info and viewing the status overview
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000014" region
     And I click on "edit-prof_deputy_costs_estimate"
     When I click on "start"
@@ -121,7 +121,7 @@ Feature: Prof deputy costs estimate
     Then I should see the "prof_deputy_costs_estimate-state-done" region
 
   Scenario: Selecting the Both Costs route directs towards Assessed Costs route
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000015" region
     And I click on "edit-prof_deputy_costs_estimate"
     When I click on "start"
@@ -131,7 +131,7 @@ Feature: Prof deputy costs estimate
 
   # Editing non Fixed Costs route answers
   Scenario: Editing the answers for the Assessed Cost route
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000016" region
     And I click on "edit-prof_deputy_costs_estimate"
     When I click on "start"
@@ -163,7 +163,7 @@ Feature: Prof deputy costs estimate
 
   # Switching between Fixed Costs and non Fixed Costs
   Scenario: Switching from Fixed Costs selection to non Fixed Costs selection
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000017" region
     And I click on "edit-prof_deputy_costs_estimate"
     When I click on "start"
@@ -194,7 +194,7 @@ Feature: Prof deputy costs estimate
     And I should see "Extra text" in the "more-info" region
 
   Scenario: Switching from non Fixed Costs selection to Fixed Costs selection
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000018" region
     And I click on "edit-prof_deputy_costs_estimate"
     When I click on "start"
@@ -224,7 +224,7 @@ Feature: Prof deputy costs estimate
 
   # Entering a completed section
   Scenario: Entering a completed Fixed Cost route takes me to summary
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000019" region
     And I click on "edit-prof_deputy_costs_estimate"
     When I click on "start"
@@ -235,7 +235,7 @@ Feature: Prof deputy costs estimate
     Then the URL should match "/report/\d+/prof-deputy-costs-estimate/summary"
 
   Scenario: Entering a completed Assessed Cost route takes me to summary
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000020" region
     And I click on "edit-prof_deputy_costs_estimate"
     When I click on "start"
@@ -251,7 +251,7 @@ Feature: Prof deputy costs estimate
 
   # Entering a partially completed section
   Scenario: Entering a partially completed non Fixed Costs route up to breakdown takes me to breakdown page
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000021" region
     And I click on "edit-prof_deputy_costs_estimate"
     When I click on "start"
@@ -262,7 +262,7 @@ Feature: Prof deputy costs estimate
     And the URL should match "/report/\d+/prof-deputy-costs-estimate/breakdown"
 
   Scenario: Entering a partially completed non Fixed Costs route up to more info takes me to more info page
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000022" region
     And I click on "edit-prof_deputy_costs_estimate"
     When I click on "start"
@@ -276,7 +276,7 @@ Feature: Prof deputy costs estimate
 
   # Form validation
   Scenario: Submitting form with missing data
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000023" region
     And I click on "edit-prof_deputy_costs_estimate"
     When I click on "start"
@@ -293,4 +293,3 @@ Feature: Prof deputy costs estimate
       | deputy_costs_estimate_profDeputyCostsEstimateMoreInfoDetails |         |
     And the step with the following values CAN be submitted:
       | deputy_costs_estimate_profDeputyCostsEstimateHasMoreInfo_0   | no      |
-

--- a/behat/tests/features/prof/03-report/07-submit-report.feature
+++ b/behat/tests/features/prof/03-report/07-submit-report.feature
@@ -1,7 +1,7 @@
 Feature: Report submit (client 31000010)
 
     Scenario: balance check and fix
-        Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "pa-report-open" in the "client-31000010" region
         Then the prof report should not be submittable
           # check balance mismatch difference
@@ -15,12 +15,12 @@ Feature: Report submit (client 31000010)
         Then the prof report should be submittable
 
     Scenario: PROF 102-5 Report should be submittable
-        Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "pa-report-open" in the "client-31000010" region
         Then the PROF report should be submittable
 
     Scenario: 102-5 report declaration page
-        Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "tab-ready"
         And I click on "pa-report-open" in the "client-31000010" region
         Then I should not see the "download-2016-report" link
@@ -42,7 +42,7 @@ Feature: Report submit (client 31000010)
         And I should not see the link "edit-deputy-contact"
 
     Scenario: 102-5 report submission
-        Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "pa-report-open" in the "client-31000010" region
         And I click on "edit-report_submit"
         Then each text should be present in the corresponding region:
@@ -66,7 +66,7 @@ Feature: Report submit (client 31000010)
         And the response status code should be 200
 
     Scenario: 102-5 assert submitted report displays correctly in client profile page
-        Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "tab-in-progress"
         And I click on "pa-report-open" in the "client-31000010" region
         And I should see the "view-report" link
@@ -78,7 +78,7 @@ Feature: Report submit (client 31000010)
         Then the current URL should match with the URL previously saved as "client-31000010-profile"
 
     Scenario: 102-5 assert 2nd year report has been created and displays correctly
-        Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
         And I click on "tab-in-progress"
         And I click on "pa-report-open" in the "client-31000010" region
         Then I should see a "#edit-contacts" element

--- a/behat/tests/features/prof/03-report/08-lodging-checklist.feature
+++ b/behat/tests/features/prof/03-report/08-lodging-checklist.feature
@@ -1,7 +1,7 @@
 Feature: Admin report checklist
 
   Scenario: Case manager submits empty Prof checklist for the report
-    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I open the "2015-to-2016" checklist for client "31000010"
     Then the URL should match "/admin/report/\d+/checklist"
     And I should see the "court-date" region
@@ -76,7 +76,7 @@ Feature: Admin report checklist
     And the URL should match "/admin/report/\d+/checklist"
 
   Scenario: Case manager saves further information on Prof checklist
-    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I open the "2015-to-2016" checklist for client "31000010"
     Then each text should be present in the corresponding region:
       | Not saved yet | lodging-last-saved-by |
@@ -108,7 +108,7 @@ Feature: Admin report checklist
 
 
   Scenario: Admin completes Prof checklist
-    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I open the "2015-to-2016" checklist for client "31000010"
     Then each text should be present in the corresponding region:
       | Case Manager1, Admin | lodging-last-saved-by |
@@ -167,7 +167,7 @@ Feature: Admin report checklist
 
 
   Scenario: Admin marked as submitted
-    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I open the "2015-to-2016" checklist for client "31000010"
     Then each text should be present in the corresponding region:
       | Case Manager1, Admin | lodging-last-saved-by     |

--- a/behat/tests/features/prof/04-dashboard-client-profile/02-dashboard.feature
+++ b/behat/tests/features/prof/04-dashboard-client-profile/02-dashboard.feature
@@ -1,7 +1,7 @@
 Feature: PROF dashboard
 
   Scenario: PROF dashboard check visibility, pagination and search
-    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     # check pagination
     And I should see the "client" region exactly 15 times
     When I click on "paginator-page-2"
@@ -19,7 +19,7 @@ Feature: PROF dashboard
     Then the URL should match "/org"
 
   Scenario: PROF links in header
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     #PROF links
     Then I should see the "org-dashboard" link
     And I should see the "org-settings" link

--- a/behat/tests/features/prof/04-dashboard-client-profile/10-client-profile.feature
+++ b/behat/tests/features/prof/04-dashboard-client-profile/10-client-profile.feature
@@ -1,7 +1,7 @@
 Feature: PROF client profile
 
   Scenario: PROF view client details
-    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000011" region
     Then each text should be present in the corresponding region:
       | Cly4 Hent4    | client-profile-details |

--- a/behat/tests/features/prof/04-dashboard-client-profile/11-client-profile-notes.feature
+++ b/behat/tests/features/prof/04-dashboard-client-profile/11-client-profile-notes.feature
@@ -1,13 +1,13 @@
 Feature: PROF client profile Notes
 
   Scenario: PROF view client notes
-    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000011" region
     Then each text should be present in the corresponding region:
       | No notes    | client-profile-notes |
 
   Scenario: PROF adds client notes
-    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000011" region
     And I click on "add-notes-button" in the "client-profile-notes" region
     # empty form
@@ -40,7 +40,7 @@ Feature: PROF client profile Notes
       | test content | client-profile-notes |
 
   Scenario: PROF edit client notes
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000011" region
     And I click on "edit-notes-button" in the "client-profile-notes" region
     Then the following fields should have the corresponding values:
@@ -61,7 +61,7 @@ Feature: PROF client profile Notes
       | test content edit | client-profile-notes |
 
   Scenario: PROF delete client notes
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000011" region
     And I save the current URL as "report-overview"
     And I click on "delete-notes-button" in the "client-profile-notes" region

--- a/behat/tests/features/prof/04-dashboard-client-profile/12-client-profile-contacts.feature
+++ b/behat/tests/features/prof/04-dashboard-client-profile/12-client-profile-contacts.feature
@@ -1,13 +1,13 @@
 Feature: PROF client profile contacts
 
   Scenario: PROF view client contacts
-    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000011" region
     Then each text should be present in the corresponding region:
       | No contacts    | client-profile-contacts |
 
   Scenario: PROF adds client contact
-    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000011" region
     And I save the current URL as "report-overview"
     And I click on "add-contact-button" in the "client-profile-contacts" region
@@ -79,7 +79,7 @@ Then I fill in the following:
       | doc@brown.com | client-profile-contacts-display-contact-info |
 
   Scenario: PROF edits client contact
-  Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+  Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
   And I click on "pa-report-open" in the "client-31000011" region
   And I save the current URL as "report-overview"
   And I click on "edit-contact-button" in the "client-profile-contacts-display-actions" region
@@ -107,7 +107,7 @@ Then I fill in the following:
     | doce@brown.com | client-profile-contacts-display-contact-info |
 
 Scenario: PROF delete client contacts
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-31000011" region
     And I save the current URL as "report-overview"
     And I click on "delete-contact-button" in the "client-profile-contacts" region

--- a/behat/tests/features/prof/04-dashboard-client-profile/13-settings.feature
+++ b/behat/tests/features/prof/04-dashboard-client-profile/13-settings.feature
@@ -1,7 +1,7 @@
 Feature: PROF settings
 
   Scenario: named PROF logs in and views profile page
-    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I click on "org-settings"
 
     # settings page
@@ -17,7 +17,7 @@ Feature: PROF settings
     And I should see "10000000001" in the "profile-phone" region
 
   Scenario: named PROF logs in and updates profile and does not see removeAdmin field
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I click on "org-settings, profile-show, profile-edit"
     Then I should not see "Give up administrator rights"
     Then I fill in the following:
@@ -39,7 +39,7 @@ Feature: PROF settings
     And I should see "United Kingdom" in the "profile-address" region
 
   Scenario: PROF Admin logs in and updates profile and sees removeAdmin field but does not
-    Given I am logged in as "DannyHarleAdmin@prof.opg" with password "Abcd1234"
+    Given I am logged in as "DannyHarleAdmin@prof.opg" with password "DigidepsPass1234"
     When I click on "org-settings, profile-show, profile-edit"
     Then I should see "Give up administrator rights"
     Then I fill in the following:
@@ -55,7 +55,7 @@ Feature: PROF settings
     And I should see "10000000012" in the "profile-phone" region
 
   Scenario: PROF Admin logs in and updates profile and removes admin
-    Given I am logged in as "DannyHarleAdmin@prof.opg" with password "Abcd1234"
+    Given I am logged in as "DannyHarleAdmin@prof.opg" with password "DigidepsPass1234"
     When I click on "org-settings, profile-show, profile-edit"
     Then I should see "Give up administrator rights"
     When I check "Give up administrator rights"
@@ -64,13 +64,13 @@ Feature: PROF settings
     And I should be on "/login"
 
   Scenario: PROF Admin is no longer admin and tests nav
-    Given I am logged in as "DannyHarleAdmin@prof.opg" with password "Abcd1234"
+    Given I am logged in as "DannyHarleAdmin@prof.opg" with password "DigidepsPass1234"
     When I click on "org-settings, org-accounts"
     And I should not see "Edit" in the "team-user-carolinepolachekteammemberprofopg" region
     But I should not see "Edit" in the "team-user-behat-prof1publicguardiangovuk" region
 
   Scenario: PROF Team member logs in and edits info
-    Given I am logged in as "CarolinePolachekTeamMember@prof.opg" with password "Abcd1234"
+    Given I am logged in as "CarolinePolachekTeamMember@prof.opg" with password "DigidepsPass1234"
     When I click on "org-settings, profile-show, profile-edit"
     Then I should not see "Give up administrator rights"
     When I fill in the following:
@@ -101,91 +101,95 @@ Feature: PROF settings
     And I should see "United Kingdom" in the "profile-address" region
 
   Scenario: Named PROF logs in and changes password
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I click on "org-settings, password-edit"
     Then I should see "Change password"
     When I press "change_password_save"
     Then the following fields should have an error:
       | change_password_current_password     |
-      | change_password_plain_password_first |
+      | change_password_password_first |
     #incorrect password
     When I fill in the following:
       | change_password_current_password       | Moo       |
-      | change_password_plain_password_first   | Abcd2345  |
-      | change_password_plain_password_second  | Abcd2345  |
+      | change_password_password_first   | DigidepsPass12345  |
+      | change_password_password_second  | DigidepsPass12345  |
     When I press "change_password_save"
     Then the following fields should have an error:
       | change_password_current_password     |
     #correct password, unmatching new passwords
     When I fill in the following:
-      | change_password_current_password       | Abcd1234  |
-      | change_password_plain_password_first   | Abcd1111  |
-      | change_password_plain_password_second  | Abcd2222  |
+      | change_password_current_password       | DigidepsPass1234  |
+      | change_password_password_first   | DigidepsPass1111  |
+      | change_password_password_second  | DigidepsPass2222  |
     When I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first   |
-    #various password inadequacies
+      | change_password_password_first   |
+    #not long enough
     When I fill in the following:
-      | change_password_current_password       | Abcd1234 |
-      | change_password_plain_password_first   | Abcd123  |
-      | change_password_plain_password_second  | Abcd123  |
+      | change_password_current_password       | DigidepsPass1234 |
+      | change_password_password_first   | Digideps1234  |
+      | change_password_password_second  | Digideps1234  |
     When I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first   |
+      | change_password_password_first   |
+    #no uppercase
     When I fill in the following:
-      | change_password_current_password       | Abcd1234  |
-      | change_password_plain_password_first   | abcd1234  |
-      | change_password_plain_password_second  | abcd1234  |
+      | change_password_current_password       | DigidepsPass1234  |
+      | change_password_password_first   | digideps1234  |
+      | change_password_password_second  | digideps1234  |
     When I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first   |
+      | change_password_password_first   |
+    #no numbers
     When I fill in the following:
-      | change_password_current_password       | Abcd1234  |
-      | change_password_plain_password_first   | Abcdefgh  |
-      | change_password_plain_password_second  | Abcdefgh  |
+      | change_password_current_password       | DigidepsPass1234  |
+      | change_password_password_first   | DigidepsPassword  |
+      | change_password_password_second  | DigidepsPassword  |
     When I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first   |
+      | change_password_password_first   |
+    #no lowercase
     When I fill in the following:
-      | change_password_current_password       | Abcd1234  |
-      | change_password_plain_password_first   | ABCD1234  |
-      | change_password_plain_password_second  | ABCD1234  |
+      | change_password_current_password       | DigidepsPass1234  |
+      | change_password_password_first   | DIGIDEPSPASS1234  |
+      | change_password_password_second  | DIGIDEPSPASS1234  |
     When I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first   |
+      | change_password_password_first   |
+    # too common password
     When I fill in the following:
-      | change_password_current_password       | Abcd1234  |
-      | change_password_plain_password_first   | Password123  |
-      | change_password_plain_password_second  | Password123  |
+      | change_password_current_password       | DigidepsPass1234  |
+      | change_password_password_first   | Password123  |
+      | change_password_password_second  | Password123  |
     When I press "change_password_save"
     Then the following fields should have an error:
-      | change_password_plain_password_first   |
+      | change_password_password_first   |
     # Finally a valid one
     When I fill in the following:
-      | change_password_current_password       | Abcd1234  |
-      | change_password_plain_password_first   | Abcd2345  |
-      | change_password_plain_password_second  | Abcd2345  |
+      | change_password_current_password       | DigidepsPass1234  |
+      | change_password_password_first   | DigidepsPass2345  |
+      | change_password_password_second  | DigidepsPass2345  |
     When I press "change_password_save"
     Then the form should be valid
     And I should see "Sign in with your new password"
     And I should be on "/login"
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd2345"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass2345"
     When I click on "org-settings, password-edit"
     Then I should see "Change password"
     When I fill in the following:
-      | change_password_current_password       | Abcd2345   |
-      | change_password_plain_password_first   | Abcd1234!! |
-      | change_password_plain_password_second  | Abcd1234!! |
+      | change_password_current_password       | DigidepsPass2345   |
+      | change_password_password_first   | DigidepsPass1234!! |
+      | change_password_password_second  | DigidepsPass1234!! |
     When I press "change_password_save"
     Then the form should be valid
 
   Scenario: Prof in two organisations can access the settings page of each organisation
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     Given the organisation "org-1.co.uk" is active
     And the organisation "abc-solicitors.uk" is active
     And "behat-prof-org-1@org-1.co.uk" has been added to the "org-1.co.uk" organisation
     And "behat-prof-org-1@org-1.co.uk" has been added to the "abc-solicitors.uk" organisation
-    When I am logged in as "behat-prof-org-1@org-1.co.uk" with password "Abcd1234"
+    When I am logged in as "behat-prof-org-1@org-1.co.uk" with password "DigidepsPass1234"
     And I click on "org-settings, org-accounts"
     And I follow "Your Organisation"
     Then I should see "Your Organisation"

--- a/behat/tests/features/prof/04-dashboard-client-profile/14-client-archive.feature
+++ b/behat/tests/features/prof/04-dashboard-client-profile/14-client-archive.feature
@@ -1,7 +1,7 @@
 Feature: PROF client archive
 
   Scenario: PROF archives a client
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234!!"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234!!"
     And I fill in "search" with "31000016"
     And I press "search_submit"
     And I click on "pa-report-open" in the "client-31000016" region

--- a/behat/tests/features/prof/04-dashboard-client-profile/15-client-search.feature
+++ b/behat/tests/features/prof/04-dashboard-client-profile/15-client-search.feature
@@ -1,7 +1,7 @@
 Feature: PROF client search
   @prof @prof-search @prof-client-search
   Scenario: Search broadly across clients by firstname or lastname
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234!!"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234!!"
     When I search for a client with the term "Updateds"
     Then I should see "Showing 0 clients"
     When I search for a client with the term "Updated"
@@ -11,7 +11,7 @@ Feature: PROF client search
 
   @prof @prof-search @prof-client-search
   Scenario: Search exact name match across clients
-    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234!!"
+    Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234!!"
     When I search for a client with the term "ame Updated"
     Then I should see "Showing 0 clients"
     When I search for a client with the term "Name Update"

--- a/behat/tests/features/prof/05-organisation/01-view-details.feature
+++ b/behat/tests/features/prof/05-organisation/01-view-details.feature
@@ -2,17 +2,17 @@ Feature: Users can view their organisations
 
   @prof
   Scenario: Without organisation, user cannot access settings pages
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     Given the following users exist:
       | ndr      | deputyType | firstName | lastName  | email                                    | postCode | activated |
       | disabled | PROF_ADMIN | Lorely    | Rodriguez | LorelyRodriguezAdminNoOrg@behat-test.com | HA4      | true      |
-    Given I am logged in as "LorelyRodriguezAdminNoOrg@behat-test.com" with password "Abcd1234"
+    Given I am logged in as "LorelyRodriguezAdminNoOrg@behat-test.com" with password "DigidepsPass1234"
     When I go to "/org/settings"
     Then I should not see "User Accounts"
 
   @prof
   Scenario: Set up organisation
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I go to admin page "/admin/organisations/add"
     And I fill in "organisation_name" with "Leever Partners"
     And I fill in "organisation_emailIdentifierType_0" with "domain"
@@ -22,8 +22,8 @@ Feature: Users can view their organisations
     # Add user manually due to fixtures auto creating the organisation
     And I go to admin page "/admin"
     And I create a new "NDR-disabled" "prof named" user "Main" "Leever Contact" with email "main.contact@leever.example" and postcode "HA4"
-    And I activate the named deputy "main.contact@leever.example" with password "Abcd1234"
-    When I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    And I activate the named deputy "main.contact@leever.example" with password "DigidepsPass1234"
+    When I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I go to admin page "/admin/organisations"
     And I follow "Leever Partners"
     And I follow "Add user"
@@ -36,7 +36,7 @@ Feature: Users can view their organisations
 
   @prof
   Scenario: When organisation is not active, user cannot access settings pages
-    Given I am logged in as "main.contact@leever.example" with password "Abcd1234"
+    Given I am logged in as "main.contact@leever.example" with password "DigidepsPass1234"
     When I go to "/org/settings"
     Then I should not see "User Accounts"
     When I go to "/org/settings/organisation"
@@ -44,12 +44,12 @@ Feature: Users can view their organisations
 
   @prof
   Scenario: User can view their active organisation
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I go to admin page "/admin/organisations"
     When I click on "edit" in the "org-leever-partners" region
     And I fill in "organisation_isActivated_0" with "1"
     And I press "Save organisation"
-    When I am logged in as "main.contact@leever.example" with password "Abcd1234"
+    When I am logged in as "main.contact@leever.example" with password "DigidepsPass1234"
     When I go to "/org/settings"
     And I follow "User accounts"
     Then the URL should match "/org/settings/organisation/\d+"
@@ -59,7 +59,7 @@ Feature: Users can view their organisations
 
   @prof
   Scenario: Super admin removes organisation
-    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "super-admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I am on admin page "/admin/organisations"
     When I click on "delete" in the "org-leever-partners" region
     And I click on "confirm"

--- a/behat/tests/features/prof/05-organisation/03-organisation-acl.feature
+++ b/behat/tests/features/prof/05-organisation/03-organisation-acl.feature
@@ -1,7 +1,7 @@
 Feature: Users can access the correct clients
 
   Scenario: New client is added to existing deputy and brand new organisation added
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     # upload new Prof client 50000051 attached to org
     When I go to admin page "/admin/org-csv-upload"
     And I attach the file "behat-prof-new-clients.csv" to "admin_upload_file"
@@ -10,23 +10,23 @@ Feature: Users can access the correct clients
 
   Scenario: Team User cannot see clients belonging to inactive organisations
     # log in as deputy should not see new client until org is activated
-    Given I am logged in as "existing-deputy1@abc-solicitors.uk" with password "Abcd1234"
+    Given I am logged in as "existing-deputy1@abc-solicitors.uk" with password "DigidepsPass1234"
     And I go to "/org/?limit=50"
     And I should see the "client-50000050" region
     And I should not see the "client-50000051" region
 
   Scenario: Organisation activated should not permit visibility of new clients belonging to org
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I go to admin page "/admin/organisations"
     When I click on "edit" in the "org-abc-solicitors" region
     And I fill in "organisation_isActivated_0" with "1"
     And I press "Save organisation"
-    And I am logged in as "existing-deputy1@abc-solicitors.uk" with password "Abcd1234"
+    And I am logged in as "existing-deputy1@abc-solicitors.uk" with password "DigidepsPass1234"
     And I should see the "client-50000050" region
     And I should not see the "client-50000051" region
 
   Scenario: Team user added to existing org should enable visibility of new client
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I go to admin page "/admin/organisations"
     And I follow "ABC Solicitors"
     #And I create a new "NDR-disabled" "Prof Named" user "ABC org" "Administrator" with email "behat-pa-org1@pa-org1.gov.uk" and postcode "SW1"
@@ -37,7 +37,7 @@ Feature: Users can access the correct clients
 
   Scenario: Active organisation permits visibility of new client
     # log in as deputy should see new client
-    Given I am logged in as "existing-deputy1@abc-solicitors.uk" with password "Abcd1234"
+    Given I am logged in as "existing-deputy1@abc-solicitors.uk" with password "DigidepsPass1234"
     And I go to "/org/?limit=50"
     And I should see the "client-50000050" region
     And I should see the "client-50000051" region
@@ -48,7 +48,7 @@ Feature: Users can access the correct clients
   Scenario: User not in an organisation attempting to access their client who is in an inactive organisation
     Given the organisation "org-1.co.uk" is inactive
     And "behat-prof-org-1@org-1.co.uk" has been removed from their organisation
-    When I am logged in as "behat-prof-org-1@org-1.co.uk" with password "Abcd1234"
+    When I am logged in as "behat-prof-org-1@org-1.co.uk" with password "DigidepsPass1234"
     Then I should see the "client-03000025" region
     And I should not see the "client-03000026" region
     And I should see the "client" region exactly 1 times
@@ -59,7 +59,7 @@ Feature: Users can access the correct clients
   Scenario: User in an inactive organisation attempting to access their client who is in an inactive organisation
     Given the organisation "org-1.co.uk" is inactive
     And "behat-prof-org-1@org-1.co.uk" has been added to the "org-1.co.uk" organisation
-    When I am logged in as "behat-prof-org-1@org-1.co.uk" with password "Abcd1234"
+    When I am logged in as "behat-prof-org-1@org-1.co.uk" with password "DigidepsPass1234"
     Then I should see the "client-03000025" region
     And I should not see the "client-03000026" region
     And I should see the "client" region exactly 1 times
@@ -67,24 +67,24 @@ Feature: Users can access the correct clients
     Then the response status code should be 200
 
   Scenario: User attempting to view report not belonging to their client
-    Given I am logged in as "behat-prof-org-2@org-1.co.uk" with password "Abcd1234"
+    Given I am logged in as "behat-prof-org-2@org-1.co.uk" with password "DigidepsPass1234"
     And I click on "pa-report-open" in the "client-03000026" region
     And I save the report as "03000026-report"
-    When I am logged in as "behat-prof-org-1@org-1.co.uk" with password "Abcd1234"
+    When I am logged in as "behat-prof-org-1@org-1.co.uk" with password "DigidepsPass1234"
     And I go to the report URL "overview" for "03000026-report"
     Then the response status code should be 404
 
   Scenario: User not in an organisation attempting to access their client who is in an active organisation
     Given the organisation "org-1.co.uk" is active
     And "behat-prof-org-1@org-1.co.uk" has been removed from their organisation
-    When I am logged in as "behat-prof-org-1@org-1.co.uk" with password "Abcd1234"
+    When I am logged in as "behat-prof-org-1@org-1.co.uk" with password "DigidepsPass1234"
     And I go to the report URL "overview" for "03000025-report"
     And the response status code should be 404
 
   Scenario: User in an active organisation attempting to access clients inside and outside of the organisation
     Given the organisation "org-1.co.uk" is active
     And "behat-prof-org-1@org-1.co.uk" has been added to the "org-1.co.uk" organisation
-    When I am logged in as "behat-prof-org-1@org-1.co.uk" with password "Abcd1234"
+    When I am logged in as "behat-prof-org-1@org-1.co.uk" with password "DigidepsPass1234"
     Then I should see the "client-03000025" region
     And I should see the "client-03000026" region
     And I should not see the "client-03000027" region

--- a/behat/tests/features/prof/05-organisation/04-organisation-updates-acl.feature
+++ b/behat/tests/features/prof/05-organisation/04-organisation-updates-acl.feature
@@ -1,7 +1,7 @@
 Feature: Organisation deputyship updates
 
   Scenario: Apply deputyship updates via CSV
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And the following users exist:
       | ndr      | deputyType | firstName | lastName | email                                 | postCode | activated |
       | disabled | PROF       | New Dep1  | Surname1 | new-behat-prof1@publicguardian.gov.uk | SW1      | true      |
@@ -21,10 +21,10 @@ Feature: Organisation deputyship updates
   # Client has different deputy in the same org. Old deputy left org - dont delete client
   Scenario: Professional deputy leaves organisation, clients appointed a new deputy within the same organisation
     # Assert new deputy can see client
-    Given I am logged in as "new-behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "new-behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should see the "client-01000010" region
     # Assert client still associated with same org
-    Then I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Then I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I visit the client page for "01000010"
     # Assert same organisation
     And I should see "PA OPG" in the "assigned-organisation" region
@@ -34,10 +34,10 @@ Feature: Organisation deputyship updates
   # Client has different deputy in different org. Client remains with current org and deputy
   Scenario: Professional deputy leaves organisation, clients appointed a new deputy within the same organisation
     # Assert new deputy can see client
-    Given I am logged in as "new-behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "new-behat-prof1@publicguardian.gov.uk" with password "DigidepsPass1234"
     Then I should see the "client-01000010" region
     # Assert client still associated with same org
-    Then I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Then I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I visit the client page for "01000010"
     # Assert same organisation
     And I should see "PA OPG" in the "assigned-organisation" region
@@ -48,10 +48,10 @@ Feature: Organisation deputyship updates
   # Client has new deputy and new org - delete client and expect new one created
   Scenario: Clients appointed to a new organisation
     #  (deputy number changes, org identifier changes to deputy of new organisation - example.com2)
-    Given I am logged in as "behat-prof1@example.com2" with password "Abcd1234"
+    Given I am logged in as "behat-prof1@example.com2" with password "DigidepsPass1234"
     And I should not see the "client-11498120" region
     # Assert client still associated with previous org
-    Then I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Then I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I search in admin for a client with the term "11498120"
     Then I should see "Found 1 clients"
     # Assert old client has not been discharged

--- a/behat/tests/features/v2/acl/organisation-acl.feature
+++ b/behat/tests/features/v2/acl/organisation-acl.feature
@@ -11,7 +11,7 @@ Feature: Managing client and report access for deputies within active organisati
       | 54234341 | Deputy8543 | PROF        | Property and Financial Affairs High Assets | 2018-01-30 |
 
   Scenario: A deputy can only view clients that belong to their sole organisation
-    Given I am logged in as "deputy8543@behat-test.com" with password "Abcd1234"
+    Given I am logged in as "deputy8543@behat-test.com" with password "DigidepsPass1234"
     Then I should see "54234341"
     And I should not see "Org 8543 Ltd"
     And I should not see "95432265"
@@ -19,7 +19,7 @@ Feature: Managing client and report access for deputies within active organisati
 
   Scenario: A deputy can only view clients that belong to their multiple organisations
     Given "deputy1943@behat-test.com" has been added to the "deputy5492@behat-test.com" organisation
-    When I am logged in as "deputy1943@behat-test.com" with password "Abcd1234"
+    When I am logged in as "deputy1943@behat-test.com" with password "DigidepsPass1234"
     Then I should see "95432265"
     And I should see "Org 1943 Ltd"
     And I should see "94235342"
@@ -27,7 +27,7 @@ Feature: Managing client and report access for deputies within active organisati
     And I should not see "54234341"
 
   Scenario: A deputy can only access reports that belong to clients within the deputy's organisations
-    When I am logged in as "deputy1943@behat-test.com" with password "Abcd1234"
+    When I am logged in as "deputy1943@behat-test.com" with password "DigidepsPass1234"
     And I follow "95432265-Client, John"
     Then I should see "Client profile"
     When "deputy1943@behat-test.com" has been removed from the "deputy1943@behat-test.com" organisation
@@ -36,4 +36,3 @@ Feature: Managing client and report access for deputies within active organisati
     When I follow "Dashboard"
     And I follow "94235342-Client, John"
     Then I should see "Client profile"
-

--- a/behat/tests/features/v2/authentication/password-reset.feature
+++ b/behat/tests/features/v2/authentication/password-reset.feature
@@ -1,7 +1,7 @@
 Feature: Users can reset their password via self-service
 
     Scenario: Set up organisation and admin
-        Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
         And the following users exist:
             | ndr      | deputyType | firstName | lastName | email                          | postCode | activated |
             | disabled | LAY        | Enrique   | Remondet | enrique75@mail.example         | SW1H 9AJ | true      |
@@ -14,13 +14,39 @@ Feature: Users can reset their password via self-service
         And I press "Reset your password"
         Then the form should be valid
         When I open the password reset page for "enrique75@mail.example"
+        # no match
         And I fill in the following:
-            | reset_password_password_first  | Abcd12345 |
-            | reset_password_password_second | Abcd12345 |
+          | reset_password_password_first   | DigidepsPass1234 |
+          | reset_password_password_second  | DigidepsPass12345 |
         And I press "Save password"
-        Then I should be on "/login"
+        Then the form should be invalid
+        # not long enough
+        When I fill in the reset password fields with "Digideps1234"
+        And I press "Save password"
+        Then the form should be invalid
+        # nolowercase
+        When I fill in the reset password fields with "DIGIDEPSPASS1234"
+        And I press "Save password"
+        Then the form should be invalid
+        # nouppercase
+        When I fill in the reset password fields with "digidepspass1234"
+        And I press "Save password"
+        Then the form should be invalid
+        # no number
+        When I fill in the reset password fields with "DigidepsPassword"
+        And I press "Save password"
+        Then the form should be invalid
+        # too common password
+        When I fill in the reset password fields with "Password123"
+        And I press "Save password"
+        Then the form should be invalid
+        # valid password!
+        When I fill in the reset password fields with "DigidepsPass12345"
+        And I press "Save password"
+        Then the form should be valid
+        And I should be on "/login"
         And I should see "Sign in with your new password"
-        When I am logged in as "enrique75@mail.example" with password "Abcd12345"
+        When I am logged in as "enrique75@mail.example" with password "DigidepsPass12345"
         Then the form should be valid
         Given I am on "/login"
         Then I should see "Sign in"
@@ -33,13 +59,39 @@ Feature: Users can reset their password via self-service
         And I press "Reset your password"
         Then the form should be valid
         When I open the admin password reset page for "o.fiecke@publicguardian.gov.uk"
+        # no match
         And I fill in the following:
-            | reset_password_password_first  | Abcd12345 |
-            | reset_password_password_second | Abcd12345 |
+          | reset_password_password_first   | DigidepsPass1234 |
+          | reset_password_password_second  | DigidepsPass12345 |
         And I press "Save password"
-        Then I should be on "/login"
+        Then the form should be invalid
+        # not long enough
+        When I fill in the reset password fields with "Digideps1234"
+        And I press "Save password"
+        Then the form should be invalid
+        # nolowercase
+        When I fill in the reset password fields with "DIGIDEPSPASS1234"
+        And I press "Save password"
+        Then the form should be invalid
+        # nouppercase
+        When I fill in the reset password fields with "digidepspass1234"
+        And I press "Save password"
+        Then the form should be invalid
+        # no number
+        When I fill in the reset password fields with "DigidepsPassword"
+        And I press "Save password"
+        Then the form should be invalid
+        # too common password
+        When I fill in the reset password fields with "Password123"
+        And I press "Save password"
+        Then the form should be invalid
+        # valid password!
+        When I fill in the reset password fields with "DigidepsPass12345"
+        And I press "Save password"
+        Then the form should be valid
+        And I should be on "/login"
         And I should see "Sign in with your new password"
-        When I am logged in to admin as "o.fiecke@publicguardian.gov.uk" with password "Abcd12345"
+        When I am logged in to admin as "o.fiecke@publicguardian.gov.uk" with password "DigidepsPass12345"
         Then the form should be valid
 
     Scenario: Invalid emails are not accepted

--- a/behat/tests/features/v2/courtOrderManagement/discharge-deputy.feature
+++ b/behat/tests/features/v2/courtOrderManagement/discharge-deputy.feature
@@ -12,7 +12,7 @@ Feature: Manually discharge deputies from a court order
       | client   | deputy    | deputy_type | report_type                                | court_date |
       | 32163425 | Deputy432 | LAY         | Property and Financial Affairs High Assets | 2018-01-30 |
     When a super admin discharges the deputy from "32163425"
-    And I am logged in as "deputy432@behat-test.com" with password "Abcd1234"
+    And I am logged in as "deputy432@behat-test.com" with password "DigidepsPass1234"
     Then I should be on "/client/add"
 
   Scenario: Super admin user manually discharges an org based named deputy from their client
@@ -21,7 +21,7 @@ Feature: Manually discharge deputies from a court order
       | 43853417 | Deputy043 | PROF        | Health and Welfare | 2018-01-30 |
       | 43853418 | Deputy043 | PROF        | Health and Welfare | 2018-01-31 |
     When a super admin discharges the deputy from "43853417"
-    And I am logged in as "deputy043@behat-test.com" with password "Abcd1234"
+    And I am logged in as "deputy043@behat-test.com" with password "DigidepsPass1234"
     Then I should see "43853418"
     And I should not see "43853417"
 
@@ -30,6 +30,6 @@ Feature: Manually discharge deputies from a court order
     Given the following court orders exist:
       | client   | deputy    | deputy_type | report_type        | court_date |
       | 84775409 | Deputy329 | PA          | Health and Welfare | 2017-03-30 |
-    When I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    When I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I visit the client page for "84775409"
     Then I should not see "Discharge deputy"

--- a/behat/tests/features/v2/organisationManagement/edit-members.feature
+++ b/behat/tests/features/v2/organisationManagement/edit-members.feature
@@ -16,7 +16,7 @@ Feature: Organisation admins can edit members of their organisation
       | guscioraonline@gmail.example | Rey Gusciora       |
 
   Scenario: Org admins can add existing users to their organisation
-    Given I am logged in as "l.degroot@malvern.example" with password "Abcd1234"
+    Given I am logged in as "l.degroot@malvern.example" with password "DigidepsPass1234"
     When I go to "/org/settings/organisation"
     And I follow "Add user"
     And I follow "Cancel"
@@ -33,7 +33,7 @@ Feature: Organisation admins can edit members of their organisation
     And I should see "l.swayzer@outsource.example"
 
   Scenario: Org admins can add new users to their organisation
-    Given I am logged in as "l.degroot@malvern.example" with password "Abcd1234"
+    Given I am logged in as "l.degroot@malvern.example" with password "DigidepsPass1234"
     When I go to "/org/settings/organisation"
     And I follow "Add user"
     And I fill in the following:
@@ -47,7 +47,7 @@ Feature: Organisation admins can edit members of their organisation
     And I should see "y.lacasse@malvern.example"
 
   Scenario: Admins of orgs with an email address identifier can add users to their organisation
-    Given I am logged in as "guscioraonline@gmail.example" with password "Abcd1234"
+    Given I am logged in as "guscioraonline@gmail.example" with password "DigidepsPass1234"
     When I go to "/org/settings/organisation"
     And I follow "Add user"
     And I fill in the following:
@@ -61,7 +61,7 @@ Feature: Organisation admins can edit members of their organisation
 
 #    TODO: uncomment once DDPB-3356 is merged
 #  Scenario: Org admins can edit non-activated users
-#    Given I am logged in as "l.degroot@malvern.example" with password "Abcd1234"
+#    Given I am logged in as "l.degroot@malvern.example" with password "DigidepsPass1234"
 #    When I go to "/org/settings/organisation"
 #    And I click on "edit" in the "team-user-yvonnelacassemalvernexample" region
 #    Then the "organisation_member_firstname" field should contain "Yvonne"
@@ -77,7 +77,7 @@ Feature: Organisation admins can edit members of their organisation
 #    And I should see "y.lacasse@malvern.example"
 
   Scenario: Org admins can resend activation emails to non-activated users
-    Given I am logged in as "l.degroot@malvern.example" with password "Abcd1234"
+    Given I am logged in as "l.degroot@malvern.example" with password "DigidepsPass1234"
     When I go to "/org/settings/organisation"
     And I click on "send-activation-email" in the "team-user-ylacassemalvernexample" region
     Then the form should be valid
@@ -85,23 +85,23 @@ Feature: Organisation admins can edit members of their organisation
   Scenario: Org admins cannot resend email to activated users
     Given I open the activation page for "y.lacasse@malvern.example"
     And I fill in the following:
-        | set_password_password_first  | Abcd1234 |
-        | set_password_password_second | Abcd1234 |
+        | set_password_password_first  | DigidepsPass1234 |
+        | set_password_password_second | DigidepsPass1234 |
     And I check "set_password_showTermsAndConditions"
     And I press "Submit"
-    When I am logged in as "l.degroot@malvern.example" with password "Abcd1234"
+    When I am logged in as "l.degroot@malvern.example" with password "DigidepsPass1234"
     And I go to "/org/settings/organisation"
     Then I should see "Edit" in the "team-user-ylacassemalvernexample" region
     And I should not see "Resend activation email" in the "team-user-ylacassemalvernexample" region
 
   Scenario: Org team members can edit themselves
-    Given I am logged in as "y.lacasse@malvern.example" with password "Abcd1234"
+    Given I am logged in as "y.lacasse@malvern.example" with password "DigidepsPass1234"
     When I go to "/org/settings/organisation"
     And I click on "edit" in the "team-user-ylacassemalvernexample" region
     Then I should be on "/org/settings/your-details/edit"
 
   Scenario: Org team members cannot edit or remove other users
-    Given I am logged in as "y.lacasse@malvern.example" with password "Abcd1234"
+    Given I am logged in as "y.lacasse@malvern.example" with password "DigidepsPass1234"
     When I go to "/org/settings/organisation"
     Then I should not see "Add user"
     And I should not see "Edit" in the "team-user-ldegrootmalvernexample" region
@@ -109,13 +109,13 @@ Feature: Organisation admins can edit members of their organisation
     And I should not see the "send-activation-email" link
 
   Scenario: Org admins can edit themselves from the organisation page
-    Given I am logged in as "l.degroot@malvern.example" with password "Abcd1234"
+    Given I am logged in as "l.degroot@malvern.example" with password "DigidepsPass1234"
     When I go to "/org/settings/organisation"
     And I click on "edit" in the "team-user-ldegrootmalvernexample" region
     Then I should be on "/org/settings/your-details/edit"
 
   Scenario: Org admins can add other admins
-    Given I am logged in as "l.degroot@malvern.example" with password "Abcd1234"
+    Given I am logged in as "l.degroot@malvern.example" with password "DigidepsPass1234"
     When I go to "/org/settings/organisation"
     And I follow "Add user"
     And I fill in the following:
@@ -129,18 +129,18 @@ Feature: Organisation admins can edit members of their organisation
   Scenario: Additional org admins can edit and remove users
     Given I open the activation page for "k.damore@malvern.example"
     And I fill in the following:
-        | set_password_password_first  | Abcd1234 |
-        | set_password_password_second | Abcd1234 |
+        | set_password_password_first  | DigidepsPass1234 |
+        | set_password_password_second | DigidepsPass1234 |
     And I check "set_password_showTermsAndConditions"
     And I press "Submit"
-    When I am logged in as "k.damore@malvern.example" with password "Abcd1234"
+    When I am logged in as "k.damore@malvern.example" with password "DigidepsPass1234"
     And I go to "/org/settings/organisation"
     Then I should see "Add user"
     And I should see "Edit" in the "team-user-ylacassemalvernexample" region
     And I should see "Remove" in the "team-user-ylacassemalvernexample" region
 
   Scenario: Org admins can delete colleagues in their organisation
-    Given I am logged in as "l.degroot@malvern.example" with password "Abcd1234"
+    Given I am logged in as "l.degroot@malvern.example" with password "DigidepsPass1234"
     When I go to "/org/settings/organisation"
     And I click on "delete" in the "team-user-ylacassemalvernexample" region
     Then I should see "Are you sure you want to remove this user from this organisation?"

--- a/behat/tests/features/v2/registration/self-registration.feature
+++ b/behat/tests/features/v2/registration/self-registration.feature
@@ -11,7 +11,7 @@ Feature: Self registration
     When these deputies register to deputise the following court orders:
       | deputySurname | deputyEmail      | deputyPostCode | clientSurname | caseNumber |
       | Parker        | peter@parker.com | SW10 1AA       | Davies        | T5001034   |
-    And I am logged in as "peter@parker.com" with password "Abcd1234"
+    And I am logged in as "peter@parker.com" with password "DigidepsPass1234"
     Then I should be on "/lay"
     And I should see "Davies"
 
@@ -20,6 +20,6 @@ Feature: Self registration
     When these deputies register to deputise the following court orders:
       | deputySurname | deputyEmail    | deputyPostCode | clientSurname | caseNumber |
       | Wayne        | bruce@wayne.com | SW1 2SA        | Hendry        | T5001041   |
-    And I am logged in as "bruce@wayne.com" with password "Abcd1234"
+    And I am logged in as "bruce@wayne.com" with password "DigidepsPass1234"
     Then I should be on "/lay"
     And I should see "Hendry"

--- a/behat/tests/features/v2/reportManagement/closing-incomplete-reports.feature
+++ b/behat/tests/features/v2/reportManagement/closing-incomplete-reports.feature
@@ -10,12 +10,12 @@ Feature: Managing reports
       | 85473219 | Deputy43 | PA          | Health and Welfare                         | 2018-01-30 |
 
   Scenario: Case manager cannot close a report that has not been unsubmitted by a case manager
-    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I visit the management page of the "2016" to "2017" report between "Deputy92" and "95465932"
     Then I should not see "Close Report"
 
   Scenario: Case manager closes a report that has been marked as incomplete by a case manager
-    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "DigidepsPass1234"
     And  I have the "2018" to "2019" report between "Deputy43" and "85473219"
     And the report has been submitted
     When a case manager makes the following changes to the report:

--- a/behat/tests/features/v2/userManagement/deleteUsers.feature
+++ b/behat/tests/features/v2/userManagement/deleteUsers.feature
@@ -6,7 +6,7 @@ Feature: Deleting Users
   And anyone who has left the OPG or otherwise should not have an account and can not access the system
 
   Scenario: Create users for scenarios
-    Given I am logged in to admin as 'admin@publicguardian.gov.uk' with password 'Abcd1234'
+    Given I am logged in to admin as 'admin@publicguardian.gov.uk' with password 'DigidepsPass1234'
     And the following admins exist:
       | adminType        | firstName     | lastName | email                                 | activated |
       | ROLE_ADMIN       | admin-1       | user     | adminUser1@publicguardian.gov.uk      | true      |
@@ -22,7 +22,7 @@ Feature: Deleting Users
       | disabled | AD         | Ad        | User     | ad123@publicguardian.gov.uk           | SW1H 9AJ | true      |
 
   Scenario: Super admin users can delete admin users
-    Given I am logged in to admin as 'superAdminUser1@publicguardian.gov.uk' with password 'Abcd1234'
+    Given I am logged in to admin as 'superAdminUser1@publicguardian.gov.uk' with password 'DigidepsPass1234'
     And I am viewing the edit user page for 'adminUser1@publicguardian.gov.uk'
     Then the url should match "/admin/edit-user"
     When I follow "Delete user"
@@ -31,7 +31,7 @@ Feature: Deleting Users
     Then the user 'adminUser1@publicguardian.gov.uk' should be deleted
 
   Scenario: Super admin users can delete super admin users
-    Given I am logged in to admin as 'superAdminUser1@publicguardian.gov.uk' with password 'Abcd1234'
+    Given I am logged in to admin as 'superAdminUser1@publicguardian.gov.uk' with password 'DigidepsPass1234'
     And I am viewing the edit user page for 'superAdminUser2@publicguardian.gov.uk'
     Then the url should match "/admin/edit-user"
     When I follow "Delete user"
@@ -40,7 +40,7 @@ Feature: Deleting Users
     Then the user 'adminuser1@publicguardian.gov.uk' should be deleted
 
   Scenario: Admin users do not have delete permissions
-    Given I am logged in to admin as 'admin@publicguardian.gov.uk' with password 'Abcd1234'
+    Given I am logged in to admin as 'admin@publicguardian.gov.uk' with password 'DigidepsPass1234'
     And I am viewing the edit user page for 'superAdminUser1@publicguardian.gov.uk'
     Then the url should match "/admin/edit-user"
     And I should not see "Delete user"
@@ -61,7 +61,7 @@ Feature: Deleting Users
     And I should not see "Delete user"
 
   Scenario: Users cannot delete themselves
-    Given I am logged in to admin as 'superAdminUser1@publicguardian.gov.uk' with password 'Abcd1234'
+    Given I am logged in to admin as 'superAdminUser1@publicguardian.gov.uk' with password 'DigidepsPass1234'
     And I am viewing the edit user page for 'superAdminUser1@publicguardian.gov.uk'
     Then the url should match "/admin/edit-user"
     And I should not see "Delete user"

--- a/behat/tests/features/v2/userManagement/editingUserDetails.feature
+++ b/behat/tests/features/v2/userManagement/editingUserDetails.feature
@@ -1,7 +1,7 @@
 Feature: Editing Deputy and Client details
 
   Scenario: Creating users to edit
-    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
 
     Given the following users exist:
       | ndr      | deputyType | firstName | lastName    | email                 | postCode | activated |
@@ -12,7 +12,7 @@ Feature: Editing Deputy and Client details
       | Jory      | Dunkeld  | 01215552222 | 1 Fake Road | Fakeville | Faketon | B4 6HQ   | JD123456   |  hena.mercia@test.com  |
 
   Scenario: edit client details
-    And I am logged in as "hena.mercia@test.com" with password "Abcd1234"
+    And I am logged in as "hena.mercia@test.com" with password "DigidepsPass1234"
     And I click on "user-account, client-show, client-edit"
     Then the following fields should have the corresponding values:
       | client_firstname | Jory |

--- a/client/src/Controller/SettingsController.php
+++ b/client/src/Controller/SettingsController.php
@@ -109,13 +109,13 @@ class SettingsController extends AbstractController
         $user = $this->userApi->getUserWithData();
 
         $form = $this->createForm(FormDir\ChangePasswordType::class, $user, [
-            'mapped' => false,
+            'mapped' => true,
             'error_bubbling' => true
         ]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $plainPassword = $request->request->get('change_password')['plain_password']['first'];
+            $plainPassword = $request->request->get('change_password')['password']['first'];
             $this->restClient->put('user/' . $user->getId() . '/set-password', json_encode([
                 'password_plain' => $plainPassword,
             ]));

--- a/client/src/Controller/UserController.php
+++ b/client/src/Controller/UserController.php
@@ -97,8 +97,7 @@ class UserController extends AbstractController
             $form = $this->createForm(
                 FormDir\SetPasswordType::class,
                 $user,
-                [ 'passwordMismatchMessage' => $passwordMismatchMessage, 'showTermsAndConditions'  => $user->isDeputy()
-                                       ]
+                [ 'passwordMismatchMessage' => $passwordMismatchMessage, 'showTermsAndConditions'  => $user->isDeputy()]
             );
             $template = '@App/User/activate.html.twig';
         } else { // 'password-reset'

--- a/client/src/Entity/User.php
+++ b/client/src/Entity/User.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Entity\Traits\LoginInfoTrait;
+use App\Validator\Constraints\CommonPassword;
 use App\Validator\Constraints\EmailSameDomain;
 use Doctrine\Common\Collections\ArrayCollection;
 use JMS\Serializer\Annotation as JMS;
@@ -112,11 +113,12 @@ class User implements AdvancedUserInterface, DeputyInterface
 
     /**
      * @JMS\Type("string")
-     * @Assert\NotBlank( message="user.password.notBlank", groups={"user_set_password"} )
-     * @Assert\Length( min=8, max=50, minMessage="user.password.minLength", maxMessage="user.password.maxLength", groups={"user_set_password", "user_change_password"} )
+     * @Assert\NotBlank( message="user.password.notBlank", groups={"user_set_password", "user_change_password"} )
+     * @Assert\Length( min=14, max=50, minMessage="user.password.minLength", maxMessage="user.password.maxLength", groups={"user_set_password", "user_change_password"} )
      * @Assert\Regex( pattern="/[a-z]/" , message="user.password.noLowerCaseChars", groups={"user_set_password", "user_change_password" } )
      * @Assert\Regex( pattern="/[A-Z]/" , message="user.password.noUpperCaseChars", groups={"user_set_password", "user_change_password" } )
      * @Assert\Regex( pattern="/[0-9]/", message="user.password.noNumber", groups={"user_set_password", "user_change_password"} )
+     * @CommonPassword(message="user.password.notCommonPassword", groups={"user_set_password", "user_change_password"})
      *
      * @var string
      */

--- a/client/src/Form/ChangePasswordType.php
+++ b/client/src/Form/ChangePasswordType.php
@@ -3,7 +3,6 @@
 namespace App\Form;
 
 use App\Validator\Constraints\DUserPassword;
-use App\Validator\Constraints\CommonPassword;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type as FormTypes;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -12,7 +11,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class ChangePasswordType extends AbstractType
 {
-    const VALIDATION_GROUP = 'change_password';
+    const VALIDATION_GROUP = 'user_change_password';
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -23,18 +22,10 @@ class ChangePasswordType extends AbstractType
                         new DUserPassword(['message' => 'user.password.existing.notCorrect', 'groups' => [self::VALIDATION_GROUP]]),
                     ],
                 ])
-                ->add('plain_password', FormTypes\RepeatedType::class, [
-                    'mapped' => false,
+                ->add('password', FormTypes\RepeatedType::class, [
+                    'mapped' => true,
                     'type' => FormTypes\PasswordType::class,
                     'invalid_message' => 'user.password.new.doesntMatch',
-                    'constraints' => [
-                        new Assert\NotBlank(['message' => 'user.password.new.notBlank', 'groups' => [self::VALIDATION_GROUP]]),
-                        new Assert\Length(['min' => 8, 'max' => 50, 'minMessage' => 'user.password.minLength', 'maxMessage' => 'user.password.maxLength', 'groups' => [self::VALIDATION_GROUP]]),
-                        new Assert\Regex(['pattern' => '/[a-z]/', 'message' => 'user.password.noLowerCaseChars', 'groups' => self::VALIDATION_GROUP]),
-                        new Assert\Regex(['pattern' => '/[A-Z]/', 'message' => 'user.password.noUpperCaseChars', 'groups' => self::VALIDATION_GROUP]),
-                        new Assert\Regex(['pattern' => '/[0-9]/', 'message' => 'user.password.noNumber', 'groups' => self::VALIDATION_GROUP]),
-                        new CommonPassword(['message' => 'user.password.notCommonPassword', 'groups' => self::VALIDATION_GROUP]),
-                    ],
                 ])
                 ->add('id', FormTypes\HiddenType::class)
                 ->add('save', FormTypes\SubmitType::class);

--- a/client/src/Form/ResetPasswordType.php
+++ b/client/src/Form/ResetPasswordType.php
@@ -9,12 +9,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ResetPasswordType extends AbstractType
 {
+    const VALIDATION_GROUP = 'user_set_password';
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
                 ->add('password', FormTypes\RepeatedType::class, [
                     'type' => FormTypes\PasswordType::class,
-                    'invalid_message' => $options['passwordMismatchMessage']
+                    'invalid_message' => $options['passwordMismatchMessage'],
                 ])
                 ->add('save', FormTypes\SubmitType::class);
     }
@@ -23,7 +25,7 @@ class ResetPasswordType extends AbstractType
     {
         $resolver->setDefaults([
             'translation_domain' => 'password-reset',
-             'validation_groups' => ['user_set_password'],
+            'validation_groups' => [self::VALIDATION_GROUP],
         ])
         ->setRequired(['passwordMismatchMessage']);
     }

--- a/client/src/Form/SetPasswordType.php
+++ b/client/src/Form/SetPasswordType.php
@@ -10,20 +10,22 @@ use Symfony\Component\Validator\Constraints as Constraints;
 
 class SetPasswordType extends AbstractType
 {
+    const VALIDATION_GROUP = 'user_set_password';
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->add(
             'password',
             FormTypes\RepeatedType::class,
             [
-            'type'            => FormTypes\PasswordType::class,
-                'invalid_message' => $options['passwordMismatchMessage']
-                       ]
+                'type'            => FormTypes\PasswordType::class,
+                'invalid_message' => $options['passwordMismatchMessage'],
+           ]
         );
         if (!empty($options['showTermsAndConditions'])) {
             $builder->add('showTermsAndConditions', FormTypes\CheckboxType::class, [
                 'mapped'=>false,
-                'constraints' => [new Constraints\NotBlank(['message' => 'user.agreeTermsUse.notBlank', 'groups'=>['user_set_password']])]
+                'constraints' => [new Constraints\NotBlank(['message' => 'user.agreeTermsUse.notBlank', 'groups'=>[self::VALIDATION_GROUP]])]
             ]);
         }
         $builder->add('save', FormTypes\SubmitType::class);
@@ -33,7 +35,7 @@ class SetPasswordType extends AbstractType
     {
         $resolver->setDefaults([
               'translation_domain'     => 'user-activate',
-              'validation_groups'      => ['user_set_password'],
+              'validation_groups'      => [self::VALIDATION_GROUP],
               'showTermsAndConditions' => false
         ])
         ->setRequired(['passwordMismatchMessage']);

--- a/client/src/Validator/Constraints/CommonPassword.php
+++ b/client/src/Validator/Constraints/CommonPassword.php
@@ -4,6 +4,7 @@ namespace App\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+/** @Annotation */
 class CommonPassword extends Constraint
 {
     public $message = 'Your password is too easy for someone to guess. Please choose a different password.';

--- a/client/src/Validator/Constraints/CommonPasswordValidator.php
+++ b/client/src/Validator/Constraints/CommonPasswordValidator.php
@@ -44,9 +44,8 @@ class CommonPasswordValidator extends ConstraintValidator
     protected function passwordMatchesCommonPasswords(string $searchTerm, string $filePath)
     {
         $matches = array();
-
         $handle = @fopen($filePath, "r");
-        if ($handle) {
+        if ($handle && strlen($searchTerm) > 0) {
             while (!feof($handle)) {
                 $buffer = fgets($handle);
                 if (strpos($buffer, $searchTerm) !== false) {

--- a/client/templates/Report/Formatted/formatted_body.html.twig
+++ b/client/templates/Report/Formatted/formatted_body.html.twig
@@ -1,6 +1,7 @@
 {% set client = report.client %}
 {% set assets = report.assets %}
 {% set debts = report.debts %}
+{% set adLoggedAsDeputy = false %}
 {% set contacts = report.getContacts %}
 {% set decisions = report.getDecisions %}
 {% set isEmailAttachment = true %}

--- a/client/templates/Settings/passwordEdit.html.twig
+++ b/client/templates/Settings/passwordEdit.html.twig
@@ -17,10 +17,10 @@
     {{ form_start(form, {attr: {novalidate: 'novalidate', class: '' } }) }}
 
     {{ form_input(form.current_password,'form.changeYourPassword.controls.currentPassword') }}
-    {{ form_input(form.plain_password.first,'form.changeYourPassword.controls.newPassword', {
+    {{ form_input(form.password.first,'form.changeYourPassword.controls.newPassword', {
         'hasHintList': true
     }) }}
-    {{ form_input(form.plain_password.second,'form.changeYourPassword.controls.confirmNewPassword') }}
+    {{ form_input(form.password.second,'form.changeYourPassword.controls.confirmNewPassword') }}
 
     {{ form_submit(form.save,'form.changeYourPassword.controls.save', {'buttonClass': 'behat-link-save'}) }}
 

--- a/client/templates/User/activate.html.twig
+++ b/client/templates/User/activate.html.twig
@@ -27,10 +27,10 @@
         {% if form.showTermsAndConditions is defined %}
             {{ form_checkbox(form.showTermsAndConditions, '', {
                 'labelText': {
-                    'left': 'I have read and understood the ',
+                    'beforeMarkupText': 'I have read and understood the ',
                     'url': path('terms'),
                     'link': 'terms of use',
-                    'right': ''
+                    'afterMarkupText': ''
                 },
                 'labelLink': true
             } ) }}

--- a/client/translations/password-reset.en.yml
+++ b/client/translations/password-reset.en.yml
@@ -7,7 +7,7 @@ form:
         label: Password
         hint: "Your password must have:"
         hintList: |
-            at least 8 characters
+            at least 14 characters
             at least 1 uppercase letter
             at least 1 lowercase letter
             at least 1 number

--- a/client/translations/settings.en.yml
+++ b/client/translations/settings.en.yml
@@ -104,7 +104,7 @@ form:
           label: New password
           hint: "Your password must have:"
           hintList: |
-            at least 8 characters
+            at least 14 characters
             at least 1 uppercase letter
             at least 1 lowercase letter
             at least 1 number

--- a/client/translations/user-activate.en.yml
+++ b/client/translations/user-activate.en.yml
@@ -10,7 +10,7 @@ password:
     label: Password
     hint: "Your password must have:"
     hintList: |
-        at least 8 characters
+        at least 14 characters
         at least 1 uppercase letter
         at least 1 lowercase letter
         at least 1 number

--- a/environment/api_service.tf
+++ b/environment/api_service.tf
@@ -101,7 +101,7 @@ locals {
       { "name": "DATABASE_NAME", "value": "${local.db.name}" },
       { "name": "DATABASE_PORT", "value": "${local.db.port}" },
       { "name": "DATABASE_USERNAME", "value": "${local.db.username}" },
-      { "name": "FIXTURES_ACCOUNTPASSWORD", "value": "Abcd1234" },
+      { "name": "FIXTURES_ACCOUNTPASSWORD", "value": "DigidepsPass1234" },
       { "name": "NGINX_APP_NAME", "value": "api" },
       { "name": "OPG_DOCKER_TAG", "value": "${var.OPG_DOCKER_TAG}" },
       { "name": "REDIS_DSN", "value": "redis://${aws_route53_record.api_redis.fqdn}" }

--- a/environment/api_service.tf
+++ b/environment/api_service.tf
@@ -101,6 +101,7 @@ locals {
       { "name": "DATABASE_NAME", "value": "${local.db.name}" },
       { "name": "DATABASE_PORT", "value": "${local.db.port}" },
       { "name": "DATABASE_USERNAME", "value": "${local.db.username}" },
+      { "name": "FIXTURES_ACCOUNTPASSWORD", "value": "Abcd1234" },
       { "name": "NGINX_APP_NAME", "value": "api" },
       { "name": "OPG_DOCKER_TAG", "value": "${var.OPG_DOCKER_TAG}" },
       { "name": "REDIS_DSN", "value": "redis://${aws_route53_record.api_redis.fqdn}" }

--- a/environment/reset_database.tf
+++ b/environment/reset_database.tf
@@ -59,7 +59,7 @@ locals {
       { "name": "DATABASE_NAME", "value": "${local.db.name}" },
       { "name": "DATABASE_PORT", "value": "${local.db.port}" },
       { "name": "DATABASE_USERNAME", "value": "${local.db.username}" },
-      { "name": "FIXTURES_ACCOUNTPASSWORD", "value": "Abcd1234" },
+      { "name": "FIXTURES_ACCOUNTPASSWORD", "value": "DigidepsPass1234" },
       { "name": "REDIS_DSN", "value": "redis://${aws_route53_record.api_redis.fqdn}" }
     ]
   }

--- a/pa11y/.pa11yci
+++ b/pa11y/.pa11yci
@@ -16,7 +16,7 @@
          "url": "https://digideps.local/login",
          "actions": [
             "set field #login_email to bobby.blue@example.com",
-            "set field #login_password to Abcd1234",
+            "set field #login_password to DigidepsPass1234",
             "click element #login_login"
          ],
          "screenCapture": "screenshots/login.png"
@@ -30,7 +30,7 @@
          "actions": [
             "navigate to https://digideps.local/login",
             "set field #login_email to behat-prof1@publicguardian.gov.uk",
-            "set field #login_password to Abcd1234",
+            "set field #login_password to DigidepsPass1234",
             "click element #login_login",
             "wait for path to be /org/",
             "wait for element .behat-link-pa-report-open to be visible",
@@ -43,7 +43,7 @@
          "actions": [
             "navigate to https://digideps.local/login",
             "set field #login_email to behat-prof1@publicguardian.gov.uk",
-            "set field #login_password to Abcd1234",
+            "set field #login_password to DigidepsPass1234",
             "click element #login_login",
             "wait for path to be /org/",
             "click element .behat-link-pa-report-open",
@@ -71,7 +71,7 @@
          "actions": [
             "navigate to https://digideps.local/login",
             "set field #login_email to behat-lay-deputy-102@publicguardian.gov.uk",
-            "set field #login_password to Abcd1234",
+            "set field #login_password to DigidepsPass1234",
             "click element #login_login",
             "set field #report_startDate_day to 01",
             "set field #report_startDate_month to 01",


### PR DESCRIPTION
## Purpose
Set password length to 14 chars min as per guidance in ITHC. 

Fixes DDPB-3876

## Approach
Refactored a bit. Made sure all the checks were being done by the Entity annotation. For some historic reason they were split out and also because I was clearly a noob I'd missed the most recent addition on a couple of them on a previous PR so there was a big gap there!

There also didn't seem to be the behat tests for full checks on reset so added that.

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
