### PR TITLE
DDPB-3920 fix missed vpc endpoint rules

### DIFF
--- a/environment/backup.tf
+++ b/environment/backup.tf
@@ -15,9 +15,12 @@ module "backup" {
 
 locals {
   backup_sg_rules = {
-    ecr  = local.common_sg_rules.ecr
-    logs = local.common_sg_rules.logs
-    s3   = local.common_sg_rules.s3
+    ecr     = local.common_sg_rules.ecr
+    logs    = local.common_sg_rules.logs
+    s3      = local.common_sg_rules.s3
+    ssm     = local.common_sg_rules.ssm
+    ecr_api = local.common_sg_rules.ecr_api
+    secrets = local.common_sg_rules.secrets
     rds = {
       port        = 5432
       protocol    = "tcp"

--- a/environment/checklist_sync.tf
+++ b/environment/checklist_sync.tf
@@ -1,9 +1,11 @@
 locals {
   checklist_sync_sg_rules = {
-    ecr  = local.common_sg_rules.ecr
-    logs = local.common_sg_rules.logs
-    s3   = local.common_sg_rules.s3
-    ssm  = local.common_sg_rules.ssm
+    ecr     = local.common_sg_rules.ecr
+    logs    = local.common_sg_rules.logs
+    s3      = local.common_sg_rules.s3
+    ssm     = local.common_sg_rules.ssm
+    ecr_api = local.common_sg_rules.ecr_api
+    secrets = local.common_sg_rules.secrets
     api = {
       port        = 443
       type        = "egress"

--- a/environment/document_sync.tf
+++ b/environment/document_sync.tf
@@ -1,9 +1,11 @@
 locals {
   document_sync_sg_rules = {
-    ecr  = local.common_sg_rules.ecr
-    logs = local.common_sg_rules.logs
-    s3   = local.common_sg_rules.s3
-    ssm  = local.common_sg_rules.ssm
+    ecr     = local.common_sg_rules.ecr
+    logs    = local.common_sg_rules.logs
+    s3      = local.common_sg_rules.s3
+    ssm     = local.common_sg_rules.ssm
+    ecr_api = local.common_sg_rules.ecr_api
+    secrets = local.common_sg_rules.secrets
     api = {
       port        = 443
       type        = "egress"

--- a/environment/integration_test.tf
+++ b/environment/integration_test.tf
@@ -15,9 +15,12 @@ module "integration_test" {
 
 locals {
   integration_test_sg_rules = {
-    ecr  = local.common_sg_rules.ecr
-    logs = local.common_sg_rules.logs
-    s3   = local.common_sg_rules.s3
+    ecr     = local.common_sg_rules.ecr
+    logs    = local.common_sg_rules.logs
+    s3      = local.common_sg_rules.s3
+    ssm     = local.common_sg_rules.ssm
+    ecr_api = local.common_sg_rules.ecr_api
+    secrets = local.common_sg_rules.secrets
     rds = {
       port        = 5432
       protocol    = "tcp"

--- a/environment/reset_database.tf
+++ b/environment/reset_database.tf
@@ -15,9 +15,12 @@ module "reset_database" {
 
 locals {
   reset_database_sg_rules = {
-    ecr  = local.common_sg_rules.ecr
-    logs = local.common_sg_rules.logs
-    s3   = local.common_sg_rules.s3
+    ecr     = local.common_sg_rules.ecr
+    logs    = local.common_sg_rules.logs
+    s3      = local.common_sg_rules.s3
+    ssm     = local.common_sg_rules.ssm
+    ecr_api = local.common_sg_rules.ecr_api
+    secrets = local.common_sg_rules.secrets
     rds = {
       port        = 5432
       protocol    = "tcp"

--- a/environment/restore.tf
+++ b/environment/restore.tf
@@ -15,9 +15,12 @@ module "restore" {
 
 locals {
   restore_sg_rules = {
-    ecr  = local.common_sg_rules.ecr
-    logs = local.common_sg_rules.logs
-    s3   = local.common_sg_rules.s3
+    ecr     = local.common_sg_rules.ecr
+    logs    = local.common_sg_rules.logs
+    s3      = local.common_sg_rules.s3
+    ssm     = local.common_sg_rules.ssm
+    ecr_api = local.common_sg_rules.ecr_api
+    secrets = local.common_sg_rules.secrets
     rds = {
       port        = 5432
       protocol    = "tcp"

--- a/environment/restore_from_production.tf
+++ b/environment/restore_from_production.tf
@@ -15,9 +15,12 @@ module "restore_from_production" {
 
 locals {
   restore_from_production_sg_rules = {
-    ecr  = local.common_sg_rules.ecr
-    logs = local.common_sg_rules.logs
-    s3   = local.common_sg_rules.s3
+    ecr     = local.common_sg_rules.ecr
+    logs    = local.common_sg_rules.logs
+    s3      = local.common_sg_rules.s3
+    ssm     = local.common_sg_rules.ssm
+    ecr_api = local.common_sg_rules.ecr_api
+    secrets = local.common_sg_rules.secrets
     rds = {
       port        = 5432
       protocol    = "tcp"

--- a/environment/smoke_test.tf
+++ b/environment/smoke_test.tf
@@ -15,9 +15,12 @@ module "smoke_test" {
 
 locals {
   smoke_test_sg_rules = {
-    ecr  = local.common_sg_rules.ecr
-    logs = local.common_sg_rules.logs
-    s3   = local.common_sg_rules.s3
+    ecr     = local.common_sg_rules.ecr
+    logs    = local.common_sg_rules.logs
+    s3      = local.common_sg_rules.s3
+    ssm     = local.common_sg_rules.ssm
+    ecr_api = local.common_sg_rules.ecr_api
+    secrets = local.common_sg_rules.secrets
     rds = {
       port        = 5432
       protocol    = "tcp"


### PR DESCRIPTION
## Purpose

Sort out permissions on vpc endpoints for CI jobs

Fixes DDPB-3920

## Approach

Clearly when I did this originally regarding the fargate upgrade months ago I hadn't done the CI bits fully. This is now causing issues. This fixes it.

## Learning

NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
