### PR TITLE
DDPB-3474 actions section behat tests

### DIFF
--- a/behat/tests/behat.yml
+++ b/behat/tests/behat.yml
@@ -206,6 +206,12 @@ v2-tests-goutte:
             contexts:
                 - DigidepsBehat\v2\Reporting\Sections\ReportingSectionsFeatureContext
 
+        section-actions:
+            description: Covering the 'Actions' section of the report
+            paths: [ "%paths.base%/features-v2/reporting/sections/actions" ]
+            contexts:
+                - DigidepsBehat\v2\Reporting\Sections\ReportingSectionsFeatureContext
+
         feedback:
             description: Covering features that allow users to give us feedback
             paths: [ "%paths.base%/features-v2/feedback" ]

--- a/behat/tests/bootstrap/v2/common/AuthTrait.php
+++ b/behat/tests/bootstrap/v2/common/AuthTrait.php
@@ -13,7 +13,7 @@ trait AuthTrait
         $this->visitPath('/logout');
         $this->visitPath('/login');
         $this->fillField('login_email', $email);
-        $this->fillField('login_password', 'Abcd1234');
+        $this->fillField('login_password', 'DigidepsPass1234');
         $this->pressButton('login_login');
 
         $this->visitPath(sprintf(self::BEHAT_FRONT_USER_DETAILS, $email));
@@ -34,7 +34,7 @@ trait AuthTrait
         $this->visitAdminPath('/logout');
         $this->visitAdminPath('/login');
         $this->fillField('login_email', $email);
-        $this->fillField('login_password', 'Abcd1234');
+        $this->fillField('login_password', 'DigidepsPass1234');
         $this->pressButton('login_login');
 
         $this->loggedInUserDetails = $this->getUserDetailsByEmail($email);

--- a/behat/tests/bootstrap/v2/common/BaseFeatureContext.php
+++ b/behat/tests/bootstrap/v2/common/BaseFeatureContext.php
@@ -55,14 +55,11 @@ class BaseFeatureContext extends MinkContext
             throw new Exception($responseData['response']);
         }
 
-        var_dump($responseData);
-
         $this->fixtureUsers[] = $this->adminDetails = new UserDetails($responseData['data']['admin-users']['admin']);
         $this->fixtureUsers[] = $this->superAdminDetails = new UserDetails($responseData['data']['admin-users']['super-admin']);
         $this->fixtureUsers[] = $this->layDeputyNotStartedDetails = new UserDetails($responseData['data']['lays']['not-started']);
         $this->fixtureUsers[] = $this->layDeputyCompletedNotSubmittedDetails = new UserDetails($responseData['data']['lays']['completed-not-submitted']);
         $this->fixtureUsers[] = $this->layDeputySubmittedDetails = new UserDetails($responseData['data']['lays']['submitted']);
-        var_dump($this->fixtureUsers);
     }
 
     /**

--- a/behat/tests/bootstrap/v2/common/IShouldBeOnTrait.php
+++ b/behat/tests/bootstrap/v2/common/IShouldBeOnTrait.php
@@ -64,10 +64,50 @@ trait IShouldBeOnTrait
     }
 
     /**
+     * @Then I should be on the financial decision actions page
+     */
+    public function iAmOnActionsPage1()
+    {
+        $this->iAmOnPage('/report\/.*\/actions\/step\/1$/');
+    }
+
+    /**
+     * @Then I should be on the concerns actions page
+     */
+    public function iAmOnActionsPage2()
+    {
+        $this->iAmOnPage('/report\/.*\/actions\/step\/2$/');
+    }
+
+    /**
+     * @Then I should be on the actions report last step page
+     */
+    public function iAmOnActionsLastStepPage()
+    {
+        $this->iAmOnPage('/report\/.*\/actions\/summary\?from\=last\-step$/');
+    }
+
+    /**
+     * @Then I should be on the actions report summary page
+     */
+    public function iAmOnActionsSummaryPage()
+    {
+        $this->iAmOnPage('/report\/.*\/actions\/summary/');
+    }
+
+    /**
+     * @Then I should be on the Lay main overview page
+     */
+    public function iAmOnLayMainPage()
+    {
+        $this->iAmOnPage('/lay$/');
+    }
+
+    /**
      * @Then I should be on the Lay reports overview page
      */
     public function iAmOnReportsOverviewPage()
     {
-        $this->iAmOnPage('/lay$/');
+        $this->iAmOnPage('/report\/.*\/overview$/');
     }
 }

--- a/behat/tests/bootstrap/v2/common/IShouldBeOnTrait.php
+++ b/behat/tests/bootstrap/v2/common/IShouldBeOnTrait.php
@@ -80,23 +80,15 @@ trait IShouldBeOnTrait
     }
 
     /**
-     * @Then I should be on the actions report last step page
-     */
-    public function iAmOnActionsLastStepPage()
-    {
-        $this->iAmOnPage('/report\/.*\/actions\/summary\?from\=last\-step$/');
-    }
-
-    /**
      * @Then I should be on the actions report summary page
      */
     public function iAmOnActionsSummaryPage()
     {
-        $this->iAmOnPage('/report\/.*\/actions\/summary/');
+        $this->iAmOnPage('/report\/.*\/actions\/summary.*/');
     }
 
     /**
-     * @Then I should be on the Lay main overview page
+     * @Then I should be on the Lay homepage
      */
     public function iAmOnLayMainPage()
     {

--- a/behat/tests/bootstrap/v2/common/ReportTrait.php
+++ b/behat/tests/bootstrap/v2/common/ReportTrait.php
@@ -34,6 +34,18 @@ trait ReportTrait
     }
 
     /**
+     * @Given a Lay Deputy logs in and has a new report
+     */
+    public function aLayDeputyLogsInAndHasNewReport()
+    {
+        if (empty($this->layDeputyNotStartedDetails)) {
+            throw new Exception('It looks like fixtures are not loaded - missing $layDeputyNotStartedDetails');
+        }
+
+        $this->loginToFrontendAs($this->layDeputyNotStartedDetails->getEmail());
+    }
+
+    /**
      * @Given a Lay Deputy completes and submits a report
      */
     public function aLayDeputyCompletesAndSubmitsAReport()

--- a/behat/tests/bootstrap/v2/common/UserDetails.php
+++ b/behat/tests/bootstrap/v2/common/UserDetails.php
@@ -49,7 +49,6 @@ class UserDetails
             );
         }
 
-        var_dump($userDetails);
         $this->setEmail($userDetails['email']);
         $this->setClientId($userDetails['clientId']);
 

--- a/behat/tests/bootstrap/v2/reporting/sections/ActionsSectionTrait.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/ActionsSectionTrait.php
@@ -1,0 +1,143 @@
+<?php declare(strict_types=1);
+
+namespace DigidepsBehat\v2\Reporting\Sections;
+
+trait ActionsSectionTrait
+{
+    private int $answeredYes = 0;
+    private int $answeredNo = 0;
+    private array $comments = [];
+
+    /**
+     * @Given I view the actions report section
+     */
+    public function iViewActionsSection()
+    {
+        $activeReportId = $this->loggedInUserDetails->getCurrentReportId();
+        $reportSectionUrl = sprintf(self::REPORT_SECTION_ENDPOINT, $activeReportId, 'actions');
+        $this->visitPath($reportSectionUrl);
+    }
+
+    /**
+     * @Given I view and start the actions report section
+     */
+    public function iViewAndStartActionsSection()
+    {
+        $this->iViewActionsSection();
+        $this->clickLink('Start actions');
+    }
+
+    /**
+     * @Given I choose no and save on financial decision actions section
+     */
+    public function iChooseNoOnFinancialDecisionActionsSection1()
+    {
+        $this->fillInActionsForm(
+            'no',
+            'action[doYouExpectFinancialDecisions]'
+        );
+    }
+
+    /**
+     * @Given I choose yes and save on financial decision actions section
+     */
+    public function iChooseYesOnFinancialDecisionActionsSection1()
+    {
+        $this->fillInActionsForm(
+            'yes',
+            'action[doYouExpectFinancialDecisions]',
+            'first comment',
+            'action[doYouExpectFinancialDecisionsDetails]'
+        );
+    }
+
+    /**
+     * @Given I choose no and save on concerns actions section
+     */
+    public function iChooseNoOnDoYouHaveConcernsActionsSection()
+    {
+        $this->fillInActionsForm(
+            'no',
+            'action[doYouHaveConcerns]',
+        );
+    }
+
+    /**
+     * @Given I choose yes and save on concerns actions section
+     */
+    public function iChooseYesOnDoYouHaveConcernsActionsSection()
+    {
+        $this->fillInActionsForm(
+            'yes',
+            'action[doYouHaveConcerns]',
+            'second comment',
+            'action[doYouHaveConcernsDetails]'
+        );
+    }
+    public function fillInActionsForm($answer, $actionName, $comment = null, $commentName = null)
+    {
+        $this->selectOption($actionName, $answer);
+        if ($answer === "no") {
+            $this->answeredNo += 1;
+        } elseif ($answer === "yes") {
+            $this->answeredYes += 1;
+        }
+        if ($comment != null) {
+            $this->fillField($commentName, $comment);
+            array_push($this->comments, $comment);
+        }
+        $this->pressButton('Save and continue');
+    }
+
+    /**
+     * @When I should see the expected action report section responses
+     */
+    public function iSeeExpectedActionSectionResponses()
+    {
+        $table = $this->getSession()->getPage()->find('css', 'dl');
+        if (!$table) {
+            $this->throwContextualException('A dl element was not found on the page');
+        }
+        $tableEntry = $table->findAll('css', 'dd');
+        if (!$tableEntry) {
+            $this->throwContextualException('A dd element was not found on the page');
+        }
+        $countNegativeReponse = 0;
+        $countPositiveReponse = 0;
+        foreach ($tableEntry as $entry) {
+            if (trim(strtolower($entry->getHtml())) === "no") {
+                $countNegativeReponse += 1;
+            } elseif (strtolower(trim($entry->getHtml())) === "yes") {
+                $countPositiveReponse += 1;
+            }
+        }
+        assert($countNegativeReponse == $this->answeredNo);
+        assert($countPositiveReponse == $this->answeredYes);
+    }
+
+    /**
+     * @Then I should see the expected action comments
+     */
+    public function iShouldSeeTheExpectedActionComments()
+    {
+        $table = $this->getSession()->getPage()->find('css', 'dl');
+        if (!$table) {
+            $this->throwContextualException('A dl element was not found on the page');
+        }
+
+        foreach ($this->comments as $comment) {
+            assert(str_contains($table->getHtml(), $comment));
+        }
+    }
+
+    /**
+     * @Then I follow edit link on concerns question
+     */
+    public function iFollowEditLinkConcernActionsPage()
+    {
+        //this should be replaced with actual link click but could not identify it properly
+        $activeReportId = $this->loggedInUserDetails->getCurrentReportId();
+        $reportConcernsUrl = 'report/' . $activeReportId . '/actions/step/2?from=summary';
+        $this->visitPath($reportConcernsUrl);
+    }
+}

--- a/behat/tests/bootstrap/v2/reporting/sections/ActionsSectionTrait.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/ActionsSectionTrait.php
@@ -77,6 +77,7 @@ trait ActionsSectionTrait
     public function fillInActionsForm($answer, $actionName, $comment = null, $commentName = null)
     {
         $this->selectOption($actionName, $answer);
+
         if ($answer === "no") {
             $this->answeredNo += 1;
         } elseif ($answer === "yes") {
@@ -86,24 +87,30 @@ trait ActionsSectionTrait
             $this->fillField($commentName, $comment);
             array_push($this->comments, $comment);
         }
+
         $this->pressButton('Save and continue');
     }
 
     /**
-     * @When I should see the expected action report section responses
+     * @Then I should see the expected action report section responses
      */
     public function iSeeExpectedActionSectionResponses()
     {
         $table = $this->getSession()->getPage()->find('css', 'dl');
+
         if (!$table) {
             $this->throwContextualException('A dl element was not found on the page');
         }
+
         $tableEntry = $table->findAll('css', 'dd');
+
         if (!$tableEntry) {
             $this->throwContextualException('A dd element was not found on the page');
         }
+
         $countNegativeReponse = 0;
         $countPositiveReponse = 0;
+
         foreach ($tableEntry as $entry) {
             if (trim(strtolower($entry->getHtml())) === "no") {
                 $countNegativeReponse += 1;
@@ -111,6 +118,7 @@ trait ActionsSectionTrait
                 $countPositiveReponse += 1;
             }
         }
+
         assert($countNegativeReponse == $this->answeredNo);
         assert($countPositiveReponse == $this->answeredYes);
     }
@@ -121,6 +129,7 @@ trait ActionsSectionTrait
     public function iShouldSeeTheExpectedActionComments()
     {
         $table = $this->getSession()->getPage()->find('css', 'dl');
+
         if (!$table) {
             $this->throwContextualException('A dl element was not found on the page');
         }

--- a/behat/tests/bootstrap/v2/reporting/sections/ReportingSectionsFeatureContext.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/ReportingSectionsFeatureContext.php
@@ -89,11 +89,14 @@ class ReportingSectionsFeatureContext extends BaseFeatureContext
     public function iShouldSeeSectionAs($section, $status)
     {
         $divs = $this->getSession()->getPage()->findAll('css', 'div');
+
         if (!$divs) {
             $this->throwContextualException('A div element was not found on the page');
         }
+
         $sectionFormatted = '/report/' . $this->loggedInUserDetails->getCurrentReportId() . '/' . $section;
         $statusCorrect = false;
+
         foreach ($divs as $div) {
             if ($div->getAttribute('href') === $sectionFormatted) {
                 $statuses = $div->findAll('css', 'span');
@@ -104,6 +107,7 @@ class ReportingSectionsFeatureContext extends BaseFeatureContext
                 }
             }
         }
+
         if (!$statusCorrect) {
             $this->throwContextualException(
                 sprintf('Report section status not as expected. Status: %s not found. ', $status)
@@ -117,19 +121,25 @@ class ReportingSectionsFeatureContext extends BaseFeatureContext
     public function iSeeTextRequestingToAnswerQuestion()
     {
         $table = $this->getSession()->getPage()->find('css', 'dl');
+
         if (!$table) {
             $this->throwContextualException('A dl element was not found on the page');
         }
+
         $tableEntry = $table->findAll('css', 'dd');
+
         if (!$tableEntry) {
             $this->throwContextualException('A dd element was not found on the page');
         }
+
         $furtherInfoNeeded = false;
+
         foreach ($tableEntry as $entry) {
             if (str_contains(trim(strtolower($entry->getHtml())), "please answer this question")) {
                 $furtherInfoNeeded = true;
             }
         }
+
         assert($furtherInfoNeeded);
     }
 }

--- a/behat/tests/bootstrap/v2/reporting/sections/ReportingSectionsFeatureContext.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/ReportingSectionsFeatureContext.php
@@ -8,6 +8,7 @@ use DigidepsBehat\v2\Common\BaseFeatureContext;
 class ReportingSectionsFeatureContext extends BaseFeatureContext
 {
     use ContactsSectionTrait;
+    use ActionsSectionTrait;
 
     const REPORT_SECTION_ENDPOINT = 'report/%s/%s';
 
@@ -53,5 +54,82 @@ class ReportingSectionsFeatureContext extends BaseFeatureContext
                 sprintf('Link contained unexpected text. Wanted: %s. Got: %s ', $sectionName, $anchor->getText())
             );
         }
+    }
+
+    /**
+     * @When I follow link back to report overview page
+     */
+    public function iNavigateBackToReportSection()
+    {
+        $this->clickLink('Deputy report overview');
+        $this->iAmOnReportsOverviewPage($this->getCurrentUrl());
+    }
+
+    /**
+     * @When I press report sub section back button
+     */
+    public function iPressReportSubSectionBackButton()
+    {
+        $this->clickLink('Back');
+    }
+
+    /**
+     * @When I go to the url for the report overview page
+     */
+    public function iGoToReportOverviewUrl()
+    {
+        $activeReportId = $this->loggedInUserDetails->getCurrentReportId();
+        $reportOverviewUrl = sprintf(self::REPORT_SECTION_ENDPOINT, $activeReportId, 'overview');
+        $this->visitPath($reportOverviewUrl);
+    }
+
+    /**
+     * @When I should see :section as :status
+     */
+    public function iShouldSeeSectionAs($section, $status)
+    {
+        $divs = $this->getSession()->getPage()->findAll('css', 'div');
+        if (!$divs) {
+            $this->throwContextualException('A div element was not found on the page');
+        }
+        $sectionFormatted = '/report/' . $this->loggedInUserDetails->getCurrentReportId() . '/' . $section;
+        $statusCorrect = false;
+        foreach ($divs as $div) {
+            if ($div->getAttribute('href') === $sectionFormatted) {
+                $statuses = $div->findAll('css', 'span');
+                foreach ($statuses as $sts) {
+                    if (str_contains(strtolower($sts->getHtml()), $status)) {
+                        $statusCorrect = true;
+                    }
+                }
+            }
+        }
+        if (!$statusCorrect) {
+            $this->throwContextualException(
+                sprintf('Report section status not as expected. Status: %s not found. ', $status)
+            );
+        }
+    }
+
+    /**
+     * @Then I should see text asking to answer the question
+     */
+    public function iSeeTextRequestingToAnswerQuestion()
+    {
+        $table = $this->getSession()->getPage()->find('css', 'dl');
+        if (!$table) {
+            $this->throwContextualException('A dl element was not found on the page');
+        }
+        $tableEntry = $table->findAll('css', 'dd');
+        if (!$tableEntry) {
+            $this->throwContextualException('A dd element was not found on the page');
+        }
+        $furtherInfoNeeded = false;
+        foreach ($tableEntry as $entry) {
+            if (str_contains(trim(strtolower($entry->getHtml())), "please answer this question")) {
+                $furtherInfoNeeded = true;
+            }
+        }
+        assert($furtherInfoNeeded);
     }
 }

--- a/behat/tests/features-v2/feedback/post-submission-feedback.report.feature
+++ b/behat/tests/features-v2/feedback/post-submission-feedback.report.feature
@@ -4,7 +4,7 @@ Feature: Providing feedback after submitting a report
     Given a Lay Deputy completes and submits a report
     Then I should be on the report submitted page
     When I press "Your reports"
-    Then I should be on the Lay reports overview page
+    Then I should be on the Lay main overview page
 
   Scenario: A user provides satisfaction feedback
     Given a Lay Deputy completes and submits a report
@@ -17,4 +17,4 @@ Feature: Providing feedback after submitting a report
     When I provide valid user research responses
     Then I should be on the user research feedback submitted page
     When I press "Your reports"
-    Then I should be on the Lay reports overview page
+    Then I should be on the Lay main overview page

--- a/behat/tests/features-v2/feedback/post-submission-feedback.report.feature
+++ b/behat/tests/features-v2/feedback/post-submission-feedback.report.feature
@@ -4,7 +4,7 @@ Feature: Providing feedback after submitting a report
     Given a Lay Deputy completes and submits a report
     Then I should be on the report submitted page
     When I press "Your reports"
-    Then I should be on the Lay main overview page
+    Then I should be on the Lay homepage
 
   Scenario: A user provides satisfaction feedback
     Given a Lay Deputy completes and submits a report
@@ -17,4 +17,4 @@ Feature: Providing feedback after submitting a report
     When I provide valid user research responses
     Then I should be on the user research feedback submitted page
     When I press "Your reports"
-    Then I should be on the Lay main overview page
+    Then I should be on the Lay homepage

--- a/behat/tests/features-v2/reporting/sections/actions/actions.feature
+++ b/behat/tests/features-v2/reporting/sections/actions/actions.feature
@@ -1,31 +1,31 @@
-@v2
+@v2 @jim
 Feature: Actions
 
-  Scenario: I complete the actions section with negative responses
+  Scenario: A user has made no financial decisions and has no concerns
     Given a Lay Deputy logs in and has a new report
     And I view and start the actions report section
     Then I should be on the financial decision actions page
     When I choose no and save on financial decision actions section
     Then I should be on the concerns actions page
     When I choose no and save on concerns actions section
-    Then I should be on the actions report last step page
+    Then I should be on the actions report summary page
     And I should see the expected action report section responses
     When I follow link back to report overview page
     Then I should be on the Lay reports overview page
     And I should see "actions" as "finished"
 
-  Scenario: I complete the actions section with positive responses
+  Scenario: A user has made financial decisions and has concerns
     Given a Lay Deputy logs in and has a new report
     And I view and start the actions report section
     Then I should be on the financial decision actions page
     When I choose yes and save on financial decision actions section
     Then I should be on the concerns actions page
     When I choose yes and save on concerns actions section
-    Then I should be on the actions report last step page
+    Then I should be on the actions report summary page
     And I should see the expected action report section responses
     And I should see the expected action comments
 
-  Scenario: I half fill in responses and come back and edit them
+  Scenario: A user partially completes the section and then edits their responses
     Given a Lay Deputy logs in and has a new report
     And I go to the url for the report overview page
     Then I should see "actions" as "not started"

--- a/behat/tests/features-v2/reporting/sections/actions/actions.feature
+++ b/behat/tests/features-v2/reporting/sections/actions/actions.feature
@@ -1,0 +1,44 @@
+@v2
+Feature: Actions
+
+  Scenario: I complete the actions section with negative responses
+    Given a Lay Deputy logs in and has a new report
+    And I view and start the actions report section
+    Then I should be on the financial decision actions page
+    When I choose no and save on financial decision actions section
+    Then I should be on the concerns actions page
+    When I choose no and save on concerns actions section
+    Then I should be on the actions report last step page
+    And I should see the expected action report section responses
+    When I follow link back to report overview page
+    Then I should be on the Lay reports overview page
+    And I should see "actions" as "finished"
+
+  Scenario: I complete the actions section with positive responses
+    Given a Lay Deputy logs in and has a new report
+    And I view and start the actions report section
+    Then I should be on the financial decision actions page
+    When I choose yes and save on financial decision actions section
+    Then I should be on the concerns actions page
+    When I choose yes and save on concerns actions section
+    Then I should be on the actions report last step page
+    And I should see the expected action report section responses
+    And I should see the expected action comments
+
+  Scenario: I half fill in responses and come back and edit them
+    Given a Lay Deputy logs in and has a new report
+    And I go to the url for the report overview page
+    Then I should see "actions" as "not started"
+    When I view and start the actions report section
+    Then I choose no and save on financial decision actions section
+    And I press report sub section back button
+    And I press report sub section back button
+    Then I should see text asking to answer the question
+    When I follow link back to report overview page
+    Then I should see "actions" as "not finished"
+    When I view the actions report section
+    Then I should be on the actions report summary page
+    When I follow edit link on concerns question
+    And I choose no and save on concerns actions section
+    And I follow link back to report overview page
+    Then I should see "actions" as "finished"


### PR DESCRIPTION
## Purpose

Capture possible permutations around the actions section of the report form

![image](https://user-images.githubusercontent.com/58939809/112766243-c0941380-9008-11eb-9c2a-ead1eacc0a9b.png)

Fixes DDPB-3474

## Approach

After talking with Alex, he suggested that we should not use the old behat links. This was a slight challenge for some elements. Also he suggested not to use variables where possible (though in one instance it did just make total sense to use variables and this can be reused for all report sections).

As such an approach that seems sensible is having  specific code in the section trait that calls more generic functions in the reporting sections feature context.

I have tried where possible to navigate the app rather than just visiting urls. The purpose of this is to make sure the correct links are where we expect them on each page and work as expected. I did have one issue here..

## Learning

I feel we could do with a nice way of hitting the right link when editing without resorting to behat tags. Couldn't quite work it out..

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
