### PR TITLE
ddpb-3935 fix python versions as breaks on latest gunicorn

### DIFF
--- a/wkhtmltopdf/Dockerfile
+++ b/wkhtmltopdf/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:rc-slim-buster
+FROM python:3.9-rc-slim-buster
 
 # Download and install wkhtmltopdf and bash (because executor can't use 'sh')
 RUN apt-get update \
@@ -9,7 +9,7 @@ RUN apt-get update \
     && dpkg -i wkhtmltox_0.12.6-1.stretch_amd64.deb
 
 # Install dependencies for running web service
-RUN pip install werkzeug executor gunicorn
+RUN pip install werkzeug==1.0.1 executor==23.2 gunicorn==20.0.4
 
 ADD docker-entrypoint.sh /docker-entrypoint.sh
 ADD app.py /app.py


### PR DESCRIPTION
## Purpose
Fix python versions. Was actually gunicorn causing the issue but we can fix the other versions as well.

Fixes DDPB-3935

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
