### PR TITLE
DDPB-3476: Behat report sections - Documents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,14 @@ api-unit-tests: reset-database reset-fixtures ## Run the api unit tests
 behat-tests: up-app-integration-tests reset-fixtures
 	docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm test
 
-behat-tests-v2-goutte: up-app-integration-tests reset-fixtures disable-debug ## Pass in profile and suite name as args e.g. make behat-profile-suite profile=<PROFILE NAME> suite=<SUITE NAME>
+behat-tests-v2-goutte: up-app-integration-tests reset-fixtures disable-debug  ## Pass in suite name as arg e.g. make behat-suite suite=<SUITE NAME>
+ifdef suite
+	docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm test --profile v2-tests-goutte --tags @v2 --suite $(suite)
+else
 	docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm test --profile v2-tests-goutte --tags @v2
+endif
 
-behat-tests-v2-browserstack: up-app-integration-tests reset-fixtures disable-debug ## Pass in profile and suite name as args e.g. make behat-profile-suite profile=<PROFILE NAME> suite=<SUITE NAME>
+behat-tests-v2-browserstack: up-app-integration-tests reset-fixtures disable-debug
 	docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm test --profile v2-tests-browserstack --tags @v2
 
 behat-suite: up-app-integration-tests reset-fixtures ## Pass in suite name as arg e.g. make behat-suite suite=<SUITE NAME>

--- a/api/src/TestHelpers/BehatFixtures.php
+++ b/api/src/TestHelpers/BehatFixtures.php
@@ -227,7 +227,7 @@ class BehatFixtures
 
     private function addClientsAndReportsToLayDeputy(User $deputy, bool $completed = false, bool $submitted = false)
     {
-        $client = $this->clientTestHelper->createClient($this->entityManager, $deputy);
+        $client = $this->clientTestHelper->generateClient($this->entityManager, $deputy);
         $report = $this->reportTestHelper->generateReport($this->entityManager, $client);
 
         $client->addReport($report);
@@ -248,7 +248,7 @@ class BehatFixtures
 
     private function addOrgClientsAndReportsToOrgDeputy(User $deputy, Organisation $organisation, bool $completed = false, bool $submitted = false)
     {
-        $client = $this->clientTestHelper->createClient($this->entityManager, $deputy, $organisation);
+        $client = $this->clientTestHelper->generateClient($this->entityManager, $deputy, $organisation);
         $report = $this->reportTestHelper->generateReport($this->entityManager, $client);
 
         $client->addReport($report);

--- a/api/src/TestHelpers/BehatFixtures.php
+++ b/api/src/TestHelpers/BehatFixtures.php
@@ -3,13 +3,14 @@
 
 namespace App\TestHelpers;
 
+use App\Entity\Organisation;
 use App\Entity\User;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
-// Not extending AbstractDataFixture so we can use this in test runs rather commands
+// Not extending AbstractDataFixture so we can use this in test runs rather than just commands
 class BehatFixtures
 {
     private EntityManagerInterface $entityManager;
@@ -19,14 +20,22 @@ class BehatFixtures
     private UserTestHelper $userTestHelper;
     private ReportTestHelper $reportTestHelper;
     private ClientTestHelper $clientTestHelper;
+    private OrganisationTestHelper $organisationTestHelper;
 
     private User $admin;
     private User $superAdmin;
+
     private User $layNotStarted;
-    private User $layCompletedNotSubmitted;
+    private User $layCompleted;
     private User $laySubmitted;
 
+    private User $profAdminNotStarted;
+    private User $profAdminCompleted;
+    private User $profAdminSubmitted;
+
     private string $testRunId = '';
+    private string $orgName = 'Test Org';
+    private string $orgEmailIdentifier = 'test-org.uk';
 
     public function __construct(
         EntityManagerInterface $entityManager,
@@ -42,6 +51,7 @@ class BehatFixtures
         $this->userTestHelper = new UserTestHelper();
         $this->reportTestHelper = new ReportTestHelper();
         $this->clientTestHelper = new ClientTestHelper();
+        $this->organisationTestHelper = new OrganisationTestHelper();
     }
 
     /**
@@ -82,15 +92,15 @@ class BehatFixtures
                     'previousReportType' => null,
                     'previousReportNdrOrReport' => $this->layNotStarted->getFirstClient()->getCurrentReport() instanceof Ndr ? 'ndr' : 'report'
                 ],
-                'completed-not-submitted' => [
-                    'email' => $this->layCompletedNotSubmitted->getEmail(),
-                    'clientId' => $this->layCompletedNotSubmitted->getFirstClient()->getId(),
-                    'currentReportId' => $this->layCompletedNotSubmitted->getFirstClient()->getCurrentReport()->getId(),
-                    'currentReportType' =>$this->layCompletedNotSubmitted->getFirstClient()->getCurrentReport()->getType(),
-                    'currentReportNdrOrReport' => $this->layCompletedNotSubmitted->getFirstClient()->getCurrentReport() instanceof Ndr ? 'ndr' : 'report',
+                'completed' => [
+                    'email' => $this->layCompleted->getEmail(),
+                    'clientId' => $this->layCompleted->getFirstClient()->getId(),
+                    'currentReportId' => $this->layCompleted->getFirstClient()->getCurrentReport()->getId(),
+                    'currentReportType' =>$this->layCompleted->getFirstClient()->getCurrentReport()->getType(),
+                    'currentReportNdrOrReport' => $this->layCompleted->getFirstClient()->getCurrentReport() instanceof Ndr ? 'ndr' : 'report',
                     'previousReportId' => null,
                     'previousReportType' => null,
-                    'previousReportNdrOrReport' => $this->layCompletedNotSubmitted->getFirstClient()->getCurrentReport() instanceof Ndr ? 'ndr' : 'report'
+                    'previousReportNdrOrReport' => $this->layCompleted->getFirstClient()->getCurrentReport() instanceof Ndr ? 'ndr' : 'report'
                 ],
                 'submitted' => [
                     'email' => $this->laySubmitted->getEmail(),
@@ -101,6 +111,40 @@ class BehatFixtures
                     'previousReportId' => $this->laySubmitted->getFirstClient()->getReports()[0]->getId(),
                     'previousReportType' => $this->laySubmitted->getFirstClient()->getReports()[0]->getType(),
                     'previousReportNdrOrReport' => $this->laySubmitted->getFirstClient()->getCurrentReport() instanceof Ndr ? 'ndr' : 'report'
+                ]
+            ],
+            'professionals' => [
+                'admin' => [
+                    'not-started' => [
+                        'email' => $this->profAdminNotStarted->getEmail(),
+                        'clientId' => $this->profAdminNotStarted->getOrganisations()[0]->getClients()[0]->getId(),
+                        'currentReportId' => $this->profAdminNotStarted->getOrganisations()[0]->getClients()[0]->getCurrentReport()->getId(),
+                        'currentReportType' => $this->profAdminNotStarted->getOrganisations()[0]->getClients()[0]->getCurrentReport()->getType(),
+                        'currentReportNdrOrReport' => $this->profAdminNotStarted->getOrganisations()[0]->getClients()[0]->getCurrentReport() instanceof Ndr ? 'ndr' : 'report',
+                        'previousReportId' => null,
+                        'previousReportType' => null,
+                        'previousReportNdrOrReport' => $this->profAdminNotStarted->getOrganisations()[0]->getClients()[0]->getCurrentReport() instanceof Ndr ? 'ndr' : 'report'
+                    ],
+                    'completed' => [
+                        'email' => $this->profAdminCompleted->getEmail(),
+                        'clientId' => $this->profAdminCompleted->getOrganisations()[0]->getClients()[0]->getId(),
+                        'currentReportId' => $this->profAdminCompleted->getOrganisations()[0]->getClients()[0]->getCurrentReport()->getId(),
+                        'currentReportType' =>$this->profAdminCompleted->getOrganisations()[0]->getClients()[0]->getCurrentReport()->getType(),
+                        'currentReportNdrOrReport' => $this->profAdminCompleted->getOrganisations()[0]->getClients()[0]->getCurrentReport() instanceof Ndr ? 'ndr' : 'report',
+                        'previousReportId' => null,
+                        'previousReportType' => null,
+                        'previousReportNdrOrReport' => $this->profAdminCompleted->getOrganisations()[0]->getClients()[0]->getCurrentReport() instanceof Ndr ? 'ndr' : 'report'
+                    ],
+                    'submitted' => [
+                        'email' => $this->profAdminSubmitted->getEmail(),
+                        'clientId' => $this->profAdminSubmitted->getOrganisations()[0]->getClients()[0]->getId(),
+                        'currentReportId' => $this->profAdminSubmitted->getOrganisations()[0]->getClients()[0]->getCurrentReport()->getId(),
+                        'currentReportType' =>$this->profAdminSubmitted->getOrganisations()[0]->getClients()[0]->getCurrentReport()->getType(),
+                        'currentReportNdrOrReport' => $this->profAdminSubmitted->getOrganisations()[0]->getClients()[0]->getCurrentReport() instanceof Ndr ? 'ndr' : 'report',
+                        'previousReportId' => $this->profAdminSubmitted->getOrganisations()[0]->getClients()[0]->getReports()[0]->getId(),
+                        'previousReportType' => $this->profAdminSubmitted->getOrganisations()[0]->getClients()[0]->getReports()[0]->getType(),
+                        'previousReportNdrOrReport' => $this->profAdminSubmitted->getOrganisations()[0]->getClients()[0]->getCurrentReport() instanceof Ndr ? 'ndr' : 'report'
+                    ]
                 ]
             ]
         ];
@@ -115,8 +159,11 @@ class BehatFixtures
             $this->admin,
             $this->superAdmin,
             $this->layNotStarted,
-            $this->layCompletedNotSubmitted,
-            $this->laySubmitted
+            $this->layCompleted,
+            $this->laySubmitted,
+            $this->profAdminNotStarted,
+            $this->profAdminCompleted,
+            $this->profAdminSubmitted,
         ];
 
         foreach ($users as $user) {
@@ -138,20 +185,47 @@ class BehatFixtures
 
     private function createDeputies()
     {
-        $this->layNotStarted = $this->userTestHelper
-            ->createUser(null, User::ROLE_LAY_DEPUTY, sprintf('lay-not-started-%s@publicguardian.gov.uk', $this->testRunId));
-        $this->addClientsAndReportsToDeputy($this->layNotStarted, false, false);
-
-        $this->layCompletedNotSubmitted = $this->userTestHelper
-            ->createUser(null, User::ROLE_LAY_DEPUTY, sprintf('lay-completed-not-submitted-%s@publicguardian.gov.uk', $this->testRunId));
-        $this->addClientsAndReportsToDeputy($this->layCompletedNotSubmitted, true, false);
-
-        $this->laySubmitted = $this->userTestHelper
-            ->createUser(null, User::ROLE_LAY_DEPUTY, sprintf('lay-submitted-%s@publicguardian.gov.uk', $this->testRunId));
-        $this->addClientsAndReportsToDeputy($this->laySubmitted, true, true);
+        $this->createLays();
+        $this->createProfs();
     }
 
-    private function addClientsAndReportsToDeputy(User $deputy, bool $completed = false, bool $submitted = false)
+    private function createLays()
+    {
+        $this->layNotStarted = $this->userTestHelper
+            ->createUser(null, User::ROLE_LAY_DEPUTY, sprintf('lay-not-started-%s@t.uk', $this->testRunId));
+        $this->addClientsAndReportsToLayDeputy($this->layNotStarted, false, false);
+
+        $this->layCompleted = $this->userTestHelper
+            ->createUser(null, User::ROLE_LAY_DEPUTY, sprintf('lay-completed-%s@t.uk', $this->testRunId));
+        $this->addClientsAndReportsToLayDeputy($this->layCompleted, true, false);
+
+        $this->laySubmitted = $this->userTestHelper
+            ->createUser(null, User::ROLE_LAY_DEPUTY, sprintf('lay-submitted-%s@t.uk', $this->testRunId));
+        $this->addClientsAndReportsToLayDeputy($this->laySubmitted, true, true);
+    }
+
+    private function createProfs()
+    {
+        $orgName = sprintf('prof-%s-%s', $this->orgName, $this->testRunId);
+        $emailIdentifier = sprintf('prof-%s-%s', $this->orgEmailIdentifier, $this->testRunId);
+
+        $organisation = $this->organisationTestHelper->createOrganisation($orgName, $emailIdentifier);
+        $this->entityManager->persist($organisation);
+
+        $this->profAdminNotStarted = $this->userTestHelper
+            ->createUser(null, User::ROLE_PROF_ADMIN, sprintf('prof-admin-not-started-%s@t.uk', $this->testRunId));
+        $this->addOrgClientsAndReportsToOrgDeputy($this->profAdminNotStarted, $organisation, false, false);
+
+        $this->profAdminCompleted = $this->userTestHelper
+            ->createUser(null, User::ROLE_PROF_ADMIN, sprintf('prof-admin-completed-%s@t.uk', $this->testRunId));
+        $this->addOrgClientsAndReportsToOrgDeputy($this->profAdminCompleted, $organisation, true, false);
+
+        $this->profAdminSubmitted = $this->userTestHelper
+            ->createUser(null, User::ROLE_PROF_ADMIN, sprintf('prof-admin-submitted-%s@t.uk', $this->testRunId));
+        $this->addOrgClientsAndReportsToOrgDeputy($this->profAdminSubmitted, $organisation, true, true);
+    }
+
+    private function addClientsAndReportsToLayDeputy(User $deputy, bool $completed = false, bool $submitted = false)
     {
         $client = $this->clientTestHelper->createClient($this->entityManager, $deputy);
         $report = $this->reportTestHelper->generateReport($this->entityManager, $client);
@@ -168,6 +242,34 @@ class BehatFixtures
             $this->reportTestHelper->submitReport($report, $this->entityManager);
         }
 
+        $this->entityManager->persist($client);
+        $this->entityManager->persist($report);
+    }
+
+    private function addOrgClientsAndReportsToOrgDeputy(User $deputy, Organisation $organisation, bool $completed = false, bool $submitted = false)
+    {
+        $client = $this->clientTestHelper->createClient($this->entityManager, $deputy, $organisation);
+        $report = $this->reportTestHelper->generateReport($this->entityManager, $client);
+
+        $client->addReport($report);
+        $client->setOrganisation($organisation);
+
+        $organisation->addClient($client);
+        $organisation->addUser($deputy);
+
+        $report->setClient($client);
+
+        $deputy->addOrganisation($organisation);
+
+        if ($completed) {
+            $this->reportTestHelper->completeLayReport($report, $this->entityManager);
+        }
+
+        if ($submitted) {
+            $this->reportTestHelper->submitReport($report, $this->entityManager);
+        }
+
+        $this->entityManager->persist($deputy);
         $this->entityManager->persist($client);
         $this->entityManager->persist($report);
     }

--- a/api/src/TestHelpers/ClientTestHelper.php
+++ b/api/src/TestHelpers/ClientTestHelper.php
@@ -4,6 +4,7 @@
 namespace App\TestHelpers;
 
 use App\Entity\Client;
+use App\Entity\Organisation;
 use App\Entity\Report\Report;
 use App\Entity\User;
 use Doctrine\ORM\EntityManager;
@@ -23,12 +24,11 @@ class ClientTestHelper extends TestCase
         return $client->reveal();
     }
 
-    public function createClient(EntityManager $em, ?User $user = null)
+    public function createClient(EntityManager $em, ?User $user = null, ?Organisation $organisation = null)
     {
         $faker = Factory::create('en_GB');
 
-        return (new Client())
-            ->addUser($user ? $user : (new UserTestHelper())->createAndPersistUser($em))
+        $client =  (new Client())
             ->setFirstname($faker->firstName)
             ->setLastname($faker->lastName)
             ->setCaseNumber(self::createValidCaseNumber())
@@ -36,6 +36,14 @@ class ClientTestHelper extends TestCase
             ->setCourtDate(new \DateTime())
             ->setAddress($faker->streetAddress)
             ->setPostcode($faker->postcode);
+
+        if ($user->getRoleName() === User::ROLE_LAY_DEPUTY) {
+            return $client->addUser($user ? $user : (new UserTestHelper())->createAndPersistUser($em));
+        }
+
+        if ($organisation) {
+            return $client->setOrganisation($organisation);
+        }
     }
 
     /**

--- a/api/src/TestHelpers/ClientTestHelper.php
+++ b/api/src/TestHelpers/ClientTestHelper.php
@@ -28,7 +28,7 @@ class ClientTestHelper extends TestCase
     {
         $faker = Factory::create('en_GB');
 
-        $client =  (new Client())
+        $client = (new Client())
             ->setFirstname($faker->firstName)
             ->setLastname($faker->lastName)
             ->setCaseNumber(self::createValidCaseNumber())
@@ -37,13 +37,15 @@ class ClientTestHelper extends TestCase
             ->setAddress($faker->streetAddress)
             ->setPostcode($faker->postcode);
 
-        if ($user->getRoleName() === User::ROLE_LAY_DEPUTY) {
+        if (!is_null($user) && $user->getRoleName() === User::ROLE_LAY_DEPUTY) {
             return $client->addUser($user ? $user : (new UserTestHelper())->createAndPersistUser($em));
         }
 
         if ($organisation) {
             return $client->setOrganisation($organisation);
         }
+
+        return $client;
     }
 
     /**

--- a/api/src/TestHelpers/OrganisationTestHelper.php
+++ b/api/src/TestHelpers/OrganisationTestHelper.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace App\TestHelpers;
+
+use App\Entity\Organisation;
+
+class OrganisationTestHelper
+{
+    public function createOrganisation(string $orgName, string $emailIdentifier)
+    {
+        return (new Organisation())
+            ->setName($orgName)
+            ->setEmailIdentifier($emailIdentifier)
+            ->setIsActivated(true);
+    }
+}

--- a/api/src/TestHelpers/ReportTestHelper.php
+++ b/api/src/TestHelpers/ReportTestHelper.php
@@ -62,7 +62,12 @@ class ReportTestHelper
 
     public function submitReport(ReportInterface $report, EntityManager $em): void
     {
-        $submittedBy = $report->getClient()->getUsers()->first();
+        if ($report->getClient()->getOrganisation()) {
+            $submittedBy = $report->getClient()->getOrganisation()->getUsers()[0];
+        } else {
+            $submittedBy = $report->getClient()->getUsers()->first();
+        }
+
         $submission = (new ReportSubmission($report, $submittedBy))
             ->setCreatedBy($submittedBy)
             ->setCreatedOn(new DateTime());

--- a/behat/tests/behat.yml
+++ b/behat/tests/behat.yml
@@ -200,11 +200,11 @@ cross-browser-android-chrome:
 
 v2-tests-goutte:
     suites:
-        section-contacts:
-            description: Covering the 'Contacts' section of the report
-            paths: [ "%paths.base%/features-v2/reporting/sections/contacts" ]
+        feedback:
+            description: Covering features that allow users to give us feedback
+            paths: [ "%paths.base%/features-v2/feedback" ]
             contexts:
-                - DigidepsBehat\v2\Reporting\Sections\ReportingSectionsFeatureContext
+                - DigidepsBehat\v2\feedback\FeedbackFeatureContext
 
         section-actions:
             description: Covering the 'Actions' section of the report
@@ -218,11 +218,18 @@ v2-tests-goutte:
             contexts:
                 - DigidepsBehat\v2\Reporting\Sections\ReportingSectionsFeatureContext
 
-        feedback:
-            description: Covering features that allow users to give us feedback
-            paths: [ "%paths.base%/features-v2/feedback" ]
+        section-contacts:
+            description: Covering the 'Contacts' section of the report
+            paths: [ "%paths.base%/features-v2/reporting/sections/contacts" ]
             contexts:
-                - DigidepsBehat\v2\feedback\FeedbackFeatureContext
+                - DigidepsBehat\v2\Reporting\Sections\ReportingSectionsFeatureContext
+
+        section-documents:
+            description: Covering the 'Documents' section of the report
+            paths: [ "%paths.base%/features-v2/reporting/sections/documents" ]
+            contexts:
+                - DigidepsBehat\v2\Reporting\Sections\ReportingSectionsFeatureContext
+
     extensions:
         Behat\MinkExtension\ServiceContainer\MinkExtension:
             files_path: '%paths.base%/fixtures/'

--- a/behat/tests/bootstrap/v2/common/AlertsTrait.php
+++ b/behat/tests/bootstrap/v2/common/AlertsTrait.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace DigidepsBehat\v2\Common;
+
+trait AlertsTrait
+{
+    public function assertOnAlertMessage(string $alertMessage)
+    {
+        $alertDiv = $this->getSession()->getPage()->find('css', 'div.opg-alert--info');
+
+        if (is_null($alertDiv)) {
+            $this->throwContextualException(
+                'A div with the class opg-alert--info was not found. This suggests the page is not was expected or a condition to display an alert has not been met'
+            );
+        }
+
+        $alertHtml = $alertDiv->getHtml();
+        $alertMessageFound = str_contains($alertHtml, $alertMessage);
+
+        if (!$alertMessageFound) {
+            $this->throwContextualException(
+                sprintf(
+                    'The alert element did not contain the expected message. Expected: "%s", got (full HTML): %s',
+                    $alertMessage,
+                    $alertHtml
+                )
+            );
+        }
+    }
+}

--- a/behat/tests/bootstrap/v2/common/BaseFeatureContext.php
+++ b/behat/tests/bootstrap/v2/common/BaseFeatureContext.php
@@ -21,6 +21,7 @@ class BaseFeatureContext extends MinkContext
     use ElementSelectionTrait;
     use ErrorsTrait;
     use AlertsTrait;
+    use IVisitTrait;
 
     const BEHAT_FRONT_RESET_FIXTURES = '/behat/frontend/reset-fixtures?testRunId=%s';
     const BEHAT_FRONT_USER_DETAILS = '/behat/frontend/user/%s/details';

--- a/behat/tests/bootstrap/v2/common/BaseFeatureContext.php
+++ b/behat/tests/bootstrap/v2/common/BaseFeatureContext.php
@@ -18,6 +18,8 @@ class BaseFeatureContext extends MinkContext
     use ReportTrait;
     use IShouldBeOnTrait;
     use PageUrlsTrait;
+    use ErrorsTrait;
+    use AlertsTrait;
 
     const BEHAT_FRONT_RESET_FIXTURES = '/behat/frontend/reset-fixtures?testRunId=%s';
     const BEHAT_FRONT_USER_DETAILS = '/behat/frontend/user/%s/details';
@@ -26,8 +28,12 @@ class BaseFeatureContext extends MinkContext
     public UserDetails $superAdminDetails;
 
     public UserDetails $layDeputyNotStartedDetails;
-    public UserDetails $layDeputyCompletedNotSubmittedDetails;
+    public UserDetails $layDeputyCompletedDetails;
     public UserDetails $layDeputySubmittedDetails;
+
+    public UserDetails $profAdminDeputyNotStartedDetails;
+    public UserDetails $profAdminDeputyCompletedDetails;
+    public UserDetails $profAdminDeputySubmittedDetails;
 
     public UserDetails $loggedInUserDetails;
 
@@ -55,12 +61,14 @@ class BaseFeatureContext extends MinkContext
             throw new Exception($responseData['response']);
         }
 
-
         $this->fixtureUsers[] = $this->adminDetails = new UserDetails($responseData['data']['admin-users']['admin']);
         $this->fixtureUsers[] = $this->superAdminDetails = new UserDetails($responseData['data']['admin-users']['super-admin']);
         $this->fixtureUsers[] = $this->layDeputyNotStartedDetails = new UserDetails($responseData['data']['lays']['not-started']);
-        $this->fixtureUsers[] = $this->layDeputyCompletedNotSubmittedDetails = new UserDetails($responseData['data']['lays']['completed-not-submitted']);
+        $this->fixtureUsers[] = $this->layDeputyCompletedDetails = new UserDetails($responseData['data']['lays']['completed']);
         $this->fixtureUsers[] = $this->layDeputySubmittedDetails = new UserDetails($responseData['data']['lays']['submitted']);
+        $this->fixtureUsers[] = $this->profAdminDeputyNotStartedDetails = new UserDetails($responseData['data']['professionals']['admin']['not-started']);
+        $this->fixtureUsers[] = $this->profAdminDeputyCompletedDetails = new UserDetails($responseData['data']['professionals']['admin']['completed']);
+        $this->fixtureUsers[] = $this->profAdminDeputySubmittedDetails = new UserDetails($responseData['data']['professionals']['admin']['submitted']);
     }
 
     /**

--- a/behat/tests/bootstrap/v2/common/ErrorsTrait.php
+++ b/behat/tests/bootstrap/v2/common/ErrorsTrait.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace DigidepsBehat\v2\Common;
+
+trait ErrorsTrait
+{
+    public function assertOnErrorMessage(string $errorMessage)
+    {
+        $errorDiv = $this->getSession()->getPage()->find('css', 'div#error-summary');
+        $flashDiv = $this->getSession()->getPage()->find('css', 'div.opg-alert--error');
+
+        if (is_null($errorDiv) && is_null($flashDiv)) {
+            $missingDivMessage = <<<MESSAGE
+A div with the id error-summary or class opg-alert--error was not found.
+This suggests one of the following:
+
+- an error was not triggered
+- the form error appears in a non-GDS error element
+- the flash error element is not using macro.notification.
+MESSAGE;
+
+            $this->throwContextualException($missingDivMessage);
+        }
+
+        $errorHtml = $errorDiv ? $errorDiv->getHtml() : $flashDiv->getHtml();
+        $errorMessageFound = str_contains($errorHtml, $errorMessage);
+
+        if (!$errorMessageFound) {
+            $this->throwContextualException(
+                sprintf(
+                    'The error summary did not contain the expected error message. Expected: "%s", got (full HTML): %s',
+                    $errorMessage,
+                    $errorHtml
+                )
+            );
+        }
+    }
+}

--- a/behat/tests/bootstrap/v2/common/IShouldBeOnTrait.php
+++ b/behat/tests/bootstrap/v2/common/IShouldBeOnTrait.php
@@ -112,4 +112,12 @@ trait IShouldBeOnTrait
     {
         return $this->iAmOnPage('/report\/.*\/overview$/');
     }
+
+    /**
+     * @Then I should be on the documents summary page
+     */
+    public function iAmOnDocumentsSummaryPage()
+    {
+        return $this->iAmOnPage('/report\/.*\/documents\/summary$/');
+    }
 }

--- a/behat/tests/bootstrap/v2/common/IShouldBeOnTrait.php
+++ b/behat/tests/bootstrap/v2/common/IShouldBeOnTrait.php
@@ -11,7 +11,7 @@ trait IShouldBeOnTrait
         $onExpectedPage = preg_match($urlRegex, $currentUrl);
 
         if (!$onExpectedPage) {
-            $this->throwContextualException(sprintf('Not on expected page. Current URL is: %s', $currentUrl));
+            $this->throwContextualException(sprintf('Not on expected page. Current URL is: %s but expected URL regex is %s', $currentUrl, $urlRegex));
         }
 
         return true;
@@ -118,6 +118,6 @@ trait IShouldBeOnTrait
      */
     public function iAmOnDocumentsSummaryPage()
     {
-        return $this->iAmOnPage('/report\/.*\/documents\/summary$/');
+        return $this->iAmOnPage('/report\/.*\/documents\/summary/');
     }
 }

--- a/behat/tests/bootstrap/v2/common/IVisitTrait.php
+++ b/behat/tests/bootstrap/v2/common/IVisitTrait.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+
+namespace DigidepsBehat\v2\Common;
+
+trait IVisitTrait
+{
+    /**
+     * @When I visit the report submitted page
+     */
+    public function iVisitReportSubmissionPage()
+    {
+        if (is_null($this->loggedInUserDetails->getPreviousReportId())) {
+            $this->throwContextualException(
+                "Logged in user doesn't have a previous report ID associated with them. Try using a user that has submitted a report instead."
+            );
+        }
+
+        $submittedReportUrl = $this->getReportSubmittedUrl($this->loggedInUserDetails->getPreviousReportId());
+        $this->visit($submittedReportUrl);
+    }
+}

--- a/behat/tests/bootstrap/v2/common/ReportTrait.php
+++ b/behat/tests/bootstrap/v2/common/ReportTrait.php
@@ -12,8 +12,8 @@ trait ReportTrait
      */
     public function iSubmitTheReport()
     {
-        $ndrOrReport = $this->layDeputyCompletedNotSubmittedDetails->getCurrentReportNdrOrReport();
-        $reportId = $this->layDeputyCompletedNotSubmittedDetails->getCurrentReportId();
+        $ndrOrReport = $this->layDeputyCompletedDetails->getCurrentReportNdrOrReport();
+        $reportId = $this->layDeputyCompletedDetails->getCurrentReportId();
 
         $this->visit("$ndrOrReport/$reportId/overview");
 
@@ -50,11 +50,11 @@ trait ReportTrait
      */
     public function aLayDeputyCompletesAndSubmitsAReport()
     {
-        if (empty($this->layDeputyCompletedNotSubmittedDetails)) {
+        if (empty($this->layDeputyCompletedDetails)) {
             throw new Exception('It looks like fixtures are not loaded - missing $layDeputyCompletedNotSubmittedDetails');
         }
 
-        $this->loginToFrontendAs($this->layDeputyCompletedNotSubmittedDetails->getEmail());
+        $this->loginToFrontendAs($this->layDeputyCompletedDetails->getEmail());
         $this->iSubmitTheReport();
     }
 
@@ -75,6 +75,22 @@ trait ReportTrait
      */
     public function aLayDeputyHasSubmittedAReport()
     {
+        if (empty($this->layDeputySubmittedDetails)) {
+            throw new Exception('It looks like fixtures are not loaded - missing $layDeputySubmittedDetails');
+        }
+
         $this->loginToFrontendAs($this->layDeputySubmittedDetails->getEmail());
+    }
+
+    /**
+     * @Given a Professional Admin Deputy has not started a report
+     */
+    public function aProfessionalAdminDeputyHasNotStartedAReport()
+    {
+        if (empty($this->profAdminDeputyNotStartedDetails)) {
+            throw new Exception('It looks like fixtures are not loaded - missing $profAdminDeputyNotStartedDetails');
+        }
+
+        $this->loginToFrontendAs($this->profAdminDeputyNotStartedDetails->getEmail());
     }
 }

--- a/behat/tests/bootstrap/v2/common/ReportTrait.php
+++ b/behat/tests/bootstrap/v2/common/ReportTrait.php
@@ -34,19 +34,9 @@ trait ReportTrait
     }
 
     /**
-     * @Given a Lay Deputy completes and submits a report
-     * @throws Exception
+     * @Given a Lay Deputy has not started a report
      */
-    public function aLayDeputyCompletesAndSubmitsAReport()
-    {
-        $this->aLayDeputyHasCompletedReport();
-        $this->iSubmitTheReport();
-    }
-
-    /**
-     * @Given a Lay Deputy has a new report
-     */
-    public function aLayDeputyHasNewReport()
+    public function aLayDeputyHasNotStartedAReport()
     {
         if (empty($this->layDeputyNotStartedDetails)) {
             throw new Exception('It looks like fixtures are not loaded - missing $layDeputyNotStartedDetails');
@@ -66,19 +56,6 @@ trait ReportTrait
         }
 
         $this->loginToFrontendAs($this->layDeputyCompletedDetails->getEmail());
-        $this->iSubmitTheReport();
-    }
-
-    /**
-     * @Given a Lay Deputy has not started a report
-     */
-    public function aLayDeputyHasNotStartedAReport()
-    {
-        if (empty($this->layDeputyNotStartedDetails)) {
-            throw new Exception('It looks like fixtures are not loaded - missing $layDeputyNotStartedDetails');
-        }
-
-        $this->loginToFrontendAs($this->layDeputyNotStartedDetails->getEmail());
     }
 
     /**

--- a/behat/tests/bootstrap/v2/feedback/FeedbackTrait.php
+++ b/behat/tests/bootstrap/v2/feedback/FeedbackTrait.php
@@ -12,11 +12,14 @@ trait FeedbackTrait
      */
     public function iProvidePostSubmissionFeedback()
     {
-        if (!$this->iAmOnReportSubmittedPage()) {
-            $loggedInUserCurrentReportId = $this->loggedInUserDetails->getCurrentReportId();
-            $this->visitFrontendPath($this->getReportSubmittedUrl($loggedInUserCurrentReportId));
+        try {
+            $this->iAmOnReportSubmittedPage();
+        } catch (\Throwable $e) {
+            $loggedInUserPreviousReportId = $this->loggedInUserDetails->getPreviousReportId();
+            $reportSubmittedUrl = $this->getReportSubmittedUrl($loggedInUserPreviousReportId);
+            $this->visitFrontendPath($reportSubmittedUrl);
 
-            if (str_contains($this->getCurrentUrl(), $this->getReportSubmittedUrl($loggedInUserCurrentReportId))) {
+            if (!str_contains($this->getCurrentUrl(), $reportSubmittedUrl)) {
                 $this->throwContextualException(sprintf("Couldn't access report submitted page for current user. Current url: %s", $this->getCurrentUrl()));
             }
         }
@@ -36,9 +39,10 @@ trait FeedbackTrait
             $this->iAmOnPostSubmissionUserResearchPage();
         } catch (\Throwable $e) {
             $submittedReportId = $this->loggedInUserDetails->getPreviousReportId();
-            $this->visitFrontendPath($this->getPostSubmissionUserResearchUrl($submittedReportId));
+            $postSubmissionURUrl = $this->getPostSubmissionUserResearchUrl($submittedReportId);
+            $this->visitFrontendPath($postSubmissionURUrl);
 
-            if (!str_contains($this->getCurrentUrl(), $this->getPostSubmissionUserResearchUrl($submittedReportId))) {
+            if (!str_contains($this->getCurrentUrl(), $postSubmissionURUrl)) {
                 $this->throwContextualException(sprintf("Couldn't access post submission user research page for current user. Current url: %s", $this->getCurrentUrl()));
             }
         }

--- a/behat/tests/bootstrap/v2/reporting/sections/DocumentsSectionTrait.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/DocumentsSectionTrait.php
@@ -1,0 +1,102 @@
+<?php declare(strict_types=1);
+
+namespace DigidepsBehat\v2\Reporting\Sections;
+
+use Behat\Behat\Hook\Scope\AfterStepScope;
+use Behat\Behat\Tester\Result\ExecutedStepResult;
+use Exception;
+use Faker\Factory;
+
+trait DocumentsSectionTrait
+{
+    /**
+     * @Given I view the documents report section
+     */
+    public function iViewDocumentsSection()
+    {
+        $activeReportId = $this->loggedInUserDetails->getCurrentReportId();
+        $reportSectionUrl = sprintf(self::REPORT_SECTION_ENDPOINT, $activeReportId, 'documents');
+
+        $this->visitPath($reportSectionUrl);
+
+        $currentUrl = $this->getCurrentUrl();
+        $onSectionPage = preg_match('/report\/.*\/documents$/', $currentUrl);
+
+        if (!$onSectionPage) {
+            $this->throwContextualException(sprintf('Not on documents section page. Current URL is: %s', $currentUrl));
+        }
+    }
+
+    /**
+     * @Given I view and start the documents report section
+     */
+    public function iViewAndStartDocumentsSection()
+    {
+        $this->iViewDocumentsSection();
+
+        $this->clickLink('Start');
+    }
+
+    /**
+     * @Given I have no documents to upload
+     */
+    public function iHaveNoDocumentsToUpload()
+    {
+        $this->fillField('document_wishToProvideDocumentation_1', 'no');
+
+        $this->pressButton('Save and continue');
+    }
+
+    /**
+     * @Then the documents summary page should not contain any documents
+     */
+    public function theDocumentsSummaryPageShouldNotContainDocuments()
+    {
+        $descriptionLists = $this->getSession()->getPage()->findAll('css', 'dl');
+
+        if (count($descriptionLists) > 1) {
+            $this->throwContextualException('Multiple dl elements found on the page - this suggests documents have been uploaded');
+        }
+    }
+
+    /**
+     * @Then the documents summary page should contain the documents I uploaded
+     */
+    public function theDocumentsSummaryPageShouldContainDocumentsIUploaded()
+    {
+        $descriptionLists = $this->getSession()->getPage()->findAll('css', 'dl');
+
+        if (count($descriptionLists) === 0) {
+            $this->throwContextualException('A dl element was not found on the page - make sure the current url is as expected');
+        }
+
+        $missingText = [];
+
+        foreach ($descriptionLists as $descriptionList) {
+            $html = $descriptionList->getHtml();
+            $found = false;
+
+            foreach ($this->formValuesEntered as $documentFormValues) {
+                $textVisible = str_contains($html, $documentFormValues);
+
+                if (!$textVisible) {
+                    $missingText[] = $documentFormValues;
+                }
+            }
+
+            if ($found) {
+                $missingText = [];
+            }
+        }
+
+        if (!empty($missingText)) {
+            $this->throwContextualException(
+                sprintf(
+                    'A dl was found but the row with the expected text was not found. Missing text: %s. HTML found: %s',
+                    implode(', ', $missingText),
+                    $html
+                )
+            );
+        }
+    }
+}

--- a/behat/tests/bootstrap/v2/reporting/sections/DocumentsSectionTrait.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/DocumentsSectionTrait.php
@@ -99,30 +99,28 @@ trait DocumentsSectionTrait
     private function findFileNamesInDls(array $descriptionLists)
     {
         $missingText = [];
-        $foundAllFiles = true;
 
-        foreach ($descriptionLists as $descriptionList) {
-            $html = $descriptionList->getHtml();
+        foreach ($this->uploadedDocumentFilenames as $uploadedDocumentFilename) {
             $foundFile = false;
 
-            foreach ($this->uploadedDocumentFilenames as $uploadedDocumentFilename) {
+            foreach ($descriptionLists as $descriptionList) {
+                $html = $descriptionList->getHtml();
                 $textVisible = str_contains($html, $uploadedDocumentFilename);
 
                 if (!$textVisible) {
                     $missingText[] = $uploadedDocumentFilename;
-                    $foundAllFiles = false;
                 } else {
                     $foundFile = true;
+                    break;
                 }
             }
-
 
             if ($foundFile) {
                 $missingText = [];
             }
         }
 
-        if (!$foundAllFiles && !empty($missingText)) {
+        if (!empty($missingText)) {
             $this->throwContextualException(
                 sprintf(
                     'A dl was found but the row with the expected text was not found. Missing text: %s. HTML found: %s',
@@ -139,6 +137,14 @@ trait DocumentsSectionTrait
     public function iUploadOneValidDocument()
     {
         $this->uploadFiles([$this->validJpegFilename]);
+    }
+
+    /**
+     * @When I upload multiple valid documents
+     */
+    public function iUploadMultipleValidDocuments()
+    {
+        $this->uploadFiles([$this->validJpegFilename, $this->validPdfFilename, $this->validPngFilename]);
     }
 
     private function uploadFiles(array $filenames)

--- a/behat/tests/bootstrap/v2/reporting/sections/DocumentsSectionTrait.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/DocumentsSectionTrait.php
@@ -2,16 +2,23 @@
 
 namespace DigidepsBehat\v2\Reporting\Sections;
 
-use Behat\Behat\Hook\Scope\AfterStepScope;
-use Behat\Behat\Tester\Result\ExecutedStepResult;
-use Exception;
-use Faker\Factory;
-
 trait DocumentsSectionTrait
 {
+    // Valid files
     private string $validJpegFilename = 'good.jpg';
     private string $validPngFilename = 'good.png';
     private string $validPdfFilename = 'good.pdf';
+
+    // Invalid files
+    private string $tooLargeFilename = 'too-big.jpg';
+    private string $txtFilename = 'eicar.txt';
+    private string $csvFilename = 'behat-pa.csv';
+
+    // Expected validation errors
+    private string $invalidFileTypeErrorMessage = 'Please upload a valid file type';
+    private string $fileTooBigErrorMessage = 'The file you selected to upload is too big';
+    private string $answerNotUpdatedErrorMessage = "Your answer could not be updated to 'No' because you have attached documents";
+    private string $orgCostCertificateMessage = "Send your final cost certificate for the previous reporting period";
 
     private array $uploadedDocumentFilenames = [];
 
@@ -148,6 +155,22 @@ trait DocumentsSectionTrait
         $this->uploadFiles([$this->validJpegFilename, $this->validPdfFilename, $this->validPngFilename]);
     }
 
+    /**
+     * @When I upload one document with an unsupported file type
+     */
+    public function iUploadOneDocumentWithUnsupportedFileType()
+    {
+        $this->uploadFiles([$this->txtFilename]);
+    }
+
+    /**
+     * @When I upload one document that is too large
+     */
+    public function iUploadOneDocumentThatIsTooLarge()
+    {
+        $this->uploadFiles([$this->tooLargeFilename]);
+    }
+
     private function uploadFiles(array $filenames)
     {
         $this->uploadedDocumentFilenames = $filenames;
@@ -195,5 +218,47 @@ trait DocumentsSectionTrait
         $this->pressButton('confirm_delete_confirm');
 
         $this->uploadedDocumentFilenames = $filenames;
+    }
+
+    /**
+     * @Then I should see an 'invalid file type' error
+     */
+    public function iShouldSeeInvalidFileTypeError()
+    {
+        $this->assertOnErrorMessage($this->invalidFileTypeErrorMessage);
+    }
+
+    /**
+     * @Then I should see a 'file too large' error
+     */
+    public function iShouldSeeFileTooLargeError()
+    {
+        $this->assertOnErrorMessage($this->fileTooBigErrorMessage);
+    }
+
+    /**
+     * @Then I should see an 'answer could not be updated' error
+     */
+    public function iShouldSeeAnswerCouldNotBeUpdatedError()
+    {
+        $this->assertOnErrorMessage($this->answerNotUpdatedErrorMessage);
+    }
+
+
+    /**
+     * @When I change my mind and confirm I have no documents to upload
+     */
+    public function changeMindNoDocumentsToUpload()
+    {
+        $this->clickLink('Edit');
+        $this->iHaveNoDocumentsToUpload();
+    }
+
+    /**
+     * @Then I should see guidance on providing the final cost certificate for the previous reporting period
+     */
+    public function iShouldSeeFeeGuidance()
+    {
+        $this->assertOnAlertMessage($this->orgCostCertificateMessage);
     }
 }

--- a/behat/tests/bootstrap/v2/reporting/sections/ReportingSectionsFeatureContext.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/ReportingSectionsFeatureContext.php
@@ -10,6 +10,7 @@ class ReportingSectionsFeatureContext extends BaseFeatureContext
     use ContactsSectionTrait;
     use ActionsSectionTrait;
     use AdditionalInformationSectionTrait;
+    use DocumentsSectionTrait;
 
     const REPORT_SECTION_ENDPOINT = 'report/%s/%s';
 

--- a/behat/tests/features-v2/feedback/post-submission-feedback.report.feature
+++ b/behat/tests/features-v2/feedback/post-submission-feedback.report.feature
@@ -1,17 +1,16 @@
-@v2
+@v2 @feedback
 Feature: Providing feedback after submitting a report
   Scenario: A user does not provide feedback
-    Given a Lay Deputy completes and submits a report
-    Then I should be on the report submitted page
+    Given a Lay Deputy has submitted a report
+    When I visit the report submitted page
     When I press "Your reports"
     Then I should be on the Lay homepage
 
   Scenario: A user provides satisfaction feedback
-    Given a Lay Deputy completes and submits a report
-    Then I should be on the report submitted page
+    Given a Lay Deputy has submitted a report
     When I provide some post-submission feedback
     Then I should be on the post-submission user research page
-  @acs
+
   Scenario: A user provides user research feedback
     Given a Lay Deputy has submitted a report
     When I provide valid user research responses

--- a/behat/tests/features-v2/reporting/sections/actions/actions.feature
+++ b/behat/tests/features-v2/reporting/sections/actions/actions.feature
@@ -2,7 +2,7 @@
 Feature: Actions
 
   Scenario: A user has made no financial decisions and has no concerns
-    Given a Lay Deputy has a new report
+    Given a Lay Deputy has not started a report
     And I view and start the actions report section
     Then I should be on the financial decision actions page
     When I choose no and save on financial decision actions section
@@ -17,7 +17,7 @@ Feature: Actions
     And I should see "actions" as "finished"
 
   Scenario: A user has made financial decisions and has concerns
-    Given a Lay Deputy has a new report
+    Given a Lay Deputy has not started a report
     And I view and start the actions report section
     Then I should be on the financial decision actions page
     When I choose yes and save on financial decision actions section
@@ -28,7 +28,7 @@ Feature: Actions
     And I should see the expected action comments
 
   Scenario: A user partially completes the section and then edits their responses
-    Given a Lay Deputy has a new report
+    Given a Lay Deputy has not started a report
     And I view the report overview page
     Then I should see "actions" as "not started"
     When I view and start the actions report section

--- a/behat/tests/features-v2/reporting/sections/additional-information/additional-information.feature
+++ b/behat/tests/features-v2/reporting/sections/additional-information/additional-information.feature
@@ -1,4 +1,4 @@
-@v2
+@v2 @additional-information
 Feature: Additional Information
 
   Scenario: A user has no additional information to add

--- a/behat/tests/features-v2/reporting/sections/contacts/contacts.feature
+++ b/behat/tests/features-v2/reporting/sections/contacts/contacts.feature
@@ -1,4 +1,4 @@
-@v2
+@v2 @contacts
 Feature: Contacts
 
   Scenario: A user has no contacts

--- a/behat/tests/features-v2/reporting/sections/documents/documents.feature
+++ b/behat/tests/features-v2/reporting/sections/documents/documents.feature
@@ -18,21 +18,23 @@ Feature: Documents - All User Roles
     Then I should be on the documents summary page
     And the documents summary page should contain the documents I uploaded
 
-#  Scenario: A user uploads two supporting document that have valid file types
-#    Given a Lay Deputy has not started a report
-#    When I view and start the documents report section
-#    And I upload two valid document
-#    Then the documents uploads page should contain the documents I uploaded
-#    When I have no more documents to upload
-#    Then I should be on the documents summary page
-#    And the documents summary page should contain the documents I uploaded
+  Scenario: A user uploads multiple supporting document that have valid file types
+    Given a Lay Deputy has not started a report
+    When I view and start the documents report section
+    And I have documents to upload
+    And I upload multiple valid documents
+    Then the documents uploads page should contain the documents I uploaded
+    When I have no further documents to upload
+    Then I should be on the documents summary page
+    And the documents summary page should contain the documents I uploaded
 #
 #  Scenario: A user deletes one supporting document that they uploaded from the uploads page
 #    Given a Lay Deputy has not started a report
 #    When I view and start the documents report section
+#    And I have documents to upload
 #    And I upload one valid document
 #    And I remove the document I uploaded
-#    When I have no more documents to upload
+#    When I have no further documents to upload
 #    Then I should be on the documents summary page
 #    When I delete the document I uploaded
 #    Then I should be on the documents start page
@@ -40,9 +42,10 @@ Feature: Documents - All User Roles
 #  Scenario: A user deletes one supporting document that they uploaded from the summary page
 #    Given a Lay Deputy has not started a report
 #    When I view and start the documents report section
+#    And I have documents to upload
 #    And I upload one valid document
 #    And I remove the document I uploaded
-#    When I have no more documents to upload
+#    When I have no further documents to upload
 #    Then I should be on the documents summary page
 #    When I delete the document I uploaded
 #    Then I should be on the documents start page
@@ -50,21 +53,24 @@ Feature: Documents - All User Roles
 #  Scenario: A user uploads one supporting document that has an invalid file type
 #    Given a Lay Deputy has not started a report
 #    When I view and start the documents report section
+#    And I have documents to upload
 #    And I upload one invalid document
 #    Then I should see an invalid file type error
 
 #  Scenario: A user uploads one supporting document that has a valid file type but is too large
 #    Given a Lay Deputy has not started a report
 #    When I view and start the documents report section
+#    And I have documents to upload
 #    And I upload one document that is too large
 #    Then I should see a file too large error
 #
 #  Scenario: A user uploads one supporting document that has a valid file type then confirms they have no files to upload
 #    Given a Lay Deputy has not started a report
 #    When I view and start the documents report section
+#    And I have documents to upload
 #    And I upload one valid document
 #    Then the documents uploads page should contain the documents I uploaded
-#    When I have no more documents to upload
+#    When I have no further documents to upload
 #    Then I should be on the documents summary page
 #    When I confirm I have no documents to upload
 #    Then I should see an answer could not be updated error

--- a/behat/tests/features-v2/reporting/sections/documents/documents.feature
+++ b/behat/tests/features-v2/reporting/sections/documents/documents.feature
@@ -5,59 +5,59 @@ Feature: Documents - All User Roles
     Given a Lay Deputy has not started a report
     When I view and start the documents report section
     And I have no documents to upload
-    Then I should be on the documents report summary page
+    Then I should be on the documents summary page
     And the documents summary page should not contain any documents
 
-  Scenario: A user uploads one supporting document that has a valid file type
-    Given a Lay Deputy has not started a report
-    When I view and start the documents report section
-    And I upload one valid document
-    Then the documents uploads page should contain the documents I uploaded
-    When I have no more documents to upload
-    Then I should be on the documents report summary page
-    And the documents summary page should contain the documents I uploaded
-
-  Scenario: A user uploads two supporting document that have valid file types
-    Given a Lay Deputy has not started a report
-    When I view and start the documents report section
-    And I upload two valid document
-    Then the documents uploads page should contain the documents I uploaded
-    When I have no more documents to upload
-    Then I should be on the documents report summary page
-    And the documents summary page should contain the documents I uploaded
-
-  Scenario: A user deletes one supporting document that they uploaded from the uploads page
-    Given a Lay Deputy has not started a report
-    When I view and start the documents report section
-    And I upload one valid document
-    And I remove the document I uploaded
-    When I have no more documents to upload
-    Then I should be on the documents report summary page
-    When I delete the document I uploaded
-    Then I should be on the documents start page
-
-  Scenario: A user deletes one supporting document that they uploaded from the summary page
-    Given a Lay Deputy has not started a report
-    When I view and start the documents report section
-    And I upload one valid document
-    And I remove the document I uploaded
-    When I have no more documents to upload
-    Then I should be on the documents report summary page
-    When I delete the document I uploaded
-    Then I should be on the documents start page
-
-  Scenario: A user uploads one supporting document that has an invalid file type
-    Given a Lay Deputy has not started a report
-    When I view and start the documents report section
-    And I upload one invalid document
-    Then I should see an invalid file type error
-
-  Scenario: A user uploads one supporting document that has a valid file type then confirms they have no files to upload
-    Given a Lay Deputy has not started a report
-    When I view and start the documents report section
-    And I upload one valid document
-    Then the documents uploads page should contain the documents I uploaded
-    When I have no more documents to upload
-    Then I should be on the documents report summary page
-    When I confirm I have no documents to upload
-    Then I should see an answer could not be updated error
+#  Scenario: A user uploads one supporting document that has a valid file type
+#    Given a Lay Deputy has not started a report
+#    When I view and start the documents report section
+#    And I upload one valid document
+#    Then the documents uploads page should contain the documents I uploaded
+#    When I have no more documents to upload
+#    Then I should be on the documents summary page
+#    And the documents summary page should contain the documents I uploaded
+#
+#  Scenario: A user uploads two supporting document that have valid file types
+#    Given a Lay Deputy has not started a report
+#    When I view and start the documents report section
+#    And I upload two valid document
+#    Then the documents uploads page should contain the documents I uploaded
+#    When I have no more documents to upload
+#    Then I should be on the documents summary page
+#    And the documents summary page should contain the documents I uploaded
+#
+#  Scenario: A user deletes one supporting document that they uploaded from the uploads page
+#    Given a Lay Deputy has not started a report
+#    When I view and start the documents report section
+#    And I upload one valid document
+#    And I remove the document I uploaded
+#    When I have no more documents to upload
+#    Then I should be on the documents summary page
+#    When I delete the document I uploaded
+#    Then I should be on the documents start page
+#
+#  Scenario: A user deletes one supporting document that they uploaded from the summary page
+#    Given a Lay Deputy has not started a report
+#    When I view and start the documents report section
+#    And I upload one valid document
+#    And I remove the document I uploaded
+#    When I have no more documents to upload
+#    Then I should be on the documents summary page
+#    When I delete the document I uploaded
+#    Then I should be on the documents start page
+#
+#  Scenario: A user uploads one supporting document that has an invalid file type
+#    Given a Lay Deputy has not started a report
+#    When I view and start the documents report section
+#    And I upload one invalid document
+#    Then I should see an invalid file type error
+#
+#  Scenario: A user uploads one supporting document that has a valid file type then confirms they have no files to upload
+#    Given a Lay Deputy has not started a report
+#    When I view and start the documents report section
+#    And I upload one valid document
+#    Then the documents uploads page should contain the documents I uploaded
+#    When I have no more documents to upload
+#    Then I should be on the documents summary page
+#    When I confirm I have no documents to upload
+#    Then I should see an answer could not be updated error

--- a/behat/tests/features-v2/reporting/sections/documents/documents.feature
+++ b/behat/tests/features-v2/reporting/sections/documents/documents.feature
@@ -1,0 +1,63 @@
+@v2
+Feature: Documents - All User Roles
+
+  Scenario: A user has no supporting documents to add
+    Given a Lay Deputy has not started a report
+    When I view and start the documents report section
+    And I have no documents to upload
+    Then I should be on the documents report summary page
+    And the documents summary page should not contain any documents
+
+  Scenario: A user uploads one supporting document that has a valid file type
+    Given a Lay Deputy has not started a report
+    When I view and start the documents report section
+    And I upload one valid document
+    Then the documents uploads page should contain the documents I uploaded
+    When I have no more documents to upload
+    Then I should be on the documents report summary page
+    And the documents summary page should contain the documents I uploaded
+
+  Scenario: A user uploads two supporting document that have valid file types
+    Given a Lay Deputy has not started a report
+    When I view and start the documents report section
+    And I upload two valid document
+    Then the documents uploads page should contain the documents I uploaded
+    When I have no more documents to upload
+    Then I should be on the documents report summary page
+    And the documents summary page should contain the documents I uploaded
+
+  Scenario: A user deletes one supporting document that they uploaded from the uploads page
+    Given a Lay Deputy has not started a report
+    When I view and start the documents report section
+    And I upload one valid document
+    And I remove the document I uploaded
+    When I have no more documents to upload
+    Then I should be on the documents report summary page
+    When I delete the document I uploaded
+    Then I should be on the documents start page
+
+  Scenario: A user deletes one supporting document that they uploaded from the summary page
+    Given a Lay Deputy has not started a report
+    When I view and start the documents report section
+    And I upload one valid document
+    And I remove the document I uploaded
+    When I have no more documents to upload
+    Then I should be on the documents report summary page
+    When I delete the document I uploaded
+    Then I should be on the documents start page
+
+  Scenario: A user uploads one supporting document that has an invalid file type
+    Given a Lay Deputy has not started a report
+    When I view and start the documents report section
+    And I upload one invalid document
+    Then I should see an invalid file type error
+
+  Scenario: A user uploads one supporting document that has a valid file type then confirms they have no files to upload
+    Given a Lay Deputy has not started a report
+    When I view and start the documents report section
+    And I upload one valid document
+    Then the documents uploads page should contain the documents I uploaded
+    When I have no more documents to upload
+    Then I should be on the documents report summary page
+    When I confirm I have no documents to upload
+    Then I should see an answer could not be updated error

--- a/behat/tests/features-v2/reporting/sections/documents/documents.feature
+++ b/behat/tests/features-v2/reporting/sections/documents/documents.feature
@@ -28,7 +28,7 @@ Feature: Documents - All User Roles
     Then I should be on the documents summary page
     And the documents summary page should contain the documents I uploaded
 
-  Scenario: A user deletes one supporting document that they uploaded from the uploads page
+  Scenario: A user deletes one supporting document they uploaded from the uploads page
     Given a Lay Deputy has not started a report
     When I view and start the documents report section
     And I have documents to upload
@@ -38,7 +38,7 @@ Feature: Documents - All User Roles
     Then I should be on the documents summary page
     And the documents summary page should contain the documents I uploaded
 
-  Scenario: A user deletes one supporting document that they uploaded from the summary page
+  Scenario: A user deletes one supporting document they uploaded from the summary page
     Given a Lay Deputy has not started a report
     When I view and start the documents report section
     And I have documents to upload
@@ -47,28 +47,28 @@ Feature: Documents - All User Roles
     Then I should be on the documents summary page
     When I remove one document I uploaded
     Then the documents summary page should contain the documents I uploaded
-#
-#  Scenario: A user uploads one supporting document that has an invalid file type
-#    Given a Lay Deputy has not started a report
-#    When I view and start the documents report section
-#    And I have documents to upload
-#    And I upload one invalid document
-#    Then I should see an invalid file type error
 
-#  Scenario: A user uploads one supporting document that has a valid file type but is too large
-#    Given a Lay Deputy has not started a report
-#    When I view and start the documents report section
-#    And I have documents to upload
-#    And I upload one document that is too large
-#    Then I should see a file too large error
-#
-#  Scenario: A user uploads one supporting document that has a valid file type then confirms they have no files to upload
-#    Given a Lay Deputy has not started a report
-#    When I view and start the documents report section
-#    And I have documents to upload
-#    And I upload one valid document
-#    Then the documents uploads page should contain the documents I uploaded
-#    When I have no further documents to upload
-#    Then I should be on the documents summary page
-#    When I confirm I have no documents to upload
-#    Then I should see an answer could not be updated error
+  Scenario: A user uploads one supporting document that has an invalid file type
+    Given a Lay Deputy has not started a report
+    When I view and start the documents report section
+    And I have documents to upload
+    And I upload one document with an unsupported file type
+    Then I should see an 'invalid file type' error
+
+  Scenario: A user uploads one supporting document that has a valid file type but is too large
+    Given a Lay Deputy has not started a report
+    When I view and start the documents report section
+    And I have documents to upload
+    And I upload one document that is too large
+    Then I should see a 'file too large' error
+
+  Scenario: A user uploads one supporting document that has a valid file type then confirms they have no files to upload
+    Given a Lay Deputy has not started a report
+    When I view and start the documents report section
+    And I have documents to upload
+    And I upload one valid document
+    Then the documents uploads page should contain the documents I uploaded
+    When I have no further documents to upload
+    Then I should be on the documents summary page
+    When I change my mind and confirm I have no documents to upload
+    Then I should see an 'answer could not be updated' error

--- a/behat/tests/features-v2/reporting/sections/documents/documents.feature
+++ b/behat/tests/features-v2/reporting/sections/documents/documents.feature
@@ -8,15 +8,16 @@ Feature: Documents - All User Roles
     Then I should be on the documents summary page
     And the documents summary page should not contain any documents
 
-#  Scenario: A user uploads one supporting document that has a valid file type
-#    Given a Lay Deputy has not started a report
-#    When I view and start the documents report section
-#    And I upload one valid document
-#    Then the documents uploads page should contain the documents I uploaded
-#    When I have no more documents to upload
-#    Then I should be on the documents summary page
-#    And the documents summary page should contain the documents I uploaded
-#
+  Scenario: A user uploads one supporting document that has a valid file type
+    Given a Lay Deputy has not started a report
+    When I view and start the documents report section
+    And I have documents to upload
+    And I upload one valid document
+    Then the documents uploads page should contain the documents I uploaded
+    When I have no further documents to upload
+    Then I should be on the documents summary page
+    And the documents summary page should contain the documents I uploaded
+
 #  Scenario: A user uploads two supporting document that have valid file types
 #    Given a Lay Deputy has not started a report
 #    When I view and start the documents report section
@@ -51,6 +52,12 @@ Feature: Documents - All User Roles
 #    When I view and start the documents report section
 #    And I upload one invalid document
 #    Then I should see an invalid file type error
+
+#  Scenario: A user uploads one supporting document that has a valid file type but is too large
+#    Given a Lay Deputy has not started a report
+#    When I view and start the documents report section
+#    And I upload one document that is too large
+#    Then I should see a file too large error
 #
 #  Scenario: A user uploads one supporting document that has a valid file type then confirms they have no files to upload
 #    Given a Lay Deputy has not started a report

--- a/behat/tests/features-v2/reporting/sections/documents/documents.feature
+++ b/behat/tests/features-v2/reporting/sections/documents/documents.feature
@@ -27,28 +27,26 @@ Feature: Documents - All User Roles
     When I have no further documents to upload
     Then I should be on the documents summary page
     And the documents summary page should contain the documents I uploaded
-#
-#  Scenario: A user deletes one supporting document that they uploaded from the uploads page
-#    Given a Lay Deputy has not started a report
-#    When I view and start the documents report section
-#    And I have documents to upload
-#    And I upload one valid document
-#    And I remove the document I uploaded
-#    When I have no further documents to upload
-#    Then I should be on the documents summary page
-#    When I delete the document I uploaded
-#    Then I should be on the documents start page
-#
-#  Scenario: A user deletes one supporting document that they uploaded from the summary page
-#    Given a Lay Deputy has not started a report
-#    When I view and start the documents report section
-#    And I have documents to upload
-#    And I upload one valid document
-#    And I remove the document I uploaded
-#    When I have no further documents to upload
-#    Then I should be on the documents summary page
-#    When I delete the document I uploaded
-#    Then I should be on the documents start page
+
+  Scenario: A user deletes one supporting document that they uploaded from the uploads page
+    Given a Lay Deputy has not started a report
+    When I view and start the documents report section
+    And I have documents to upload
+    And I upload multiple valid documents
+    And I remove one document I uploaded
+    When I have no further documents to upload
+    Then I should be on the documents summary page
+    And the documents summary page should contain the documents I uploaded
+
+  Scenario: A user deletes one supporting document that they uploaded from the summary page
+    Given a Lay Deputy has not started a report
+    When I view and start the documents report section
+    And I have documents to upload
+    And I upload multiple valid documents
+    When I have no further documents to upload
+    Then I should be on the documents summary page
+    When I remove one document I uploaded
+    Then the documents summary page should contain the documents I uploaded
 #
 #  Scenario: A user uploads one supporting document that has an invalid file type
 #    Given a Lay Deputy has not started a report

--- a/behat/tests/features-v2/reporting/sections/documents/documents.feature
+++ b/behat/tests/features-v2/reporting/sections/documents/documents.feature
@@ -1,4 +1,4 @@
-@v2
+@v2 @documents
 Feature: Documents - All User Roles
 
   Scenario: A user has no supporting documents to add

--- a/behat/tests/features-v2/reporting/sections/documents/documents.org.feature
+++ b/behat/tests/features-v2/reporting/sections/documents/documents.org.feature
@@ -1,7 +1,7 @@
 @v2
 Feature: Documents - Org User Roles
 
-  Scenario: Organisation users should see guidance on sending the previous years cost certificate
-    Given a Professional Deputy has not started a report
-    When I view the documents report section
-    Then I should see guidance on providing the final cost certificate for the previous reporting period
+#  Scenario: Organisation users should see guidance on sending the previous years cost certificate
+#    Given a Professional Deputy has not started a report
+#    When I view the documents report section
+#    Then I should see guidance on providing the final cost certificate for the previous reporting period

--- a/behat/tests/features-v2/reporting/sections/documents/documents.org.feature
+++ b/behat/tests/features-v2/reporting/sections/documents/documents.org.feature
@@ -1,7 +1,7 @@
 @v2
 Feature: Documents - Org User Roles
 
-#  Scenario: Organisation users should see guidance on sending the previous years cost certificate
-#    Given a Professional Deputy has not started a report
-#    When I view the documents report section
-#    Then I should see guidance on providing the final cost certificate for the previous reporting period
+  Scenario: Organisation users should see guidance on sending the previous years cost certificate
+    Given a Professional Admin Deputy has not started a report
+    When I view the documents report section
+    Then I should see guidance on providing the final cost certificate for the previous reporting period

--- a/behat/tests/features-v2/reporting/sections/documents/documents.org.feature
+++ b/behat/tests/features-v2/reporting/sections/documents/documents.org.feature
@@ -1,4 +1,4 @@
-@v2
+@v2 @documents
 Feature: Documents - Org User Roles
 
   Scenario: Organisation users should see guidance on sending the previous years cost certificate

--- a/behat/tests/features-v2/reporting/sections/documents/documents.org.feature
+++ b/behat/tests/features-v2/reporting/sections/documents/documents.org.feature
@@ -1,0 +1,7 @@
+@v2
+Feature: Documents - Org User Roles
+
+  Scenario: Organisation users should see guidance on sending the previous years cost certificate
+    Given a Professional Deputy has not started a report
+    When I view the documents report section
+    Then I should see guidance on providing the final cost certificate for the previous reporting period

--- a/behat/tests/features-v2/reporting/sections/gifts/gifts.feature
+++ b/behat/tests/features-v2/reporting/sections/gifts/gifts.feature
@@ -2,7 +2,7 @@
 Feature: Gifts
 
   Scenario: A user has not donated any gifts
-    Given a Lay Deputy has a new report
+    Given a Lay Deputy has not started a report
     When I view and start the gifts report section
     And I have not given any gifts
     Then I should see the expected gifts report section responses
@@ -10,7 +10,7 @@ Feature: Gifts
     Then I should see "gifts" as "no gifts"
 
   Scenario: A user has donated multiple gifts
-    Given a Lay Deputy has a new report
+    Given a Lay Deputy has not started a report
     When I view and start the gifts report section
     And I have given multiple gifts
     Then I should see the expected gifts report section responses
@@ -32,7 +32,7 @@ Feature: Gifts
     Then I should see the expected gifts report section responses
 
   Scenario: A user adds and deletes gifts
-    Given a Lay Deputy has a new report
+    Given a Lay Deputy has not started a report
     When I view and start the gifts report section
     And I have given multiple gifts
     Then I should see the expected gifts report section responses


### PR DESCRIPTION
## Purpose
Covers off the documents section of the report in new style behat tests.

Fixes DDPB-3476.

## Approach
I've really doubled down on trying to make the BDD as understandable and domain-specific as possible in this ticket. Hopefully, I've got the balance right between step naming and asserting in the context files but wide open to feedback if things could be clearer.

I've also added our first professional fixture users in to pass a test on org user specific alerting. I've only used them to log in so far so we could find things aren't quite right when we come to use them for more involved tests but there's a basis to build all other org fixture users out from. We should also keep an eye on the time it takes to build out the fixtures between each scenario. I'm kind of on the fence with at the end of the exercise just outputting some SQL that can be executed if the run time starts to creep up too high but I don't think we're there yet.

## Learning
Used an ifdef in the makefile to allow passing command line vars to make commands without having to have a new make command 🥳 

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes
