### PR TITLE
Ddpb 3478 - Add accounts behat tests

### DIFF
--- a/api/src/Entity/Ndr/Ndr.php
+++ b/api/src/Entity/Ndr/Ndr.php
@@ -437,6 +437,20 @@ class Ndr implements ReportInterface
     }
 
     /**
+     * Add accounts.
+     *
+     * @param BankAccount $accounts
+     *
+     * @return Ndr
+     */
+    public function addAccount(BankAccount $accounts)
+    {
+        $this->bankAccounts[] = $accounts;
+
+        return $this;
+    }
+
+    /**
      * Remove assets.
      *
      * @param Asset $assets

--- a/api/src/TestHelpers/BehatFixtures.php
+++ b/api/src/TestHelpers/BehatFixtures.php
@@ -153,7 +153,8 @@ class BehatFixtures
 
     private function addClientsAndReportsToDeputy(User $deputy, bool $completed = false, bool $submitted = false)
     {
-        $client = $this->clientTestHelper->createClient($this->entityManager, $deputy);
+        $client = $this->clientTestHelper->generateClient($this->entityManager, $deputy);
+
         $report = $this->reportTestHelper->generateReport($this->entityManager, $client);
 
         $client->addReport($report);

--- a/api/src/TestHelpers/BehatFixtures.php
+++ b/api/src/TestHelpers/BehatFixtures.php
@@ -4,7 +4,9 @@
 namespace App\TestHelpers;
 
 use App\Entity\Organisation;
+use App\Entity\Report\Report;
 use App\Entity\User;
+use App\Entity\Ndr\Ndr;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\ORM\EntityManagerInterface;
 use Exception;
@@ -28,6 +30,10 @@ class BehatFixtures
     private User $layNotStarted;
     private User $layCompleted;
     private User $laySubmitted;
+
+    private User $ndrLayNotStarted;
+    private User $ndrLayCompleted;
+    private User $ndrLaySubmitted;
 
     private User $profAdminNotStarted;
     private User $profAdminCompleted;
@@ -113,6 +119,26 @@ class BehatFixtures
                     'previousReportNdrOrReport' => $this->laySubmitted->getFirstClient()->getCurrentReport() instanceof Ndr ? 'ndr' : 'report'
                 ]
             ],
+            'lays-ndr' => [
+                'not-started' => [
+                    'email' => $this->ndrLayNotStarted->getEmail(),
+                    'clientId' => $this->ndrLayNotStarted->getFirstClient()->getId(),
+                    'currentReportId' => $this->ndrLayNotStarted->getFirstClient()->getNdr()->getId(),
+                    'currentReportNdrOrReport' => 'ndr'
+                ],
+                'completed' => [
+                    'email' => $this->ndrLayCompleted->getEmail(),
+                    'clientId' => $this->ndrLayCompleted->getFirstClient()->getId(),
+                    'currentReportId' => $this->ndrLayCompleted->getFirstClient()->getNdr()->getId(),
+                    'currentReportNdrOrReport' => 'ndr'
+                ],
+                'submitted' => [
+                    'email' => $this->ndrLaySubmitted->getEmail(),
+                    'clientId' => $this->ndrLaySubmitted->getFirstClient()->getId(),
+                    'currentReportId' => $this->ndrLaySubmitted->getFirstClient()->getNdr()->getId(),
+                    'currentReportNdrOrReport' => 'ndr'
+                ]
+            ],
             'professionals' => [
                 'admin' => [
                     'not-started' => [
@@ -161,6 +187,9 @@ class BehatFixtures
             $this->layNotStarted,
             $this->layCompleted,
             $this->laySubmitted,
+            $this->ndrLayNotStarted,
+            $this->ndrLayCompleted,
+            $this->ndrLaySubmitted,
             $this->profAdminNotStarted,
             $this->profAdminCompleted,
             $this->profAdminSubmitted,
@@ -186,6 +215,7 @@ class BehatFixtures
     private function createDeputies()
     {
         $this->createLays();
+        $this->createNdrLays();
         $this->createProfs();
     }
 
@@ -202,6 +232,21 @@ class BehatFixtures
         $this->laySubmitted = $this->userTestHelper
             ->createUser(null, User::ROLE_LAY_DEPUTY, sprintf('lay-submitted-%s@t.uk', $this->testRunId));
         $this->addClientsAndReportsToLayDeputy($this->laySubmitted, true, true);
+    }
+
+    private function createNdrLays()
+    {
+        $this->ndrLayNotStarted = $this->userTestHelper
+            ->createUser(null, User::ROLE_LAY_DEPUTY, sprintf('lay-ndr-not-started-%s@t.uk', $this->testRunId));
+        $this->addClientsAndReportsToNdrLayDeputy($this->ndrLayNotStarted, false, false);
+
+        $this->ndrLayCompleted = $this->userTestHelper
+            ->createUser(null, User::ROLE_LAY_DEPUTY, sprintf('lay-ndr-completed-%s@t.uk', $this->testRunId));
+        $this->addClientsAndReportsToNdrLayDeputy($this->ndrLayCompleted, true, false);
+
+        $this->ndrLaySubmitted = $this->userTestHelper
+            ->createUser(null, User::ROLE_LAY_DEPUTY, sprintf('lay-ndr-submitted-%s@t.uk', $this->testRunId));
+        $this->addClientsAndReportsToNdrLayDeputy($this->ndrLaySubmitted, true, true);
     }
 
     private function createProfs()
@@ -245,6 +290,29 @@ class BehatFixtures
 
         $this->entityManager->persist($client);
         $this->entityManager->persist($report);
+    }
+
+    private function addClientsAndReportsToNdrLayDeputy(User $deputy, bool $completed = false, bool $submitted = false)
+    {
+        $client = $this->clientTestHelper->generateClient($this->entityManager, $deputy);
+
+        $ndr = new Ndr($client);
+        $this->entityManager->persist($ndr);
+        $deputy->setNdrEnabled(true);
+        $client->setNdr($ndr);
+
+        $deputy->addClient($client);
+
+        if ($completed) {
+            $this->reportTestHelper->completeNdrLayReport($ndr, $this->entityManager);
+        }
+
+//        if ($submitted) {
+//            placeholder for when submitted version needed...
+//        }
+
+        $this->entityManager->persist($ndr);
+        $this->entityManager->persist($client);
     }
 
     private function addOrgClientsAndReportsToOrgDeputy(User $deputy, Organisation $organisation, bool $completed = false, bool $submitted = false)

--- a/api/src/TestHelpers/BehatFixtures.php
+++ b/api/src/TestHelpers/BehatFixtures.php
@@ -297,7 +297,6 @@ class BehatFixtures
         $client = $this->clientTestHelper->generateClient($this->entityManager, $deputy);
 
         $ndr = new Ndr($client);
-        $this->entityManager->persist($ndr);
         $deputy->setNdrEnabled(true);
         $client->setNdr($ndr);
 

--- a/api/src/TestHelpers/ReportTestHelper.php
+++ b/api/src/TestHelpers/ReportTestHelper.php
@@ -60,6 +60,18 @@ class ReportTestHelper
         $this->completeLifestyle($report);
     }
 
+    public function completeNdrLayReport(ReportInterface $report, EntityManager $em): void
+    {
+        $this->completeVisitsCare($report);
+        $this->completeActions($report);
+        $this->completeOtherInfo($report);
+        $this->completeDeputyExpenses($report);
+        $this->completeIncomeBenefits($report);
+        $this->completeBankAccounts($report, $em);
+        $this->completeAssets($report);
+        $this->completeDebts($report);
+    }
+
     public function submitReport(ReportInterface $report, EntityManager $em): void
     {
         if ($report->getClient()->getOrganisation()) {
@@ -200,6 +212,7 @@ class ReportTestHelper
     {
         if ($report instanceof Ndr\Ndr) {
             $ba = (new Ndr\BankAccount())->setNdr($report);
+            $report->addAccount($ba);
             $em->persist($ba);
         } else {
             $ba = (new BankAccount())->setReport($report)->setClosingBalance(1000);

--- a/api/src/v2/Fixture/Controller/FixtureController.php
+++ b/api/src/v2/Fixture/Controller/FixtureController.php
@@ -659,7 +659,7 @@ class FixtureController extends AbstractController
         } catch (\Throwable $e) {
             return new JsonResponse(
                 [
-                    'response' => sprintf('Beaht fixtures not loaded: %s', $e->getMessage()),
+                    'response' => sprintf('Behat fixtures not loaded: %s', $e->getMessage()),
                     'data' => null
                 ],
                 Response::HTTP_INTERNAL_SERVER_ERROR

--- a/behat/tests/behat.yml
+++ b/behat/tests/behat.yml
@@ -200,9 +200,9 @@ cross-browser-android-chrome:
 
 v2-tests-goutte:
     suites:
-        section-contacts:
-            description: Covering the 'Contacts' section of the report
-            paths: [ "%paths.base%/features-v2/reporting/sections/contacts" ]
+        section-accounts:
+            description: Covering the 'Accounts' section of the report
+            paths: [ "%paths.base%/features-v2/reporting/sections/accounts" ]
             contexts:
                 - DigidepsBehat\v2\Reporting\Sections\ReportingSectionsFeatureContext
 
@@ -212,15 +212,21 @@ v2-tests-goutte:
             contexts:
                 - DigidepsBehat\v2\Reporting\Sections\ReportingSectionsFeatureContext
 
-        section-gifts:
-            description: Covering the 'Gifts' section of the report
-            paths: [ "%paths.base%/features-v2/reporting/sections/gifts" ]
-            contexts:
-                - DigidepsBehat\v2\Reporting\Sections\ReportingSectionsFeatureContext
-
         section-additional-information:
             description: Covering the 'Additional Information' section of the report
             paths: [ "%paths.base%/features-v2/reporting/sections/additional-information" ]
+            contexts:
+                - DigidepsBehat\v2\Reporting\Sections\ReportingSectionsFeatureContext
+
+        section-contacts:
+            description: Covering the 'Contacts' section of the report
+            paths: [ "%paths.base%/features-v2/reporting/sections/contacts" ]
+            contexts:
+                - DigidepsBehat\v2\Reporting\Sections\ReportingSectionsFeatureContext
+
+        section-gifts:
+            description: Covering the 'Gifts' section of the report
+            paths: [ "%paths.base%/features-v2/reporting/sections/gifts" ]
             contexts:
                 - DigidepsBehat\v2\Reporting\Sections\ReportingSectionsFeatureContext
 

--- a/behat/tests/bootstrap/v2/common/BaseFeatureContext.php
+++ b/behat/tests/bootstrap/v2/common/BaseFeatureContext.php
@@ -37,6 +37,10 @@ class BaseFeatureContext extends MinkContext
     public UserDetails $profAdminDeputyCompletedDetails;
     public UserDetails $profAdminDeputySubmittedDetails;
 
+    public UserDetails $ndrLayDeputyNotStartedDetails;
+    public UserDetails $ndrLayDeputyCompletedDetails;
+    public UserDetails $ndrLayDeputySubmittedDetails;
+
     public UserDetails $loggedInUserDetails;
 
     public array $fixtureUsers = [];
@@ -68,6 +72,9 @@ class BaseFeatureContext extends MinkContext
         $this->fixtureUsers[] = $this->layDeputyNotStartedDetails = new UserDetails($responseData['data']['lays']['not-started']);
         $this->fixtureUsers[] = $this->layDeputyCompletedDetails = new UserDetails($responseData['data']['lays']['completed']);
         $this->fixtureUsers[] = $this->layDeputySubmittedDetails = new UserDetails($responseData['data']['lays']['submitted']);
+        $this->fixtureUsers[] = $this->ndrLayDeputyNotStartedDetails = new UserDetails($responseData['data']['lays-ndr']['not-started']);
+        $this->fixtureUsers[] = $this->ndrLayDeputyCompletedDetails = new UserDetails($responseData['data']['lays-ndr']['completed']);
+        $this->fixtureUsers[] = $this->ndrLayDeputySubmittedDetails = new UserDetails($responseData['data']['lays-ndr']['submitted']);
         $this->fixtureUsers[] = $this->profAdminDeputyNotStartedDetails = new UserDetails($responseData['data']['professionals']['admin']['not-started']);
         $this->fixtureUsers[] = $this->profAdminDeputyCompletedDetails = new UserDetails($responseData['data']['professionals']['admin']['completed']);
         $this->fixtureUsers[] = $this->profAdminDeputySubmittedDetails = new UserDetails($responseData['data']['professionals']['admin']['submitted']);

--- a/behat/tests/bootstrap/v2/common/ElementSelectionTrait.php
+++ b/behat/tests/bootstrap/v2/common/ElementSelectionTrait.php
@@ -20,7 +20,9 @@ trait ElementSelectionTrait
             }
         }
 
+        var_dump($linksArray[$elementIndex]);
         $xpath = sprintf("//a[@href='%s']", $linksArray[$elementIndex]);
+        var_dump($xpath);
         $session = $this->getSession();
         $element = $session->getPage()->find(
             'xpath',

--- a/behat/tests/bootstrap/v2/common/ElementSelectionTrait.php
+++ b/behat/tests/bootstrap/v2/common/ElementSelectionTrait.php
@@ -35,10 +35,10 @@ trait ElementSelectionTrait
         $element->click();
     }
 
-    // Click on a link (a or button css ref for example) based on the value of it's id.
-    public function iClickBasedOnElementId(string $elementType, string $attributeValue)
+    // Click on a link (a or button css ref for example) based on the value of it's attribute type.
+    public function iClickBasedOnElementId(string $elementType, string $attributeType, string $attributeValue)
     {
-        $xpath = sprintf("//%s[@id='%s']", $elementType, $attributeValue);
+        $xpath = sprintf("//%s[@%s='%s']", $elementType, $attributeType, $attributeValue);
         $session = $this->getSession();
         $element = $session->getPage()->find(
             'xpath',

--- a/behat/tests/bootstrap/v2/common/ElementSelectionTrait.php
+++ b/behat/tests/bootstrap/v2/common/ElementSelectionTrait.php
@@ -99,18 +99,16 @@ trait ElementSelectionTrait
     // Select radio dialogue based on name
     public function iSelectRadioBasedOnName(string $elementType, string $attributeType, string $attributeValue, string $name)
     {
-        $xpath = sprintf("//%s[@%s='%s']", $elementType, $attributeType, $attributeValue);
+        $xpath = sprintf("//%s[@%s='%s']//input", $elementType, $attributeType, $attributeValue);
         $session = $this->getSession();
-        $element = $session->getPage()->find(
+        $values = $session->getPage()->findAll(
             'xpath',
             $session->getSelectorsHandler()->selectorToXpath('xpath', $xpath)
         );
 
-        if (null === $element) {
+        if (null === $values) {
             throw new \InvalidArgumentException(sprintf('Could not evaluate XPath: "%s"', $xpath));
         }
-
-        $values = $element->findAll('css', 'input');
 
         foreach ($values as $value) {
             if ($value->getAttribute('value') == $name) {
@@ -119,8 +117,6 @@ trait ElementSelectionTrait
             }
         }
 
-        $page = $this->getSession()->getPage();
-        $page->selectFieldOption($select, $option);
-//        $page->selectFieldOption('account[accountType]', 'current');
+        $this->getSession()->getPage()->selectFieldOption($select, $option);
     }
 }

--- a/behat/tests/bootstrap/v2/common/ElementSelectionTrait.php
+++ b/behat/tests/bootstrap/v2/common/ElementSelectionTrait.php
@@ -20,9 +20,8 @@ trait ElementSelectionTrait
             }
         }
 
-        var_dump($linksArray[$elementIndex]);
         $xpath = sprintf("//a[@href='%s']", $linksArray[$elementIndex]);
-        var_dump($xpath);
+
         $session = $this->getSession();
         $element = $session->getPage()->find(
             'xpath',
@@ -114,8 +113,6 @@ trait ElementSelectionTrait
         $values = $element->findAll('css', 'input');
 
         foreach ($values as $value) {
-//            var_dump($value->getAttribute('name'));
-//            var_dump($value->getAttribute('value'));
             if ($value->getAttribute('value') == $name) {
                 $select = trim($value->getAttribute('name'));
                 $option = trim($value->getAttribute('value'));

--- a/behat/tests/bootstrap/v2/common/ElementSelectionTrait.php
+++ b/behat/tests/bootstrap/v2/common/ElementSelectionTrait.php
@@ -94,4 +94,34 @@ trait ElementSelectionTrait
 
         return $choices[$choiceNumber];
     }
+
+    // Select radio dialogue based on name
+    public function iSelectRadioBasedOnName(string $elementType, string $attributeType, string $attributeValue, string $name)
+    {
+        $xpath = sprintf("//%s[@%s='%s']", $elementType, $attributeType, $attributeValue);
+        $session = $this->getSession();
+        $element = $session->getPage()->find(
+            'xpath',
+            $session->getSelectorsHandler()->selectorToXpath('xpath', $xpath)
+        );
+
+        if (null === $element) {
+            throw new \InvalidArgumentException(sprintf('Could not evaluate XPath: "%s"', $xpath));
+        }
+
+        $values = $element->findAll('css', 'input');
+
+        foreach ($values as $value) {
+//            var_dump($value->getAttribute('name'));
+//            var_dump($value->getAttribute('value'));
+            if ($value->getAttribute('value') == $name) {
+                $select = trim($value->getAttribute('name'));
+                $option = trim($value->getAttribute('value'));
+            }
+        }
+
+        $page = $this->getSession()->getPage();
+        $page->selectFieldOption($select, $option);
+//        $page->selectFieldOption('account[accountType]', 'current');
+    }
 }

--- a/behat/tests/bootstrap/v2/common/IShouldBeOnTrait.php
+++ b/behat/tests/bootstrap/v2/common/IShouldBeOnTrait.php
@@ -161,4 +161,28 @@ trait IShouldBeOnTrait
     {
         return $this->iAmOnPage('/report\/.*\/gifts$/');
     }
+
+    /**
+     * @Then I should be on the accounts summary page
+     */
+    public function iAmOnAccountsSummaryPage()
+    {
+        return $this->iAmOnPage('/report\/.*\/bank-accounts\/summary$/');
+    }
+
+    /**
+     * @Then I should be on the add another accounts page
+     */
+    public function iAmOnAccountsAddAnotherPage()
+    {
+        return $this->iAmOnPage('/report\/.*\/bank-accounts\/add_another$/');
+    }
+
+    /**
+     * @Then I should be on add initial account page
+     */
+    public function iAmOnAccountsAddInitialPage()
+    {
+        return $this->iAmOnPage('/report\/.*\/bank-account\/step1$/');
+    }
 }

--- a/behat/tests/bootstrap/v2/common/IShouldBeOnTrait.php
+++ b/behat/tests/bootstrap/v2/common/IShouldBeOnTrait.php
@@ -190,7 +190,7 @@ trait IShouldBeOnTrait
      */
     public function iAmOnAccountsAddInitialPage()
     {
-        return $this->iAmOnPage('/report\/.*\/bank-account\/step1$/');
+        return $this->iAmOnPage('/report\/.*\/bank-account\/step1.*$/');
     }
 
     /**
@@ -199,5 +199,21 @@ trait IShouldBeOnTrait
     public function iAmOnAccountsDetailsPage()
     {
         return $this->iAmOnPage('/report\/.*\/bank-account\/step2.*$/');
+    }
+
+    /**
+     * @Then I should be on delete account details page
+     */
+    public function iAmOnAccountsDeletePage()
+    {
+        return $this->iAmOnPage('/report\/.*\/bank-account\/.*\/delete$/');
+    }
+
+    /**
+     * @Then I should be on account start page
+     */
+    public function iAmOnAccountsStartPage()
+    {
+        return $this->iAmOnPage('/report\/.*\/bank-accounts$/');
     }
 }

--- a/behat/tests/bootstrap/v2/common/IShouldBeOnTrait.php
+++ b/behat/tests/bootstrap/v2/common/IShouldBeOnTrait.php
@@ -192,4 +192,12 @@ trait IShouldBeOnTrait
     {
         return $this->iAmOnPage('/report\/.*\/bank-account\/step1$/');
     }
+
+    /**
+     * @Then I should be on add account details page
+     */
+    public function iAmOnAccountsDetailsPage()
+    {
+        return $this->iAmOnPage('/report\/.*\/bank-account\/step2.*$/');
+    }
 }

--- a/behat/tests/bootstrap/v2/common/IShouldBeOnTrait.php
+++ b/behat/tests/bootstrap/v2/common/IShouldBeOnTrait.php
@@ -110,7 +110,7 @@ trait IShouldBeOnTrait
      */
     public function iAmOnReportsOverviewPage()
     {
-        return $this->iAmOnPage('/report\/.*\/overview$/');
+        return $this->iAmOnPage(sprintf('/%s\/.*\/overview$/', $this->reportUrlPrefix));
     }
 
     /**
@@ -174,7 +174,7 @@ trait IShouldBeOnTrait
      */
     public function iAmOnAccountsSummaryPage()
     {
-        return $this->iAmOnPage('/report\/.*\/bank-accounts\/summary$/');
+        return $this->iAmOnPage(sprintf('/%s\/.*\/bank-account.*\/summary$/', $this->reportUrlPrefix));
     }
 
     /**
@@ -182,7 +182,7 @@ trait IShouldBeOnTrait
      */
     public function iAmOnAccountsAddAnotherPage()
     {
-        return $this->iAmOnPage('/report\/.*\/bank-accounts\/add_another$/');
+        return $this->iAmOnPage(sprintf('/%s\/.*\/bank-account.*\/add_another$/', $this->reportUrlPrefix));
     }
 
     /**
@@ -190,7 +190,7 @@ trait IShouldBeOnTrait
      */
     public function iAmOnAccountsAddInitialPage()
     {
-        return $this->iAmOnPage('/report\/.*\/bank-account\/step1.*$/');
+        return $this->iAmOnPage(sprintf('/%s\/.*\/bank-account\/step1.*$/', $this->reportUrlPrefix));
     }
 
     /**
@@ -198,7 +198,7 @@ trait IShouldBeOnTrait
      */
     public function iAmOnAccountsDetailsPage()
     {
-        return $this->iAmOnPage('/report\/.*\/bank-account\/step2.*$/');
+        return $this->iAmOnPage(sprintf('/%s\/.*\/bank-account\/step2.*$/', $this->reportUrlPrefix));
     }
 
     /**
@@ -206,7 +206,7 @@ trait IShouldBeOnTrait
      */
     public function iAmOnAccountsDeletePage()
     {
-        return $this->iAmOnPage('/report\/.*\/bank-account\/.*\/delete$/');
+        return $this->iAmOnPage(sprintf('/%s\/.*\/bank-account\/.*\/delete$/', $this->reportUrlPrefix));
     }
 
     /**
@@ -214,6 +214,6 @@ trait IShouldBeOnTrait
      */
     public function iAmOnAccountsStartPage()
     {
-        return $this->iAmOnPage('/report\/.*\/bank-accounts$/');
+        return $this->iAmOnPage(sprintf('/%s\/.*\/bank-accounts$/', $this->reportUrlPrefix));
     }
 }

--- a/behat/tests/bootstrap/v2/common/PageUrlsTrait.php
+++ b/behat/tests/bootstrap/v2/common/PageUrlsTrait.php
@@ -11,7 +11,8 @@ trait PageUrlsTrait
     private string $contactsSummaryUrl = '/report/%s/contacts/summary';
     private string $contactsAddUrl = '/report/%s/contacts/add';
     private string $contactsAddAnotherUrl = '/report/%s/contacts/add_another';
-    private string $accountsAddAnAccountUrl = 'report/%s/bank-account/step1';
+    private string $accountsAddAnAccountUrl = '%s/%s/bank-account/step1';
+    private string $accountsSummaryUrl = '%s/%s/bank-account/summary';
     private string $layReportsOverviewUrl = '/lay';
 
     /**
@@ -27,7 +28,15 @@ trait PageUrlsTrait
      */
     public function getAccountsAddAnAccountUrl(int $reportId): string
     {
-        return sprintf($this->accountsAddAnAccountUrl, $reportId);
+        return sprintf($this->accountsAddAnAccountUrl, $this->reportUrlPrefix, $reportId);
+    }
+
+    /**
+     * @return string
+     */
+    public function getAccountsSummaryUrl(int $reportId): string
+    {
+        return sprintf($this->accountsSummaryUrl, $this->reportUrlPrefix, $reportId);
     }
 
     /**

--- a/behat/tests/bootstrap/v2/common/PageUrlsTrait.php
+++ b/behat/tests/bootstrap/v2/common/PageUrlsTrait.php
@@ -11,6 +11,7 @@ trait PageUrlsTrait
     private string $contactsSummaryUrl = '/report/%s/contacts/summary';
     private string $contactsAddUrl = '/report/%s/contacts/add';
     private string $contactsAddAnotherUrl = '/report/%s/contacts/add_another';
+    private string $accountsAddAnAccountUrl = 'report/%s/bank-account/step1';
     private string $layReportsOverviewUrl = '/lay';
 
     /**
@@ -19,6 +20,14 @@ trait PageUrlsTrait
     public function getReportSubmittedUrl(int $reportId): string
     {
         return sprintf($this->reportSubmittedUrl, $reportId);
+    }
+
+    /**
+     * @return string
+     */
+    public function getAccountsAddAnAccountUrl(int $reportId): string
+    {
+        return sprintf($this->accountsAddAnAccountUrl, $reportId);
     }
 
     /**

--- a/behat/tests/bootstrap/v2/common/ReportTrait.php
+++ b/behat/tests/bootstrap/v2/common/ReportTrait.php
@@ -7,6 +7,8 @@ use Exception;
 
 trait ReportTrait
 {
+    public string $reportUrlPrefix = 'report';
+
     /**
      * @Given /^I submit the report$/
      */
@@ -56,6 +58,33 @@ trait ReportTrait
         }
 
         $this->loginToFrontendAs($this->layDeputyCompletedDetails->getEmail());
+    }
+
+    /**
+     * @Given a Lay Deputy has not started an NDR report
+     */
+    public function aNdrLayDeputyHasNotStartedAReport()
+    {
+        if (empty($this->ndrLayDeputyNotStartedDetails)) {
+            throw new Exception('It looks like fixtures are not loaded - missing $ndrLayDeputyNotStartedDetails');
+        }
+
+        $this->loginToFrontendAs($this->ndrLayDeputyNotStartedDetails->getEmail());
+        $this->reportUrlPrefix = $this->ndrLayDeputyNotStartedDetails->getCurrentReportNdrOrReport();
+    }
+
+    /**
+     * @Given a Lay Deputy has a completed NDR report
+     * @throws Exception
+     */
+    public function aNdrLayDeputyHasCompletedReport()
+    {
+        if (empty($this->ndrLayDeputyCompletedDetails)) {
+            throw new Exception('It looks like fixtures are not loaded - missing $ndrLayDeputyCompletedDetails');
+        }
+
+        $this->loginToFrontendAs($this->ndrLayDeputyCompletedDetails->getEmail());
+        $this->reportUrlPrefix = $this->ndrLayDeputyCompletedDetails->getCurrentReportNdrOrReport();
     }
 
     /**

--- a/behat/tests/bootstrap/v2/reporting/sections/AccountsSectionTrait.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/AccountsSectionTrait.php
@@ -53,11 +53,145 @@ trait AccountsSectionTrait
     public function iMissOneOfTheFields()
     {
         $this->iFillInAccountDetails(
+            '1111',
+            '01-01-01',
+            '',
+            'account-1'
+        );
+
+        $this->assertOnErrorMessage('Please select either \'Yes\' or \'No\'');
+
+        $this->iFillInAccountDetails(
             '',
             '01-01-01',
             'no',
             'account-1'
         );
+
+        $this->assertOnErrorMessage('Enter the last 4 numbers of the account number');
+
+        $this->iFillInAccountDetails(
+            '1111',
+            '',
+            'no',
+            'account-1'
+        );
+
+        $this->assertOnErrorMessage('The sort code should only contain numbers');
+        $this->assertOnErrorMessage('The sort code must be 6 numbers long');
+
+        $this->iFillInAccountDetails(
+            '1111',
+            '01-01-01',
+            'no',
+            ''
+        );
+
+        $this->assertOnErrorMessage('Enter the bank or building society name');
+    }
+
+    /**
+     * @When I get the correct validation responses
+     */
+    public function iGetTheCorrectValidationResponses()
+    {
+        $this->iAmOnAccountsDetailsPage();
+    }
+
+    /**
+     * @When I try to enter letters where it should be digits
+     */
+    public function iTryToEnterLettersInsteadOfDigits()
+    {
+        $this->iFillInAccountDetails(
+            '1111',
+            'AA-BB-CC',
+            'no',
+            'account-1'
+        );
+
+        $this->assertOnErrorMessage('The sort code should only contain numbers');
+    }
+
+    /**
+     * @When I correctly enter account details
+     */
+    public function iCorrectlyEnterAccountDetails()
+    {
+        $this->accountList[] =
+            [
+                'account' => 'current',
+                'accountType' => 'current account',
+                'name' => 'account-1',
+                'accountNumber' => '1111',
+                'sortCode' => '01-01-01',
+                'joint' => 'no',
+                'openingBalance' => '101',
+                'closingBalance' => '201'
+            ];
+
+        $this->iFillInAccountDetails(
+            $this->accountList[0]['accountNumber'],
+            $this->accountList[0]['sortCode'],
+            $this->accountList[0]['joint'],
+            $this->accountList[0]['name']
+        );
+
+        $this->iFillInAccountBalance(
+            $this->accountList[0]['openingBalance'],
+            $this->accountList[0]['closingBalance']
+        );
+
+        $this->iAmOnAccountsAddAnotherPage();
+        $this->selectOption('add_another[addAnother]', 'no');
+        $this->pressButton('Continue');
+    }
+
+    /**
+     * @When I need to update my current account to a different one
+     */
+    public function iUpdateCurrentAccountToDifferentOne()
+    {
+        $this->accountList[] =
+            [
+                'account' => 'current',
+                'accountType' => 'current account',
+                'name' => 'account-2',
+                'accountNumber' => '2222',
+                'sortCode' => '02-02-02',
+                'joint' => 'no',
+                'openingBalance' => '102',
+                'closingBalance' => '202'
+            ];
+
+        $urlRegex = '/report\/.*\/bank-account\/step1\/[0-9].*$/';
+//        /report/482/bank-account/step1/357
+        $this->iClickOnNthElementBasedOnRegex($urlRegex, 0);
+
+        $this->iAddAnAccount(
+            $this->accountList[0]['account'],
+            $this->accountList[0]['name'],
+            $this->accountList[0]['accountNumber'],
+            $this->accountList[0]['sortCode'],
+            $this->accountList[0]['joint'],
+            $this->accountList[0]['openingBalance'],
+            $this->accountList[0]['closingBalance'],
+        );
+//        $this->iFillInAccountDetails(
+//            $this->accountList[0]['accountNumber'],
+//            $this->accountList[0]['sortCode'],
+//            $this->accountList[0]['joint'],
+//            $this->accountList[0]['name']
+//        );
+//
+//        $this->iFillInAccountBalance(
+//            $this->accountList[0]['openingBalance'],
+//            $this->accountList[0]['closingBalance']
+//        );
+
+        $this->iAmOnAccountsAddAnotherPage();
+        $this->selectOption('add_another[addAnother]', 'no');
+        $this->pressButton('Continue');
     }
 
     /**
@@ -252,7 +386,10 @@ trait AccountsSectionTrait
             $this->fillField('account[sortCode][sort_code_part_3]', explode('-', $sortCode)[2]);
         }
 
-        $this->iSelectRadioBasedOnName('div', 'data-module', 'govuk-radios', $joint);
+        if (strlen($joint) > 0) {
+            $this->iSelectRadioBasedOnName('div', 'data-module', 'govuk-radios', $joint);
+        }
+
         $this->pressButton('Save and continue');
     }
 

--- a/behat/tests/bootstrap/v2/reporting/sections/AccountsSectionTrait.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/AccountsSectionTrait.php
@@ -99,7 +99,7 @@ trait AccountsSectionTrait
     }
 
     /**
-     * @When I get the correct validation responses
+     * @When I get the correct validation warnings
      */
     public function iGetTheCorrectValidationResponses()
     {
@@ -156,7 +156,7 @@ trait AccountsSectionTrait
     }
 
     /**
-     * @When I need to update my current account to a different one
+     * @When I update my current account to a different one
      */
     public function iUpdateCurrentAccountToDifferentOne()
     {
@@ -188,7 +188,7 @@ trait AccountsSectionTrait
     }
 
     /**
-     * @When I add one of each account type with a mixture of responses
+     * @When I add one of each account type with valid details
      */
     public function iAddOneOfEachTypeOfAccounts()
     {
@@ -361,7 +361,7 @@ trait AccountsSectionTrait
     /**
      * @When I add a couple of new accounts
      */
-    public function iAddANewAccount()
+    public function iAddACoupleOfNewAccounts()
     {
         $this->accountList = [
             [

--- a/behat/tests/bootstrap/v2/reporting/sections/AccountsSectionTrait.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/AccountsSectionTrait.php
@@ -1,0 +1,265 @@
+<?php declare(strict_types=1);
+
+namespace DigidepsBehat\v2\Reporting\Sections;
+
+trait AccountsSectionTrait
+{
+    private array $accountList = [];
+
+    /**
+     * @When I view the accounts report section
+     */
+    public function iViewAccountsSection()
+    {
+        $activeReportId = $this->loggedInUserDetails->getCurrentReportId();
+        $reportSectionUrl = sprintf(self::REPORT_SECTION_ENDPOINT, $activeReportId, 'bank-accounts');
+        $this->visitPath($reportSectionUrl);
+    }
+
+    /**
+     * @When I view and start the accounts report section
+     */
+    public function iViewAndStartAccountsSection()
+    {
+        $this->iViewAccountsSection();
+        $this->clickLink('Start accounts');
+    }
+
+    /**
+     * @When I go to add a new current account
+     */
+    public function iGoToAddNewCurrentAccount()
+    {
+        $account = [
+            'account' => 'current',
+            'accountType' => 'current account',
+            'name' => 'account-1',
+            'accountNumber' => '1111',
+            'sortCode' => '01-01-01',
+            'joint' => 'no',
+            'openingBalance' => '101',
+            'closingBalance' => '201'
+        ];
+
+        $this->accountList[] = $account;
+        $this->visitPath($this->getAccountsAddAnAccountUrl($this->loggedInUserDetails->getCurrentReportId()));
+        $this->iAmOnAccountsAddInitialPage();
+        $this->iChooseAccountType('current');
+    }
+
+    /**
+     * @When I miss one of the fields
+     */
+    public function iMissOneOfTheFields()
+    {
+        $this->iFillInAccountDetails(
+            '',
+            '01-01-01',
+            'no',
+            'account-1'
+        );
+    }
+
+    /**
+     * @When I add one of each account type with a mixture of responses
+     */
+    public function iAddOneOfEachTypeOfAccounts()
+    {
+        $this->accountList = [
+            [
+                'account' => 'current',
+                'accountType' => 'current account',
+                'name' => 'account-1',
+                'accountNumber' => '1111',
+                'sortCode' => '01-01-01',
+                'joint' => 'no',
+                'openingBalance' => '101',
+                'closingBalance' => '201'
+            ],
+            [
+                'account' => 'savings',
+                'accountType' => 'savings account',
+                'name' => 'account-2',
+                'accountNumber' => '2222',
+                'sortCode' => '02-02-02',
+                'joint' => 'yes',
+                'openingBalance' => '102',
+                'closingBalance' => '202'
+            ],
+            [
+                'account' => 'isa',
+                'accountType' => 'isa',
+                'name' => 'account-3',
+                'accountNumber' => '3333',
+                'sortCode' => '03-03-03',
+                'joint' => 'no',
+                'openingBalance' => '103',
+                'closingBalance' => '203'
+            ],
+            [
+                'account' => 'postoffice',
+                'accountType' => 'post office account',
+                'name' => '',
+                'accountNumber' => '4444',
+                'sortCode' => '',
+                'joint' => 'yes',
+                'openingBalance' => '104',
+                'closingBalance' => '204'
+            ],
+            [
+                'account' => 'cfo',
+                'accountType' => 'court funds office account',
+                'name' => '',
+                'accountNumber' => '5555',
+                'sortCode' => '',
+                'joint' => 'no',
+                'openingBalance' => '105',
+                'closingBalance' => '205'
+            ],
+            [
+                'account' => 'other',
+                'accountType' => 'other',
+                'name' => 'account-6',
+                'accountNumber' => '6666',
+                'sortCode' => '06-06-06',
+                'joint' => 'yes',
+                'openingBalance' => '106',
+                'closingBalance' => '206'
+            ],
+            [
+                'account' => 'other_no_sortcode',
+                'accountType' => 'other without sort code',
+                'name' => 'account-7',
+                'accountNumber' => '7777',
+                'sortCode' => '',
+                'joint' => 'no',
+                'openingBalance' => '107',
+                'closingBalance' => '207'
+            ],
+        ];
+
+        foreach ($this->accountList as $account) {
+            $this->iAddAnAccount(
+                $account['account'],
+                $account['name'],
+                $account['accountNumber'],
+                $account['sortCode'],
+                $account['joint'],
+                $account['openingBalance'],
+                $account['closingBalance'],
+            );
+        }
+        $this->iAmOnAccountsAddAnotherPage();
+        $this->selectOption('add_another[addAnother]', 'no');
+        $this->pressButton('Continue');
+    }
+
+    /**
+     * @Then I should see the expected accounts on the summary page
+     */
+    public function iShouldSeeTheExpectedAccountsOnSummaryPage()
+    {
+        $this->iAmOnAccountsSummaryPage();
+
+        $tableBody = $this->getSession()->getPage()->find('css', 'tbody');
+
+        if (!$tableBody) {
+            $this->throwContextualException('A tbody element was not found on the page');
+        }
+
+        $tableRows = $tableBody->findAll('css', 'tr');
+
+        if (!$tableRows) {
+            $this->throwContextualException('A tr element was not found on the page');
+        }
+
+        foreach ($tableRows as $tRowKey=>$tableRow) {
+            $tableHeader = $tableRow->find('css', 'th');
+            $headHtml = trim(strtolower($tableHeader->getHtml()));
+            assert(
+                str_contains($headHtml, $this->accountList[$tRowKey]['accountType']),
+                sprintf('matching account %s ', $this->accountList[$tRowKey]['accountType'])
+            );
+            assert(
+                str_contains($headHtml, $this->accountList[$tRowKey]['name']),
+                sprintf('matching name %s ', $this->accountList[$tRowKey]['name'])
+            );
+            assert(
+                str_contains($headHtml, $this->accountList[$tRowKey]['accountNumber']),
+                sprintf('matching account number %s ', $this->accountList[$tRowKey]['accountNumber'])
+            );
+            $sortCode = str_replace('-', '', $this->accountList[$tRowKey]['sortCode']);
+            assert(
+                str_contains($headHtml, $sortCode),
+                sprintf('matching sort code %s ', $sortCode)
+            );
+            assert(
+                str_contains($headHtml, $this->accountList[$tRowKey]['joint']),
+                sprintf('matching sort code %s ', $this->accountList[$tRowKey]['joint'])
+            );
+
+            $tableFields = $tableRow->findAll('css', 'td');
+
+            foreach ($tableFields as $tFieldKey=>$tableField) {
+                $balanceItem = trim(strtolower($tableField->getHtml()));
+                if ($tFieldKey == 0) {
+                    assert(
+                        str_contains($balanceItem, $this->accountList[$tRowKey]['openingBalance']),
+                        $this->accountList[$tRowKey]['openingBalance']
+                    );
+                } elseif ($tFieldKey == 1) {
+                    assert(
+                        str_contains($balanceItem, $this->accountList[$tRowKey]['closingBalance']),
+                        $this->accountList[$tRowKey]['closingBalance']
+                    );
+                }
+            }
+        }
+    }
+
+    public function iAddAnAccount(
+        string $account,
+        string $name,
+        string $accountNumber,
+        string $sortCode,
+        string $joint,
+        string $openingBalance,
+        string $closingBalance
+    ) {
+        $this->iChooseAccountType($account);
+        $this->iFillInAccountDetails($name, $accountNumber, $sortCode, $joint);
+        $this->iFillInAccountBalance($openingBalance, $closingBalance);
+    }
+
+    public function iChooseAccountType(string $account)
+    {
+        $this->visitPath($this->getAccountsAddAnAccountUrl($this->loggedInUserDetails->getCurrentReportId()));
+        $this->iSelectRadioBasedOnName('div', 'data-module', 'govuk-radios', $account);
+        $this->pressButton('Save and continue');
+    }
+
+    public function iFillInAccountDetails(string $accountNumber, string $sortCode, string $joint, string $name)
+    {
+        if ($this->elementExistsOnPage('input', 'name', 'account[bank]')) {
+            $this->fillField('account[bank]', $name);
+        }
+
+        $this->fillField('account[accountNumber]', $accountNumber);
+
+        if ($this->elementExistsOnPage('input', 'name', 'account[sortCode][sort_code_part_1]')) {
+            $this->fillField('account[sortCode][sort_code_part_1]', explode('-', $sortCode)[0]);
+            $this->fillField('account[sortCode][sort_code_part_2]', explode('-', $sortCode)[1]);
+            $this->fillField('account[sortCode][sort_code_part_3]', explode('-', $sortCode)[2]);
+        }
+
+        $this->iSelectRadioBasedOnName('div', 'data-module', 'govuk-radios', $joint);
+        $this->pressButton('Save and continue');
+    }
+
+    public function iFillInAccountBalance(string $openingBalance, string $closingBalance)
+    {
+        $this->fillField('account[openingBalance]', $openingBalance);
+        $this->fillField('account[closingBalance]', $closingBalance);
+        $this->pressButton('Save and continue');
+    }
+}

--- a/behat/tests/bootstrap/v2/reporting/sections/ActionsSectionTrait.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/ActionsSectionTrait.php
@@ -14,7 +14,7 @@ trait ActionsSectionTrait
     public function iViewActionsSection()
     {
         $activeReportId = $this->loggedInUserDetails->getCurrentReportId();
-        $reportSectionUrl = sprintf(self::REPORT_SECTION_ENDPOINT, $activeReportId, 'actions');
+        $reportSectionUrl = sprintf(self::REPORT_SECTION_ENDPOINT, $this->reportUrlPrefix, $activeReportId, 'actions');
         $this->visitPath($reportSectionUrl);
     }
 

--- a/behat/tests/bootstrap/v2/reporting/sections/AdditionalInformationSectionTrait.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/AdditionalInformationSectionTrait.php
@@ -30,7 +30,7 @@ trait AdditionalInformationSectionTrait
     public function iViewAdditionalInformationSection()
     {
         $activeReportId = $this->loggedInUserDetails->getCurrentReportId();
-        $reportSectionUrl = sprintf(self::REPORT_SECTION_ENDPOINT, $activeReportId, 'any-other-info');
+        $reportSectionUrl = sprintf(self::REPORT_SECTION_ENDPOINT, $this->reportUrlPrefix, $activeReportId, 'any-other-info');
 
         $this->visitPath($reportSectionUrl);
 

--- a/behat/tests/bootstrap/v2/reporting/sections/ContactsSectionTrait.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/ContactsSectionTrait.php
@@ -45,7 +45,7 @@ trait ContactsSectionTrait
     public function iViewContactsSection()
     {
         $activeReportId = $this->loggedInUserDetails->getCurrentReportId();
-        $reportSectionUrl = sprintf(self::REPORT_SECTION_ENDPOINT, $activeReportId, 'contacts');
+        $reportSectionUrl = sprintf(self::REPORT_SECTION_ENDPOINT, $this->reportUrlPrefix, $activeReportId, 'contacts');
 
         $this->visitPath($reportSectionUrl);
 

--- a/behat/tests/bootstrap/v2/reporting/sections/DocumentsSectionTrait.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/DocumentsSectionTrait.php
@@ -28,7 +28,7 @@ trait DocumentsSectionTrait
     public function iViewDocumentsSection()
     {
         $activeReportId = $this->loggedInUserDetails->getCurrentReportId();
-        $reportSectionUrl = sprintf(self::REPORT_SECTION_ENDPOINT, $activeReportId, 'documents');
+        $reportSectionUrl = sprintf(self::REPORT_SECTION_ENDPOINT, $this->reportUrlPrefix, $activeReportId, 'documents');
 
         $this->visitPath($reportSectionUrl);
 

--- a/behat/tests/bootstrap/v2/reporting/sections/GiftsSectionTrait.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/GiftsSectionTrait.php
@@ -13,7 +13,7 @@ trait GiftsSectionTrait
     public function iViewGiftsSection()
     {
         $activeReportId = $this->loggedInUserDetails->getCurrentReportId();
-        $reportSectionUrl = sprintf(self::REPORT_SECTION_ENDPOINT, $activeReportId, 'gifts');
+        $reportSectionUrl = sprintf(self::REPORT_SECTION_ENDPOINT, $this->reportUrlPrefix, $activeReportId, 'gifts');
         $this->visitPath($reportSectionUrl);
     }
 

--- a/behat/tests/bootstrap/v2/reporting/sections/GiftsSectionTrait.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/GiftsSectionTrait.php
@@ -97,7 +97,7 @@ trait GiftsSectionTrait
      */
     public function iFollowEditLinkForGifts()
     {
-        $this->iClickBasedOnElementId('a', 'edit-gifts');
+        $this->iClickBasedOnElementId('a', 'id', 'edit-gifts');
     }
 
     /**
@@ -152,7 +152,7 @@ trait GiftsSectionTrait
      */
     public function iChooseToRemoveGift()
     {
-        $this->iClickBasedOnElementId('button', 'confirm_delete_confirm');
+        $this->iClickBasedOnElementId('button', 'id', 'confirm_delete_confirm');
     }
 
     /**

--- a/behat/tests/bootstrap/v2/reporting/sections/GiftsSectionTrait.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/GiftsSectionTrait.php
@@ -287,7 +287,7 @@ trait GiftsSectionTrait
             $tableRows = $tableBody->findAll('css', 'tr');
 
             if (!$tableRows) {
-                $this->throwContextualException('A tbody element was not found on the page');
+                $this->throwContextualException('A tr element was not found on the page');
             }
 
             foreach ($tableRows as $tableRow) {

--- a/behat/tests/bootstrap/v2/reporting/sections/ReportingSectionsFeatureContext.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/ReportingSectionsFeatureContext.php
@@ -65,8 +65,7 @@ class ReportingSectionsFeatureContext extends BaseFeatureContext
      */
     public function iNavigateBackToReportSection()
     {
-        $linkText = $this->reportUrlPrefix == 'ndr' ? 'New deputy report overview' : 'Deputy report overview';
-        $this->clickLink($linkText);
+        $this->iClickBasedOnElementId('a', 'data-action', 'report.overview');
         assert($this->iAmOnReportsOverviewPage());
     }
 

--- a/behat/tests/bootstrap/v2/reporting/sections/ReportingSectionsFeatureContext.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/ReportingSectionsFeatureContext.php
@@ -7,10 +7,11 @@ use DigidepsBehat\v2\Common\BaseFeatureContext;
 
 class ReportingSectionsFeatureContext extends BaseFeatureContext
 {
-    use ContactsSectionTrait;
+    use AccountsSectionTrait;
     use ActionsSectionTrait;
-    use GiftsSectionTrait;
     use AdditionalInformationSectionTrait;
+    use ContactsSectionTrait;
+    use GiftsSectionTrait;
 
     const REPORT_SECTION_ENDPOINT = 'report/%s/%s';
 

--- a/behat/tests/bootstrap/v2/reporting/sections/ReportingSectionsFeatureContext.php
+++ b/behat/tests/bootstrap/v2/reporting/sections/ReportingSectionsFeatureContext.php
@@ -14,7 +14,7 @@ class ReportingSectionsFeatureContext extends BaseFeatureContext
     use DocumentsSectionTrait;
     use GiftsSectionTrait;
 
-    const REPORT_SECTION_ENDPOINT = 'report/%s/%s';
+    const REPORT_SECTION_ENDPOINT = '%s/%s/%s';
 
     /**
      * @Then the previous section should be :sectionName
@@ -65,7 +65,8 @@ class ReportingSectionsFeatureContext extends BaseFeatureContext
      */
     public function iNavigateBackToReportSection()
     {
-        $this->clickLink('Deputy report overview');
+        $linkText = $this->reportUrlPrefix == 'ndr' ? 'New deputy report overview' : 'Deputy report overview';
+        $this->clickLink($linkText);
         assert($this->iAmOnReportsOverviewPage());
     }
 
@@ -83,7 +84,17 @@ class ReportingSectionsFeatureContext extends BaseFeatureContext
     public function iGoToReportOverviewUrl()
     {
         $activeReportId = $this->loggedInUserDetails->getCurrentReportId();
-        $reportOverviewUrl = sprintf(self::REPORT_SECTION_ENDPOINT, $activeReportId, 'overview');
+        $reportOverviewUrl = sprintf(self::REPORT_SECTION_ENDPOINT, $this->reportUrlPrefix, $activeReportId, 'overview');
+        $this->visitPath($reportOverviewUrl);
+    }
+
+    /**
+     * @When I view the NDR overview page
+     */
+    public function iGoToNDROverviewUrl()
+    {
+        $activeReportId = $this->loggedInUserDetails->getCurrentReportId();
+        $reportOverviewUrl = sprintf(self::REPORT_SECTION_ENDPOINT, $this->reportUrlPrefix, $activeReportId, 'overview');
         $this->visitPath($reportOverviewUrl);
     }
 
@@ -92,17 +103,18 @@ class ReportingSectionsFeatureContext extends BaseFeatureContext
      */
     public function iShouldSeeSectionAs($section, $status)
     {
-        $divs = $this->getSession()->getPage()->findAll('css', 'div');
+        $divs = $this->getSession()->getPage()->findAll('css', 'div.opg-overview-section');
 
         if (!$divs) {
             $this->throwContextualException('A div element was not found on the page');
         }
 
-        $sectionFormatted = '/report/' . $this->loggedInUserDetails->getCurrentReportId() . '/' . $section;
+        $sectionFormatted = sprintf('/%s/%s/%s', $this->reportUrlPrefix, $this->loggedInUserDetails->getCurrentReportId(), $section);
+
         $statusCorrect = false;
 
         foreach ($divs as $div) {
-            if ($div->getAttribute('href') === $sectionFormatted) {
+            if ($div->find('css', 'a')->getAttribute('href') === $sectionFormatted) {
                 $statuses = $div->findAll('css', 'span');
 
                 foreach ($statuses as $sts) {
@@ -115,7 +127,7 @@ class ReportingSectionsFeatureContext extends BaseFeatureContext
 
         if (!$statusCorrect) {
             $this->throwContextualException(
-                sprintf('Report section status not as expected. Status: %s not found. ', $status)
+                sprintf('Report section status not as expected. Status "%s" not found. ', $status)
             );
         }
     }

--- a/behat/tests/features-v2/reporting/sections/accounts/accounts.feature
+++ b/behat/tests/features-v2/reporting/sections/accounts/accounts.feature
@@ -11,23 +11,22 @@ Feature: Accounts
 #    When I follow link back to report overview page
 #    Then I should see "bank-accounts" as "7 accounts"
 
-  Scenario: A user incorrectly enters an account before correctly entering it
-    Given a Lay Deputy has a new report
-#    And I view and start the accounts report section
-    When I go to add a new current account
-    And I miss one of the fields
-#    Then I get the correct validation response
+#  Scenario: A user incorrectly enters an account before correctly entering it
+#    Given a Lay Deputy has not started a report
+#    When I go to add a new current account
+#    And I miss one of the fields
+#    Then I get the correct validation responses
 #    When I try to enter letters where it should be digits
-#    Then I get the correct validation response
+#    Then I get the correct validation responses
 #    When I correctly enter account details
 #    Then I should see the expected accounts on the summary page
 #
-#  Scenario: A user edits an existing account
-#    Given a Lay Deputy has a completed report
-#    And I view and start the accounts report section
-#    Then I should be on accounts summary page
-#    When I need to update my current account to a different one
-#    Then I should see the expected account on the summary page
+  Scenario: A user edits an existing account
+    Given a Lay Deputy has a completed report
+    And I view the accounts report section
+    Then I should be on the accounts summary page
+    When I need to update my current account to a different one
+    Then I should see the expected accounts on the summary page
 #
 #  Scenario: A user adds accounts and then changes their mind and deletes them
 #    Given a Lay Deputy has a completed report

--- a/behat/tests/features-v2/reporting/sections/accounts/accounts.feature
+++ b/behat/tests/features-v2/reporting/sections/accounts/accounts.feature
@@ -1,0 +1,41 @@
+@v2 @accounts
+Feature: Accounts
+
+#  Scenario: A user adds one of each account type
+#    Given a Lay Deputy has a new report
+#    And I view the report overview page
+#    Then I should see "bank-accounts" as "not started"
+#    When I view and start the accounts report section
+#    And I add one of each account type with a mixture of responses
+#    Then I should see the expected accounts on the summary page
+#    When I follow link back to report overview page
+#    Then I should see "bank-accounts" as "7 accounts"
+
+  Scenario: A user incorrectly enters an account before correctly entering it
+    Given a Lay Deputy has a new report
+#    And I view and start the accounts report section
+    When I go to add a new current account
+    And I miss one of the fields
+#    Then I get the correct validation response
+#    When I try to enter letters where it should be digits
+#    Then I get the correct validation response
+#    When I correctly enter account details
+#    Then I should see the expected accounts on the summary page
+#
+#  Scenario: A user edits an existing account
+#    Given a Lay Deputy has a completed report
+#    And I view and start the accounts report section
+#    Then I should be on accounts summary page
+#    When I need to update my current account to a different one
+#    Then I should see the expected account on the summary page
+#
+#  Scenario: A user adds accounts and then changes their mind and deletes them
+#    Given a Lay Deputy has a completed report
+#    When I add an account
+#    Then I should see the expected accounts on the summary page
+#    When I remove the last account
+#    Then I should see the expected accounts on the summary page
+#    When I remove the remaining account
+#    Then I should be on accounts start page
+#    When I follow link back to report overview page
+#    Then I should see "accounts" as "not started"

--- a/behat/tests/features-v2/reporting/sections/accounts/accounts.feature
+++ b/behat/tests/features-v2/reporting/sections/accounts/accounts.feature
@@ -6,7 +6,7 @@ Feature: Accounts (Lay / PA / Prof share same functionality)
     And I view the report overview page
     Then I should see "bank-accounts" as "not started"
     When I view and start the accounts report section
-    And I add one of each account type with a mixture of responses
+    And I add one of each account type with valid details
     Then I should see the expected accounts on the summary page
     When I follow link back to report overview page
     Then I should see "bank-accounts" as "7 accounts"
@@ -15,9 +15,9 @@ Feature: Accounts (Lay / PA / Prof share same functionality)
     Given a Lay Deputy has not started a report
     When I go to add a new current account
     And I miss one of the fields
-    Then I get the correct validation responses
+    Then I get the correct validation warnings
     When I try to enter letters where it should be digits
-    Then I get the correct validation responses
+    Then I get the correct validation warnings
     When I correctly enter account details
     Then I should see the expected accounts on the summary page
 
@@ -25,7 +25,7 @@ Feature: Accounts (Lay / PA / Prof share same functionality)
     Given a Lay Deputy has a completed report
     And I view the accounts report section
     Then I should be on the accounts summary page
-    When I need to update my current account to a different one
+    When I update my current account to a different one
     Then I should see the expected accounts on the summary page
 
   Scenario: A user adds accounts and then changes their mind and deletes them

--- a/behat/tests/features-v2/reporting/sections/accounts/accounts.feature
+++ b/behat/tests/features-v2/reporting/sections/accounts/accounts.feature
@@ -1,40 +1,41 @@
 @v2 @accounts
-Feature: Accounts
+Feature: Accounts (Lay / PA / Prof share same functionality)
 
-#  Scenario: A user adds one of each account type
-#    Given a Lay Deputy has a new report
-#    And I view the report overview page
-#    Then I should see "bank-accounts" as "not started"
-#    When I view and start the accounts report section
-#    And I add one of each account type with a mixture of responses
-#    Then I should see the expected accounts on the summary page
-#    When I follow link back to report overview page
-#    Then I should see "bank-accounts" as "7 accounts"
+  Scenario: A user adds one of each account type
+    Given a Lay Deputy has not started a report
+    And I view the report overview page
+    Then I should see "bank-accounts" as "not started"
+    When I view and start the accounts report section
+    And I add one of each account type with a mixture of responses
+    Then I should see the expected accounts on the summary page
+    When I follow link back to report overview page
+    Then I should see "bank-accounts" as "7 accounts"
 
-#  Scenario: A user incorrectly enters an account before correctly entering it
-#    Given a Lay Deputy has not started a report
-#    When I go to add a new current account
-#    And I miss one of the fields
-#    Then I get the correct validation responses
-#    When I try to enter letters where it should be digits
-#    Then I get the correct validation responses
-#    When I correctly enter account details
-#    Then I should see the expected accounts on the summary page
-#
+  Scenario: A user incorrectly enters an account before correctly entering it
+    Given a Lay Deputy has not started a report
+    When I go to add a new current account
+    And I miss one of the fields
+    Then I get the correct validation responses
+    When I try to enter letters where it should be digits
+    Then I get the correct validation responses
+    When I correctly enter account details
+    Then I should see the expected accounts on the summary page
+
   Scenario: A user edits an existing account
     Given a Lay Deputy has a completed report
     And I view the accounts report section
     Then I should be on the accounts summary page
     When I need to update my current account to a different one
     Then I should see the expected accounts on the summary page
-#
-#  Scenario: A user adds accounts and then changes their mind and deletes them
-#    Given a Lay Deputy has a completed report
-#    When I add an account
-#    Then I should see the expected accounts on the summary page
-#    When I remove the last account
-#    Then I should see the expected accounts on the summary page
-#    When I remove the remaining account
-#    Then I should be on accounts start page
-#    When I follow link back to report overview page
-#    Then I should see "accounts" as "not started"
+
+  Scenario: A user adds accounts and then changes their mind and deletes them
+    Given a Lay Deputy has not started a report
+    When I view and start the accounts report section
+    And I add a couple of new accounts
+    Then I should see the expected accounts on the summary page
+    When I remove the second account
+    Then I should see the expected accounts on the summary page
+    When I remove the remaining account
+    Then I should be on account start page
+    When I follow link back to report overview page
+    Then I should see "bank-accounts" as "not started"

--- a/behat/tests/features-v2/reporting/sections/accounts/accounts.ndr.feature
+++ b/behat/tests/features-v2/reporting/sections/accounts/accounts.ndr.feature
@@ -1,0 +1,41 @@
+@v2 @accounts.ndr
+Feature: Accounts (NDR)
+
+  Scenario: A user adds one of each account type
+    Given a Lay Deputy has not started an NDR report
+    And I view the NDR overview page
+    Then I should see "bank-accounts" as "not started"
+    When I view and start the accounts report section
+    And I add one of each account type with a mixture of responses
+    Then I should see the expected accounts on the summary page
+    When I follow link back to report overview page
+    Then I should see "bank-accounts" as "7 accounts"
+
+  Scenario: A user incorrectly enters an account before correctly entering it
+    Given a Lay Deputy has not started an NDR report
+    When I go to add a new current account
+    And I miss one of the fields
+    Then I get the correct validation responses
+    When I try to enter letters where it should be digits
+    Then I get the correct validation responses
+    When I correctly enter account details
+    Then I should see the expected accounts on the summary page
+
+  Scenario: A user edits an existing account
+    Given a Lay Deputy has a completed NDR report
+    And I view the accounts report section
+    Then I should be on the accounts summary page
+    When I need to update my current account to a different one
+    Then I should see the expected accounts on the summary page
+
+  Scenario: A user adds accounts and then changes their mind and deletes them
+    Given a Lay Deputy has not started an NDR report
+    When I view and start the accounts report section
+    And I add a couple of new accounts
+    Then I should see the expected accounts on the summary page
+    When I remove the second account
+    Then I should see the expected accounts on the summary page
+    When I remove the remaining account
+    Then I should be on account start page
+    When I follow link back to report overview page
+    Then I should see "bank-accounts" as "not started"

--- a/behat/tests/features-v2/reporting/sections/accounts/accounts.ndr.feature
+++ b/behat/tests/features-v2/reporting/sections/accounts/accounts.ndr.feature
@@ -6,7 +6,7 @@ Feature: Accounts (NDR)
     And I view the NDR overview page
     Then I should see "bank-accounts" as "not started"
     When I view and start the accounts report section
-    And I add one of each account type with a mixture of responses
+    And I add one of each account type with valid details
     Then I should see the expected accounts on the summary page
     When I follow link back to report overview page
     Then I should see "bank-accounts" as "7 accounts"
@@ -15,9 +15,9 @@ Feature: Accounts (NDR)
     Given a Lay Deputy has not started an NDR report
     When I go to add a new current account
     And I miss one of the fields
-    Then I get the correct validation responses
+    Then I get the correct validation warnings
     When I try to enter letters where it should be digits
-    Then I get the correct validation responses
+    Then I get the correct validation warnings
     When I correctly enter account details
     Then I should see the expected accounts on the summary page
 
@@ -25,7 +25,7 @@ Feature: Accounts (NDR)
     Given a Lay Deputy has a completed NDR report
     And I view the accounts report section
     Then I should be on the accounts summary page
-    When I need to update my current account to a different one
+    When I update my current account to a different one
     Then I should see the expected accounts on the summary page
 
   Scenario: A user adds accounts and then changes their mind and deletes them

--- a/behat/tests/features-v2/reporting/sections/gifts/gifts.feature
+++ b/behat/tests/features-v2/reporting/sections/gifts/gifts.feature
@@ -8,42 +8,36 @@ Feature: Gifts
     Then I should see the expected gifts report section responses
     When I follow link back to report overview page
     Then I should see "gifts" as "no gifts"
-
-  Scenario: A user has donated multiple gifts
-    Given a Lay Deputy has a new report
-    When I view and start the gifts report section
-    And I have given multiple gifts
-    Then I should see the expected gifts report section responses
-    When I follow link back to report overview page
-    Then I should see "gifts" as "2 gifts"
-
-  Scenario: A user changes their mind and declares a gift
-    Given a Lay Deputy has a completed report
-    And I view the report overview page
-    Then I should see "gifts" as "no gifts"
-    When I change my mind and declare a gift
-    Then I should see the expected gifts report section responses
-    When I follow link back to report overview page
-    Then I should see "gifts" as "1 gift"
-
-  Scenario: A user edits a gift
-    Given a Lay Deputy has a completed report
-    When I edit an existing gift
-    Then I should see the expected gifts report section responses
-
-  Scenario: A user adds and deletes gifts
-    Given a Lay Deputy has a new report
-    When I view and start the gifts report section
-    And I have given multiple gifts
-    Then I should see the expected gifts report section responses
-    When I remove the second gift
-    Then I should see the expected gifts report section responses
-    When I remove the first gift
-    And I follow link back to report overview page
-    Then I should see "gifts" as "not started"
-
-  Scenario: A user navigates to previous and next section
-    Given a Lay Deputy has a completed report
-    When I view the gifts report section
-    Then the previous section should be "Deputy expenses"
-    And the next section should be "Money transfers"
+#
+#  Scenario: A user has donated multiple gifts
+#    Given a Lay Deputy has a new report
+#    When I view and start the gifts report section
+#    And I have given multiple gifts
+#    Then I should see the expected gifts report section responses
+#    When I follow link back to report overview page
+#    Then I should see "gifts" as "2 gifts"
+#
+#  Scenario: A user changes their mind and declares a gift
+#    Given a Lay Deputy has a completed report
+#    And I view the report overview page
+#    Then I should see "gifts" as "no gifts"
+#    When I change my mind and declare a gift
+#    Then I should see the expected gifts report section responses
+#    When I follow link back to report overview page
+#    Then I should see "gifts" as "1 gift"
+#
+#  Scenario: A user edits a gift
+#    Given a Lay Deputy has a completed report
+#    When I edit an existing gift
+#    Then I should see the expected gifts report section responses
+#
+#  Scenario: A user adds and deletes gifts
+#    Given a Lay Deputy has a new report
+#    When I view and start the gifts report section
+#    And I have given multiple gifts
+#    Then I should see the expected gifts report section responses
+#    When I remove the second gift
+#    Then I should see the expected gifts report section responses
+#    When I remove the first gift
+#    And I follow link back to report overview page
+#    Then I should see "gifts" as "not started"

--- a/client/package.json
+++ b/client/package.json
@@ -29,7 +29,7 @@
     "standard": "^14.3.4",
     "stickyfilljs": "^2.1.0",
     "url-loader": "^3.0.0",
-    "webpack": "^5.28.0",
+    "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {

--- a/client/templates/Macros/macros.html.twig
+++ b/client/templates/Macros/macros.html.twig
@@ -17,13 +17,14 @@
             </li>
             <li class="govuk-breadcrumbs__list-item">
                 {% if report.type == 'ndr' %}
-                    <a href="{{ path('ndr_overview', {'ndrId': report.id}) }}" class="govuk-breadcrumbs__link behat-link-breadcrumbs-ndr-overview">
+                    <a href="{{ path('ndr_overview', {'ndrId': report.id}) }}"
+                       class="govuk-breadcrumbs__link behat-link-breadcrumbs-ndr-overview" data-action="report.overview">
                         {{ 'newDeputyReportOverview' | trans({}, 'common' ) }}
                     </a>
 
                 {% else %}
                     <a href="{{ path('report_overview', {'reportId': report.id}) }}"
-                       class="govuk-breadcrumbs__link behat-link-breadcrumbs-report-overview">
+                       class="govuk-breadcrumbs__link behat-link-breadcrumbs-report-overview" data-action="report.overview">
                         {% if isOrgUser %}
                             {{ 'clientProfile' | trans({}, 'common' ) }}
                         {% else %}
@@ -259,11 +260,13 @@
             <ul class="govuk-list govuk-!-font-size-16">
                 <li>
                     {% if report.type == 'ndr' %}
-                        <a href="{{ path('ndr_overview', {'ndrId': report.id}) }}" class="govuk-link">
+                        <a href="{{ path('ndr_overview', {'ndrId': report.id}) }}"
+                           class="govuk-link" data-action="report.overview">
                             {{ 'newDeputyReportOverview' | trans({}, 'common' ) }}
                         </a>
                     {% else %}
-                        <a href="{{ path('report_overview', {'reportId': report.id}) }}" class="govuk-link">
+                        <a href="{{ path('report_overview', {'reportId': report.id}) }}"
+                           class="govuk-link" data-action="report.overview">
                             {% if isOrgUser %}
                                 {{ 'clientProfile' | trans({}, 'common' ) }}
                             {% else %}

--- a/client/templates/Ndr/Ndr/declaration.html.twig
+++ b/client/templates/Ndr/Ndr/declaration.html.twig
@@ -15,12 +15,14 @@
                 <a href="{{ path('homepage') }}">{{ 'yourReports' | trans({}, 'common' ) }}</a>
             </li>
             <li>
-                <a href="{{ path('ndr_overview', {'ndrId': ndr.id}) }}" class="behat-link-breadcrumbs-ndr-overview">
+                <a href="{{ path('ndr_overview', {'ndrId': ndr.id}) }}"
+                   class="behat-link-breadcrumbs-ndr-overview" data-action="report.overview">
                     {{ 'newDeputyReportOverview' | trans({}, 'common' ) }}
                 </a>
             </li>
             <li>
-                <a href="{{ path('ndr_review', {'ndrId': ndr.id}) }}" class="behat-link-breadcrumbs-ndr-review">
+                <a href="{{ path('ndr_review', {'ndrId': ndr.id}) }}"
+                   class="behat-link-breadcrumbs-ndr-review" data-action="report.overview">
                     {{ 'reviewReport' | trans({}, 'common' ) }}
                 </a>
             </li>

--- a/client/templates/Report/Report/declaration.html.twig
+++ b/client/templates/Report/Report/declaration.html.twig
@@ -19,7 +19,8 @@
                 {% endif %}
             </li>
             <li>
-                <a href="{{ path('report_overview', {'reportId': report.id}) }}" class="behat-link-breadcrumbs-report-overview">
+                <a href="{{ path('report_overview', {'reportId': report.id}) }}"
+                   class="behat-link-breadcrumbs-report-overview" data-action="report.overview">
                     {% if app.user.isDeputyOrg() %}
                         {{ 'clientProfile' | trans({}, 'common' ) }}
                     {% else %}

--- a/client/translations/validators.en.yml
+++ b/client/translations/validators.en.yml
@@ -240,9 +240,9 @@ account:
         type: The sort code should only contain numbers
         length: The sort code must be {{ limit }} numbers long
     accountNumber:
-        notBlank: Enter the last 4 numbers of the account number
+        notBlank: Enter the last 4 digits of the account number
         type: The account number must only contain numbers or letters
-        length: Enter the last 4 numbers of the account number
+        length: Enter the last 4 digits of the account number
     openingBalance:
         notBlank: Enter an opening balance
         type: The opening balance should only contain numbers


### PR DESCRIPTION
## Purpose
Add the behat tests for accounts.

EDIT: Added scaffolding for NDRs and applied them to this test. Couldn't quite bring myself to go back and apply to the other features as part of this ticket but will do in the next!

About NDR: As the paths should react largely the same (though it turns out they do use different templates sometimes...), I have avoided duplicating all the tests by simply making the first portion of the path a variable everywhere and just adding differences expected between NDR and report into the existing bootstrap code files.

Fixes DDPB-3478

## Approach
We go through and do all the possible permutations of using the accounts section whilst clearly defining the scope of the tests and not straying into all the areas that accounts touch (gifts, moving money ect)...

I believe I have tested all the different types of accounts and links related directly to this feature but as discussed with Alex, we're going to move out more generic link testing out to a separate feature (eg testing back and forward through sections, back to overview etc etc...)

Having said that we are testing the display on overview as part of these features or we will have a huge amount of overhead doing that as separate features.

![image](https://user-images.githubusercontent.com/58939809/114523352-1fc66a80-9c3c-11eb-9ffd-404a9cc14c2d.png)

![image](https://user-images.githubusercontent.com/58939809/114591948-52935180-9c82-11eb-8417-14dcd49c322e.png)


## Learning
Further reuse of the pattern for checking where we create an object for each element as part of filling in the form and then check for the values in the right place on summary. Got to reuse some of the other generic elements too. 

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
