### PR TITLE
DDPB-3956: Remove final traces of teams and clear up team user client associations

### DIFF
--- a/api/src/Migrations/Version250.php
+++ b/api/src/Migrations/Version250.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version250 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Removing teams tables and clearing associations between team members and clients';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->addSql("DELETE from deputy_case WHERE user_id IN (SELECT id FROM dd_user WHERE role_name != 'ROLE_LAY_DEPUTY')");
+        $this->addSql('ALTER TABLE user_team DROP CONSTRAINT fk_be61ead6296cd8ae');
+        $this->addSql('DROP SEQUENCE dd_team_id_seq CASCADE');
+        $this->addSql('DROP TABLE dd_team');
+        $this->addSql('DROP TABLE user_team');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->addSql('CREATE SEQUENCE dd_team_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('CREATE TABLE dd_team (id SERIAL NOT NULL, team_name VARCHAR(50) DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE TABLE user_team (user_id INT NOT NULL, team_id INT NOT NULL, PRIMARY KEY(user_id, team_id))');
+        $this->addSql('CREATE INDEX idx_be61ead6296cd8ae ON user_team (team_id)');
+        $this->addSql('CREATE INDEX idx_be61ead6a76ed395 ON user_team (user_id)');
+        $this->addSql('ALTER TABLE user_team ADD CONSTRAINT fk_be61ead6a76ed395 FOREIGN KEY (user_id) REFERENCES dd_user (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE user_team ADD CONSTRAINT fk_be61ead6296cd8ae FOREIGN KEY (team_id) REFERENCES dd_team (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+}

--- a/api/tests/Fixtures.php
+++ b/api/tests/Fixtures.php
@@ -560,7 +560,7 @@ class Fixtures
 
     public static function deleteReportsData($additionalTables = [])
     {
-        $tables = array_merge(['document', 'casrec', 'deputy_case', 'report_submission', 'report', 'odr', 'dd_team'], $additionalTables);
+        $tables = array_merge(['document', 'casrec', 'deputy_case', 'report_submission', 'report', 'odr'], $additionalTables);
         self::pgCommand('PGOPTIONS=\'--client-min-messages=warning\' psql -c "truncate table ' . implode(',', $tables) . '  RESTART IDENTITY cascade";');
     }
 

--- a/behat/tests/bootstrap/DbTrait.php
+++ b/behat/tests/bootstrap/DbTrait.php
@@ -14,7 +14,7 @@ trait DbTrait
     {
         $sqlFile = self::getSnapshotPath($status);
         // truncate cascade + insert. faster than drop + table recreate
-        exec('echo "SET client_min_messages TO WARNING; truncate dd_user, satisfaction, dd_team, named_deputy, organisation, casrec, setting, user_team, client cascade;" > ' . $sqlFile);
+        exec('echo "SET client_min_messages TO WARNING; truncate dd_user, satisfaction, named_deputy, organisation, casrec, setting, client cascade;" > ' . $sqlFile);
         exec('pg_dump ' . self::$dbName . "  --data-only  --inserts --exclude-table='migrations' | sed '/EXTENSION/d' >> {$sqlFile}", $output, $return);
         if (!file_exists($sqlFile) || filesize($sqlFile) < 100) {
             throw new \RuntimeException("SQL snapshot $sqlFile not created or not valid");


### PR DESCRIPTION
## Purpose
Getting rid of the team related tables and removing associations between clients and non-lay deputies.

Fixes DDPB-3956

## Approach
We were alerted to a case of org members still seeing a client list even after being removed from the org. After further investigation, we found that the old mechanism for team members to view clients/reports was still in place (essentially using the same mechanism as lay deputies by associating the client with the team user in the deputy_case table).

We've already run the client association removal code on prod so this is just recording the fact in source control but the migration included here also drops the dd_team and user_team tables and constraints. 

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
