### PR TITLE
DDPB-3961: Add PHPStan to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,8 @@ repos:
     hooks:
     - id: php-cs-fixer
       files: \.(php)$
+    - id: php-stan
+      files: \.(php)$
 -   repo: https://github.com/ministryofjustice/opg-pre-commit-hooks.git
     rev: v0.1.0
     hooks:

--- a/Makefile
+++ b/Makefile
@@ -116,3 +116,9 @@ enable-debug: ## Puts app in dev mode and enables debug (so the app has toolbar/
 	  APP_ENV=dev APP_DEBUG=1 docker-compose up -d --no-deps $$c; \
 	  echo "$$c: debug enabled." ; \
 	done
+
+phpstan-api:
+	docker-compose run --rm api vendor/phpstan/phpstan/phpstan analyse src --memory-limit=0 --level=max
+
+phpstan-frontend:
+	docker-compose run --rm frontend vendor/phpstan/phpstan/phpstan analyse src --memory-limit=0 --level=max

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ down-app: ### Tears down the app
 
 client-unit-tests: ## Run the client unit tests
 	REQUIRE_XDEBUG_FRONTEND=false REQUIRE_XDEBUG_API=false docker-compose build frontend admin
-	docker-compose -f docker-compose.yml run -e APP_ENV=unit_test -e APP_DEBUG=0 --rm frontend bin/phpunit -c tests/phpunit
+	docker-compose -f docker-compose.yml run -e APP_ENV=unit_test -e APP_DEBUG=0 --rm frontend vendor/bin/phpunit -c tests/phpunit
 
 api-unit-tests: reset-database reset-fixtures ## Run the api unit tests
 	REQUIRE_XDEBUG_FRONTEND=false REQUIRE_XDEBUG_API=false docker-compose build api

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -76,7 +76,7 @@ RUN mkdir -p var/cache \
 # https://symfony.com/doc/3.4/quick_tour/the_architecture.html
 COPY docker/confd /etc/confd
 COPY --from=composer /app/app app
-COPY --from=composer /app/bin bin
+COPY --from=composer /app/vendor/bin bin
 COPY --from=composer /app/vendor vendor
 COPY --from=composer /app/composer.lock composer.lock
 COPY --from=composer /app/config/parameters.yml config/parameters.yml

--- a/api/composer.json
+++ b/api/composer.json
@@ -55,7 +55,6 @@
     ]
   },
   "config": {
-    "bin-dir": "bin",
     "sort-packages": true
   },
   "minimum-stability": "stable",

--- a/api/phpstan.neon
+++ b/api/phpstan.neon
@@ -3,5 +3,3 @@ includes:
   - vendor/phpstan/phpstan-phpunit/extension.neon
 parameters:
   checkMissingIterableValueType: false
-  autoload_directories:
-    - DoctrineMigrations

--- a/api/scripts/apiunittest.sh
+++ b/api/scripts/apiunittest.sh
@@ -13,16 +13,16 @@ export PGUSER=${DATABASE_USERNAME:=api}
 
 # Run each folder of unit tests individually. If we were to run them all
 # individually it would cause a memory leak.
-php bin/phpunit -c tests tests/App/Command/ --coverage-php tests/coverage/Command.cov
-php bin/phpunit -c tests tests/App/Controller/ --coverage-php tests/coverage/Controller.cov
-php bin/phpunit -c tests tests/App/ControllerReport/ --coverage-php tests/coverage/ControllerReport.cov
-php bin/phpunit -c tests tests/App/Controller-Ndr/ --coverage-php tests/coverage/Controller-Ndr.cov
-php bin/phpunit -c tests tests/App/Entity/ --coverage-php tests/coverage/Entity.cov
-php bin/phpunit -c tests tests/App/Factory/ --coverage-php tests/coverage/Factory.cov
-php bin/phpunit -c tests tests/App/Security/ --coverage-php tests/coverage/Security.cov
-php bin/phpunit -c tests tests/App/Service/ --coverage-php tests/coverage/Service.cov
-php bin/phpunit -c tests tests/App/Stats/ --coverage-php tests/coverage/Stats.cov
-php bin/phpunit -c tests tests/App/Transformer/ --coverage-php tests/coverage/Transformer.cov
-php bin/phpunit -c tests tests/App/v2/ --coverage-php tests/coverage/v2.cov
+php vendor/bin/phpunit -c tests tests/App/Command/ --coverage-php tests/coverage/Command.cov
+php vendor/bin/phpunit -c tests tests/App/Controller/ --coverage-php tests/coverage/Controller.cov
+php vendor/bin/phpunit -c tests tests/App/ControllerReport/ --coverage-php tests/coverage/ControllerReport.cov
+php vendor/bin/phpunit -c tests tests/App/Controller-Ndr/ --coverage-php tests/coverage/Controller-Ndr.cov
+php vendor/bin/phpunit -c tests tests/App/Entity/ --coverage-php tests/coverage/Entity.cov
+php vendor/bin/phpunit -c tests tests/App/Factory/ --coverage-php tests/coverage/Factory.cov
+php vendor/bin/phpunit -c tests tests/App/Security/ --coverage-php tests/coverage/Security.cov
+php vendor/bin/phpunit -c tests tests/App/Service/ --coverage-php tests/coverage/Service.cov
+php vendor/bin/phpunit -c tests tests/App/Stats/ --coverage-php tests/coverage/Stats.cov
+php vendor/bin/phpunit -c tests tests/App/Transformer/ --coverage-php tests/coverage/Transformer.cov
+php vendor/bin/phpunit -c tests tests/App/v2/ --coverage-php tests/coverage/v2.cov
 
 php vendor/phpunit/phpcov/phpcov merge --clover "./tests/coverage/api-unit-tests.xml" "./tests/coverage"

--- a/behat/tests/bootstrap/v2/common/BaseFeatureContext.php
+++ b/behat/tests/bootstrap/v2/common/BaseFeatureContext.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 
 
-namespace DigidepsBehat\v2\Common;
+namespace DigidepsBehat\v2\Common ;
 
 use Behat\Mink\Driver\GoutteDriver;
 use Behat\MinkExtension\Context\MinkContext;

--- a/behat/tests/bootstrap/v2/common/BaseFeatureContext.php
+++ b/behat/tests/bootstrap/v2/common/BaseFeatureContext.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 
 
-namespace DigidepsBehat\v2\Common ;
+namespace DigidepsBehat\v2\Common;
 
 use Behat\Mink\Driver\GoutteDriver;
 use Behat\MinkExtension\Context\MinkContext;

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -87,7 +87,7 @@ RUN mkdir -p var/cache \
 # See this page for directories required
 # https://symfony.com/doc/3.4/quick_tour/the_architecture.html
 COPY --from=composer /app/app app
-COPY --from=composer /app/bin bin
+COPY --from=composer /app/vendor/bin bin
 COPY --from=composer /app/vendor vendor
 COPY --from=composer /app/composer.lock composer.lock
 COPY --from=composer /app/config/parameters.yml config/parameters.yml

--- a/client/composer.json
+++ b/client/composer.json
@@ -40,7 +40,6 @@
         ]
     },
     "config": {
-        "bin-dir": "bin",
         "sort-packages": true
     },
     "minimum-stability": "stable",

--- a/client/phpstan.neon
+++ b/client/phpstan.neon
@@ -3,5 +3,3 @@ includes:
   - vendor/phpstan/phpstan-phpunit/extension.neon
   - vendor/jangregor/phpstan-prophecy/src/extension.neon
 parameters:
-  autoload_directories:
-    - tests/phpunit

--- a/client/scripts/client-unit-tests.sh
+++ b/client/scripts/client-unit-tests.sh
@@ -2,6 +2,6 @@
 # exit on error
 set -e
 
-php bin/phpunit -c tests/phpunit --coverage-php tests/phpunit/coverage/client-unit-tests.cov
+php vendor/bin/phpunit -c tests/phpunit --coverage-php tests/phpunit/coverage/client-unit-tests.cov
 
 php vendor/phpunit/phpcov/phpcov merge --clover "./tests/phpunit/coverage/client-unit-tests.xml" "./tests/phpunit/coverage"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,6 +24,7 @@ services:
       - ./client/templates:/var/www/templates
       - ./client/translations:/var/www/translations
       - ./client/phpstan.neon:/var/www/phpstan.neon
+      - ./client/bin:/var/www/vendor/bin
 
   api:
     volumes:
@@ -37,6 +38,7 @@ services:
       - ./api/api.env:/var/www/api.env
       - ./api/postgres.env:/var/www/postgres.env
       - ./api/phpstan.neon:/var/www/phpstan.neon
+      - ./api/bin:/var/www/vendor/bin
 
   frontend:
     volumes:
@@ -55,6 +57,7 @@ services:
       - ./client/templates:/var/www/templates
       - ./client/translations:/var/www/translations
       - ./client/phpstan.neon:/var/www/phpstan.neon
+      - ./client/bin:/var/www/vendor/bin
 
   wkhtmltopdf:
     volumes:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,10 +3,6 @@ includes:
   - client/vendor/phpstan/phpstan-phpunit/extension.neon
   - client/vendor/jangregor/phpstan-prophecy/src/extension.neon
 parameters:
-  autoload_directories:
-    - client/tests/phpunit
-    - api/tests
-    - api/src/Migrations
   bootstrapFiles:
     - client/vendor/autoload.php
     - api/vendor/autoload.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,12 @@
 includes:
-  - vendor/phpstan/phpstan-mockery/extension.neon
-  - vendor/phpstan/phpstan-phpunit/extension.neon
-  - vendor/jangregor/phpstan-prophecy/src/extension.neon
+  - client/vendor/phpstan/phpstan-mockery/extension.neon
+  - client/vendor/phpstan/phpstan-phpunit/extension.neon
+  - client/vendor/jangregor/phpstan-prophecy/src/extension.neon
 parameters:
   autoload_directories:
-    - tests/phpunit
+    - client/tests/phpunit
+    - api/tests
+    - api/src/Migrations
+  bootstrapFiles:
+    - client/vendor/autoload.php
+    - api/vendor/autoload.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+includes:
+  - vendor/phpstan/phpstan-mockery/extension.neon
+  - vendor/phpstan/phpstan-phpunit/extension.neon
+  - vendor/jangregor/phpstan-prophecy/src/extension.neon
+parameters:
+  autoload_directories:
+    - tests/phpunit


### PR DESCRIPTION
## Purpose
Adding PHPStan to pre-commit hooks to ensure any new code we write has some base level of static analysis applied. 

I've also formalised running PHPStan under a couple of makefile commands so we can get depressed about the thousands of errors its spits out. At some point, it would be nice to tackle them level by level but for now, having the new code we've written checked is a good first step.

Fixes DDPB-3961.