### PR TITLE
DDPB-3977 update composer to latest version

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 # Install composer dependencies
 COPY composer.json .
 COPY composer.lock .
-
+# Remove '--ignore-platform-req=php' when we move to php 8
 RUN composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-req=php
 
 COPY app app

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:2.0.8 AS composer
+FROM composer:2 AS composer
 
 WORKDIR /app
 
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY composer.json .
 COPY composer.lock .
 
-RUN composer install --prefer-dist --no-interaction --no-scripts
+RUN composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-req=php
 
 COPY app app
 COPY config config

--- a/behat/Dockerfile
+++ b/behat/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 # Install composer dependencies
 COPY composer.json .
 COPY composer.lock .
-
+# Remove '--ignore-platform-req=php' when we move to php 8
 RUN composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-req=php
 RUN composer dump-autoload --optimize
 

--- a/behat/Dockerfile
+++ b/behat/Dockerfile
@@ -1,11 +1,11 @@
-FROM composer:2.0.8 AS composer
+FROM composer:2 AS composer
 WORKDIR /app
 
 # Install composer dependencies
 COPY composer.json .
 COPY composer.lock .
 
-RUN composer install --prefer-dist --no-interaction --no-scripts
+RUN composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-req=php
 RUN composer dump-autoload --optimize
 
 

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -29,6 +29,7 @@ RUN composer --version
 # Install composer dependencies
 COPY composer.json .
 COPY composer.lock .
+# Remove '--ignore-platform-req=php' when we move to php 8
 RUN composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-req=php
 
 COPY app app

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -18,17 +18,18 @@ RUN npm audit --production
 #Build assets
 RUN NODE_ENV=production npm run build
 
-FROM composer:2.0.8 AS composer
+FROM composer:2 AS composer
 WORKDIR /app
 
 RUN apk update
 
 RUN apk add libpng libpng-dev libjpeg-turbo-dev libwebp-dev zlib-dev libxpm-dev gd && docker-php-ext-install gd
 
+RUN composer --version
 # Install composer dependencies
 COPY composer.json .
 COPY composer.lock .
-RUN composer install --prefer-dist --no-interaction --no-scripts
+RUN composer install --prefer-dist --no-interaction --no-scripts --ignore-platform-req=php
 
 COPY app app
 COPY config config


### PR DESCRIPTION
## Purpose
No longer need to pin composer. Fix security vulnerability in composer.

Fixes DDPB-3977

## Approach
Needed extra argument to ignore platform req for php as otherwise it expects php8

## Learning

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
