### PR TITLE
Ddpb 3482 - money out behat tests

### DIFF
--- a/api/src/TestHelpers/ReportTestHelper.php
+++ b/api/src/TestHelpers/ReportTestHelper.php
@@ -202,6 +202,8 @@ class ReportTestHelper
     {
         $mt = (new MoneyTransaction($report))->setCategory('care-fees')->setAmount(200);
         $report->addMoneyTransaction($mt);
+        $mt2 = (new MoneyTransaction($report))->setCategory('electricity')->setAmount(100);
+        $report->addMoneyTransaction($mt2);
     }
 
     private function completeAssets(ReportInterface $report): void

--- a/api/tests/Behat/behat.yml
+++ b/api/tests/Behat/behat.yml
@@ -254,8 +254,8 @@ v2-tests-goutte:
             contexts:
                 - App\Tests\Behat\v2\ClientManagement\ClientManagementFeatureContext
 
-        section-money-out:
-            description: Covering the 'Money Out' section of the report
+        section-money-out-short:
+            description: Covering the 'Money Out Short' section of the report
             paths: [ "%paths.base%/features-v2/reporting/sections/money-out" ]
             contexts:
                 - App\Tests\Behat\v2\Reporting\Sections\ReportingSectionsFeatureContext

--- a/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnTrait.php
@@ -371,6 +371,14 @@ trait IShouldBeOnTrait
     }
 
     /**
+     * @Then I should be on the money out delete page
+     */
+    public function iAmOnMoneyOutDeletePage()
+    {
+        return $this->iAmOnPage(sprintf('/%s\/.*\/money-out\/.*\/delete.*$/', $this->reportUrlPrefix));
+    }
+
+    /**
      * @Then I should be on the any other info summary page
      */
     public function iAmOnAnyOtherInfoSummaryPage()

--- a/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnTrait.php
@@ -339,6 +339,38 @@ trait IShouldBeOnTrait
     }
 
     /**
+     * @Then I should be on the money out add payment page
+     */
+    public function iAmOnMoneyOutAddPaymentPage()
+    {
+        return $this->iAmOnPage(sprintf('/%s\/.*\/money-out\/step1.*/', $this->reportUrlPrefix));
+    }
+
+    /**
+     * @Then I should be on the money out add payment details page
+     */
+    public function iAmOnMoneyOutAddPaymentDetailsPage()
+    {
+        return $this->iAmOnPage(sprintf('/%s\/.*\/money-out\/step2.*$/', $this->reportUrlPrefix));
+    }
+
+    /**
+     * @Then I should be on the money out add another payment page
+     */
+    public function iAmOnMoneyOutAddAnotherPaymentPage()
+    {
+        return $this->iAmOnPage(sprintf('/%s\/.*\/money-out\/add_another.*$/', $this->reportUrlPrefix));
+    }
+
+    /**
+     * @Then I should be on the money out summary page
+     */
+    public function iAmOnMoneyOutSummaryPage()
+    {
+        return $this->iAmOnPage(sprintf('/%s\/.*\/money-out\/summary.*$/', $this->reportUrlPrefix));
+    }
+
+    /**
      * @Then I should be on the any other info summary page
      */
     public function iAmOnAnyOtherInfoSummaryPage()

--- a/api/tests/Behat/bootstrap/v2/Common/IVisitFrontendTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/IVisitFrontendTrait.php
@@ -46,6 +46,22 @@ trait IVisitFrontendTrait
     }
 
     /**
+     * @When I visit the money out report section
+     */
+    public function iVisitMoneyOutSection()
+    {
+        $this->visitPath($this->getMoneyOutSectionUrl($this->loggedInUserDetails->getCurrentReportId()));
+    }
+
+    /**
+     * @When I visit the money out summary section
+     */
+    public function iVisitMoneyOutSummarySection()
+    {
+        $this->visitPath($this->getMoneyOutShortSectionSummaryUrl($this->loggedInUserDetails->getCurrentReportId()));
+    }
+
+    /**
      * @When I visit the accounts report section
      */
     public function iViewAccountsSection()

--- a/api/tests/Behat/bootstrap/v2/Common/IVisitFrontendTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/IVisitFrontendTrait.php
@@ -58,7 +58,7 @@ trait IVisitFrontendTrait
      */
     public function iVisitMoneyOutSummarySection()
     {
-        $this->visitPath($this->getMoneyOutShortSectionSummaryUrl($this->loggedInUserDetails->getCurrentReportId()));
+        $this->visitPath($this->getMoneyOutSectionSummaryUrl($this->loggedInUserDetails->getCurrentReportId()));
     }
 
     /**

--- a/api/tests/Behat/bootstrap/v2/Common/PageUrlsTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/PageUrlsTrait.php
@@ -19,6 +19,8 @@ trait PageUrlsTrait
     private string $reportOverviewUrl = '/%s/%s/overview';
     private string $moneyOutShortSectionUrl = '%s/%s/money-out-short';
     private string $moneyOutShortSectionSummaryUrl = '%s/%s/money-out-short/summary';
+    private string $moneyOutSectionUrl = '%s/%s/money-out';
+    private string $moneyOutSectionSummaryUrl = '%s/%s/money-out/summary';
 
     // Admin
     private string $adminClientSearchUrl = '/admin/client/search';
@@ -55,6 +57,16 @@ trait PageUrlsTrait
     public function getMoneyOutShortSectionSummaryUrl(int $reportId): string
     {
         return sprintf($this->moneyOutShortSectionSummaryUrl, $this->reportUrlPrefix, $reportId);
+    }
+
+    public function getMoneyOutSectionUrl(int $reportId): string
+    {
+        return sprintf($this->moneyOutSectionUrl, $this->reportUrlPrefix, $reportId);
+    }
+
+    public function getMoneyOutSectionSummaryUrl(int $reportId): string
+    {
+        return sprintf($this->moneyOutSectionSummaryUrl, $this->reportUrlPrefix, $reportId);
     }
 
     public function getPostSubmissionUserResearchUrl(int $reportId): string

--- a/api/tests/Behat/bootstrap/v2/Common/ReportTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/ReportTrait.php
@@ -75,6 +75,7 @@ trait ReportTrait
 
     /**
      * @Given a Lay Deputy has a completed report
+     * @Given a Lay Deputy has completed a Pfa High Assets report
      *
      * @throws Exception
      */

--- a/api/tests/Behat/bootstrap/v2/Reporting/Sections/MoneyOutSectionTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Reporting/Sections/MoneyOutSectionTrait.php
@@ -1,0 +1,446 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Behat\v2\Reporting\Sections;
+
+trait MoneyOutSectionTrait
+{
+    private array $paymentsList = [];
+    private array $paymentsListForFills = [];
+    private float $oneOffPaymentsTotal = 0.0;
+
+    /**
+     * @When I view and start the money out report section
+     */
+    public function iViewAndStartMoneyOutSection()
+    {
+        $this->iVisitMoneyOutSection();
+        $this->clickLink('Start money out');
+    }
+
+    /**
+     * @When I try to save and continue without adding a payment
+     */
+    public function iSaveAndContinueWithoutAddingPayment()
+    {
+        $this->iAmOnMoneyOutAddPaymentPage();
+        $this->clickLink('Save and continue');
+    }
+
+    /**
+     * @Then I should see correct money out validation message
+     */
+    public function iShouldSeeCorrectMoneyOutValidation()
+    {
+        $this->assertOnAlertMessage('Please choose an option');
+    }
+
+    /**
+     * @When I add one of each type of money out payment
+     */
+    public function iAddOneOfEachTypeOfMoneyOutPayment()
+    {
+        $this->iAmOnMoneyOutAddPaymentPage();
+
+        $xpath = "//form[@name='account']//fieldset";
+        $fieldSets = $this->getSession()->getPage()->findAll('xpath', $xpath);
+
+        foreach ($fieldSets as $fieldSetKey => $fieldset) {
+            $total = 0;
+            $xpath = "//div[contains(@class, 'govuk-radios__item')]";
+            $divs = $fieldset->findAll('xpath', $xpath);
+
+            foreach ($divs as $divKey => $div) {
+                $xpath = "//label[contains(@class, 'govuk-radios__label')]";
+                $label = $div->find('xpath', $xpath);
+                $xpath = "//input[contains(@name, 'account[category]')]";
+                $radioBox = $div->find('xpath', $xpath);
+
+                $amount = (1000 + $divKey);
+
+                $paymentObject =
+                    [
+                        'paymentName' => trim($label->getText()),
+                        'description' => $this->faker->text(100),
+                        'amount' => strval($amount),
+                        'selectValue' => $this->getStringBetween($radioBox->getOuterHtml(), 'value="', '"'),
+                    ];
+                $this->paymentsListForFills[] = $paymentObject;
+
+                $this->paymentsList[$fieldSetKey * 2][] = $this->formatPaymentObject($paymentObject);
+
+                $total += $amount;
+            }
+
+            $this->paymentsList[$fieldSetKey * 2 + 1][] =
+                [
+                    'label' => 'total amount',
+                    'total' => $this->moneyFormat($total),
+                ];
+        }
+
+//        var_dump($this->paymentsListForFills);
+
+        foreach ($this->paymentsListForFills as $paymentKey => $payment) {
+            if ($paymentKey >= (count($this->paymentsListForFills) - 1)) {
+                $this->addPayment($payment, 'no');
+            } else {
+                $this->addPayment($payment, 'yes');
+            }
+        }
+    }
+
+    private function formatPaymentObject($paymentObject)
+    {
+        $paymentObject['amount'] = $this->moneyFormat($paymentObject['amount']);
+        unset($paymentObject['selectValue']);
+
+        return array_values($paymentObject);
+    }
+
+    /**
+     * @When I should see the expected results on money out summary page
+     */
+    public function iShouldSeeExpectedResultsOnMoneyOutPage()
+    {
+        $this->iAmOnMoneyOutSummaryPage();
+
+//        $this->expectedResultsDisplayed(2, $this->paymentsList[2], 'Money Out Payments', true);
+
+        foreach ($this->paymentsList as $entryKey => $entry) {
+            $this->expectedResultsDisplayed($entryKey, $this->paymentsList[$entryKey], 'Money Out Payments');
+        }
+    }
+
+    public function addPayment($payment, $anotherFlag)
+    {
+        $this->selectOption('account[category]', $payment['selectValue']);
+        $this->pressButton('Save and continue');
+        $this->iAmOnMoneyOutAddPaymentDetailsPage();
+        $this->fillField('account[description]', $payment['description']);
+        $this->fillField('account[amount]', $payment['amount']);
+        $this->pressButton('Save and continue');
+        $this->iAmOnMoneyOutAddAnotherPaymentPage();
+        $this->selectOption('add_another[addAnother]', $anotherFlag);
+        $this->pressButton('Save and continue');
+    }
+
+    public function getStringBetween($string, $start, $end)
+    {
+        $string = ' '.$string;
+        $ini = strpos($string, $start);
+        if (0 == $ini) {
+            return '';
+        }
+        $ini += strlen($start);
+        $len = strpos($string, $end, $ini) - $ini;
+
+        return substr($string, $ini, $len);
+    }
+
+//            $payment =
+//                [
+//                    'paymentName' => $this->getStringBetween($radioBox->getOuterHtml(), 'value="', '"'),
+//                    'description' => $this->faker->text(100),
+//                    'amount' => strval(1000 + $radioBoxKey)
+//                ];
+//
+//            $this->fill
+//$fullstring = 'this is my [tag]dog[/tag]';
+//$parsed = get_string_between($fullstring, '[tag]', '[/tag]');
+//
+//echo $parsed; // (result = dog)
+
+//    /**
+//     * @When I have made no payments out
+//     */
+//    public function iHaveMadeNoPaymentsOut()
+//    {
+//        $this->iAmOnMoneyOutShortCategoryPage();
+//        $this->iClickBasedOnAttributeTypeAndValue('button', 'id', 'money_short_save');
+//        $this->iAnswerNoOneOffPaymentsOver1k();
+//    }
+//
+//    /**
+//     * @When I add some categories of money paid out
+//     */
+//    public function iAddSomeCategoriesOfMoneyOut()
+//    {
+//        $this->iAmOnMoneyOutShortCategoryPage();
+//        $this->getSession()->getPage()->selectFieldOption('money_short[moneyShortCategoriesOut][0][present]', '1');
+//        $this->categoryList[] = 'accommodation costs';
+//        $this->getSession()->getPage()->selectFieldOption('money_short[moneyShortCategoriesOut][3][present]', '1');
+//        $this->categoryList[] = 'household bills';
+//        $this->iClickBasedOnAttributeTypeAndValue('button', 'id', 'money_short_save');
+//    }
+//
+//    /**
+//     * @When I answer that there are no one-off payments over £1k
+//     */
+//    public function iAnswerNoOneOffPaymentsOver1k()
+//    {
+//        $this->oneOffPaymentOver1kExists('no');
+//    }
+//
+//    /**
+//     * @When I add all the categories of money paid out
+//     */
+//    public function iAddAllTheCategoriesOfMoneyPaidOut()
+//    {
+//        $this->iAmOnMoneyOutShortCategoryPage();
+//        $this->getSession()->getPage()->selectFieldOption('money_short[moneyShortCategoriesOut][0][present]', '1');
+//        $this->categoryList[] = 'accommodation costs';
+//        $this->getSession()->getPage()->selectFieldOption('money_short[moneyShortCategoriesOut][1][present]', '1');
+//        $this->categoryList[] = 'care fees';
+//        $this->getSession()->getPage()->selectFieldOption('money_short[moneyShortCategoriesOut][2][present]', '1');
+//        $this->categoryList[] = 'holidays and trips';
+//        $this->getSession()->getPage()->selectFieldOption('money_short[moneyShortCategoriesOut][3][present]', '1');
+//        $this->categoryList[] = 'household bills';
+//        $this->getSession()->getPage()->selectFieldOption('money_short[moneyShortCategoriesOut][4][present]', '1');
+//        $this->categoryList[] = 'personal allowance';
+//        $this->getSession()->getPage()->selectFieldOption('money_short[moneyShortCategoriesOut][5][present]', '1');
+//        $this->categoryList[] = 'professional fees';
+//        $this->getSession()->getPage()->selectFieldOption('money_short[moneyShortCategoriesOut][6][present]', '1');
+//        $this->categoryList[] = 'new investments';
+//        $this->getSession()->getPage()->selectFieldOption('money_short[moneyShortCategoriesOut][7][present]', '1');
+//        $this->categoryList[] = 'travel costs';
+//        $this->iClickBasedOnAttributeTypeAndValue('button', 'id', 'money_short_save');
+//    }
+//
+//    /**
+//     * @When I answer that there are a couple of one-off payments over £1k
+//     */
+//    public function iAnswerTwoOneOffPaymentsOver1k()
+//    {
+//        $this->oneOffPaymentOver1kExists('yes');
+//        $this->addAMoneyOutPayment('test_payment_1', '1001', '01', '02', '2019');
+//        $this->addAnotherMoneyOutPayment('yes');
+//        $this->addAMoneyOutPayment('test_payment_2', '1002', '03', '04', '2020');
+//        $this->addAnotherMoneyOutPayment('no');
+//        $this->iAmOnMoneyOutShortSummaryPage();
+//    }
+//
+//    /**
+//     * @When I remove an existing money out payment
+//     */
+//    public function iRemoveOneOffPayment()
+//    {
+//        $this->iVisitMoneyOutShortSummarySection();
+//        $this->iAmOnMoneyOutShortSummaryPage();
+//        $urlRegex = sprintf('/%s\/.*\/money-out-short\/exist.*$/', $this->reportUrlPrefix);
+//        $this->iClickOnNthElementBasedOnRegex($urlRegex, 0);
+//        $this->oneOffPaymentOver1kExists('yes');
+//        $this->addAMoneyOutPayment('to_remove_1', '1003', '10', '11', '2019');
+//        $this->addAnotherMoneyOutPayment('yes');
+//        $this->addAMoneyOutPayment('to_remove_2', '1004', '11', '12', '2020');
+//        $this->addAnotherMoneyOutPayment('no');
+//        $this->iAmOnMoneyOutShortSummaryPage();
+//        $this->iRemoveAOneOffPayment(0);
+//        $this->iAmOnMoneyOutShortSummaryPage();
+//    }
+//
+//    /**
+//     * @When I edit an existing money out payment
+//     */
+//    public function iEditOneOffPayment()
+//    {
+//        $this->iVisitMoneyOutShortSummarySection();
+//        $this->iAmOnMoneyOutShortSummaryPage();
+//        $urlRegex = sprintf('/%s\/.*\/money-out-short\/exist.*$/', $this->reportUrlPrefix);
+//        $this->iClickOnNthElementBasedOnRegex($urlRegex, 0);
+//        $this->oneOffPaymentOver1kExists('yes');
+//        $this->addAMoneyOutPayment('to_edit_1', '1004', '08', '10', '2019');
+//        $this->addAnotherMoneyOutPayment('no');
+//        $this->iAmOnMoneyOutShortSummaryPage();
+//        $this->iEditAOneOffPayment(0, 'to_edit_2', '1005', '09', '11', '2020');
+//        $this->iAmOnMoneyOutShortSummaryPage();
+//    }
+//
+//    /**
+//     * @When I add a payment and state no further payments
+//     */
+//    public function iAddAPaymentAndStateNoFurtherPayments()
+//    {
+//        $this->iVisitMoneyOutShortSummarySection();
+//        $this->iAmOnMoneyOutShortSummaryPage();
+//        $urlRegex = sprintf('/%s\/.*\/money-out-short\/exist.*$/', $this->reportUrlPrefix);
+//        $this->iClickOnNthElementBasedOnRegex($urlRegex, 0);
+//        $this->oneOffPaymentOver1kExists('yes');
+//        $this->addAMoneyOutPayment('payment_1', '1006', '01', '01', '2018');
+//        $this->addAnotherMoneyOutPayment('no');
+//    }
+//
+//    /**
+//     * @When I change my mind and add another payment
+//     */
+//    public function iChangeMyMindAndAddAnotherPayment()
+//    {
+//        $this->iAmOnMoneyOutShortSummaryPage();
+//        $urlRegex = sprintf('/%s\/.*\/money-out-short\/add.*$/', $this->reportUrlPrefix);
+//        $this->iClickOnNthElementBasedOnRegex($urlRegex, 0);
+//        $this->addAMoneyOutPayment('payment_1', '1006', '01', '01', '2018');
+//        $this->addAnotherMoneyOutPayment('no');
+//        $this->iAmOnMoneyOutShortSummaryPage();
+//    }
+//
+//    /**
+//     * @When I add a one off payment of less than £1k
+//     */
+//    public function iAddAOneOffPaymentOfLessThan1k()
+//    {
+//        $this->iVisitMoneyOutShortSummarySection();
+//        $this->iAmOnMoneyOutShortSummaryPage();
+//        $urlRegex = sprintf('/%s\/.*\/money-out-short\/exist.*$/', $this->reportUrlPrefix);
+//        $this->iClickOnNthElementBasedOnRegex($urlRegex, 0);
+//        $this->oneOffPaymentOver1kExists('yes');
+//        $this->addAMoneyOutPayment('payment_1', '10', '01', '01', '2018');
+//    }
+//
+//    /**
+//     * @Then I should see correct validation message
+//     */
+//    public function iShouldSeeCorrectValidationMessage()
+//    {
+//        $this->assertOnAlertMessage('Please input a value of at least £1,000');
+//    }
+//
+//    /**
+//     * @Then I should see the expected money out section summary
+//     */
+//    public function iShouldSeeTheExpectedMoneyOutSummary()
+//    {
+//        $this->iAmOnMoneyOutShortSummaryPage();
+//
+//        if (count($this->categoryList) > 0) {
+//            $categoryWrapper[] = $this->categoryList;
+//        } else {
+//            $categoryWrapper[] = ['none'];
+//        }
+//
+//        $this->expectedResultsDisplayed(0, $categoryWrapper, 'Categories Entered');
+//
+//        if (count($this->oneOffPaymentsList) > 0) {
+//            $oneOffExistsWrapper[] = ['yes'];
+//        } else {
+//            $oneOffExistsWrapper[] = ['no'];
+//        }
+//
+//        // Check the one off payments exist response
+//        $this->expectedResultsDisplayed(1, $oneOffExistsWrapper, 'Answers for "One off payments exist"');
+//
+//        // Only check if we have one off payments
+//        if (count($this->oneOffPaymentsList) > 0) {
+//            // get one of payments nested array into the correct format to compare
+//            $expectedOneOffPayments = $this->oneOffPaymentsList;
+//            foreach ($expectedOneOffPayments as $oneOffPaymentKey => $oneOffPayment) {
+//                $expectedOneOffPayments[$oneOffPaymentKey]['amount'] = $this->moneyFormat($this->oneOffPaymentsList[$oneOffPaymentKey]['amount']);
+//                $dateTimestamp = sprintf(
+//                    '%s-%s-%s 00:00',
+//                    $expectedOneOffPayments[$oneOffPaymentKey]['year'],
+//                    $expectedOneOffPayments[$oneOffPaymentKey]['month'],
+//                    $expectedOneOffPayments[$oneOffPaymentKey]['day']
+//                );
+//                $date = date('j F Y', strtotime($dateTimestamp));
+//                //            $expectedOneOffPayments[$oneOffPaymentKey]['date'] = $date;
+//                unset($expectedOneOffPayments[$oneOffPaymentKey]['day']);
+//                unset($expectedOneOffPayments[$oneOffPaymentKey]['month']);
+//                unset($expectedOneOffPayments[$oneOffPaymentKey]['year']);
+//                $expectedOneOffPayments[$oneOffPaymentKey] = $this->insertArrayAtPosition($expectedOneOffPayments[$oneOffPaymentKey], ['date' => $date], 1);
+//                $this->oneOffPaymentsTotal += floatval($this->oneOffPaymentsList[$oneOffPaymentKey]['amount']);
+//            }
+//            $expectedOneOffPayments = array_values($expectedOneOffPayments);
+//
+//            // Check the individual one off payments
+//            $this->expectedResultsDisplayed(2, $expectedOneOffPayments, 'One of payments details');
+//            // Check the total
+//            $this->expectedResultsDisplayed(3, [[$this->moneyFormat($this->oneOffPaymentsTotal)]], 'One of payments total');
+//        }
+//    }
+//
+//    private function iEditAOneOffPayment($paymentOccurrence, $description, $amount, $day, $month, $year)
+//    {
+//        // Click on the nth row to delete
+//        $urlRegex = sprintf('/%s\/.*\/money-out-short\/edit\/[0-9].*$/', $this->reportUrlPrefix);
+//        $this->iClickOnNthElementBasedOnRegex($urlRegex, $paymentOccurrence);
+//        $this->iAmOnMoneyOutShortEditPage();
+//
+//        // Remove the payment from our array
+//        $this->oneOffPaymentsList[$paymentOccurrence]['description'] = $description;
+//        $this->oneOffPaymentsList[$paymentOccurrence]['amount'] = $amount;
+//        $this->oneOffPaymentsList[$paymentOccurrence]['day'] = $day;
+//        $this->oneOffPaymentsList[$paymentOccurrence]['month'] = $month;
+//        $this->oneOffPaymentsList[$paymentOccurrence]['year'] = $year;
+//        $this->oneOffPaymentsList = array_values($this->oneOffPaymentsList);
+//
+//        $this->fillField('money_short_transaction[description]', $description);
+//        $this->fillField('money_short_transaction[amount]', $amount);
+//        $this->fillField('money_short_transaction[date][day]', $day);
+//        $this->fillField('money_short_transaction[date][month]', $month);
+//        $this->fillField('money_short_transaction[date][year]', $year);
+//        $this->iClickBasedOnAttributeTypeAndValue('button', 'id', 'money_short_transaction_save');
+//    }
+//
+//    private function iRemoveAOneOffPayment($paymentOccurrence)
+//    {
+//        // Click on the nth row to delete
+//        $urlRegex = sprintf('/%s\/.*\/money-out-short\/.*\/delete$/', $this->reportUrlPrefix);
+//        $this->iClickOnNthElementBasedOnRegex($urlRegex, $paymentOccurrence);
+//
+//        // Remove the payment from our array
+//        unset($this->oneOffPaymentsList[$paymentOccurrence]);
+//        $this->oneOffPaymentsList = array_values($this->oneOffPaymentsList);
+//
+//        $this->iClickBasedOnAttributeTypeAndValue('button', 'id', 'confirm_delete_confirm');
+//    }
+//
+//    private function oneOffPaymentOver1kExists($selection)
+//    {
+//        $this->iAmOnMoneyOutShortExistsPage();
+//        $this->selectOption('yes_no[moneyTransactionsShortOutExist]', $selection);
+//        $this->iClickBasedOnAttributeTypeAndValue('button', 'id', 'yes_no_save');
+//    }
+//
+//    private function addAMoneyOutPayment($description, $amount, $day, $month, $year)
+//    {
+//        $oneOffPayment = [
+//            'description' => $description,
+//            'amount' => $amount,
+//            'day' => $day,
+//            'month' => $month,
+//            'year' => $year,
+//        ];
+//
+//        $this->oneOffPaymentsList[] = $oneOffPayment;
+//
+//        $this->iAmOnMoneyOutShortAddPage();
+//        $this->fillField('money_short_transaction[description]', $description);
+//        $this->fillField('money_short_transaction[amount]', $amount);
+//        $this->fillField('money_short_transaction[date][day]', $day);
+//        $this->fillField('money_short_transaction[date][month]', $month);
+//        $this->fillField('money_short_transaction[date][year]', $year);
+//        $this->iClickBasedOnAttributeTypeAndValue('button', 'id', 'money_short_transaction_save');
+//    }
+//
+//    private function addAnotherMoneyOutPayment($selection)
+//    {
+//        $this->iAmOnMoneyOutShortAddAnotherPage();
+//        $this->selectOption('add_another[addAnother]', $selection);
+//        $this->iClickBasedOnAttributeTypeAndValue('button', 'id', 'add_another_save');
+//    }
+//
+//    private function moneyFormat($value)
+//    {
+//        return number_format(floatval($value), 2, '.', ',');
+//    }
+//
+//    private function insertArrayAtPosition($array, $insert, $position)
+//    {
+//        /*
+//        $array : The initial array i want to modify
+//        $insert : the new array i want to add, eg array('key' => 'value') or array('value')
+//        $position : the position where the new array will be inserted into. Please mind that arrays start at 0
+//        */
+//        return array_slice($array, 0, $position, true) + $insert + array_slice($array, $position, null, true);
+//    }
+}

--- a/api/tests/Behat/bootstrap/v2/Reporting/Sections/MoneyOutShortSectionTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Reporting/Sections/MoneyOutShortSectionTrait.php
@@ -11,7 +11,7 @@ trait MoneyOutShortSectionTrait
     private float $oneOffPaymentsTotal = 0.0;
 
     /**
-     * @When I view and start the money out report section
+     * @When I view and start the money out short report section
      */
     public function iViewAndStartMoneyOutShortSection()
     {
@@ -296,10 +296,10 @@ trait MoneyOutShortSectionTrait
         $this->iClickBasedOnAttributeTypeAndValue('button', 'id', 'add_another_save');
     }
 
-    private function moneyFormat($value)
-    {
-        return number_format(floatval($value), 2, '.', ',');
-    }
+//    private function moneyFormat($value)
+//    {
+//        return number_format(floatval($value), 2, '.', ',');
+//    }
 
     private function insertArrayAtPosition($array, $insert, $position)
     {

--- a/api/tests/Behat/bootstrap/v2/Reporting/Sections/MoneyOutShortSectionTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Reporting/Sections/MoneyOutShortSectionTrait.php
@@ -89,7 +89,7 @@ trait MoneyOutShortSectionTrait
     }
 
     /**
-     * @When I remove an existing money out payment
+     * @When I remove an existing money out short payment
      */
     public function iRemoveOneOffPayment()
     {
@@ -108,9 +108,9 @@ trait MoneyOutShortSectionTrait
     }
 
     /**
-     * @When I edit an existing money out payment
+     * @When I edit an existing money out short payment
      */
-    public function iEditOneOffPayment()
+    public function iEditOneOffShortPayment()
     {
         $this->iVisitMoneyOutShortSummarySection();
         $this->iAmOnMoneyOutShortSummaryPage();
@@ -120,7 +120,7 @@ trait MoneyOutShortSectionTrait
         $this->addAMoneyOutPayment('to_edit_1', '1004', '08', '10', '2019');
         $this->addAnotherMoneyOutPayment('no');
         $this->iAmOnMoneyOutShortSummaryPage();
-        $this->iEditAOneOffPayment(0, 'to_edit_2', '1005', '09', '11', '2020');
+        $this->iEditAOneOffShortPayment(0, 'to_edit_2', '1005', '09', '11', '2020');
         $this->iAmOnMoneyOutShortSummaryPage();
     }
 
@@ -225,7 +225,7 @@ trait MoneyOutShortSectionTrait
         }
     }
 
-    private function iEditAOneOffPayment($paymentOccurrence, $description, $amount, $day, $month, $year)
+    private function iEditAOneOffShortPayment($paymentOccurrence, $description, $amount, $day, $month, $year)
     {
         // Click on the nth row to delete
         $urlRegex = sprintf('/%s\/.*\/money-out-short\/edit\/[0-9].*$/', $this->reportUrlPrefix);
@@ -295,11 +295,6 @@ trait MoneyOutShortSectionTrait
         $this->selectOption('add_another[addAnother]', $selection);
         $this->iClickBasedOnAttributeTypeAndValue('button', 'id', 'add_another_save');
     }
-
-//    private function moneyFormat($value)
-//    {
-//        return number_format(floatval($value), 2, '.', ',');
-//    }
 
     private function insertArrayAtPosition($array, $insert, $position)
     {

--- a/api/tests/Behat/bootstrap/v2/Reporting/Sections/ReportingSectionsFeatureContext.php
+++ b/api/tests/Behat/bootstrap/v2/Reporting/Sections/ReportingSectionsFeatureContext.php
@@ -15,6 +15,7 @@ class ReportingSectionsFeatureContext extends BaseFeatureContext
     use DocumentsSectionTrait;
     use GiftsSectionTrait;
     use MoneyOutShortSectionTrait;
+    use MoneyOutSectionTrait;
     use VisitsCareSectionTrait;
     use MoneyInHighAssetsTrait;
 
@@ -176,5 +177,10 @@ class ReportingSectionsFeatureContext extends BaseFeatureContext
     public function iChooseToSaveAndContinue()
     {
         $this->pressButton('Save and continue');
+    }
+
+    public function moneyFormat($value)
+    {
+        return number_format(floatval($value), 2, '.', ',');
     }
 }

--- a/api/tests/Behat/features-v2/reporting/sections/money-out/money-out-short.feature
+++ b/api/tests/Behat/features-v2/reporting/sections/money-out/money-out-short.feature
@@ -31,12 +31,12 @@ Feature: Money Out Short
 
   Scenario: A user removes a one off payment
     Given a Lay Deputy has completed a Pfa Low Assets report
-    When I remove an existing money out payment
+    When I remove an existing money out short payment
     Then I should see the expected money out section summary
 
   Scenario: A user edits a one off payment
     Given a Lay Deputy has completed a Pfa Low Assets report
-    When I edit an existing money out payment
+    When I edit an existing money out short payment
     Then I should see the expected money out section summary
 
   Scenario: A user adds an additional one off payment

--- a/api/tests/Behat/features-v2/reporting/sections/money-out/money-out-short.feature
+++ b/api/tests/Behat/features-v2/reporting/sections/money-out/money-out-short.feature
@@ -1,11 +1,11 @@
-@v2 @money-out
-Feature: Money Out
+@v2 @money-out-short
+Feature: Money Out Short
 
   Scenario: A user has had no money go out
     Given a Lay Deputy has not started a Pfa Low Assets report
     And I visit the report overview page
     Then I should see "money-out-short" as "not started"
-    When I view and start the money out report section
+    When I view and start the money out short report section
     And I have made no payments out
     Then I should see the expected money out section summary
     When I follow link back to report overview page
@@ -13,7 +13,7 @@ Feature: Money Out
 
   Scenario: A user has had some money go out but nothing over £1k
     Given a Lay Deputy has not started a Pfa Low Assets report
-    When I view and start the money out report section
+    When I view and start the money out short report section
     And I add some categories of money paid out
     And I answer that there are no one-off payments over £1k
     Then I should see the expected money out section summary
@@ -22,7 +22,7 @@ Feature: Money Out
 
   Scenario: A user has had some money go out including payments over £1k
     Given a Lay Deputy has not started a Pfa Low Assets report
-    When I view and start the money out report section
+    When I view and start the money out short report section
     And I add all the categories of money paid out
     And I answer that there are a couple of one-off payments over £1k
     Then I should see the expected money out section summary

--- a/api/tests/Behat/features-v2/reporting/sections/money-out/money-out.feature
+++ b/api/tests/Behat/features-v2/reporting/sections/money-out/money-out.feature
@@ -1,13 +1,13 @@
 @v2 @money-out
 Feature: Money Out
 
-#  Scenario: A user attempts to not enter any payments
-#    Given a Lay Deputy has not started a Pfa High Assets report
-#    And I visit the report overview page
-#    Then I should see "money-out" as "not started"
-#    When I view and start the money out report section
-#    And I try to save and continue without adding a payment
-#    Then I should see correct money out validation message
+  Scenario: A user attempts to not enter any payments
+    Given a Lay Deputy has not started a Pfa High Assets report
+    And I visit the report overview page
+    Then I should see "money-out" as "not started"
+    When I view and start the money out report section
+    And I try to save and continue without adding a payment
+    Then I should see correct money out validation message
 
   Scenario: A user adds one of each payment type
     Given a Lay Deputy has not started a Pfa High Assets report
@@ -17,24 +17,28 @@ Feature: Money Out
     When I follow link back to report overview page
     Then I should see "money-out" as "39 items"
 
-  Scenario: A user removes a one off payment
+  Scenario: A user removes a payment
     Given a Lay Deputy has completed a Pfa High Assets report
-    When I remove an existing money out payment
-    Then I should see the the expected results on money out page
-    Then I should see the expected money out section summary
+    When I visit the money out summary section
+    And I remove an existing money out payment
+    Then I should see the expected results on money out summary page
 
-#  Scenario: A user edits a one off payment
-#    Given a Lay Deputy has completed a Pfa Low Assets report
-#    When I edit an existing money out payment
-#    Then I should see the expected money out section summary
-#
-#  Scenario: A user adds an additional one off payment
-#    Given a Lay Deputy has completed a Pfa Low Assets report
-#    When I add a payment and state no further payments
-#    When I change my mind and add another payment
-#    Then I should see the expected money out section summary
-#
-#  Scenario: A user tries to add a one off payment of less than £1k
-#    Given a Lay Deputy has completed a Pfa Low Assets report
-#    When I add a one off payment of less than £1k
-#    Then I should see correct validation message
+  Scenario: A user edits an existing payment
+    Given a Lay Deputy has completed a Pfa High Assets report
+    When I visit the money out summary section
+    And I edit an existing money out payment
+    Then I should see the expected results on money out summary page
+
+  Scenario: A user adds an additional payment
+    Given a Lay Deputy has completed a Pfa High Assets report
+    When I visit the money out summary section
+    When I add another money out payment from an existing account
+    Then I should see the expected results on money out summary page
+
+  Scenario: A user tries to add a one off payment of less than £1k
+    Given a Lay Deputy has not started a Pfa High Assets report
+    When I view and start the money out report section
+    And I add a payment without filling in description
+    Then I should see correct money out description validation message
+    When I add a payment without filling in amount
+    Then I should see correct money out amount validation message

--- a/api/tests/Behat/features-v2/reporting/sections/money-out/money-out.feature
+++ b/api/tests/Behat/features-v2/reporting/sections/money-out/money-out.feature
@@ -1,0 +1,40 @@
+@v2 @money-out
+Feature: Money Out
+
+#  Scenario: A user attempts to not enter any payments
+#    Given a Lay Deputy has not started a Pfa High Assets report
+#    And I visit the report overview page
+#    Then I should see "money-out" as "not started"
+#    When I view and start the money out report section
+#    And I try to save and continue without adding a payment
+#    Then I should see correct money out validation message
+
+  Scenario: A user adds one of each payment type
+    Given a Lay Deputy has not started a Pfa High Assets report
+    When I view and start the money out report section
+    And I add one of each type of money out payment
+    Then I should see the expected results on money out summary page
+    When I follow link back to report overview page
+    Then I should see "money-out" as "39 items"
+
+  Scenario: A user removes a one off payment
+    Given a Lay Deputy has completed a Pfa High Assets report
+    When I remove an existing money out payment
+    Then I should see the the expected results on money out page
+    Then I should see the expected money out section summary
+
+#  Scenario: A user edits a one off payment
+#    Given a Lay Deputy has completed a Pfa Low Assets report
+#    When I edit an existing money out payment
+#    Then I should see the expected money out section summary
+#
+#  Scenario: A user adds an additional one off payment
+#    Given a Lay Deputy has completed a Pfa Low Assets report
+#    When I add a payment and state no further payments
+#    When I change my mind and add another payment
+#    Then I should see the expected money out section summary
+#
+#  Scenario: A user tries to add a one off payment of less than £1k
+#    Given a Lay Deputy has completed a Pfa Low Assets report
+#    When I add a one off payment of less than £1k
+#    Then I should see correct validation message


### PR DESCRIPTION
## Purpose

Money out long section behat tests as run on pfa high assets

![image](https://user-images.githubusercontent.com/58939809/119160429-2c668b80-ba50-11eb-96f1-1a82ff6aaffa.png)

Fixes DDPB-3482

## Approach
This one was a tricksey one so it twas. Because of the extra subsection type layout in the summary page, it made any sort of looping a bit painful. Worked it out eventually and using the expected helper function didn't make this any more difficult really. Just had to think about the structure of the objects...

## Learning
Nothing really except that these ones are a pain.. not sure if the next one of these type will be much quicker. Hopefully a bit now we have a template...

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
