### PR TITLE
Tweak behat colours

### DIFF
--- a/api/tests/Behat/behat.yml
+++ b/api/tests/Behat/behat.yml
@@ -199,6 +199,20 @@ cross-browser-android-chrome:
                     build: 'Android'
 
 v2-tests-goutte:
+    formatters:
+        pretty:
+            output_styles:
+                passed: [ white, green, [ bold ] ]
+                passed_param: [ white, green, [ underscore, bold ] ]
+                undefined: [ yellow, null, [ underscore, bold ] ]
+                pending: [ yellow, null, [ underscore ] ]
+                pending_param: [ yellow, null, [ underscore, bold ] ]
+                failed: [ white, red, [ bold ] ]
+                failed_param: [ white, red, [ underscore, bold ] ]
+                skipped: [ cyan ]
+                skipped_param: [ cyan, null, [ bold ] ]
+                comment: [ cyan ]
+                tag: [ cyan ]
     suites:
         feedback:
             description: Covering features that allow users to give us feedback


### PR DESCRIPTION
## Purpose
Increases contrast for both light and dark terminals when outputting behat text.

Before:
![Screenshot 2021-06-08 at 12 30 57](https://user-images.githubusercontent.com/17926619/121338228-35db6900-c915-11eb-81ea-71f979651421.png)

![Screenshot 2021-06-09 at 11 30 20](https://user-images.githubusercontent.com/17926619/121339175-1f81dd00-c916-11eb-8d4a-2f90ab1544dc.png)


After:
![Screenshot 2021-06-09 at 11 10 16](https://user-images.githubusercontent.com/17926619/121338251-3bd14a00-c915-11eb-9e99-60226eb3bc87.png)

![Screenshot 2021-06-09 at 11 29 30](https://user-images.githubusercontent.com/17926619/121339195-26105480-c916-11eb-9a03-a218eb4860f6.png)
