### PR TITLE
Revert wkhtmltopdf changes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,9 +153,9 @@ services:
         restart: always
 
     file-scanner-server:
-        image: mkodockx/docker-clamav:1.0.1-alpine
+        image: mkodockx/docker-clamav:1.0.3-alpine
         environment:
-            CLAMD_CONF_SelfCheck: 0
+            CLAMD_CONF_SelfCheck: 100000
             FRESHCLAM_CONF_NotifyClamd: 'no'
 
     file-scanner-rest:

--- a/environment/scan.tf
+++ b/environment/scan.tf
@@ -115,7 +115,7 @@ EOF
       "healthCheck": {
         "command": [
           "CMD-SHELL",
-          "wget --quiet --tries=1 --spider http://localhost:3310/"
+          "wget --quiet --tries=3 --spider http://localhost:3310/"
         ],
         "interval": 30,
         "retries": 5,
@@ -130,7 +130,7 @@ EOF
         }
       },
       "environment": [
-        { "name": "CLAMD_CONF_SelfCheck", "value": "0" },
+        { "name": "CLAMD_CONF_SelfCheck", "value": "100000" },
         { "name": "FRESHCLAM_CONF_NotifyClamd", "value": "no" }
       ]
   }

--- a/wkhtmltopdf/Dockerfile
+++ b/wkhtmltopdf/Dockerfile
@@ -1,19 +1,23 @@
-FROM python:3.10-rc-alpine3.14
+FROM python:3.10-rc-slim-buster
 
-RUN apk update
-RUN apk add bash wkhtmltopdf curl xvfb fontconfig freetype ttf-dejavu ttf-droid ttf-freefont ttf-liberation
-RUN apk upgrade
+# Download and install wkhtmltopdf and bash (because executor can't use 'sh')
+RUN apt-get update \
+    && apt-get -y install fontconfig libjpeg62-turbo libx11-6 libxcb1 libxext6 libxrender1 curl \
+    && apt-get -y install cron wget xfonts-base xfonts-75dpi \
+    && apt-get -y upgrade \
+    && wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox_0.12.6-1.stretch_amd64.deb \
+    && dpkg -i wkhtmltox_0.12.6-1.stretch_amd64.deb
 
 # Install dependencies for running web service
 RUN pip install werkzeug==1.0.1 executor==23.2 gunicorn==20.0.4
 
 ADD docker-entrypoint.sh /docker-entrypoint.sh
 ADD app.py /app.py
-ADD clean-tmp /etc/periodic/hourly/clean-tmp
+ADD clean-tmp /etc/cron.hourly/clean-tmp
 EXPOSE 80
 
 # Make commands executable
-RUN ["chmod", "+x", "/etc/periodic/hourly/clean-tmp"]
+RUN ["chmod", "+x", "/etc/cron.hourly/clean-tmp"]
 RUN ["chmod", "+x", "/docker-entrypoint.sh"]
 
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
Despite it working flawlessly and passing all the tests and generating lovely pdfs, the alerts brought up some interesting behaviour. 

Turns our our new alpine version uses a lot more cpu and memory and so dies after a while on smaller specced services. Couldn't guarantee the behaviour on prod and don't really want to just up the services. Also it seems to take a bit longer to generate PDFs. Not hugely longer but enough to give us response time alerts from manage/availability...

Tried a few things...

tried to make my own binary work in alpine.. failed. Tried to up glibc version but it's super baked into buster. Tried to use a python slim debian bullseye image but none existed so made one from scratch. That worked but it still had lots of sec vulnerabilities so not a huge point there.. I think if we want no sec vulns long term then we really need to use alpine images. 

Looked at weasyprint. It's python and looks like easy replacement. That would be my suggestion...

I also checked out issues we had on prod with clamav last sunday and before. The actual thing that caused it to bring up new services was a failed local healthcheck. This may be due to high cpu as it did go high but memory stayed the same and actually the memory could be the new service starting up. The logs were as clean as a whistle except the self checks which it's not supposed to do.  Set retry count to 3 on the healthcheck to see if that evens it out. 
I looked found out through trial and error that the env var for self check is working but 0 just makes it revert to default which is every 10 mins. I've set it 100000 secs which is a nice round number that is over 24 hours (which is when the overnight job restarts it) so this should have the effect of it not doing self checks... I'm fairly confident this will fix all our clam woes..