### PR TITLE
DDPB-3943 behat tests for user administration

### DIFF
--- a/api/tests/Behat/behat.yml
+++ b/api/tests/Behat/behat.yml
@@ -334,6 +334,11 @@ v2-tests-goutte:
             contexts:
                 - App\Tests\Behat\v2\Reporting\Sections\ReportingSectionsFeatureContext
 
+        user-management:
+            description: Covering the user management features of the app (admin)
+            paths: [ "%paths.base%/features-v2/user-management" ]
+            contexts:
+                - App\Tests\Behat\v2\UserManagement\UserManagementFeatureContext
     extensions:
         Behat\MinkExtension:
             files_path: '%paths.base%/fixtures/'

--- a/api/tests/Behat/bootstrap/v2/Common/AlertsTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/AlertsTrait.php
@@ -8,16 +8,8 @@ trait AlertsTrait
 {
     public function assertOnAlertMessage(string $alertMessage)
     {
-        $alertDiv = $this->getSession()->getPage()->find('css', 'div.opg-alert--info');
-        if (is_null($alertDiv)) {
-            // fall back to error div
-            $alertDiv = $this->getSession()->getPage()->find('css', 'div.govuk-error-summary');
-            if (is_null($alertDiv)) {
-                $this->throwContextualException(
-                    'A div with the class opg-alert--info was not found. This suggests the page is not what was expected or a condition to display an alert has not been met'
-                );
-            }
-        }
+        $xpath = '//div[contains(@class, \'opg-alert__message\')]|//div[contains(@class, \'opg-alert--info\')]|//div[contains(@class, \'govuk-error-summary\')]';
+        $alertDiv = $this->getSession()->getPage()->find('xpath', $xpath);
 
         $alertHtml = $alertDiv->getHtml();
         $alertMessageFound = str_contains($alertHtml, $alertMessage);

--- a/api/tests/Behat/bootstrap/v2/Common/AlertsTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/AlertsTrait.php
@@ -8,7 +8,7 @@ trait AlertsTrait
 {
     public function assertOnAlertMessage(string $alertMessage)
     {
-        $xpath = '//div[contains(@class, \'opg-alert__message\')]|//div[contains(@class, \'opg-alert--info\')]|//div[contains(@class, \'govuk-error-summary\')]';
+        $xpath = '//div[contains(@class, "opg-alert__message")]|//div[contains(@class, "opg-alert--info")]|//div[contains(@class, "govuk-error-summary")]';
         $alertDiv = $this->getSession()->getPage()->find('xpath', $xpath);
 
         $alertHtml = $alertDiv->getHtml();

--- a/api/tests/Behat/bootstrap/v2/Common/AssertTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/AssertTrait.php
@@ -43,6 +43,29 @@ trait AssertTrait
         );
     }
 
+    public function assertBoolIsTrue(
+        $expected,
+        string $comparisonSubject
+    ) {
+        assert(
+            true == $expected,
+            $this->getAssertMessage($expected, 'false', $comparisonSubject)
+        );
+    }
+
+    public function assertStringDoesNotContainString(
+        $notExpected,
+        $found,
+        string $comparisonSubject
+    ) {
+        $foundFormatted = strval(trim(strtolower($found)));
+        $notExpectedFormatted = strval(trim(strtolower($notExpected)));
+        assert(
+            !str_contains($foundFormatted, $notExpectedFormatted),
+            $this->getAssertMessage('\''.$notExpectedFormatted.'\' should not exist in searched element!', $foundFormatted, $comparisonSubject)
+        );
+    }
+
     private function getAssertMessage(
         $expected,
         $found,

--- a/api/tests/Behat/bootstrap/v2/Common/AssertTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/AssertTrait.php
@@ -48,7 +48,7 @@ trait AssertTrait
         string $comparisonSubject
     ) {
         assert(
-            true == $expected,
+            true === $expected,
             $this->getAssertMessage($expected, 'false', $comparisonSubject)
         );
     }

--- a/api/tests/Behat/bootstrap/v2/Common/BaseFeatureContext.php
+++ b/api/tests/Behat/bootstrap/v2/Common/BaseFeatureContext.php
@@ -373,4 +373,14 @@ class BaseFeatureContext extends MinkContext
         $rndKey = rand(0, 99999);
         $this->fixtureHelper->createDataForAnalytics('a_'.'_'.strval($rndKey).strval($runNumber), $timeAgo, $satisfactionScore);
     }
+
+    public function createAdditionalDataForUserSearchTests()
+    {
+        $this->fixtureHelper->createDataForAdminUserTests('search');
+    }
+
+    public function createAdditionalDataForUserEditTests()
+    {
+        $this->fixtureHelper->createDataForAdminUserTests('edit');
+    }
 }

--- a/api/tests/Behat/bootstrap/v2/Common/ElementSelectionTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/ElementSelectionTrait.php
@@ -64,6 +64,13 @@ trait ElementSelectionTrait
         $element->click();
     }
 
+    public function clickBasedOnText($text)
+    {
+        $xpath = sprintf('//a[text()[contains(., \'%s\')]]', $text);
+        $link = $this->getSession()->getPage()->find('xpath', $xpath);
+        $link->click();
+    }
+
     /**
      * @param string $sectionText Text that appears in the row/container element with the link you want to select
      * @param string $linkText    Text of the link you want to select

--- a/api/tests/Behat/bootstrap/v2/Common/ElementSelectionTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/ElementSelectionTrait.php
@@ -102,10 +102,10 @@ trait ElementSelectionTrait
     public function iClickBasedOnAttributeTypeAndValue(string $elementType, string $attributeType, string $attributeValue)
     {
         $xpath = sprintf("//%s[@%s='%s']", $elementType, $attributeType, $attributeValue);
-        $session = $this->getSession();
-        $element = $session->getPage()->find(
+
+        $element = $this->getSession()->getPage()->find(
             'xpath',
-            $session->getSelectorsHandler()->selectorToXpath('xpath', $xpath)
+            $xpath
         );
 
         if (null === $element) {

--- a/api/tests/Behat/bootstrap/v2/Common/INavigateToAdminTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/INavigateToAdminTrait.php
@@ -31,6 +31,15 @@ trait INavigateToAdminTrait
     }
 
     /**
+     * @When I navigate to the add a new user page
+     */
+    public function iNavigateToAddNewUser()
+    {
+        $this->iAmOnAdminUsersSearchPage();
+        $this->clickBasedOnText('Add new user');
+    }
+
+    /**
      * @When I navigate to the admin analytics page
      */
     public function iNavigateToAdminAnalyticsSearchPage()

--- a/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnAdminTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnAdminTrait.php
@@ -37,6 +37,38 @@ trait IShouldBeOnAdminTrait
     }
 
     /**
+     * @Then I should be on the admin view user page
+     */
+    public function iAmOnAdminViewUserPage()
+    {
+        return $this->iAmOnPage('/admin\/user\/[0-9].*/');
+    }
+
+    /**
+     * @Then I should be on the admin add user page
+     */
+    public function iAmOnAdminAddUserPage()
+    {
+        return $this->iAmOnPage('/admin\/user-add$/');
+    }
+
+    /**
+     * @Then I should be on the admin edit user page
+     */
+    public function iAmOnAdminEditUserPage()
+    {
+        return $this->iAmOnPage('/admin\/edit-user.*$/');
+    }
+
+    /**
+     * @Then I should be on the admin delete confirm user page
+     */
+    public function iAmOnAdminDeleteConfirmUserPage()
+    {
+        return $this->iAmOnPage('/admin\/delete-confirm\/[0-9].*$/');
+    }
+
+    /**
      * @Then I should be on the admin organisation search page
      */
     public function iAmOnAdminOrganisationSearchPage()

--- a/api/tests/Behat/bootstrap/v2/Common/IVisitAdminTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/IVisitAdminTrait.php
@@ -61,6 +61,14 @@ trait IVisitAdminTrait
     }
 
     /**
+     * @When I visit the admin Search Users page
+     */
+    public function iVisitAdminSearchUserPage()
+    {
+        $this->visitAdminPath($this->getAdminSearchUserPage());
+    }
+
+    /**
      * @When I visit the admin View User page for the user I'm interacting with
      */
     public function iVisitAdminViewUserPageForInteractingWithUser()

--- a/api/tests/Behat/bootstrap/v2/Common/PageUrlsTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/PageUrlsTrait.php
@@ -37,6 +37,7 @@ trait PageUrlsTrait
     private string $adminClientSearchUrl = '/admin/client/search';
     private string $adminClientDetailsUrl = '/admin/client/%s/details';
     private string $adminAddUserUrl = '/admin/user-add';
+    private string $adminUserSearchUrl = '/admin';
     private string $adminViewUserUrl = '/admin/user/%s';
     private string $adminEditUserUrl = '/admin/edit-user?filter=%s';
     private string $adminMyUserProfileUrl = '/deputyship-details/your-details';
@@ -148,6 +149,11 @@ trait PageUrlsTrait
     public function getAdminAddUserPage(): string
     {
         return $this->adminAddUserUrl;
+    }
+
+    public function getAdminSearchUserPage(): string
+    {
+        return $this->adminUserSearchUrl;
     }
 
     public function getAdminViewUserPage(int $userId): string

--- a/api/tests/Behat/bootstrap/v2/Helpers/FixtureHelper.php
+++ b/api/tests/Behat/bootstrap/v2/Helpers/FixtureHelper.php
@@ -907,6 +907,37 @@ class FixtureHelper
         );
     }
 
+    public function createDataForAdminUserTests(string $testPurpose)
+    {
+        $userRoles = [
+            ['typeSuffix' => 'lay', 'role' => User::ROLE_LAY_DEPUTY],
+            ['typeSuffix' => 'pa-n', 'role' => User::ROLE_PA_NAMED],
+            ['typeSuffix' => 'pa', 'role' => User::ROLE_PA],
+            ['typeSuffix' => 'prof-n', 'role' => User::ROLE_PROF_NAMED],
+            ['typeSuffix' => 'prof', 'role' => User::ROLE_PROF],
+            ['typeSuffix' => 'admin', 'role' => User::ROLE_ADMIN],
+            ['typeSuffix' => 'manager', 'role' => User::ROLE_ADMIN_MANAGER],
+            ['typeSuffix' => 'super', 'role' => User::ROLE_SUPER_ADMIN],
+            ['typeSuffix' => 'ad', 'role' => User::ROLE_AD],
+        ];
+
+        foreach ($userRoles as $userRole) {
+            $user = $this->userTestHelper
+                ->createUser(null, $userRole['role'], sprintf('%s-%s@t.uk', $testPurpose.'-test-'.$userRole['typeSuffix'], $this->testRunId));
+            $this->setClientPassword($user);
+        }
+
+        $this->createClientAndReport(
+            $this->testRunId,
+            User::ROLE_LAY_DEPUTY,
+            $testPurpose.'-test-ndr',
+            Report::TYPE_104,
+            false,
+            false,
+            true
+        );
+    }
+
     private function createOrganisation($testRunId)
     {
         $orgName = sprintf('prof-%s-%s', $this->orgName, $testRunId);

--- a/api/tests/Behat/bootstrap/v2/UserManagement/UserManagementFeatureContext.php
+++ b/api/tests/Behat/bootstrap/v2/UserManagement/UserManagementFeatureContext.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Behat\v2\UserManagement;
+
+use App\Tests\Behat\v2\Common\BaseFeatureContext;
+
+class UserManagementFeatureContext extends BaseFeatureContext
+{
+    use UserManagementTrait;
+}

--- a/api/tests/Behat/bootstrap/v2/UserManagement/UserManagementTrait.php
+++ b/api/tests/Behat/bootstrap/v2/UserManagement/UserManagementTrait.php
@@ -1,0 +1,677 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Behat\v2\UserManagement;
+
+trait UserManagementTrait
+{
+    private ?int $userCount = null;
+    private array $userEmails = [];
+    private array $expectedUsers = [];
+    private array $userRoles = [];
+    private string $userRole = '';
+
+    // ======= SEARCH FUNCTIONALITY =======
+
+    /**
+     * @When I have created the appropriate search test users
+     */
+    public function iHaveCreatedAppropriateSearchTestUsers()
+    {
+        $this->createAdditionalDataForUserSearchTests();
+    }
+
+    /**
+     * @When I search for one of the test users using partial name
+     */
+    public function iSearchForOneOfTestUsersUsingPartialName()
+    {
+        $this->iAmOnAdminUsersSearchPage();
+        $this->fillField('admin_q', 'search-test-');
+        $this->pressButton('Search');
+        $this->setFixtureUserEmailsAndCount();
+    }
+
+    /**
+     * @When I search for one of the test users using full name
+     */
+    public function iSearchForOneOfTestUsersUsingFullName()
+    {
+        $this->iAmOnAdminUsersSearchPage();
+        $this->fillField('admin_q', 'search-test-pa-n-'.$this->testRunId.'@t.uk');
+        $this->pressButton('Search');
+        $this->userCount = 1;
+        $this->userEmails = ['search-test-pa-n-'.$this->testRunId.'@t.uk'];
+    }
+
+    /**
+     * @When I should see the correct search results
+     */
+    public function iShouldSeeTheCorrectSearchResult()
+    {
+        $xpath = '//h2[@id="users-list-title"]/parent::div/p[@class="govuk-body"]';
+        $userText = $this->getSession()->getPage()->find('xpath', $xpath)->getHtml();
+        $pluralUsers = 1 == $this->userCount ? 'user' : 'users';
+        $userMessage = sprintf('found %s %s', strval($this->userCount), $pluralUsers);
+        $this->assertStringEqualsString($userMessage, $userText, 'Users Found');
+        $xpath = '//table[@class="table-govuk-body-s"]/tbody/tr';
+        $userElements = $this->getSession()->getPage()->findAll('xpath', $xpath);
+        $userRowCount = count($userElements);
+        $this->assertIntEqualsInt($userRowCount, $this->userCount, 'User rows visible');
+
+        foreach ($this->userEmails as $userEmail) {
+            $xpath = '//table[@class="table-govuk-body-s"]/tbody';
+            $userResultsTable = $this->getSession()->getPage()->find('xpath', $xpath)->getHtml();
+            $this->assertStringContainsString($userEmail, $userResultsTable, 'Results on page');
+        }
+    }
+
+    /**
+     * @When I search for one of the test users with the Lay filter
+     */
+    public function iSearchForTestUsersWithTheFilter()
+    {
+        $this->searchUserWithFilter('ROLE_LAY_DEPUTY', 'search-test-');
+        $this->userCount = 2;
+        $this->userEmails = ['search-test-lay-'.$this->testRunId.'@t.uk', 'search-test-ndr-'.$this->testRunId.'@t.uk'];
+    }
+
+    /**
+     * @When I search for one of the test users with the Professional filter
+     */
+    public function iSearchForTestUsersWithTheProfFilter()
+    {
+        $this->searchUserWithFilter('ROLE_PROF%', 'search-test-');
+        $this->userCount = 2;
+        $this->userEmails = ['search-test-prof-'.$this->testRunId.'@t.uk', 'search-test-prof-n-'.$this->testRunId.'@t.uk'];
+    }
+
+    /**
+     * @When I search for one of the test users with the Professional Named filter
+     */
+    public function iSearchForTestUsersWithTheProfNamedFilter()
+    {
+        $this->searchUserWithFilter('ROLE_PROF_NAMED', 'search-test-');
+        $this->userCount = 1;
+        $this->userEmails = ['search-test-prof-n-'.$this->testRunId.'@t.uk'];
+    }
+
+    /**
+     * @When I search for one of the test users with the Public Authority filter
+     */
+    public function iSearchForTestUsersWithThePAFilter()
+    {
+        $this->searchUserWithFilter('ROLE_PA%', 'search-test-');
+        $this->userCount = 2;
+        $this->userEmails = ['search-test-pa-'.$this->testRunId.'@t.uk', 'search-test-pa-n-'.$this->testRunId.'@t.uk'];
+    }
+
+    /**
+     * @When I search for one of the test users with the Public Authority Named filter
+     */
+    public function iSearchForTestUsersWithThePANamedFilter()
+    {
+        $this->searchUserWithFilter('ROLE_PA_NAMED', 'search-test-');
+        $this->userCount = 1;
+        $this->userEmails = ['search-test-pa-n-'.$this->testRunId.'@t.uk'];
+    }
+
+    /**
+     * @When I search for one of the test users with the Admin filter
+     */
+    public function iSearchForTestUsersWithTheAdminFilter()
+    {
+        $this->searchUserWithFilter('ROLE_ADMIN', 'search-test-');
+        $this->userCount = 1;
+        $this->userEmails = ['search-test-admin-'.$this->testRunId.'@t.uk'];
+    }
+
+    /**
+     * @When I search for one of the test users with the Super Admin filter
+     */
+    public function iSearchForTestUsersWithTheSuperFilter()
+    {
+        $this->searchUserWithFilter('ROLE_SUPER_ADMIN', 'search-test-');
+        $this->userCount = 1;
+        $this->userEmails = ['search-test-super-'.$this->testRunId.'@t.uk'];
+    }
+
+    /**
+     * @When I search for one of the test users with the All Roles filter
+     */
+    public function iSearchForTestUsersWithTheAllFilter()
+    {
+        $this->searchUserWithFilter('', 'search-test-');
+        $this->setFixtureUserEmailsAndCount();
+    }
+
+    /**
+     * @When I search for one of the NDR test users with the All Roles filter
+     */
+    public function iSearchForTestUsersWithTheNDRFilter()
+    {
+        $this->iAmOnAdminUsersSearchPage();
+        $this->fillField('admin_q', 'search-test-');
+        $this->selectOption('admin[role_name]', '');
+        $this->checkOption('admin[ndr_enabled]');
+        $this->pressButton('Search');
+        $this->userCount = 1;
+        $this->userEmails = ['search-test-ndr-'.$this->testRunId.'@t.uk'];
+    }
+
+    private function setFixtureUserEmailsAndCount()
+    {
+        $this->userCount = 10;
+        $this->userEmails = [
+            'search-test-lay-'.$this->testRunId.'@t.uk',
+            'search-test-pa-n-'.$this->testRunId.'@t.uk',
+            'search-test-pa-'.$this->testRunId.'@t.uk',
+            'search-test-prof-n-'.$this->testRunId.'@t.uk',
+            'search-test-prof-'.$this->testRunId.'@t.uk',
+            'search-test-admin-'.$this->testRunId.'@t.uk',
+            'search-test-manager-'.$this->testRunId.'@t.uk',
+            'search-test-super-'.$this->testRunId.'@t.uk',
+            'search-test-ad-'.$this->testRunId.'@t.uk',
+            'search-test-ndr-'.$this->testRunId.'@t.uk',
+        ];
+    }
+
+    private function searchUserWithFilter(string $filterText, string $searchField)
+    {
+        $this->iAmOnAdminUsersSearchPage();
+        $this->fillField('admin_q', $searchField);
+        $this->selectOption('admin[role_name]', $filterText);
+        $this->pressButton('Search');
+    }
+
+    // ======= CREATE USER FUNCTIONALITY =======
+
+    /**
+     * @When I add a new lay deputy user
+     */
+    public function iAddNewLayDeputyUser()
+    {
+        $this->pressButton('Add new user');
+        $this->expectedUsers = [
+            [
+                'email' => 'add-user-1-'.$this->testRunId.'@t.com',
+                'firstName' => 'added',
+                'lastName' => 'user1',
+                'postcode' => 'B99 5ZZ',
+                'roleType' => 'deputy',
+                'role' => 'ROLE_LAY_DEPUTY',
+            ],
+        ];
+        $this->fillInAndSubmitUsers(
+            $this->expectedUsers[0]['email'],
+            $this->expectedUsers[0]['firstName'],
+            $this->expectedUsers[0]['lastName'],
+            $this->expectedUsers[0]['postcode'],
+            $this->expectedUsers[0]['roleType'],
+            $this->expectedUsers[0]['role']
+        );
+    }
+
+    /**
+     * @When I search for the newly created user
+     */
+    public function iSearchForNewlyCreatedUser()
+    {
+        $this->searchUserWithFilter('', $this->expectedUsers[0]['email']);
+    }
+
+    /**
+     * @When I can see the user as non active in search results
+     */
+    public function iCanSeeTheUserAsNonActiveInSearchResults()
+    {
+        $this->iAmOnAdminUsersSearchPage();
+        $xpath = '//tbody/tr';
+        $firstRow = $this->getSession()->getPage()->find('xpath', $xpath)->getHtml();
+        $this->assertStringContainsString($this->expectedUsers[0]['firstName'], $firstRow, 'Add user check - first name');
+        $this->assertStringContainsString($this->expectedUsers[0]['lastName'], $firstRow, 'Add user check - last name');
+        $this->assertStringContainsString($this->expectedUsers[0]['email'], $firstRow, 'Add user check - email');
+        $this->assertStringContainsString('(Re)send activation email', $firstRow, 'Add user check - activation text');
+    }
+
+    private function createArrayOfAddUsersFromArray($rolesArray)
+    {
+        foreach ($rolesArray as $key => $role) {
+            $email = 'add-user-'.$this->userRole.'-'.$role['roleName'].'-'.$this->testRunId.'@t.uk';
+            $this->expectedUsers[] = [
+                'email' => $email,
+                'firstName' => 'added',
+                'lastName' => 'user'.$role['roleName'].$this->userRole,
+                'postcode' => 'B'.strval($key).' 1ZZ',
+                'roleType' => $role['roleType'],
+                'role' => $role['role'],
+            ];
+            $this->userEmails[] = $email;
+        }
+    }
+
+    private function createArrayOfEditUsersFromArray($rolesArray)
+    {
+        foreach ($rolesArray as $key => $role) {
+            $email = 'edit-test-'.$role['roleName'].'-'.$this->testRunId.'@t.uk';
+            $this->expectedUsers[] = [
+                'email' => $email,
+                'firstName' => 'first'.str_replace('_', '', strtolower($role['role'])),
+                'lastName' => 'last'.str_replace('_', '', strtolower($role['role'])),
+                'postcode' => 'B'.strval($key).' 1YY',
+                'roleType' => $role['roleType'],
+                'role' => $role['role'],
+            ];
+            $this->userEmails[] = $email;
+        }
+    }
+
+    private function addUserInApplication()
+    {
+        $this->userCount = 0;
+        foreach ($this->expectedUsers as $addedUser) {
+            $this->iNavigateToAddNewUser();
+            $this->iAmOnAdminAddUserPage();
+            $this->checkRolesExistToAdd($this->userRoles);
+            $this->fillInAndSubmitUsers(
+                $addedUser['email'],
+                $addedUser['firstName'],
+                $addedUser['lastName'],
+                $addedUser['postcode'],
+                $addedUser['roleType'],
+                $addedUser['role']
+            );
+            ++$this->userCount;
+        }
+    }
+
+    /**
+     * @When I navigate to the add a new user page
+     */
+    public function iNavigateToAddNewUser()
+    {
+        $this->iAmOnAdminUsersSearchPage();
+        $this->clickBasedOnText('Add new user');
+    }
+
+    /**
+     * @When I add invalid details in each of the fields
+     */
+    public function iAddInvalidDetailsInEachField()
+    {
+        $this->fillInAndSubmitUsers(
+            'invalidemailwithoutatsymbol.com',
+            'This is a really long string that makes this invalid',
+            'This is a really long string that makes this invalid',
+            'POSTCODE TOO LONG',
+            'deputy',
+            'ROLE_LAY_DEPUTY'
+        );
+    }
+
+    /**
+     * @When I get the correct validation messages for invalid user
+     */
+    public function iGetCorrectValidationMessagesForInvalidUser()
+    {
+        $this->assertOnAlertMessage('This email is not valid');
+        $this->assertOnAlertMessage('The first name cannot be longer than 50 letters');
+        $this->assertOnAlertMessage('The last name cannot be longer than 50 letters');
+        $this->assertOnAlertMessage('The postcode cannot be longer than 10 characters');
+    }
+
+    private function checkRolesExistToAdd($roles)
+    {
+        $options = $this->getSession()->getPage()->findAll('xpath', '//option');
+        $expectedOptions = [];
+        foreach ($options as $option) {
+            $expectedOptions[] = $option->getValue();
+        }
+        foreach ($roles as $role) {
+            $exists = in_array($role['role'], $expectedOptions);
+            $this->assertBoolIsTrue($exists, 'Role: '.$role['role'].' in list');
+        }
+    }
+
+    private function setUniversalUserRoles()
+    {
+        $this->userRoles = [
+            ['role' => 'ROLE_LAY_DEPUTY', 'roleName' => 'lay', 'roleType' => 'deputy'],
+            ['role' => 'ROLE_PA_NAMED', 'roleName' => 'pa', 'roleType' => 'deputy'],
+            ['role' => 'ROLE_PA_ADMIN', 'roleName' => 'pa-admin', 'roleType' => 'deputy'],
+            ['role' => 'ROLE_PA_TEAM_MEMBER', 'roleName' => 'pa-team', 'roleType' => 'deputy'],
+            ['role' => 'ROLE_PROF_NAMED', 'roleName' => 'prof-named', 'roleType' => 'deputy'],
+            ['role' => 'ROLE_PROF_ADMIN', 'roleName' => 'prof-admin', 'roleType' => 'deputy'],
+            ['role' => 'ROLE_PROF_TEAM_MEMBER', 'roleName' => 'prof-team', 'roleType' => 'deputy'],
+            ['role' => 'ROLE_ADMIN', 'roleName' => 'admin', 'roleType' => 'staff'],
+        ];
+    }
+
+    /**
+     * @When I add each of the appropriate user types for a super admin
+     */
+    public function iAddEachUserTypeForSuperAdmin()
+    {
+        $this->userRole = 'super';
+        $this->setUniversalUserRoles();
+        $this->userRoles[] = ['role' => 'ROLE_ADMIN_MANAGER', 'roleName' => 'manager', 'roleType' => 'staff'];
+        $this->userRoles[] = ['role' => 'ROLE_SUPER_ADMIN', 'roleName' => 'super', 'roleType' => 'staff'];
+        $this->createArrayOfAddUsersFromArray($this->userRoles);
+        $this->addUserInApplication();
+    }
+
+    /**
+     * @When I check we can add the appropriate user types for an admin manager
+     */
+    public function iCheckCanAddEachUserTypeForAdminManager()
+    {
+        $this->userRole = 'manager';
+        $this->setUniversalUserRoles();
+        $this->iNavigateToAddNewUser();
+    }
+
+    /**
+     * @When I check we can add the appropriate user types for an admin
+     */
+    public function iCheckCanAddEachUserTypeForAdmin()
+    {
+        $this->userRole = 'admin';
+        $this->setUniversalUserRoles();
+        $this->iNavigateToAddNewUser();
+    }
+
+    /**
+     * @Then I see the appropriate user types available to add
+     */
+    public function iSeeUserTypesAvailableToAddAsNewUser()
+    {
+        $this->checkRolesExistToAdd($this->userRoles);
+        $this->clickLink('Cancel');
+        $this->iAmOnAdminUsersSearchPage();
+    }
+
+    /**
+     * @Then I should see each created users in the search window
+     */
+    public function iSeeEachCreatedUsersInSearchWindow()
+    {
+        $this->searchUserWithFilter('', 'add-user-'.$this->userRole.'-');
+        $this->iShouldSeeTheCorrectSearchResult();
+    }
+
+    /**
+     * @When I resend activation email
+     */
+    public function iResendActivationEmail()
+    {
+        $this->iAmOnAdminUsersSearchPage();
+        $this->clickLink('(Re)send activation email');
+    }
+
+    /**
+     * @Then I see that activation link has been sent
+     */
+    public function iSeeActivationLinkHasBeenSent()
+    {
+        $xpath = '//body/p';
+        $response = $this->getSession()->getPage()->find('xpath', $xpath)->getHtml();
+        $this->assertStringContainsString('[Link sent]', $response, 'Add user check - link sent');
+    }
+
+    /**
+     * @Then I see that an activation email has been sent to the user
+     */
+    public function iSeeActivationEmailHasBeenSent()
+    {
+        $this->assertOnAlertMessage('An activation email has been sent to the user');
+    }
+
+    // ======= EDIT USER FUNCTIONALITY =======
+
+    /**
+     * @When I have created the appropriate test users to edit
+     */
+    public function iHaveCreatedTheAppropriateTestUsersToEdit()
+    {
+        $this->createAdditionalDataForUserEditTests();
+    }
+
+    private function fillInAndSubmitUsers($email, $firstName, $lastName, $postcode, $roleType, $role)
+    {
+        $this->iAmOnAdminAddUserPage();
+        $selectType = 'deputy' == $roleType ? 'admin[roleNameDeputy]' : 'admin[roleNameStaff]';
+        $this->fillField('admin[email]', $email);
+        $this->fillField('admin[firstname]', $firstName);
+        $this->fillField('admin[lastname]', $lastName);
+        $this->fillField('admin[addressPostcode]', $postcode);
+        $this->selectOption('admin[roleType]', $roleType);
+        $this->selectOption($selectType, $role);
+        $this->pressButton('Save user');
+    }
+
+    /**
+     * @When I edit each of the test users
+     */
+    public function iEditEachOfTheTestUsers()
+    {
+        $this->generateEditExistingUserArray();
+        foreach ($this->expectedUsers as $key => $addedUser) {
+            $this->iAmOnAdminUsersSearchPage();
+            $this->searchUserWithFilter('', $addedUser['email']);
+            //update the email now we have searched for it...
+            $this->expectedUsers[$key]['email'] = $addedUser['email'].'.edit';
+            //click on the first result (should only be one)
+            $this->iClickOnFirstUserReturnedBySearch();
+            $this->iNavigateToEditUser();
+            $this->fillFieldsAndSubmitOnEditExistingUser($this->expectedUsers[$key]);
+            $this->clickLink('Cancel');
+        }
+    }
+
+    /**
+     * @Then I should see the users have been correctly updated
+     */
+    public function iShouldSeeUsersCorrectlyUpdated()
+    {
+        $this->iAmOnAdminUsersSearchPage();
+        $this->searchUserWithFilter('', 'edit-test-');
+        $xpath = '//table[@class="table-govuk-body-s"]/tbody';
+        $resultsTable = $this->getSession()->getPage()->find('xpath', $xpath)->getHtml();
+        foreach ($this->expectedUsers as $addedUser) {
+            $this->assertStringContainsString($addedUser['firstName'], $resultsTable, 'Edit user check - first name');
+            $this->assertStringContainsString($addedUser['lastName'], $resultsTable, 'Edit user check - last name');
+            $this->assertStringContainsString($addedUser['email'], $resultsTable, 'Edit user check - email');
+        }
+    }
+
+    /**
+     * @When I navigate to the lay user for edit tests
+     */
+    public function iNavigateToLayUserForEditTests()
+    {
+        $this->iAmOnAdminUsersSearchPage();
+        $layDeputy = $this->expectedUsers[0];
+        $this->searchUserWithFilter('', $layDeputy['email']);
+        $this->iClickOnFirstUserReturnedBySearch();
+        $this->iNavigateToEditUser();
+    }
+
+    /**
+     * @Then I see user details are displayed correctly
+     */
+    public function iSeeUserDetailsAreDisplayedCorrectly()
+    {
+        $layDeputy = $this->expectedUsers[0];
+        $firstName = $this->getSession()->getPage()->find('xpath', '//input[@id="admin_firstname"]')->getValue();
+        $lastName = $this->getSession()->getPage()->find('xpath', '//input[@id="admin_lastname"]')->getValue();
+        $email = $this->getSession()->getPage()->find('xpath', '//input[@id="admin_email"]')->getValue();
+        $postcode = $this->getSession()->getPage()->find('xpath', '//input[@id="admin_addressPostcode"]')->getValue();
+        $this->assertStringEqualsString($layDeputy['firstName'], $firstName, 'Edit user - first name check');
+        $this->assertStringEqualsString($layDeputy['lastName'], $lastName, 'Edit user - last name check');
+        $this->assertStringEqualsString($layDeputy['email'], $email, 'Edit user - email check');
+        $this->assertStringEqualsString($layDeputy['postcode'], $postcode, 'Edit user - postcode check');
+    }
+
+    /**
+     * @When I view the super admin user
+     */
+    public function iViewSuperAdminUser()
+    {
+        $this->iAmOnAdminUsersSearchPage();
+        $this->searchUserWithFilter('', 'edit-test-super-'.$this->testRunId.'@t.uk');
+        $this->iClickOnFirstUserReturnedBySearch();
+    }
+
+    /**
+     * @When I view the admin manager user
+     */
+    public function iViewAdminManagerUser()
+    {
+        $this->iVisitAdminSearchUserPage();
+        $this->iAmOnAdminUsersSearchPage();
+        $this->searchUserWithFilter('', 'edit-test-manager-'.$this->testRunId.'@t.uk');
+        $this->iClickOnFirstUserReturnedBySearch();
+        $this->iAmOnAdminViewUserPage();
+    }
+
+    /**
+     * @When I view the admin user
+     */
+    public function iViewAdminUser()
+    {
+        $this->iVisitAdminSearchUserPage();
+        $this->iAmOnAdminUsersSearchPage();
+        $this->searchUserWithFilter('', 'edit-test-admin-'.$this->testRunId.'@t.uk');
+        $this->iClickOnFirstUserReturnedBySearch();
+    }
+
+    /**
+     * @Then I should not be able to edit that user
+     */
+    public function iShouldNotBeAbleToEditThatUser()
+    {
+        $this->iAmOnAdminViewUserPage();
+        $xpath = "//a[text()[contains(., 'Edit user')]]";
+        $link = $this->getSession()->getPage()->find('xpath', $xpath);
+        $this->assertIsNull($link, 'Edit button present');
+    }
+
+    /**
+     * @Then I should be able to delete that user
+     */
+    public function iShouldBeAbleToDeleteThatUser()
+    {
+        $this->iAmOnAdminViewUserPage();
+        $this->clickBasedOnText('Delete user');
+        $this->iAmOnAdminDeleteConfirmUserPage();
+    }
+
+    /**
+     * @Then I should be able to edit that user
+     */
+    public function iShouldBeAbleToEditThatUser()
+    {
+        $this->iAmOnAdminViewUserPage();
+        $this->clickBasedOnText('Edit user');
+        $this->iAmOnAdminEditUserPage();
+        $this->iClickOnNthElementBasedOnRegex('/admin\/$/', 0);
+    }
+
+    /**
+     * @When I delete the admin manager
+     */
+    public function iDeleteTheAdminManager()
+    {
+        $this->deleteAdmin('manager');
+    }
+
+    /**
+     * @When I delete the admin
+     */
+    public function iDeleteTheAdmin()
+    {
+        $this->deleteAdmin('admin');
+    }
+
+    /**
+     * @Then I no longer see the admin manager in search results
+     */
+    public function iNoLongerSeeAdminManagerInSearchResults()
+    {
+        $this->noResultsReturnedForUserType('manager');
+    }
+
+    /**
+     * @Then I no longer see the admin in search results
+     */
+    public function iNoLongerSeeAdminInSearchResults()
+    {
+        $this->noResultsReturnedForUserType('admin');
+    }
+
+    private function noResultsReturnedForUserType($userType)
+    {
+        $this->iVisitAdminSearchUserPage();
+        $this->iAmOnAdminUsersSearchPage();
+        $email = 'edit-test-'.$userType.'-'.$this->testRunId.'@t.uk';
+        $this->searchUserWithFilter('', $email);
+        $xpath = '//tbody';
+        $tbody = $this->getSession()->getPage()->find('xpath', $xpath)->getHtml();
+        $this->assertStringDoesNotContainString($email, $tbody, 'Delete test - '.$userType);
+    }
+
+    private function deleteAdmin($userType)
+    {
+        $this->iVisitAdminSearchUserPage();
+        $this->iAmOnAdminUsersSearchPage();
+        $this->searchUserWithFilter('', 'edit-test-'.$userType.'-'.$this->testRunId.'@t.uk');
+        $this->iClickOnFirstUserReturnedBySearch();
+        $this->clickBasedOnText('Edit user');
+        $this->iAmOnAdminEditUserPage();
+        $this->clickBasedOnText('Delete user');
+        $this->iAmOnAdminDeleteConfirmUserPage();
+        $this->clickLink('Yes, I\'m sure');
+    }
+
+    private function generateEditExistingUserArray()
+    {
+        $this->userRoles = [
+            ['role' => 'ROLE_LAY_DEPUTY', 'roleName' => 'lay', 'roleType' => 'deputy'],
+            ['role' => 'ROLE_PA_NAMED', 'roleName' => 'pa', 'roleType' => 'deputy'],
+            ['role' => 'ROLE_PROF_ADMIN', 'roleName' => 'prof', 'roleType' => 'deputy'],
+            ['role' => 'ROLE_ADMIN', 'roleName' => 'admin', 'roleType' => 'staff'],
+            ['role' => 'ROLE_SUPER_ADMIN', 'roleName' => 'super', 'roleType' => 'staff'],
+            ['role' => 'ROLE_ADMIN_MANAGER', 'roleName' => 'manager', 'roleType' => 'staff'],
+        ];
+        $this->createArrayOfEditUsersFromArray($this->userRoles);
+    }
+
+    private function iNavigateToEditUser()
+    {
+        $this->iAmOnAdminViewUserPage();
+        $this->clickBasedOnText('Edit user');
+    }
+
+    private function fillFieldsAndSubmitOnEditExistingUser($addedUser)
+    {
+        $this->iAmOnAdminEditUserPage();
+        $this->fillField('admin[email]', $addedUser['email']);
+        $this->fillField('admin[firstname]', $addedUser['firstName']);
+        $this->fillField('admin[lastname]', $addedUser['lastName']);
+        $this->fillField('admin[addressPostcode]', $addedUser['postcode']);
+        $this->pressButton('Update user');
+    }
+
+    private function iClickOnFirstUserReturnedBySearch()
+    {
+        $this->iClickOnNthElementBasedOnRegex('/admin\/user\/[0-9].*$/', 0);
+    }
+
+    private function clickBasedOnText($text)
+    {
+        $xpath = sprintf('//a[text()[contains(., \'%s\')]]', $text);
+        $link = $this->getSession()->getPage()->find('xpath', $xpath);
+        $link->click();
+    }
+}

--- a/api/tests/Behat/bootstrap/v2/UserManagement/UserManagementTrait.php
+++ b/api/tests/Behat/bootstrap/v2/UserManagement/UserManagementTrait.php
@@ -52,7 +52,7 @@ trait UserManagementTrait
     {
         $xpath = '//h2[@id="users-list-title"]/parent::div/p[@class="govuk-body"]';
         $userText = $this->getSession()->getPage()->find('xpath', $xpath)->getHtml();
-        $pluralUsers = 1 == $this->userCount ? 'user' : 'users';
+        $pluralUsers = 1 === $this->userCount ? 'user' : 'users';
         $userMessage = sprintf('found %s %s', strval($this->userCount), $pluralUsers);
         $this->assertStringEqualsString($userMessage, $userText, 'Users Found');
         $xpath = '//table[@class="table-govuk-body-s"]/tbody/tr';
@@ -222,7 +222,7 @@ trait UserManagementTrait
     }
 
     /**
-     * @When I can see the user as non active in search results
+     * @Then I can see the user as non active in search results
      */
     public function iCanSeeTheUserAsNonActiveInSearchResults()
     {
@@ -349,7 +349,7 @@ trait UserManagementTrait
     }
 
     /**
-     * @When I add each of the appropriate user types for a super admin
+     * @When I add each of the available user types for a super admin
      */
     public function iAddEachUserTypeForSuperAdmin()
     {

--- a/api/tests/Behat/bootstrap/v2/UserManagement/UserManagementTrait.php
+++ b/api/tests/Behat/bootstrap/v2/UserManagement/UserManagementTrait.php
@@ -287,15 +287,6 @@ trait UserManagementTrait
     }
 
     /**
-     * @When I navigate to the add a new user page
-     */
-    public function iNavigateToAddNewUser()
-    {
-        $this->iAmOnAdminUsersSearchPage();
-        $this->clickBasedOnText('Add new user');
-    }
-
-    /**
      * @When I add invalid details in each of the fields
      */
     public function iAddInvalidDetailsInEachField()
@@ -666,12 +657,5 @@ trait UserManagementTrait
     private function iClickOnFirstUserReturnedBySearch()
     {
         $this->iClickOnNthElementBasedOnRegex('/admin\/user\/[0-9].*$/', 0);
-    }
-
-    private function clickBasedOnText($text)
-    {
-        $xpath = sprintf('//a[text()[contains(., \'%s\')]]', $text);
-        $link = $this->getSession()->getPage()->find('xpath', $xpath);
-        $link->click();
     }
 }

--- a/api/tests/Behat/features-v2/user-management/create-user.feature
+++ b/api/tests/Behat/features-v2/user-management/create-user.feature
@@ -1,0 +1,37 @@
+@v2 @admin-user-create @admin-user
+Feature: Admin - User Create
+
+@super-admin
+  Scenario: A super admin user creates a deputy user
+    Given a super admin user accesses the admin app
+    When I add a new lay deputy user
+    Then I see that an activation email has been sent to the user
+    When I search for the newly created user
+    Then I can see the user as non active in search results
+    When I resend activation email
+    Then I see that activation link has been sent
+
+@super-admin
+Scenario: A super admin creates admin users
+    Given a super admin user accesses the admin app
+    When I add each of the appropriate user types for a super admin
+    Then I should see each created users in the search window
+
+@admin-manager
+Scenario: A admin manager creates admin users
+    Given an admin manager user accesses the admin app
+    When I check we can add the appropriate user types for an admin manager
+    Then I see the appropriate user types available to add
+
+@admin
+Scenario: A admin creates admin users
+    Given an admin user accesses the admin app
+    When I check we can add the appropriate user types for an admin
+    Then I see the appropriate user types available to add
+
+@super-admin
+Scenario: A super admin user enters invalid details
+    Given a super admin user accesses the admin app
+    When I navigate to the add a new user page
+    And I add invalid details in each of the fields
+    Then I get the correct validation messages for invalid user

--- a/api/tests/Behat/features-v2/user-management/create-user.feature
+++ b/api/tests/Behat/features-v2/user-management/create-user.feature
@@ -14,7 +14,7 @@ Feature: Admin - User Create
 @super-admin
 Scenario: A super admin creates admin users
     Given a super admin user accesses the admin app
-    When I add each of the appropriate user types for a super admin
+    When I add each of the available user types for a super admin
     Then I should see each created users in the search window
 
 @admin-manager

--- a/api/tests/Behat/features-v2/user-management/edit-user.feature
+++ b/api/tests/Behat/features-v2/user-management/edit-user.feature
@@ -1,0 +1,43 @@
+@v2 @admin-user-edit @admin-user
+Feature: Admin - User Edit
+
+    @super-admin
+    Scenario: A super admin user edits each user
+        Given a super admin user accesses the admin app
+        And I have created the appropriate test users to edit
+        When I edit each of the test users
+        Then I should see the users have been correctly updated
+        When I navigate to the lay user for edit tests
+        Then I see user details are displayed correctly
+
+    @super-admin
+    Scenario: A super admin user tries to delete users
+        Given a super admin user accesses the admin app
+        And I have created the appropriate test users to edit
+        When I delete the admin manager
+        Then I no longer see the admin manager in search results
+        When I delete the admin
+        Then I no longer see the admin in search results
+
+    @admin-manager
+    Scenario: A admin manager user edits other admins
+        Given an admin manager user accesses the admin app
+        And I have created the appropriate test users to edit
+        When I view the super admin user
+        Then I should not be able to edit that user
+        When I view the admin manager user
+        Then I should not be able to edit that user
+        But I should be able to delete that user
+        When I view the admin user
+        Then I should be able to edit that user
+
+    @admin
+    Scenario: A admin user edits a super admin
+        Given an admin user accesses the admin app
+        And I have created the appropriate test users to edit
+        When I view the super admin user
+        Then I should not be able to edit that user
+        When I view the admin manager user
+        Then I should not be able to edit that user
+        When I view the admin user
+        Then I should be able to edit that user

--- a/api/tests/Behat/features-v2/user-management/search-user.feature
+++ b/api/tests/Behat/features-v2/user-management/search-user.feature
@@ -1,5 +1,5 @@
 @v2 @admin-user-search @admin-user
-Feature: Admin - User Search
+Feature: Admin - User Search (same functionality for all admin types)
 
     @super-admin
     Scenario: A super admin user searches for a user

--- a/api/tests/Behat/features-v2/user-management/search-user.feature
+++ b/api/tests/Behat/features-v2/user-management/search-user.feature
@@ -1,0 +1,29 @@
+@v2 @admin-user-search @admin-user
+Feature: Admin - User Search
+
+    @super-admin
+    Scenario: A super admin user searches for a user
+        Given a super admin user accesses the admin app
+        And I have created the appropriate search test users
+        When I search for one of the test users using partial name
+        Then I should see the correct search results
+        When I search for one of the test users using full name
+        Then I should see the correct search results
+        When I search for one of the test users with the Lay filter
+        Then I should see the correct search results
+        When I search for one of the test users with the Professional filter
+        Then I should see the correct search results
+        When I search for one of the test users with the Professional Named filter
+        Then I should see the correct search results
+        When I search for one of the test users with the Public Authority filter
+        Then I should see the correct search results
+        When I search for one of the test users with the Public Authority Named filter
+        Then I should see the correct search results
+        When I search for one of the test users with the Admin filter
+        Then I should see the correct search results
+        When I search for one of the test users with the Super Admin filter
+        Then I should see the correct search results
+        When I search for one of the test users with the All Roles filter
+        Then I should see the correct search results
+        When I search for one of the NDR test users with the All Roles filter
+        Then I should see the correct search results

--- a/api/tests/Behat/features/admin/08-deputy-search.feature
+++ b/api/tests/Behat/features/admin/08-deputy-search.feature
@@ -4,7 +4,7 @@ Feature: Deputy search
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I search in admin for a deputy with the term "User-2"
     Then I should see "User-2"
-    And I should see "Found 1 users"
+    And I should see "Found 1 user"
 
   @admin @admin-search @deputy-search
   Scenario: Search broadly across deputy by a role, excluding clients
@@ -13,7 +13,7 @@ Feature: Deputy search
     Then I should see "Found 0 users"
     When I search in admin for a deputy with the term "Manager1" and filter role by "Admin"
     And I press "admin_search"
-    Then I should see "Found 1 users"
+    Then I should see "Found 1 user"
 
   @admin @admin-search @deputy-search
   Scenario: Search broadly across all deputy roles, including clients
@@ -22,21 +22,21 @@ Feature: Deputy search
     Then I should see "Found 0 users"
     And I should not see "LAY Deputy 103 User"
     When I search in admin for a deputy with the term "103-client" and include clients
-    Then I should see "Found 1 users"
+    Then I should see "Found 1 user"
     And I should see "LAY Deputy 103 User"
 
   @admin@admin-search  @deputy-search
   Scenario: Search broadly across deputy by a role, including clients
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     When I search in admin for a deputy with the term "103-6-client" and filter role by "Public Authority deputies (named)" and include clients
-    Then I should see "Found 1 users"
+    Then I should see "Found 1 user"
 
   @admin @admin-search @deputy-search
   Scenario: Search exact name match across all deputy roles, excluding clients
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "DigidepsPass1234"
     And I search in admin for a deputy with the term "Admin User"
     Then I should see "admin user"
-    And I should see "Found 1 users"
+    And I should see "Found 1 user"
 
   @admin @admin-search @deputy-search
   Scenario: Search exact name match across all deputy roles, including clients
@@ -44,7 +44,7 @@ Feature: Deputy search
     And I search in admin for a deputy with the term "john 104-client"
     Then I should see "Found 0 users"
     When I search in admin for a deputy with the term "john 104-client" and include clients
-    Then I should see "Found 1 users"
+    Then I should see "Found 1 user"
     And I should see "Lay Deputy 104 User"
 
   @admin @admin-search @deputy-search
@@ -53,5 +53,5 @@ Feature: Deputy search
     When I search in admin for a deputy with the term "Admin User" and filter role by "Public Authority deputies (named)"
     Then I should see "Found 0 users"
     When I search in admin for a deputy with the term "Admin User" and filter role by "Admin"
-    Then I should see "Found 1 users"
+    Then I should see "Found 1 user"
     And I should see "Admin User"

--- a/client/src/Entity/User.php
+++ b/client/src/Entity/User.php
@@ -226,7 +226,7 @@ class User implements UserInterface, DeputyInterface
      * @JMS\Type("string")
      * @JMS\Groups({"user_details_full", "profile_org", "admin_add_user", "ad_add_user", "admin_edit_user"})
      * @Assert\NotBlank( message="user.addressPostcode.notBlank", groups={"user_details_full", "verify-codeputy", "admin_edit_user"} )
-     * @Assert\Length(min=2, max=10, minMessage="user.addressPostcode.minLength", maxMessage="user.addressPostcode.maxLength", groups={"user_details_full", "profile_org", "verify-codeputy", "admin_edit_user"} )
+     * @Assert\Length(min=2, max=10, minMessage="user.addressPostcode.minLength", maxMessage="user.addressPostcode.maxLength", groups={"user_details_full", "profile_org", "verify-codeputy", "admin_edit_user", "admin_add_user"} )
      *
      * @var string
      */

--- a/client/src/Form/Admin/SearchType.php
+++ b/client/src/Form/Admin/SearchType.php
@@ -15,15 +15,15 @@ class SearchType extends AbstractType
         $builder->add('q', FormTypes\TextType::class)
             ->add('role_name', FormTypes\ChoiceType::class, [
                 'choices' => array_flip([
-                    ''                     => 'ALL ROLES',
+                    '' => 'ALL ROLES',
                     User::ROLE_SUPER_ADMIN => 'Super admin',
-                    User::ROLE_ADMIN       => 'Admin',
-                    User::ROLE_LAY_DEPUTY  => 'Lay Deputy',
-                    User::ROLE_AD          => 'Assisted Digital',
-                    'ROLE_PA_%'            => 'All Public Authority deputies',
-                    User::ROLE_PA_NAMED    => 'Public Authority deputies (named) ',
-                    'ROLE_PROF_%'          => 'All Professional Deputies',
-                    User::ROLE_PROF_NAMED  => 'Professional Deputies (named)',
+                    User::ROLE_ADMIN => 'Admin',
+                    User::ROLE_LAY_DEPUTY => 'Lay Deputy',
+                    User::ROLE_AD => 'Assisted Digital',
+                    'ROLE_PA%' => 'All Public Authority deputies',
+                    User::ROLE_PA_NAMED => 'Public Authority deputies (named) ',
+                    'ROLE_PROF%' => 'All Professional Deputies',
+                    User::ROLE_PROF_NAMED => 'Professional Deputies (named)',
                 ]),
             ])
             ->add('ndr_enabled', FormTypes\CheckboxType::class)
@@ -35,7 +35,7 @@ class SearchType extends AbstractType
     {
         $resolver->setDefaults([
             'translation_domain' => 'admin',
-            'validation_groups'  => ['admin_add_user'],
+            'validation_groups' => ['admin_add_user'],
         ]);
     }
 

--- a/client/templates/Admin/Index/index.html.twig
+++ b/client/templates/Admin/Index/index.html.twig
@@ -67,7 +67,7 @@
                     </p>
                 {% else %}
                     <p class="govuk-body">
-                        Found {{ users | length }} users
+                        {% if (users | length) == 1 %}Found 1 user{% else %}Found {{ users | length }} users{% endif %}
                     </p>
                 {% endif %}
             </div>

--- a/client/translations/admin-clients.en.yml
+++ b/client/translations/admin-clients.en.yml
@@ -4,7 +4,7 @@ clientSearch:
   searchBy: Search by client surname or case number
   clientTable:
     heading: Client list
-    results: Found %numberOfClients% clients jim
+    results: Found %numberOfClients% clients
     resultsLimited:
       line01: Results limited to 100 clients.
       line02: Use search to filter the wanted clients.


### PR DESCRIPTION
## Purpose
Create user administration behat tests (not file upload of users though)

Fixes DDPB-3942

## Approach
Fairly standard approach. A few caveats though:
- When we edit users, the super user edits each type but for admin and manager I decided it would take too long so just checked they have the edit option available.
- Same for checking the fields. I only go into the view on a lay rather than each as it's the same mechanism (though i do check all of them in the search window for updates).

Picked up a few mistakes in the templates as I was doing this. Fixed them. 

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
