### PR TITLE
DDPB-3947: Behat rewrite - report management

### DIFF
--- a/api/tests/Behat/behat.yml
+++ b/api/tests/Behat/behat.yml
@@ -238,6 +238,12 @@ v2-tests-goutte:
             contexts:
                 - App\Tests\Behat\v2\OrganisationManagement\OrganisationManagementFeatureContext
 
+        report-management:
+            description: Coverage of report management features in the admin side of the app
+            paths: [ "%paths.base%/features-v2/report-management" ]
+            contexts:
+                - App\Tests\Behat\v2\ReportManagement\ReportManagementFeatureContext
+
         section-accounts:
             description: Covering the 'Accounts' section of the report
             paths: [ "%paths.base%/features-v2/reporting/sections/accounts" ]

--- a/api/tests/Behat/bootstrap/v2/ClientManagement/ClientManagementTrait.php
+++ b/api/tests/Behat/bootstrap/v2/ClientManagement/ClientManagementTrait.php
@@ -256,26 +256,28 @@ MESSAGE;
 
         $pageContent = $this->getSession()->getPage()->find('css', 'main#main-content')->getHtml();
 
-        $currentReportDueDateVisible = str_contains($pageContent, $this->interactingWithUserDetails->getCurrentReportDueDate());
+        $currentReportDateString = $this->interactingWithUserDetails->getCurrentReportDueDate()->format('j F Y');
+        $currentReportDueDateVisible = str_contains($pageContent, $currentReportDateString);
 
         if (!$currentReportDueDateVisible) {
             $this->throwContextualException(
                 sprintf(
                     'Expected to find report with a due date of "%s" visible but it does not appear on the page. Got (full HTML): %s',
-                    $this->interactingWithUserDetails->getCurrentReportDueDate(),
+                    $currentReportDateString,
                     $pageContent
                 )
             );
         }
 
         if (!is_null($this->interactingWithUserDetails->getPreviousReportDueDate())) {
-            $previousReportDueDateVisible = str_contains($pageContent, $this->interactingWithUserDetails->getPreviousReportDueDate());
+            $previousReportDateString = $this->interactingWithUserDetails->getPreviousReportDueDate()->format('j F Y');
+            $previousReportDueDateVisible = str_contains($pageContent, $previousReportDateString);
 
             if (!$previousReportDueDateVisible) {
                 $this->throwContextualException(
                     sprintf(
                         'Expected to find report with a due date of "%s" visible but it does not appear on the page. Got (full HTML): %s',
-                        $this->interactingWithUserDetails->getPreviousReportDueDate(),
+                        $previousReportDateString,
                         $pageContent
                     )
                 );

--- a/api/tests/Behat/bootstrap/v2/ClientManagement/ClientManagementTrait.php
+++ b/api/tests/Behat/bootstrap/v2/ClientManagement/ClientManagementTrait.php
@@ -16,7 +16,7 @@ trait ClientManagementTrait
      */
     public function iSearchForExistingClientByFirstName()
     {
-        $user = is_null($this->interactingWithUserDetails) ? $this->profAdminDeputyNotStartedDetails : $this->interactingWithUserDetails;
+        $user = is_null($this->interactingWithUserDetails) ? $this->profAdminDeputyHealthWelfareNotStartedDetails : $this->interactingWithUserDetails;
         $this->searchForClientBy($user->getClientFirstName(), $user);
     }
 
@@ -25,7 +25,7 @@ trait ClientManagementTrait
      */
     public function iSearchForExistingClientByLastName()
     {
-        $user = is_null($this->interactingWithUserDetails) ? $this->profAdminDeputyNotStartedDetails : $this->interactingWithUserDetails;
+        $user = is_null($this->interactingWithUserDetails) ? $this->profAdminDeputyHealthWelfareNotStartedDetails : $this->interactingWithUserDetails;
         $this->searchForClientBy($user->getClientLastName(), $user);
     }
 
@@ -34,7 +34,7 @@ trait ClientManagementTrait
      */
     public function iSearchForExistingClientByFullName()
     {
-        $user = is_null($this->interactingWithUserDetails) ? $this->profAdminDeputyNotStartedDetails : $this->interactingWithUserDetails;
+        $user = is_null($this->interactingWithUserDetails) ? $this->profAdminDeputyHealthWelfareNotStartedDetails : $this->interactingWithUserDetails;
         $fullName = sprintf('%s %s', $user->getClientFirstName(), $user->getClientLastName());
         $this->searchForClientBy($fullName, $user);
     }
@@ -44,7 +44,7 @@ trait ClientManagementTrait
      */
     public function iSearchForExistingClientByCaseNumber()
     {
-        $user = is_null($this->interactingWithUserDetails) ? $this->profAdminDeputyNotStartedDetails : $this->interactingWithUserDetails;
+        $user = is_null($this->interactingWithUserDetails) ? $this->profAdminDeputyHealthWelfareNotStartedDetails : $this->interactingWithUserDetails;
         $this->searchForClientBy($user->getClientCaseNumber(), $user);
     }
 

--- a/api/tests/Behat/bootstrap/v2/Common/AuthTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/AuthTrait.php
@@ -108,4 +108,14 @@ trait AuthTrait
 
         return $filteredUser;
     }
+
+    /**
+     * @When the user I'm interacting with logs in to the frontend of the app
+     */
+    public function interactingWithUserLogsInToFrontend()
+    {
+        $this->assertInteractingWithUserIsSet();
+
+        $this->loginToFrontendAs($this->interactingWithUserDetails->getUserEmail());
+    }
 }

--- a/api/tests/Behat/bootstrap/v2/Common/BaseFeatureContext.php
+++ b/api/tests/Behat/bootstrap/v2/Common/BaseFeatureContext.php
@@ -66,6 +66,10 @@ class BaseFeatureContext extends MinkContext
     public UserDetails $profAdminDeputyCompletedDetails;
     public UserDetails $profAdminDeputySubmittedDetails;
 
+    public UserDetails $publicAuthorityNamedDeputyNotStartedDetails;
+    public UserDetails $publicAuthorityNamedDeputyCompletedDetails;
+    public UserDetails $publicAuthorityNamedDeputySubmittedDetails;
+
     public UserDetails $layNdrDeputyNotStartedDetails;
     public UserDetails $layNdrDeputyCompletedDetails;
     public UserDetails $layNdrDeputySubmittedDetails;
@@ -258,6 +262,33 @@ class BaseFeatureContext extends MinkContext
     {
         $userDetails = $this->fixtureHelper->createProfAdminSubmitted($this->testRunId);
         $this->fixtureUsers[] = $this->profAdminDeputySubmittedDetails = new UserDetails($userDetails);
+    }
+
+    /**
+     * @BeforeScenario @pa-named-not-started
+     */
+    public function createPaNamedNotStarted()
+    {
+        $userDetails = $this->fixtureHelper->createPaNamedHealthWelfareNotStarted($this->testRunId);
+        $this->fixtureUsers[] = $this->publicAuthorityNamedDeputyNotStartedDetails = new UserDetails($userDetails);
+    }
+
+    /**
+     * @BeforeScenario @pa-named-completed
+     */
+    public function createPaNamedCompleted()
+    {
+        $userDetails = $this->fixtureHelper->createPaNamedHealthWelfareCompleted($this->testRunId);
+        $this->fixtureUsers[] = $this->publicAuthorityNamedDeputyCompletedDetails = new UserDetails($userDetails);
+    }
+
+    /**
+     * @BeforeScenario @pa-named-submitted
+     */
+    public function createPaNamedSubmitted()
+    {
+        $userDetails = $this->fixtureHelper->createPaNamedHealthWelfareSubmitted($this->testRunId);
+        $this->fixtureUsers[] = $this->publicAuthorityNamedDeputySubmittedDetails = new UserDetails($userDetails);
     }
 
     /**

--- a/api/tests/Behat/bootstrap/v2/Common/BaseFeatureContext.php
+++ b/api/tests/Behat/bootstrap/v2/Common/BaseFeatureContext.php
@@ -54,6 +54,10 @@ class BaseFeatureContext extends MinkContext
     public UserDetails $layDeputyCompletedHealthWelfareDetails;
     public UserDetails $layDeputySubmittedHealthWelfareDetails;
 
+    public UserDetails $layDeputyNotStartedCombinedHighDetails;
+    public UserDetails $layDeputyCompletedCombinedHighDetails;
+    public UserDetails $layDeputySubmittedCombinedHighDetails;
+
     public UserDetails $profNamedDeputyNotStartedHealthWelfareDetails;
     public UserDetails $profNamedDeputyCompletedHealthWelfareDetails;
     public UserDetails $profNamedDeputySubmittedHealthWelfareDetails;
@@ -181,6 +185,33 @@ class BaseFeatureContext extends MinkContext
     {
         $userDetails = $this->fixtureHelper->createLayHealthWelfareCompleted($this->testRunId);
         $this->fixtureUsers[] = $this->layDeputyCompletedHealthWelfareDetails = new UserDetails($userDetails);
+    }
+
+    /**
+     * @BeforeScenario @lay-combined-high-not-started
+     */
+    public function createLayCombinedHighNotStarted()
+    {
+        $userDetails = $this->fixtureHelper->createLayCombinedHighAssetsNotStarted($this->testRunId);
+        $this->fixtureUsers[] = $this->layDeputyNotStartedCombinedHighDetails = new UserDetails($userDetails);
+    }
+
+    /**
+     * @BeforeScenario @lay-combined-high-completed
+     */
+    public function createLayCombinedHighCompleted()
+    {
+        $userDetails = $this->fixtureHelper->createLayCombinedHighAssetsCompleted($this->testRunId);
+        $this->fixtureUsers[] = $this->layDeputyCompletedCombinedHighDetails = new UserDetails($userDetails);
+    }
+
+    /**
+     * @BeforeScenario @lay-combined-high-submitted
+     */
+    public function createLayCombinedHighSubmitted()
+    {
+        $userDetails = $this->fixtureHelper->createLayCombinedHighAssetsSubmitted($this->testRunId);
+        $this->fixtureUsers[] = $this->layDeputySubmittedCombinedHighDetails = new UserDetails($userDetails);
     }
 
     /**

--- a/api/tests/Behat/bootstrap/v2/Common/BaseFeatureContext.php
+++ b/api/tests/Behat/bootstrap/v2/Common/BaseFeatureContext.php
@@ -66,13 +66,17 @@ class BaseFeatureContext extends MinkContext
     public UserDetails $profTeamDeputyCompletedHealthWelfareDetails;
     public UserDetails $profTeamDeputySubmittedHealthWelfareDetails;
 
-    public UserDetails $profAdminDeputyNotStartedDetails;
-    public UserDetails $profAdminDeputyCompletedDetails;
-    public UserDetails $profAdminDeputySubmittedDetails;
+    public UserDetails $profAdminDeputyHealthWelfareNotStartedDetails;
+    public UserDetails $profAdminDeputyHealthWelfareCompletedDetails;
+    public UserDetails $profAdminDeputyHealthWelfareSubmittedDetails;
 
     public UserDetails $publicAuthorityNamedDeputyNotStartedDetails;
     public UserDetails $publicAuthorityNamedDeputyCompletedDetails;
     public UserDetails $publicAuthorityNamedDeputySubmittedDetails;
+
+    public UserDetails $publicAuthorityAdminCombinedHighNotStartedDetails;
+    public UserDetails $publicAuthorityAdminCombinedHighCompletedDetails;
+    public UserDetails $publicAuthorityAdminCombinedHighSubmittedDetails;
 
     public UserDetails $layNdrDeputyNotStartedDetails;
     public UserDetails $layNdrDeputyCompletedDetails;
@@ -274,7 +278,7 @@ class BaseFeatureContext extends MinkContext
     public function createProfAdminNotStarted()
     {
         $userDetails = $this->fixtureHelper->createProfAdminNotStarted($this->testRunId);
-        $this->fixtureUsers[] = $this->profAdminDeputyNotStartedDetails = new UserDetails($userDetails);
+        $this->fixtureUsers[] = $this->profAdminDeputyHealthWelfareNotStartedDetails = new UserDetails($userDetails);
     }
 
     /**
@@ -283,7 +287,7 @@ class BaseFeatureContext extends MinkContext
     public function createProfAdminCompleted()
     {
         $userDetails = $this->fixtureHelper->createProfAdminCompleted($this->testRunId);
-        $this->fixtureUsers[] = $this->profAdminDeputyCompletedDetails = new UserDetails($userDetails);
+        $this->fixtureUsers[] = $this->profAdminDeputyHealthWelfareCompletedDetails = new UserDetails($userDetails);
     }
 
     /**
@@ -292,7 +296,7 @@ class BaseFeatureContext extends MinkContext
     public function createProfAdminSubmitted()
     {
         $userDetails = $this->fixtureHelper->createProfAdminSubmitted($this->testRunId);
-        $this->fixtureUsers[] = $this->profAdminDeputySubmittedDetails = new UserDetails($userDetails);
+        $this->fixtureUsers[] = $this->profAdminDeputyHealthWelfareSubmittedDetails = new UserDetails($userDetails);
     }
 
     /**
@@ -320,6 +324,33 @@ class BaseFeatureContext extends MinkContext
     {
         $userDetails = $this->fixtureHelper->createPaNamedHealthWelfareSubmitted($this->testRunId);
         $this->fixtureUsers[] = $this->publicAuthorityNamedDeputySubmittedDetails = new UserDetails($userDetails);
+    }
+
+    /**
+     * @BeforeScenario @pa-admin-combined-high-not-started
+     */
+    public function createPaAdminCombinedHighNotStarted()
+    {
+        $userDetails = $this->fixtureHelper->createPaAdminCombinedHighNotStarted($this->testRunId);
+        $this->fixtureUsers[] = $this->publicAuthorityAdminCombinedHighNotStartedDetails = new UserDetails($userDetails);
+    }
+
+    /**
+     * @BeforeScenario @pa-admin-combined-high-completed
+     */
+    public function createPaAdminCombinedHighCompleted()
+    {
+        $userDetails = $this->fixtureHelper->createPaAdminCombinedHighCompleted($this->testRunId);
+        $this->fixtureUsers[] = $this->publicAuthorityAdminCombinedHighCompletedDetails = new UserDetails($userDetails);
+    }
+
+    /**
+     * @BeforeScenario @pa-admin-combined-high-submitted
+     */
+    public function createPaAdminCombinedHighSubmitted()
+    {
+        $userDetails = $this->fixtureHelper->createPaAdminCombinedHighSubmitted($this->testRunId);
+        $this->fixtureUsers[] = $this->publicAuthorityAdminCombinedHighSubmittedDetails = new UserDetails($userDetails);
     }
 
     /**

--- a/api/tests/Behat/bootstrap/v2/Common/FixturesTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/FixturesTrait.php
@@ -117,7 +117,7 @@ trait FixturesTrait
         }
     }
 
-    public function createAdditionalProfHealthWelfareUsers(int $numberOfUsers)
+    public function createAdditionalProfHealthWelfareUsers(int $numberOfUsers): array
     {
         $users = [];
 

--- a/api/tests/Behat/bootstrap/v2/Common/FormFillingTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/FormFillingTrait.php
@@ -110,7 +110,32 @@ trait FormFillingTrait
         }
     }
 
-    private function determineAnswerGroup(string $formSectionName, string $inputLabel)
+    /**
+     * @param string      $checkboxGroupName define with a name that describes the checkbox group - keep consistent with
+     *                                       all checkboxes in the group that are ticked
+     * @param mixed       $option            option value to check
+     * @param string|null $formSectionName   define with any name you like - only include if you want to assert on
+     *                                       the value entered on a summary page at the end of the form flow
+     * @param string|null $translatedOption  The full or partial string the option is translated to on the front end
+     *                                       e.g. all_care_is_paid_by_someone_else could be:
+     *
+     *                                       'All John's care is paid for by someone else (for example, by the local authority, council or NHS)'
+     *                                       or
+     *                                       'paid for by someone else'
+     *
+     *                                       Only provide this if you are asserting on the translation on the summary page.
+     */
+    public function tickCheckbox(string $checkboxGroupName, $option, ?string $formSectionName = null, ?string $translatedOption = null)
+    {
+        $this->checkOption($option);
+
+        if ($formSectionName) {
+            $option = $translatedOption ?: $option;
+            $this->submittedAnswersByFormSections[$formSectionName][0][$checkboxGroupName][] = $option;
+        }
+    }
+
+    private function determineAnswerGroup(string $formSectionName, string $inputLabel): int
     {
         $lastMatchingIndex = 0;
 

--- a/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnAdminTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnAdminTrait.php
@@ -101,4 +101,9 @@ trait IShouldBeOnAdminTrait
     {
         return $this->iAmOnPage('/admin\/report\/.*\/manage-confirm$/');
     }
+
+    public function iAmOnAdminManageCloseReportConfirmPage()
+    {
+        return $this->iAmOnPage('/admin\/report\/.*\/manage-close-report-confirm$/');
+    }
 }

--- a/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnAdminTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnAdminTrait.php
@@ -91,4 +91,14 @@ trait IShouldBeOnAdminTrait
     {
         return $this->iAmOnPage('/admin\/stats\/satisfaction$/');
     }
+
+    public function iAmOnAdminManageReportPage()
+    {
+        return $this->iAmOnPage('/admin\/report\/.*\/manage$/');
+    }
+
+    public function iAmOnAdminManageReportConfirmPage()
+    {
+        return $this->iAmOnPage('/admin\/report\/.*\/manage-confirm$/');
+    }
 }

--- a/api/tests/Behat/bootstrap/v2/Common/IVisitAdminTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/IVisitAdminTrait.php
@@ -36,6 +36,17 @@ trait IVisitAdminTrait
     }
 
     /**
+     * @When I visit the admin client details page associated with the deputy I'm interacting with
+     */
+    public function iVisitAdminClientDetailsPageForDeputyInteractingWith()
+    {
+        $this->assertInteractingWithUserIsSet();
+
+        $clientDetailsUrl = $this->getAdminClientDetailsUrl($this->interactingWithUserDetails->getClientId());
+        $this->visitAdminPath($clientDetailsUrl);
+    }
+
+    /**
      * @When I visit the admin client details page for an existing client linked to a deputy in an Organisation
      */
     public function iVisitAdminOrgClientDetailsPage()

--- a/api/tests/Behat/bootstrap/v2/Common/IVisitAdminTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/IVisitAdminTrait.php
@@ -57,10 +57,10 @@ trait IVisitAdminTrait
             );
         }
 
-        $clientDetailsUrl = $this->getAdminClientDetailsUrl($this->profAdminDeputySubmittedDetails->getClientId());
+        $clientDetailsUrl = $this->getAdminClientDetailsUrl($this->profAdminDeputyHealthWelfareSubmittedDetails->getClientId());
         $this->visitAdminPath($clientDetailsUrl);
 
-        $this->interactingWithUserDetails = $this->profAdminDeputySubmittedDetails;
+        $this->interactingWithUserDetails = $this->profAdminDeputyHealthWelfareSubmittedDetails;
     }
 
     /**

--- a/api/tests/Behat/bootstrap/v2/Common/ReportTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/ReportTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Behat\v2\Common;
 
+use App\Tests\Behat\BehatException;
 use Exception;
 
 trait ReportTrait
@@ -188,5 +189,47 @@ trait ReportTrait
         }
 
         $this->loginToFrontendAs($this->layDeputyCompletedHealthWelfareDetails->getUserEmail());
+    }
+
+    /**
+     * @Given a Professional Deputy has submitted a Health and Welfare report
+     * @Given a Professional Deputy has submitted a report
+     *
+     * @throws BehatException
+     */
+    public function aProfessionalDeputyHasSubmittedAReport()
+    {
+        if (empty($this->profAdminDeputySubmittedDetails)) {
+            throw new BehatException('It looks like fixtures are not loaded - missing $profAdminDeputySubmittedDetails');
+        }
+
+        $this->interactingWithUserDetails = $this->profAdminDeputySubmittedDetails;
+    }
+
+    /**
+     * @Given a Public Authority Deputy has submitted a Health and Welfare report
+     *
+     * @throws BehatException
+     */
+    public function aPublicAuthorityDeputyHasSubmittedAReport()
+    {
+        if (empty($this->publicAuthorityNamedDeputySubmittedDetails)) {
+            throw new BehatException('It looks like fixtures are not loaded - missing $publicAuthorityNamedDeputySubmittedDetails');
+        }
+
+        $this->interactingWithUserDetails = $this->publicAuthorityNamedDeputySubmittedDetails;
+    }
+
+    /**
+     * @Given a Professional Deputy has completed a Pfa Low Assets report
+     * @Given a Professional Deputy has completed a report
+     */
+    public function aProfDeputyHasCompletedAPfaLowAssetsReport()
+    {
+        if (empty($this->profAdminDeputyCompletedDetails)) {
+            throw new Exception('It looks like fixtures are not loaded - missing $profAdminDeputyCompletedDetails');
+        }
+
+        $this->interactingWithUserDetails = $this->profAdminDeputyCompletedDetails;
     }
 }

--- a/api/tests/Behat/bootstrap/v2/Common/ReportTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/ReportTrait.php
@@ -192,6 +192,18 @@ trait ReportTrait
     }
 
     /**
+     * @Given a Lay Deputy has submitted a Combined High Assets report
+     */
+    public function aLayDeputyHasSubmittedACombinedHighAssetsReport()
+    {
+        if (empty($this->layDeputySubmittedCombinedHighDetails)) {
+            throw new Exception('It looks like fixtures are not loaded - missing $layDeputySubmittedCombinedHighDetails');
+        }
+
+        $this->interactingWithUserDetails = $this->layDeputySubmittedCombinedHighDetails;
+    }
+
+    /**
      * @Given a Professional Deputy has submitted a Health and Welfare report
      * @Given a Professional Deputy has submitted a report
      *

--- a/api/tests/Behat/bootstrap/v2/Common/ReportTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/ReportTrait.php
@@ -112,11 +112,11 @@ trait ReportTrait
      */
     public function aProfessionalAdminDeputyHasNotStartedAReport()
     {
-        if (empty($this->profAdminDeputyNotStartedDetails)) {
+        if (empty($this->profAdminDeputyHealthWelfareNotStartedDetails)) {
             throw new Exception('It looks like fixtures are not loaded - missing $profAdminDeputyNotStartedDetails');
         }
 
-        $this->loginToFrontendAs($this->profAdminDeputyNotStartedDetails->getUserEmail());
+        $this->loginToFrontendAs($this->profAdminDeputyHealthWelfareNotStartedDetails->getUserEmail());
     }
 
     /**
@@ -211,11 +211,11 @@ trait ReportTrait
      */
     public function aProfessionalDeputyHasSubmittedAReport()
     {
-        if (empty($this->profAdminDeputySubmittedDetails)) {
+        if (empty($this->profAdminDeputyHealthWelfareSubmittedDetails)) {
             throw new BehatException('It looks like fixtures are not loaded - missing $profAdminDeputySubmittedDetails');
         }
 
-        $this->interactingWithUserDetails = $this->profAdminDeputySubmittedDetails;
+        $this->interactingWithUserDetails = $this->profAdminDeputyHealthWelfareSubmittedDetails;
     }
 
     /**
@@ -238,10 +238,22 @@ trait ReportTrait
      */
     public function aProfDeputyHasCompletedAPfaLowAssetsReport()
     {
-        if (empty($this->profAdminDeputyCompletedDetails)) {
+        if (empty($this->profAdminDeputyHealthWelfareCompletedDetails)) {
             throw new Exception('It looks like fixtures are not loaded - missing $profAdminDeputyCompletedDetails');
         }
 
-        $this->interactingWithUserDetails = $this->profAdminDeputyCompletedDetails;
+        $this->interactingWithUserDetails = $this->profAdminDeputyHealthWelfareCompletedDetails;
+    }
+
+    /**
+     * @Given a Public Authority Deputy has submitted a Combined High Assets report
+     */
+    public function aProfessionalDeputyHasSubmittedACombinedHighAssetsReport()
+    {
+        if (empty($this->publicAuthorityAdminCombinedHighSubmittedDetails)) {
+            throw new Exception('It looks like fixtures are not loaded - missing $publicAuthorityAdminCombinedHighSubmittedDetails');
+        }
+
+        $this->interactingWithUserDetails = $this->publicAuthorityAdminCombinedHighSubmittedDetails;
     }
 }

--- a/api/tests/Behat/bootstrap/v2/Common/UserDetails.php
+++ b/api/tests/Behat/bootstrap/v2/Common/UserDetails.php
@@ -32,10 +32,16 @@ class UserDetails
     private ?string $currentReportType = null;
     private ?string $currentReportNdrOrReport = null;
     private ?string $currentReportDueDate = null;
+    private ?string $currentReportStartDate = null;
+    private ?string $currentReportEndDate = null;
+    private ?string $currentReportPeriod = null;
     private ?int $previousReportId = null;
     private ?string $previousReportType = null;
     private ?string $previousReportNdrOrReport = null;
     private ?string $previousReportDueDate = null;
+    private ?string $previousReportStartDate = null;
+    private ?string $previousReportEndDate = null;
+    private ?string $previousReportPeriod = null;
 
     public function __construct(array $userDetails)
     {
@@ -86,12 +92,18 @@ class UserDetails
         $this->setCurrentReportType($userDetails['currentReportType']);
         $this->setCurrentReportNdrOrReport($userDetails['currentReportNdrOrReport']);
         $this->setCurrentReportDueDate($userDetails['currentReportDueDate']);
+        $this->setCurrentReportStartDate($userDetails['currentReportStartDate']);
+        $this->setCurrentReportEndDate($userDetails['currentReportEndDate']);
+        $this->setCurrentReportPeriod($userDetails['currentReportPeriod']);
 
         if ($userDetails['currentReportId'] !== $userDetails['previousReportId']) {
             $this->setPreviousReportId($userDetails['previousReportId']);
             $this->setPreviousReportType($userDetails['previousReportType']);
             $this->setPreviousReportNdrOrReport($userDetails['previousReportNdrOrReport']);
             $this->setPreviousReportDueDate($userDetails['previousReportDueDate']);
+            $this->setPreviousReportStartDate($userDetails['previousReportStartDate']);
+            $this->setPreviousReportEndDate($userDetails['previousReportEndDate']);
+            $this->setPreviousReportPeriod($userDetails['previousReportPeriod']);
         }
     }
 
@@ -392,6 +404,78 @@ class UserDetails
     public function setUserId(?int $userId): UserDetails
     {
         $this->userId = $userId;
+
+        return $this;
+    }
+
+    public function getCurrentReportStartDate(): ?string
+    {
+        return $this->currentReportStartDate;
+    }
+
+    public function setCurrentReportStartDate(?string $currentReportStartDate): UserDetails
+    {
+        $this->currentReportStartDate = $currentReportStartDate;
+
+        return $this;
+    }
+
+    public function getCurrentReportEndDate(): ?string
+    {
+        return $this->currentReportEndDate;
+    }
+
+    public function setCurrentReportEndDate(?string $currentReportEndDate): UserDetails
+    {
+        $this->currentReportEndDate = $currentReportEndDate;
+
+        return $this;
+    }
+
+    public function getPreviousReportStartDate(): ?string
+    {
+        return $this->previousReportStartDate;
+    }
+
+    public function setPreviousReportStartDate(?string $previousReportStartDate): UserDetails
+    {
+        $this->previousReportStartDate = $previousReportStartDate;
+
+        return $this;
+    }
+
+    public function getPreviousReportEndDate(): ?string
+    {
+        return $this->previousReportEndDate;
+    }
+
+    public function setPreviousReportEndDate(?string $previousReportEndDate): UserDetails
+    {
+        $this->previousReportEndDate = $previousReportEndDate;
+
+        return $this;
+    }
+
+    public function getCurrentReportPeriod(): ?string
+    {
+        return $this->currentReportPeriod;
+    }
+
+    public function setCurrentReportPeriod(?string $currentReportPeriod): UserDetails
+    {
+        $this->currentReportPeriod = $currentReportPeriod;
+
+        return $this;
+    }
+
+    public function getPreviousReportPeriod(): ?string
+    {
+        return $this->previousReportPeriod;
+    }
+
+    public function setPreviousReportPeriod(?string $previousReportPeriod): UserDetails
+    {
+        $this->previousReportPeriod = $previousReportPeriod;
 
         return $this;
     }

--- a/api/tests/Behat/bootstrap/v2/Common/UserDetails.php
+++ b/api/tests/Behat/bootstrap/v2/Common/UserDetails.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Behat\v2\Common;
 
+use DateTime;
 use Exception;
 use ReflectionClass;
 use ReflectionProperty;
@@ -31,17 +32,15 @@ class UserDetails
     private ?int $currentReportId = null;
     private ?string $currentReportType = null;
     private ?string $currentReportNdrOrReport = null;
-    private ?string $currentReportDueDate = null;
-    private ?string $currentReportStartDate = null;
-    private ?string $currentReportEndDate = null;
-    private ?string $currentReportPeriod = null;
+    private ?DateTime $currentReportDueDate = null;
+    private ?DateTime $currentReportStartDate = null;
+    private ?DateTime $currentReportEndDate = null;
     private ?int $previousReportId = null;
     private ?string $previousReportType = null;
     private ?string $previousReportNdrOrReport = null;
-    private ?string $previousReportDueDate = null;
-    private ?string $previousReportStartDate = null;
-    private ?string $previousReportEndDate = null;
-    private ?string $previousReportPeriod = null;
+    private ?DateTime $previousReportDueDate = null;
+    private ?DateTime $previousReportStartDate = null;
+    private ?DateTime $previousReportEndDate = null;
 
     public function __construct(array $userDetails)
     {
@@ -94,7 +93,6 @@ class UserDetails
         $this->setCurrentReportDueDate($userDetails['currentReportDueDate']);
         $this->setCurrentReportStartDate($userDetails['currentReportStartDate']);
         $this->setCurrentReportEndDate($userDetails['currentReportEndDate']);
-        $this->setCurrentReportPeriod($userDetails['currentReportPeriod']);
 
         if ($userDetails['currentReportId'] !== $userDetails['previousReportId']) {
             $this->setPreviousReportId($userDetails['previousReportId']);
@@ -103,7 +101,6 @@ class UserDetails
             $this->setPreviousReportDueDate($userDetails['previousReportDueDate']);
             $this->setPreviousReportStartDate($userDetails['previousReportStartDate']);
             $this->setPreviousReportEndDate($userDetails['previousReportEndDate']);
-            $this->setPreviousReportPeriod($userDetails['previousReportPeriod']);
         }
     }
 
@@ -336,24 +333,24 @@ class UserDetails
         return $this;
     }
 
-    public function getCurrentReportDueDate(): ?string
+    public function getCurrentReportDueDate(): ?DateTime
     {
         return $this->currentReportDueDate;
     }
 
-    public function setCurrentReportDueDate(?string $currentReportDueDate): UserDetails
+    public function setCurrentReportDueDate(?DateTime $currentReportDueDate): UserDetails
     {
         $this->currentReportDueDate = $currentReportDueDate;
 
         return $this;
     }
 
-    public function getPreviousReportDueDate(): ?string
+    public function getPreviousReportDueDate(): ?DateTime
     {
         return $this->previousReportDueDate;
     }
 
-    public function setPreviousReportDueDate(?string $previousReportDueDate): UserDetails
+    public function setPreviousReportDueDate(?DateTime $previousReportDueDate): UserDetails
     {
         $this->previousReportDueDate = $previousReportDueDate;
 
@@ -408,48 +405,48 @@ class UserDetails
         return $this;
     }
 
-    public function getCurrentReportStartDate(): ?string
+    public function getCurrentReportStartDate(): ?DateTime
     {
         return $this->currentReportStartDate;
     }
 
-    public function setCurrentReportStartDate(?string $currentReportStartDate): UserDetails
+    public function setCurrentReportStartDate(?DateTime $currentReportStartDate): UserDetails
     {
         $this->currentReportStartDate = $currentReportStartDate;
 
         return $this;
     }
 
-    public function getCurrentReportEndDate(): ?string
+    public function getCurrentReportEndDate(): ?DateTime
     {
         return $this->currentReportEndDate;
     }
 
-    public function setCurrentReportEndDate(?string $currentReportEndDate): UserDetails
+    public function setCurrentReportEndDate(?DateTime $currentReportEndDate): UserDetails
     {
         $this->currentReportEndDate = $currentReportEndDate;
 
         return $this;
     }
 
-    public function getPreviousReportStartDate(): ?string
+    public function getPreviousReportStartDate(): ?DateTime
     {
         return $this->previousReportStartDate;
     }
 
-    public function setPreviousReportStartDate(?string $previousReportStartDate): UserDetails
+    public function setPreviousReportStartDate(?DateTime $previousReportStartDate): UserDetails
     {
         $this->previousReportStartDate = $previousReportStartDate;
 
         return $this;
     }
 
-    public function getPreviousReportEndDate(): ?string
+    public function getPreviousReportEndDate(): ?DateTime
     {
         return $this->previousReportEndDate;
     }
 
-    public function setPreviousReportEndDate(?string $previousReportEndDate): UserDetails
+    public function setPreviousReportEndDate(?DateTime $previousReportEndDate): UserDetails
     {
         $this->previousReportEndDate = $previousReportEndDate;
 
@@ -458,25 +455,19 @@ class UserDetails
 
     public function getCurrentReportPeriod(): ?string
     {
-        return $this->currentReportPeriod;
-    }
-
-    public function setCurrentReportPeriod(?string $currentReportPeriod): UserDetails
-    {
-        $this->currentReportPeriod = $currentReportPeriod;
-
-        return $this;
+        return sprintf(
+            '%s-%s',
+            $this->getCurrentReportStartDate()->format('Y'),
+            $this->getCurrentReportEndDate()->format('Y'),
+        );
     }
 
     public function getPreviousReportPeriod(): ?string
     {
-        return $this->previousReportPeriod;
-    }
-
-    public function setPreviousReportPeriod(?string $previousReportPeriod): UserDetails
-    {
-        $this->previousReportPeriod = $previousReportPeriod;
-
-        return $this;
+        return sprintf(
+            '%s-%s',
+            $this->getPreviousReportStartDate()->format('Y'),
+            $this->getPreviousReportEndDate()->format('Y'),
+        );
     }
 }

--- a/api/tests/Behat/bootstrap/v2/Helpers/FixtureHelper.php
+++ b/api/tests/Behat/bootstrap/v2/Helpers/FixtureHelper.php
@@ -31,46 +31,6 @@ class FixtureHelper
     private OrganisationTestHelper $organisationTestHelper;
     private NamedDeputyTestHelper $namedDeputyTestHelper;
 
-    private User $admin;
-    private User $adminManager;
-    private User $superAdmin;
-
-    private User $layPfaHighAssetsNotStarted;
-    private User $layPfaHighAssetsCompleted;
-    private User $layPfaHighAssetsSubmitted;
-
-    private User $layPfaLowAssetsNotStarted;
-    private User $layPfaLowAssetsCompleted;
-    private User $layPfaLowAssetsSubmitted;
-
-    private User $layHealthWelfareNotStarted;
-    private User $layHealthWelfareCompleted;
-    private User $layHealthWelfareSubmitted;
-
-    private User $layCombinedHighAssetsNotStarted;
-    private User $layCombinedHighAssetsCompleted;
-    private User $layCombinedHighAssetsSubmitted;
-
-    private User $profNamedHealthWelfareNotStarted;
-    private User $profNamedHealthWelfareCompleted;
-    private User $profNamedHealthWelfareSubmitted;
-
-    private User $paNamedHealthWelfareNotStarted;
-    private User $paNamedHealthWelfareCompleted;
-    private User $paNamedHealthWelfareSubmitted;
-
-    private User $profTeamHealthWelfareNotStarted;
-    private User $profTeamHealthWelfareCompleted;
-    private User $profTeamHealthWelfareSubmitted;
-
-    private User $layNdrNotStarted;
-    private User $layNdrCompleted;
-    private User $layNdrSubmitted;
-
-    private User $profAdminNotStarted;
-    private User $profAdminCompleted;
-    private User $profAdminSubmitted;
-
     private string $testRunId = '';
     private string $orgName = 'Test Org';
     private string $orgEmailIdentifier = 'test-org.uk';
@@ -329,7 +289,7 @@ class FixtureHelper
 
     public function createLayPfaHighAssetsNotStarted(string $testRunId): array
     {
-        $this->layPfaHighAssetsNotStarted = $this->createDeputyClientAndReport(
+        $user = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-pfa-high-assets-not-started',
@@ -338,12 +298,12 @@ class FixtureHelper
             false
         );
 
-        return self::buildUserDetails($this->layPfaHighAssetsNotStarted);
+        return self::buildUserDetails($user);
     }
 
     public function createLayPfaHighAssetsCompleted(string $testRunId): array
     {
-        $this->layPfaHighAssetsCompleted = $this->createDeputyClientAndReport(
+        $user = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-pfa-high-assets-completed',
@@ -352,12 +312,12 @@ class FixtureHelper
             false
         );
 
-        return self::buildUserDetails($this->layPfaHighAssetsCompleted);
+        return self::buildUserDetails($user);
     }
 
     public function createLayPfaHighAssetsSubmitted(string $testRunId): array
     {
-        $this->layPfaHighAssetsSubmitted = $this->createDeputyClientAndReport(
+        $user = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-pfa-high-assets-submitted',
@@ -366,12 +326,12 @@ class FixtureHelper
             true
         );
 
-        return self::buildUserDetails($this->layPfaHighAssetsSubmitted);
+        return self::buildUserDetails($user);
     }
 
     public function createLayPfaLowAssetsNotStarted(string $testRunId): array
     {
-        $this->layPfaLowAssetsNotStarted = $this->createDeputyClientAndReport(
+        $user = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-pfa-low-assets-not-started',
@@ -380,12 +340,12 @@ class FixtureHelper
             false
         );
 
-        return self::buildUserDetails($this->layPfaLowAssetsNotStarted);
+        return self::buildUserDetails($user);
     }
 
     public function createLayPfaLowAssetsCompleted(string $testRunId): array
     {
-        $this->layPfaLowAssetsCompleted = $this->createDeputyClientAndReport(
+        $user = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-pfa-low-assets-completed',
@@ -394,12 +354,12 @@ class FixtureHelper
             false
         );
 
-        return self::buildUserDetails($this->layPfaLowAssetsCompleted);
+        return self::buildUserDetails($user);
     }
 
     public function createLayPfaLowAssetsSubmitted(string $testRunId): array
     {
-        $this->layPfaLowAssetsSubmitted = $this->createDeputyClientAndReport(
+        $user = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-pfa-low-assets-submitted',
@@ -408,12 +368,12 @@ class FixtureHelper
             true
         );
 
-        return self::buildUserDetails($this->layPfaLowAssetsSubmitted);
+        return self::buildUserDetails($user);
     }
 
     public function createLayHealthWelfareNotStarted(string $testRunId): array
     {
-        $this->layHealthWelfareNotStarted = $this->createDeputyClientAndReport(
+        $user = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-health-welfare-not-started',
@@ -422,12 +382,12 @@ class FixtureHelper
             false
         );
 
-        return self::buildUserDetails($this->layHealthWelfareNotStarted);
+        return self::buildUserDetails($user);
     }
 
     public function createLayHealthWelfareCompleted(string $testRunId): array
     {
-        $this->layHealthWelfareCompleted = $this->createDeputyClientAndReport(
+        $user = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-health-welfare-completed',
@@ -436,12 +396,12 @@ class FixtureHelper
             false
         );
 
-        return self::buildUserDetails($this->layHealthWelfareCompleted);
+        return self::buildUserDetails($user);
     }
 
     public function createLayHealthWelfareSubmitted(string $testRunId): array
     {
-        $this->layHealthWelfareSubmitted = $this->createDeputyClientAndReport(
+        $user = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-health-welfare-submitted',
@@ -450,12 +410,12 @@ class FixtureHelper
             true
         );
 
-        return self::buildUserDetails($this->layHealthWelfareSubmitted);
+        return self::buildUserDetails($user);
     }
 
     public function createLayCombinedHighAssetsNotStarted(string $testRunId): array
     {
-        $this->layCombinedHighAssetsNotStarted = $this->createDeputyClientAndReport(
+        $user = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-combined-high-not-started',
@@ -464,12 +424,12 @@ class FixtureHelper
             false
         );
 
-        return self::buildUserDetails($this->layCombinedHighAssetsNotStarted);
+        return self::buildUserDetails($user);
     }
 
     public function createLayCombinedHighAssetsCompleted(string $testRunId): array
     {
-        $this->layCombinedHighAssetsCompleted = $this->createDeputyClientAndReport(
+        $user = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-combined-high-completed',
@@ -478,12 +438,12 @@ class FixtureHelper
             false
         );
 
-        return self::buildUserDetails($this->layCombinedHighAssetsCompleted);
+        return self::buildUserDetails($user);
     }
 
     public function createLayCombinedHighAssetsSubmitted(string $testRunId): array
     {
-        $this->layCombinedHighAssetsSubmitted = $this->createDeputyClientAndReport(
+        $user = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-combined-high-submitted',
@@ -492,12 +452,12 @@ class FixtureHelper
             true
         );
 
-        return self::buildUserDetails($this->layCombinedHighAssetsSubmitted);
+        return self::buildUserDetails($user);
     }
 
     public function createProfNamedHealthWelfareNotStarted(string $testRunId): array
     {
-        $this->profNamedHealthWelfareNotStarted = $this->createOrgUserClientNamedDeputyAndReport(
+        $user = $this->createOrgUserClientNamedDeputyAndReport(
             $testRunId,
             User::ROLE_PROF_NAMED,
             'prof-named-health-welfare-not-started',
@@ -506,12 +466,12 @@ class FixtureHelper
             false
         );
 
-        return self::buildOrgUserDetails($this->profNamedHealthWelfareNotStarted);
+        return self::buildOrgUserDetails($user);
     }
 
     public function createProfNamedHealthWelfareCompleted(string $testRunId): array
     {
-        $this->profNamedHealthWelfareCompleted = $this->createOrgUserClientNamedDeputyAndReport(
+        $user = $this->createOrgUserClientNamedDeputyAndReport(
             $testRunId,
             User::ROLE_PROF_NAMED,
             'prof-named-health-welfare-completed',
@@ -520,12 +480,12 @@ class FixtureHelper
             false
         );
 
-        return self::buildOrgUserDetails($this->profNamedHealthWelfareCompleted);
+        return self::buildOrgUserDetails($user);
     }
 
     public function createProfNamedHealthWelfareSubmitted(string $testRunId): array
     {
-        $this->profNamedHealthWelfareSubmitted = $this->createOrgUserClientNamedDeputyAndReport(
+        $user = $this->createOrgUserClientNamedDeputyAndReport(
             $testRunId,
             User::ROLE_PROF_NAMED,
             'prof-named-health-welfare-submitted',
@@ -534,12 +494,12 @@ class FixtureHelper
             true
         );
 
-        return self::buildOrgUserDetails($this->profNamedHealthWelfareSubmitted);
+        return self::buildOrgUserDetails($user);
     }
 
     public function createPaNamedHealthWelfareNotStarted(string $testRunId): array
     {
-        $this->paNamedHealthWelfareNotStarted = $this->createOrgUserClientNamedDeputyAndReport(
+        $user = $this->createOrgUserClientNamedDeputyAndReport(
             $testRunId,
             User::ROLE_PA_NAMED,
             'pa-named-health-welfare-not-started',
@@ -548,12 +508,12 @@ class FixtureHelper
             false
         );
 
-        return self::buildOrgUserDetails($this->paNamedHealthWelfareNotStarted);
+        return self::buildOrgUserDetails($user);
     }
 
     public function createPaNamedHealthWelfareCompleted(string $testRunId): array
     {
-        $this->paNamedHealthWelfareCompleted = $this->createOrgUserClientNamedDeputyAndReport(
+        $user = $this->createOrgUserClientNamedDeputyAndReport(
             $testRunId,
             User::ROLE_PA_NAMED,
             'pa-named-health-welfare-completed',
@@ -562,12 +522,12 @@ class FixtureHelper
             false
         );
 
-        return self::buildOrgUserDetails($this->paNamedHealthWelfareCompleted);
+        return self::buildOrgUserDetails($user);
     }
 
     public function createPaNamedHealthWelfareSubmitted(string $testRunId): array
     {
-        $this->paNamedHealthWelfareSubmitted = $this->createOrgUserClientNamedDeputyAndReport(
+        $user = $this->createOrgUserClientNamedDeputyAndReport(
             $testRunId,
             User::ROLE_PA_NAMED,
             'pa-named-health-welfare-submitted',
@@ -576,12 +536,54 @@ class FixtureHelper
             true
         );
 
-        return self::buildOrgUserDetails($this->paNamedHealthWelfareSubmitted);
+        return self::buildOrgUserDetails($user);
+    }
+
+    public function createPaAdminCombinedHighNotStarted(string $testRunId): array
+    {
+        $user = $this->createOrgUserClientNamedDeputyAndReport(
+            $testRunId,
+            User::ROLE_PA_ADMIN,
+            'pa-admin-combined-high-not-started',
+            Report::TYPE_102_4_5,
+            false,
+            false
+        );
+
+        return self::buildOrgUserDetails($user);
+    }
+
+    public function createPaAdminCombinedHighCompleted(string $testRunId): array
+    {
+        $user = $this->createOrgUserClientNamedDeputyAndReport(
+            $testRunId,
+            User::ROLE_PA_ADMIN,
+            'pa-admin-combined-high-completed',
+            Report::TYPE_102_4_5,
+            true,
+            false
+        );
+
+        return self::buildOrgUserDetails($user);
+    }
+
+    public function createPaAdminCombinedHighSubmitted(string $testRunId): array
+    {
+        $user = $this->createOrgUserClientNamedDeputyAndReport(
+            $testRunId,
+            User::ROLE_PA_ADMIN,
+            'pa-admin-combined-high-submitted',
+            Report::TYPE_102_4_5,
+            true,
+            true
+        );
+
+        return self::buildOrgUserDetails($user);
     }
 
     public function createProfTeamHealthWelfareNotStarted(string $testRunId): array
     {
-        $this->profTeamHealthWelfareNotStarted = $this->createOrgUserClientNamedDeputyAndReport(
+        $user = $this->createOrgUserClientNamedDeputyAndReport(
             $testRunId,
             User::ROLE_PROF_TEAM_MEMBER,
             'prof-team-health-welfare-not-started',
@@ -590,12 +592,12 @@ class FixtureHelper
             false
         );
 
-        return self::buildOrgUserDetails($this->profTeamHealthWelfareNotStarted);
+        return self::buildOrgUserDetails($user);
     }
 
     public function createProfTeamHealthWelfareCompleted(string $testRunId): array
     {
-        $this->profTeamHealthWelfareCompleted = $this->createOrgUserClientNamedDeputyAndReport(
+        $user = $this->createOrgUserClientNamedDeputyAndReport(
             $testRunId,
             User::ROLE_PROF_TEAM_MEMBER,
             'prof-team-health-welfare-completed',
@@ -604,12 +606,12 @@ class FixtureHelper
             false
         );
 
-        return self::buildOrgUserDetails($this->profTeamHealthWelfareCompleted);
+        return self::buildOrgUserDetails($user);
     }
 
     public function createProfTeamHealthWelfareSubmitted(string $testRunId): array
     {
-        $this->profTeamHealthWelfareSubmitted = $this->createOrgUserClientNamedDeputyAndReport(
+        $user = $this->createOrgUserClientNamedDeputyAndReport(
             $testRunId,
             User::ROLE_PROF_TEAM_MEMBER,
             'prof-team-health-welfare-submitted',
@@ -618,12 +620,12 @@ class FixtureHelper
             true
         );
 
-        return self::buildOrgUserDetails($this->profTeamHealthWelfareSubmitted);
+        return self::buildOrgUserDetails($user);
     }
 
     public function createLayNdrNotStarted(string $testRunId): array
     {
-        $this->layNdrNotStarted = $this->createDeputyClientAndReport(
+        $user = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-ndr-not-started',
@@ -633,12 +635,12 @@ class FixtureHelper
             true
         );
 
-        return self::buildUserDetails($this->layNdrNotStarted);
+        return self::buildUserDetails($user);
     }
 
     public function createLayNdrCompleted(string $testRunId): array
     {
-        $this->layNdrCompleted = $this->createDeputyClientAndReport(
+        $user = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-ndr-completed',
@@ -648,12 +650,12 @@ class FixtureHelper
             true
         );
 
-        return self::buildUserDetails($this->layNdrCompleted);
+        return self::buildUserDetails($user);
     }
 
     public function createLayNdrSubmitted(string $testRunId): array
     {
-        $this->layNdrSubmitted = $this->createDeputyClientAndReport(
+        $user = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-ndr-submitted',
@@ -663,12 +665,12 @@ class FixtureHelper
             true
         );
 
-        return self::buildUserDetails($this->layNdrSubmitted);
+        return self::buildUserDetails($user);
     }
 
     public function createProfAdminNotStarted(string $testRunId): array
     {
-        $this->profAdminNotStarted = $this->createOrgUserClientNamedDeputyAndReport(
+        $user = $this->createOrgUserClientNamedDeputyAndReport(
             $testRunId,
             User::ROLE_PROF_ADMIN,
             'prof-admin-not-started',
@@ -677,12 +679,12 @@ class FixtureHelper
             false
         );
 
-        return self::buildOrgUserDetails($this->profAdminNotStarted);
+        return self::buildOrgUserDetails($user);
     }
 
     public function createProfAdminCompleted(string $testRunId): array
     {
-        $this->profAdminCompleted = $this->createOrgUserClientNamedDeputyAndReport(
+        $user = $this->createOrgUserClientNamedDeputyAndReport(
             $testRunId,
             User::ROLE_PROF_ADMIN,
             'prof-admin-completed',
@@ -691,12 +693,12 @@ class FixtureHelper
             false
         );
 
-        return self::buildOrgUserDetails($this->profAdminCompleted);
+        return self::buildOrgUserDetails($user);
     }
 
     public function createProfAdminSubmitted(string $testRunId): array
     {
-        $this->profAdminSubmitted = $this->createOrgUserClientNamedDeputyAndReport(
+        $user = $this->createOrgUserClientNamedDeputyAndReport(
             $testRunId,
             User::ROLE_PROF_ADMIN,
             'prof-admin-submitted',
@@ -705,40 +707,40 @@ class FixtureHelper
             true
         );
 
-        return self::buildOrgUserDetails($this->profAdminSubmitted);
+        return self::buildOrgUserDetails($user);
     }
 
     public function createAdmin(string $testRunId): array
     {
-        $this->admin = $this->createAdminUser(
+        $user = $this->createAdminUser(
             $testRunId,
             User::ROLE_ADMIN,
             'admin'
         );
 
-        return self::buildAdminUserDetails($this->admin);
+        return self::buildAdminUserDetails($user);
     }
 
     public function createAdminManager(string $testRunId): array
     {
-        $this->adminManager = $this->createAdminUser(
+        $user = $this->createAdminUser(
             $testRunId,
             User::ROLE_ADMIN_MANAGER,
             'admin-manager'
         );
 
-        return self::buildAdminUserDetails($this->adminManager);
+        return self::buildAdminUserDetails($user);
     }
 
     public function createSuperAdmin(string $testRunId): array
     {
-        $this->superAdmin = $this->createAdminUser(
+        $user = $this->createAdminUser(
             $testRunId,
             User::ROLE_SUPER_ADMIN,
             'super-admin'
         );
 
-        return self::buildAdminUserDetails($this->superAdmin);
+        return self::buildAdminUserDetails($user);
     }
 
     public function createDataForAnalytics(string $testRunId, $timeAgo, $satisfactionScore)

--- a/api/tests/Behat/bootstrap/v2/Helpers/FixtureHelper.php
+++ b/api/tests/Behat/bootstrap/v2/Helpers/FixtureHelper.php
@@ -47,6 +47,10 @@ class FixtureHelper
     private User $layHealthWelfareCompleted;
     private User $layHealthWelfareSubmitted;
 
+    private User $layCombinedHighAssetsNotStarted;
+    private User $layCombinedHighAssetsCompleted;
+    private User $layCombinedHighAssetsSubmitted;
+
     private User $profNamedHealthWelfareNotStarted;
     private User $profNamedHealthWelfareCompleted;
     private User $profNamedHealthWelfareSubmitted;
@@ -114,14 +118,9 @@ class FixtureHelper
             'currentReportId' => $currentReport->getId(),
             'currentReportType' => $currentReportType,
             'currentReportNdrOrReport' => $currentReport instanceof Ndr ? 'ndr' : 'report',
-            'currentReportDueDate' => $currentReport->getDueDate()->format('j F Y'),
-            'currentReportStartDate' => $currentReport->getStartDate()->format('j F Y'),
-            'currentReportEndDate' => $currentReport instanceof Ndr ? null : $currentReport->getEndDate()->format('j F Y'),
-            'currentReportPeriod' => $currentReport instanceof Ndr ? null : sprintf(
-                '%s-%s',
-                $currentReport->getStartDate()->format('Y'),
-                $currentReport->getEndDate()->format('Y')
-            ),
+            'currentReportDueDate' => $currentReport->getDueDate(),
+            'currentReportStartDate' => $currentReport->getStartDate(),
+            'currentReportEndDate' => $currentReport instanceof Ndr ? null : $currentReport->getEndDate(),
         ];
 
         if ($previousReport && $previousReport->getId() !== $currentReport->getId()) {
@@ -131,14 +130,9 @@ class FixtureHelper
                     'previousReportId' => $previousReport->getId(),
                     'previousReportType' => $previousReport->getType(),
                     'previousReportNdrOrReport' => $previousReport instanceof Ndr ? 'ndr' : 'report',
-                    'previousReportDueDate' => $previousReport->getDueDate()->format('j F Y'),
-                    'previousReportStartDate' => $previousReport->getStartDate()->format('j F Y'),
-                    'previousReportEndDate' => $previousReport->getEndDate()->format('j F Y'),
-                    'previousReportPeriod' => sprintf(
-                        '%s-%s',
-                        $previousReport->getStartDate()->format('Y'),
-                        $previousReport->getEndDate()->format('Y')
-                    ),
+                    'previousReportDueDate' => $previousReport->getDueDate(),
+                    'previousReportStartDate' => $previousReport->getStartDate(),
+                    'previousReportEndDate' => $previousReport->getEndDate(),
                 ]
             );
         }
@@ -335,7 +329,7 @@ class FixtureHelper
 
     public function createLayPfaHighAssetsNotStarted(string $testRunId): array
     {
-        $this->layPfaHighAssetsNotStarted = $this->createClientAndReport(
+        $this->layPfaHighAssetsNotStarted = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-pfa-high-assets-not-started',
@@ -349,7 +343,7 @@ class FixtureHelper
 
     public function createLayPfaHighAssetsCompleted(string $testRunId): array
     {
-        $this->layPfaHighAssetsCompleted = $this->createClientAndReport(
+        $this->layPfaHighAssetsCompleted = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-pfa-high-assets-completed',
@@ -363,7 +357,7 @@ class FixtureHelper
 
     public function createLayPfaHighAssetsSubmitted(string $testRunId): array
     {
-        $this->layPfaHighAssetsSubmitted = $this->createClientAndReport(
+        $this->layPfaHighAssetsSubmitted = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-pfa-high-assets-submitted',
@@ -377,7 +371,7 @@ class FixtureHelper
 
     public function createLayPfaLowAssetsNotStarted(string $testRunId): array
     {
-        $this->layPfaLowAssetsNotStarted = $this->createClientAndReport(
+        $this->layPfaLowAssetsNotStarted = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-pfa-low-assets-not-started',
@@ -391,7 +385,7 @@ class FixtureHelper
 
     public function createLayPfaLowAssetsCompleted(string $testRunId): array
     {
-        $this->layPfaLowAssetsCompleted = $this->createClientAndReport(
+        $this->layPfaLowAssetsCompleted = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-pfa-low-assets-completed',
@@ -405,7 +399,7 @@ class FixtureHelper
 
     public function createLayPfaLowAssetsSubmitted(string $testRunId): array
     {
-        $this->layPfaLowAssetsSubmitted = $this->createClientAndReport(
+        $this->layPfaLowAssetsSubmitted = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-pfa-low-assets-submitted',
@@ -419,7 +413,7 @@ class FixtureHelper
 
     public function createLayHealthWelfareNotStarted(string $testRunId): array
     {
-        $this->layHealthWelfareNotStarted = $this->createClientAndReport(
+        $this->layHealthWelfareNotStarted = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-health-welfare-not-started',
@@ -433,7 +427,7 @@ class FixtureHelper
 
     public function createLayHealthWelfareCompleted(string $testRunId): array
     {
-        $this->layHealthWelfareCompleted = $this->createClientAndReport(
+        $this->layHealthWelfareCompleted = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-health-welfare-completed',
@@ -447,7 +441,7 @@ class FixtureHelper
 
     public function createLayHealthWelfareSubmitted(string $testRunId): array
     {
-        $this->layHealthWelfareSubmitted = $this->createClientAndReport(
+        $this->layHealthWelfareSubmitted = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-health-welfare-submitted',
@@ -457,6 +451,48 @@ class FixtureHelper
         );
 
         return self::buildUserDetails($this->layHealthWelfareSubmitted);
+    }
+
+    public function createLayCombinedHighAssetsNotStarted(string $testRunId): array
+    {
+        $this->layCombinedHighAssetsNotStarted = $this->createDeputyClientAndReport(
+            $testRunId,
+            User::ROLE_LAY_DEPUTY,
+            'lay-combined-high-not-started',
+            Report::TYPE_102_4,
+            false,
+            false
+        );
+
+        return self::buildUserDetails($this->layCombinedHighAssetsNotStarted);
+    }
+
+    public function createLayCombinedHighAssetsCompleted(string $testRunId): array
+    {
+        $this->layCombinedHighAssetsCompleted = $this->createDeputyClientAndReport(
+            $testRunId,
+            User::ROLE_LAY_DEPUTY,
+            'lay-combined-high-completed',
+            Report::TYPE_102_4,
+            true,
+            false
+        );
+
+        return self::buildUserDetails($this->layCombinedHighAssetsCompleted);
+    }
+
+    public function createLayCombinedHighAssetsSubmitted(string $testRunId): array
+    {
+        $this->layCombinedHighAssetsSubmitted = $this->createDeputyClientAndReport(
+            $testRunId,
+            User::ROLE_LAY_DEPUTY,
+            'lay-combined-high-submitted',
+            Report::TYPE_102_4,
+            true,
+            true
+        );
+
+        return self::buildUserDetails($this->layCombinedHighAssetsSubmitted);
     }
 
     public function createProfNamedHealthWelfareNotStarted(string $testRunId): array
@@ -587,7 +623,7 @@ class FixtureHelper
 
     public function createLayNdrNotStarted(string $testRunId): array
     {
-        $this->layNdrNotStarted = $this->createClientAndReport(
+        $this->layNdrNotStarted = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-ndr-not-started',
@@ -602,7 +638,7 @@ class FixtureHelper
 
     public function createLayNdrCompleted(string $testRunId): array
     {
-        $this->layNdrCompleted = $this->createClientAndReport(
+        $this->layNdrCompleted = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-ndr-completed',
@@ -617,7 +653,7 @@ class FixtureHelper
 
     public function createLayNdrSubmitted(string $testRunId): array
     {
-        $this->layNdrSubmitted = $this->createClientAndReport(
+        $this->layNdrSubmitted = $this->createDeputyClientAndReport(
             $testRunId,
             User::ROLE_LAY_DEPUTY,
             'lay-ndr-submitted',
@@ -663,7 +699,7 @@ class FixtureHelper
         $this->profAdminSubmitted = $this->createOrgUserClientNamedDeputyAndReport(
             $testRunId,
             User::ROLE_PROF_ADMIN,
-            'prof-admin-completed',
+            'prof-admin-submitted',
             Report::TYPE_104_5,
             true,
             true
@@ -731,7 +767,7 @@ class FixtureHelper
             $satisfactionScore
         );
 
-        $this->createClientAndReport(
+        $this->createDeputyClientAndReport(
             $testRunId.'_3',
             User::ROLE_LAY_DEPUTY,
             'analytics-lay-submitted',
@@ -755,26 +791,26 @@ class FixtureHelper
         return $organisation;
     }
 
-    private function createClientAndReport(string $testRunId, $userRole, $emailPrefix, $reportType, $completed, $submitted,
-                                           bool $ndr = false, ?DateTime $startDate = null, int $satisfactionScore = null)
+    private function createDeputyClientAndReport(string $testRunId, $userRole, $emailPrefix, $reportType, $completed, $submitted,
+                                                 bool $ndr = false, ?DateTime $startDate = null, int $satisfactionScore = null)
     {
         if ('prod' === $this->symfonyEnvironment) {
             throw new Exception('Prod mode enabled - cannot create fixture users');
         }
         $this->testRunId = $testRunId;
 
-        $client = $this->userTestHelper
+        $deputy = $this->userTestHelper
             ->createUser(null, $userRole, sprintf('%s-%s@t.uk', $emailPrefix, $this->testRunId));
 
         if ($ndr) {
-            $this->addClientsAndReportsToNdrLayDeputy($client, $completed, $submitted);
+            $this->addClientsAndReportsToNdrLayDeputy($deputy, $completed, $submitted);
         } else {
-            $this->addClientsAndReportsToLayDeputy($client, $completed, $submitted, $reportType, $startDate, $satisfactionScore);
+            $this->addClientsAndReportsToLayDeputy($deputy, $completed, $submitted, $reportType, $startDate, $satisfactionScore);
         }
 
-        $this->setClientPassword($client);
+        $this->setClientPassword($deputy);
 
-        return $client;
+        return $deputy;
     }
 
     private function createAdminUser(string $testRunId, $userRole, $emailPrefix)

--- a/api/tests/Behat/bootstrap/v2/Helpers/FixtureHelper.php
+++ b/api/tests/Behat/bootstrap/v2/Helpers/FixtureHelper.php
@@ -550,7 +550,7 @@ class FixtureHelper
             $testRunId,
             User::ROLE_PA_ADMIN,
             'pa-admin-combined-high-not-started',
-            Report::TYPE_102_4_5,
+            Report::TYPE_102_4_6,
             false,
             false
         );
@@ -564,7 +564,7 @@ class FixtureHelper
             $testRunId,
             User::ROLE_PA_ADMIN,
             'pa-admin-combined-high-completed',
-            Report::TYPE_102_4_5,
+            Report::TYPE_102_4_6,
             true,
             false
         );
@@ -578,7 +578,7 @@ class FixtureHelper
             $testRunId,
             User::ROLE_PA_ADMIN,
             'pa-admin-combined-high-submitted',
-            Report::TYPE_102_4_5,
+            Report::TYPE_102_4_6,
             true,
             true
         );

--- a/api/tests/Behat/bootstrap/v2/ReportManagement/ReportManagementFeatureContext.php
+++ b/api/tests/Behat/bootstrap/v2/ReportManagement/ReportManagementFeatureContext.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Tests\Behat\v2\ReportManagement;
+
+use App\Tests\Behat\v2\Common\BaseFeatureContext;
+
+class ReportManagementFeatureContext extends BaseFeatureContext
+{
+    use ReportManagementTrait;
+}

--- a/api/tests/Behat/bootstrap/v2/ReportManagement/ReportManagementTrait.php
+++ b/api/tests/Behat/bootstrap/v2/ReportManagement/ReportManagementTrait.php
@@ -208,9 +208,17 @@ trait ReportManagementTrait
         );
 
         if ('start' === $event) {
-            $this->interactingWithUserDetails->setCurrentReportStartDate($dateObject);
+            if ('completed' === $this->reportStatus) {
+                $this->interactingWithUserDetails->setCurrentReportStartDate($dateObject);
+            } else {
+                $this->interactingWithUserDetails->setPreviousReportStartDate($dateObject);
+            }
         } else {
-            $this->interactingWithUserDetails->setCurrentReportEndDate($dateObject);
+            if ('completed' === $this->reportStatus) {
+                $this->interactingWithUserDetails->setCurrentReportEndDate($dateObject);
+            } else {
+                $this->interactingWithUserDetails->setPreviousReportEndDate($dateObject);
+            }
         }
     }
 
@@ -219,13 +227,21 @@ trait ReportManagementTrait
      */
     public function iShouldSeeReportSectionsLabelledAsChangesNeeded()
     {
-        $this->clickLink(
-            sprintf(
+        if ('completed' === $this->reportStatus) {
+            $reportPeriod = sprintf(
                 '%s to %s report',
                 $this->interactingWithUserDetails->getCurrentReportStartDate()->format('Y'),
                 $this->interactingWithUserDetails->getCurrentReportEndDate()->format('Y')
-            )
-        );
+            );
+        } else {
+            $reportPeriod = sprintf(
+                '%s to %s report',
+                $this->interactingWithUserDetails->getPreviousReportStartDate()->format('Y'),
+                $this->interactingWithUserDetails->getPreviousReportEndDate()->format('Y')
+            );
+        }
+
+        $this->clickLink($reportPeriod);
 
         $sectionsMarkedIncomplete = $this->getSectionAnswers('manage-report')[0]['incompleteSectionsForm'];
 

--- a/api/tests/Behat/bootstrap/v2/ReportManagement/ReportManagementTrait.php
+++ b/api/tests/Behat/bootstrap/v2/ReportManagement/ReportManagementTrait.php
@@ -4,10 +4,38 @@ declare(strict_types=1);
 
 namespace App\Tests\Behat\v2\ReportManagement;
 
+use App\Tests\Behat\BehatException;
 use DateTime;
 
 trait ReportManagementTrait
 {
+    private array $baseReportCheckboxValuesAndTranslations = [
+        'decisions' => 'Decisions',
+        'contacts' => 'Contacts',
+        'visitsCare' => 'Visits and care',
+        'lifestyle' => 'Health and lifestyle',
+        'bankAccounts' => 'Accounts',
+        'moneyTransfers' => 'Money transfers',
+        'moneyIn' => 'Money in',
+        'moneyOut' => 'Money out',
+        'assets' => 'Assets',
+        'debts' => 'Debts',
+        'gifts' => 'Gifts',
+        'balance' => 'Accounts balance check',
+        'actions' => 'Actions you plan to take',
+        'otherInfo' => 'Any other information',
+        'documents' => 'Supporting documents',
+    ];
+
+    private array $orgExtraCheckboxes = [
+        'profDeputyCosts' => 'Deputy costs',
+        'profDeputyCostsEstimate' => 'Deputy costs estimate',
+    ];
+
+    private array $layExtraCheckboxes = [
+        'deputyExpenses' => 'Deputy expenses',
+    ];
+
     /**
      * @When I manage the deputies :reportStatus report
      */
@@ -32,8 +60,31 @@ trait ReportManagementTrait
     public function iChangeReportTypeTo(string $reportType)
     {
         $this->iAmOnAdminManageReportPage();
+        $this->assertInteractingWithUserIsSet();
 
-        $this->chooseOption('manage_report[type]', '104-5', 'manage-report');
+        $isLay = is_null($this->interactingWithUserDetails->getOrganisationName);
+
+        switch ($reportType) {
+            case 'Health and welfare':
+                $option = $isLay ? '104' : '104-5';
+                break;
+            case 'PFA high assets':
+                $option = $isLay ? '102' : '102-5';
+                break;
+            case 'PFA low assets':
+                $option = $isLay ? '103' : '103-5';
+                break;
+            case 'Combined high assets':
+                $option = $isLay ? '102-4' : '102-4-5';
+                break;
+            case 'Combined low assets':
+                $option = $isLay ? '103-4' : '103-4-5';
+                break;
+            default:
+                throw new BehatException('Invalid report type - see options in ReportManagementTrait::iChangeReportTypeTo()');
+        }
+
+        $this->chooseOption('manage_report[type]', $option, 'manage-report');
     }
 
     /**
@@ -43,7 +94,11 @@ trait ReportManagementTrait
     {
         $this->iAmOnAdminManageReportPage();
 
-        $this->fillInField('manage_report[dueDateChoice]', '3', 'manage-report');
+        if (!in_array($numberOfWeeks, ['3', '4', '5'])) {
+            throw new BehatException('Due date weeks available are 3, 4 or 5 - rewrite this step to use a valid option');
+        }
+
+        $this->fillInField('manage_report[dueDateChoice]', $numberOfWeeks, 'manage-report');
     }
 
     /**
@@ -55,6 +110,7 @@ trait ReportManagementTrait
         $this->pressButton('Continue');
 
         $this->iAmOnAdminManageReportConfirmPage();
+        $this->selectOption('manage_report_confirm[confirm]', 'yes');
         $this->pressButton('Confirm');
     }
 
@@ -63,8 +119,9 @@ trait ReportManagementTrait
      */
     public function reportDetailsShouldBeUpdated()
     {
-        $reportPeriod = $this->interactingWithUserDetails->getCurrentReportPeriod();
+        $this->iAmOnAdminClientDetailsPage();
 
+        $reportPeriod = $this->interactingWithUserDetails->getCurrentReportPeriod();
         $locator = sprintf(
             "//td[normalize-space()='%s']/..",
             $reportPeriod
@@ -72,13 +129,9 @@ trait ReportManagementTrait
 
         $reportRow = $this->getSession()->getPage()->find('xpath', $locator);
 
-        $expectedReportType = $this->getSectionAnswers('manage-report')[0]['manage_report[type]'];
-
-        $this->assertStringContainsString(
-            $expectedReportType,
-            $reportRow->getHtml(),
-            'Comparing form answers against report row of client details page'
-        );
+        if (is_null($reportRow)) {
+            throw new BehatException(sprintf('Could not find a table data element with text %s on the page. HTML of page: %s', $reportPeriod, $this->getSession()->getPage()->find('xpath', '//main')->getHtml()));
+        }
 
         $numberWeeksExtended = $this->getSectionAnswers('manage-report')[0]['manage_report[dueDateChoice]'];
         $expectedDueDate = (new DateTime())
@@ -92,5 +145,94 @@ trait ReportManagementTrait
             $reportRow->getHtml(),
             'Comparing form answers against report row of client details page'
         );
+    }
+
+    /**
+     * @When I confirm all report sections are incomplete
+     */
+    public function confirmAllReportSectionsIncomplete()
+    {
+        $this->iAmOnAdminManageReportPage();
+        $isLay = is_null($this->interactingWithUserDetails->getOrganisationName);
+
+        $checkboxValuesAndTranslations = array_merge(
+            $this->baseReportCheckboxValuesAndTranslations,
+            $isLay ? $this->layExtraCheckboxes : $this->orgExtraCheckboxes
+        );
+
+        foreach ($checkboxValuesAndTranslations as $value => $translation) {
+            $this->tickCheckbox(
+                'incompleteSectionsForm',
+                $this->determineCheckboxName($value, $checkboxValuesAndTranslations),
+                'manage-report',
+                $translation)
+            ;
+        }
+    }
+
+    private function determineCheckboxName(string $value, array $checkboxValuesAndTranslations)
+    {
+        $checkboxDictionary = array_flip(array_keys($checkboxValuesAndTranslations));
+
+        return sprintf('manage_report[unsubmittedSection][%s][present]', $checkboxDictionary[$value]);
+    }
+
+    /**
+     * @When I change the report :event date to :date
+     */
+    public function iChangeReportEventToDate(string $event, string $date)
+    {
+        $this->iAmOnAdminManageReportPage();
+
+        if (!in_array($event, ['start', 'end'])) {
+            throw new BehatException('$event must be either "start" or "end"');
+        }
+
+        $dateObject = new DateTime($date);
+
+        $this->fillInDateFields(
+            sprintf('manage_report[%sDate]', $event),
+            intval($dateObject->format('j')),
+            intval($dateObject->format('n')),
+            intval($dateObject->format('Y')),
+            'manage-report'
+        );
+
+        if ('start' === $event) {
+            $this->interactingWithUserDetails->setCurrentReportStartDate($dateObject);
+        } else {
+            $this->interactingWithUserDetails->setCurrentReportEndDate($dateObject);
+        }
+    }
+
+    /**
+     * @Then I should see the report sections the admin ticked as incomplete labelled as changes needed
+     */
+    public function iShouldSeeReportSectionsLabelledAsChangesNeeded()
+    {
+        $this->clickLink(
+            sprintf(
+                '%s to %s report',
+                $this->interactingWithUserDetails->getCurrentReportStartDate()->format('Y'),
+                $this->interactingWithUserDetails->getCurrentReportEndDate()->format('Y')
+            )
+        );
+
+        $sectionsMarkedIncomplete = $this->getSectionAnswers('manage-report')[0]['incompleteSectionsForm'];
+
+        foreach ($sectionsMarkedIncomplete as $incompleteSectionName) {
+            $locator = sprintf("//li//a[normalize-space()='%s']/../../..", $incompleteSectionName);
+            $sectionListItem = $this->getSession()->getPage()->find('xpath', $locator);
+
+            if (is_null($sectionListItem)) {
+                throw new BehatException(sprintf('Could not find a list item containing an anchor element with text "%s". HTML of page: %s', $incompleteSectionName, $this->getSession()->getPage()->find('xpath', '//main')->getHtml()));
+            }
+
+            $this->assertStringContainsString(
+                'Changes needed',
+                $sectionListItem->getHtml(),
+                'Searching for "Changes needed" in list item that contains incomplete section name'
+            );
+        }
     }
 }

--- a/api/tests/Behat/bootstrap/v2/ReportManagement/ReportManagementTrait.php
+++ b/api/tests/Behat/bootstrap/v2/ReportManagement/ReportManagementTrait.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Behat\v2\ReportManagement;
+
+use DateTime;
+
+trait ReportManagementTrait
+{
+    /**
+     * @When I manage the deputies :reportStatus report
+     */
+    public function iManageTheDeputiesSubmittedReport(string $reportStatus)
+    {
+        $this->iAmOnAdminClientDetailsPage();
+
+        $reportId = 'completed' === $reportStatus ? $this->interactingWithUserDetails->getCurrentReportId() : $this->interactingWithUserDetails->getPreviousReportId();
+
+        $xpathLocator = sprintf(
+            "//a[contains(@href,'/admin/report/%s/manage')]",
+            $reportId
+        );
+
+        $reportLink = $this->getSession()->getPage()->find('xpath', $xpathLocator);
+        $reportLink->click();
+    }
+
+    /**
+     * @When I change the report type to :reportType
+     */
+    public function iChangeReportTypeTo(string $reportType)
+    {
+        $this->iAmOnAdminManageReportPage();
+
+        $this->chooseOption('manage_report[type]', '104-5', 'manage-report');
+    }
+
+    /**
+     * @When I change the report due date to :numberOfWeeks weeks from now
+     */
+    public function iChangeReportDueDateToWeeks(string $numberOfWeeks)
+    {
+        $this->iAmOnAdminManageReportPage();
+
+        $this->fillInField('manage_report[dueDateChoice]', '3', 'manage-report');
+    }
+
+    /**
+     * @When I submit the new report details
+     */
+    public function iSubmitNewReportDetails()
+    {
+        $this->iAmOnAdminManageReportPage();
+        $this->pressButton('Continue');
+
+        $this->iAmOnAdminManageReportConfirmPage();
+        $this->pressButton('Confirm');
+    }
+
+    /**
+     * @Then the report details should be updated
+     */
+    public function reportDetailsShouldBeUpdated()
+    {
+        $reportPeriod = $this->interactingWithUserDetails->getCurrentReportPeriod();
+
+        $locator = sprintf(
+            "//td[normalize-space()='%s']/..",
+            $reportPeriod
+        );
+
+        $reportRow = $this->getSession()->getPage()->find('xpath', $locator);
+
+        $expectedReportType = $this->getSectionAnswers('manage-report')[0]['manage_report[type]'];
+
+        $this->assertStringContainsString(
+            $expectedReportType,
+            $reportRow->getHtml(),
+            'Comparing form answers against report row of client details page'
+        );
+
+        $numberWeeksExtended = $this->getSectionAnswers('manage-report')[0]['manage_report[dueDateChoice]'];
+        $expectedDueDate = (new DateTime())
+            ->modify(
+                sprintf('+ %s weeks', $numberWeeksExtended)
+            )
+            ->format('j F Y');
+
+        $this->assertStringContainsString(
+            $expectedDueDate,
+            $reportRow->getHtml(),
+            'Comparing form answers against report row of client details page'
+        );
+    }
+}

--- a/api/tests/Behat/features-v2/report-management/report-management.feature
+++ b/api/tests/Behat/features-v2/report-management/report-management.feature
@@ -1,22 +1,32 @@
 @v2 @report-management
 Feature: Report Management (applies to all admin roles)
 
-    @super-admin @prof-admin-completed @acs
+    @super-admin @prof-admin-completed
     Scenario: An admin user changes report type and due date for a in progress report
         Given a super admin user accesses the admin app
         And a Professional Deputy has completed a Pfa Low Assets report
         When I visit the admin client details page associated with the deputy I'm interacting with
         And I manage the deputies 'completed' report
-        And I change the report type to 'Health and Welfare'
+        And I change the report type to 'Health and welfare'
         And I change the report due date to '3' weeks from now
         And I submit the new report details
         Then the report details should be updated
 
-    @admin-manager @prof-admin-submitted
+    @admin-manager @lay-combined-high-submitted @acs
     Scenario: An admin user un-submits a submitted report
-        Given a Professional Deputy has submitted a Health and Welfare report
-        When I visit the client summary page associated with the deputy
-        And I manage the submitted report
+        Given an admin manager user accesses the admin app
+        And a Lay Deputy has submitted a Combined High Assets report
+        When I visit the admin client details page associated with the deputy I'm interacting with
+        And I manage the deputies 'submitted' report
+        And I change the report 'start' date to '29 June 2021'
+        And I change the report 'end' date to '28 June 2022'
+        And I change the report due date to '4' weeks from now
+        And I confirm all report sections are incomplete
+        And I submit the new report details
+        Then the report details should be updated
+        When the user I'm interacting with logs in to the frontend of the app
+        Then I should see the report sections the admin ticked as incomplete labelled as changes needed
+#        And I should not be able to re-submit until I have confirmed I have completed the sections labelled as changes needed
 
     @admin
     Scenario: An admin user changes report type and due date for an un-submitted report

--- a/api/tests/Behat/features-v2/report-management/report-management.feature
+++ b/api/tests/Behat/features-v2/report-management/report-management.feature
@@ -1,0 +1,31 @@
+@v2 @report-management
+Feature: Report Management (applies to all admin roles)
+
+    @super-admin @prof-admin-completed @acs
+    Scenario: An admin user changes report type and due date for a in progress report
+        Given a super admin user accesses the admin app
+        And a Professional Deputy has completed a Pfa Low Assets report
+        When I visit the admin client details page associated with the deputy I'm interacting with
+        And I manage the deputies 'completed' report
+        And I change the report type to 'Health and Welfare'
+        And I change the report due date to '3' weeks from now
+        And I submit the new report details
+        Then the report details should be updated
+
+    @admin-manager @prof-admin-submitted
+    Scenario: An admin user un-submits a submitted report
+        Given a Professional Deputy has submitted a Health and Welfare report
+        When I visit the client summary page associated with the deputy
+        And I manage the submitted report
+
+    @admin
+    Scenario: An admin user changes report type and due date for an un-submitted report
+        Given
+
+    @admin
+    Scenario: An admin user closes an un-submitted report
+        Given
+
+    @admin
+    Scenario: An admin user downloads a submitted report
+        Given

--- a/api/tests/Behat/features-v2/report-management/report-management.feature
+++ b/api/tests/Behat/features-v2/report-management/report-management.feature
@@ -1,4 +1,4 @@
-@v2 @report-management
+@v2 @report-management @acs
 Feature: Report Management (applies to all admin roles)
 
     @super-admin @prof-admin-completed
@@ -12,7 +12,7 @@ Feature: Report Management (applies to all admin roles)
         And I submit the new report details
         Then the report details should be updated
 
-    @admin-manager @lay-combined-high-submitted @acs
+    @admin-manager @lay-combined-high-submitted
     Scenario: An admin user un-submits a submitted report
         Given an admin manager user accesses the admin app
         And a Lay Deputy has submitted a Combined High Assets report

--- a/api/tests/Behat/features-v2/report-management/report-management.feature
+++ b/api/tests/Behat/features-v2/report-management/report-management.feature
@@ -12,7 +12,7 @@ Feature: Report Management (applies to all admin roles)
         And I submit the new report details
         Then the report details should be updated
 
-    @admin-manager @lay-combined-high-submitted @acs
+    @admin-manager @lay-combined-high-submitted
     Scenario: An admin user un-submits a submitted report
         Given an admin manager user accesses the admin app
         And a Lay Deputy has submitted a Combined High Assets report
@@ -26,16 +26,45 @@ Feature: Report Management (applies to all admin roles)
         Then the report details should be updated
         When the user I'm interacting with logs in to the frontend of the app
         Then I should see the report sections the admin ticked as incomplete labelled as changes needed
-#        And I should not be able to re-submit until I have confirmed I have completed the sections labelled as changes needed
 
-    @admin
+    @admin @pa-admin-combined-high-submitted
     Scenario: An admin user changes report type and due date for an un-submitted report
-        Given
+        Given an admin user accesses the admin app
+        And a Public Authority Deputy has submitted a Combined High Assets report
+        When I visit the admin client details page associated with the deputy I'm interacting with
+        And I manage the deputies 'submitted' report
+        And I confirm all report sections are incomplete
+        And I submit the new report details
+        And I manage the deputies 'un-submitted' report
+        And I change the report due date to '5' weeks from now
+        And I change the report type to 'Health and welfare'
+        And I submit the new report details
+        Then the report details should be updated
 
-    @admin
+    @admin @pa-admin-combined-high-submitted
     Scenario: An admin user closes an un-submitted report
-        Given
+        Given an admin user accesses the admin app
+        And a Public Authority Deputy has submitted a Combined High Assets report
+        When I visit the admin client details page associated with the deputy I'm interacting with
+        And I manage the deputies 'submitted' report
+        And I confirm all report sections are incomplete
+        And I submit the new report details
+        And I close the un-submitted report
+        Then the report should should show as submitted
 
-    @admin
-    Scenario: An admin user downloads a submitted report
-        Given
+    @super-admin @pa-admin-combined-high-submitted
+    Scenario: A super admin can download a submitted report PDF
+        Given a super admin user accesses the admin app
+        And a Public Authority Deputy has submitted a Combined High Assets report
+        When I visit the admin client details page associated with the deputy I'm interacting with
+        Then the link to download the submitted report should be visible
+
+    @admin @admin-manager @pa-admin-combined-high-submitted
+    Scenario: Non-super admin cannot download a submitted report PDF
+        Given an admin user accesses the admin app
+        And a Public Authority Deputy has submitted a Combined High Assets report
+        When I visit the admin client details page associated with the deputy I'm interacting with
+        Then the link to download the submitted report should not be visible
+        Given an admin manager user accesses the admin app
+        When I visit the admin client details page associated with the deputy I'm interacting with
+        Then the link to download the submitted report should not be visible

--- a/api/tests/Behat/features-v2/report-management/report-management.feature
+++ b/api/tests/Behat/features-v2/report-management/report-management.feature
@@ -12,7 +12,7 @@ Feature: Report Management (applies to all admin roles)
         And I submit the new report details
         Then the report details should be updated
 
-    @admin-manager @lay-combined-high-submitted
+    @admin-manager @lay-combined-high-submitted @acs
     Scenario: An admin user un-submits a submitted report
         Given an admin manager user accesses the admin app
         And a Lay Deputy has submitted a Combined High Assets report

--- a/client/templates/Admin/Client/Client/details.html.twig
+++ b/client/templates/Admin/Client/Client/details.html.twig
@@ -54,7 +54,7 @@
             {% if not client.organisation.isActivated %}
                 {{ (page ~ '.organisationInactive') | trans }}
             {% endif %}
-            <br>
+            <br />
         </dd>
     {% endif %}
 
@@ -84,7 +84,7 @@
             </h3>
             <p class="govuk-body">
                 {% for addressPart in namedDeputy.addressNotEmptyParts %}
-                    {{ addressPart }}<br/>
+                    {{ addressPart }}<br />
                 {% endfor %}
             </p>
         {% endif %}
@@ -93,16 +93,16 @@
         </h3>
         <p class="govuk-body">
             {% if namedDeputy.phoneMain %}
-                {{ 'phone' | trans({}, 'common') }}: {{ namedDeputy.phoneMain }}<br>
+                {{ 'phone' | trans({}, 'common') }}: {{ namedDeputy.phoneMain }}<br />
             {% endif %}
             {% if namedDeputy.email %}
-                {{ 'email' | trans({}, 'common') }}: {{ namedDeputy.email }}<br>
+                {{ 'email' | trans({}, 'common') }}: {{ namedDeputy.email }}<br />
             {% endif %}
             {% if namedDeputy.email2 is defined and namedDeputy.email2 %}
-                {{ 'alternativeEmail' | trans({}, 'common') }}: {{ namedDeputy.email2 }}<br>
+                {{ 'alternativeEmail' | trans({}, 'common') }}: {{ namedDeputy.email2 }}<br />
             {% endif %}
             {% if namedDeputy.email3 is defined and namedDeputy.email3 %}
-                {{ 'alternativeEmail' | trans({}, 'common') }}: {{ namedDeputy.email3 }}<br>
+                {{ 'alternativeEmail' | trans({}, 'common') }}: {{ namedDeputy.email3 }}<br />
             {% endif %}
         </p>
         {% if is_granted('ROLE_ADMIN_MANAGER') %}
@@ -168,7 +168,7 @@
                         {% if report.type == 'ndr' %}
                             NDR
                         {% else %}
-                            {{ report.period | replace({' to ': '–'}) }}
+                            {{ report.period | replace({' to ': '-'}) }}
                         {% endif %}
                     </td>
                     <td class="govuk-table__cell">


### PR DESCRIPTION
## Purpose
Covers the report management section of the app on the admin side.

Fixes DDPB-3947

## Approach
I took the opportunity to:

* Drop out a bunch of properties from `FixtureHelper` that was a hangover from when behat was separate to API. We were just setting them and then passing them to a function on the next line down so seemed pointless.
* Make some of the fixture users more explicit in their naming for report types
* Use DateTime objects for UserDetails properties rather than strings to expand their usage in tests
* Fixed the pesky en dash used in the report period on client overview page
