### PR TITLE
tweak to sirius request timeout

### DIFF
--- a/client/src/Service/Client/Sirius/SiriusApiGatewayClient.php
+++ b/client/src/Service/Client/Sirius/SiriusApiGatewayClient.php
@@ -14,11 +14,11 @@ use Symfony\Component\Serializer\Serializer;
 
 class SiriusApiGatewayClient
 {
-    const SIRIUS_API_GATEWAY_VERSION = 'v2';
-    const SIRIUS_REPORT_ENDPOINT = 'clients/%s/reports';
-    const SIRIUS_SUPPORTING_DOCUMENTS_ENDPOINT = 'clients/%s/reports/%s/supportingdocuments';
-    const SIRIUS_CHECKLIST_POST_ENDPOINT = 'clients/%s/reports/%s/checklists';
-    const SIRIUS_CHECKLIST_PUT_ENDPOINT = 'clients/%s/reports/%s/checklists/%s';
+    public const SIRIUS_API_GATEWAY_VERSION = 'v2';
+    public const SIRIUS_REPORT_ENDPOINT = 'clients/%s/reports';
+    public const SIRIUS_SUPPORTING_DOCUMENTS_ENDPOINT = 'clients/%s/reports/%s/supportingdocuments';
+    public const SIRIUS_CHECKLIST_POST_ENDPOINT = 'clients/%s/reports/%s/checklists';
+    public const SIRIUS_CHECKLIST_PUT_ENDPOINT = 'clients/%s/reports/%s/checklists/%s';
 
     /** @var Client */
     private $httpClient;
@@ -60,7 +60,7 @@ class SiriusApiGatewayClient
     {
         $signedRequest = $this->buildSignedRequest($endpoint, 'GET');
 
-        return $this->httpClient->send($signedRequest, ['connect_timeout' => 2, 'timeout' => 3]);
+        return $this->httpClient->send($signedRequest, ['connect_timeout' => 1, 'timeout' => 1.5]);
     }
 
     /**

--- a/client/tests/phpunit/Service/Client/Sirius/SiriusApiGatewayClientTest.php
+++ b/client/tests/phpunit/Service/Client/Sirius/SiriusApiGatewayClientTest.php
@@ -1,15 +1,13 @@
-<?php declare(strict_types=1);
+<?php
 
+declare(strict_types=1);
 
 namespace App\Service\Client\Sirius;
 
 use App\Service\AWS\RequestSigner;
-use DateTime;
-use DigidepsTests\Helpers\SiriusHelpers;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -52,24 +50,24 @@ class SiriusApiGatewayClientTest extends KernelTestCase
         $signedRequest = $this->buildRequest($this->baseURL, $this->endpoint, 'GET', ['A-Header' => 'value']);
 
         $this->requestSigner->signRequest($expectedRequest, 'execute-api')->shouldBeCalled()->willReturn($signedRequest);
-        $this->httpClient->send($signedRequest, ['connect_timeout' => 2, 'timeout' => 3])->shouldBeCalled()->willReturn(new Response());
+        $this->httpClient->send($signedRequest, ['connect_timeout' => 1, 'timeout' => 1.5])->shouldBeCalled()->willReturn(new Response());
 
         $sut = new SiriusApiGatewayClient($this->httpClient->reveal(), $this->requestSigner->reveal(), $this->baseURL, $this->serializer, $this->logger->reveal());
         $sut->get($this->endpoint);
     }
 
-    private function buildRequest(string $baseURL, string $endpoint, string $method, array $additionalHeaders=[], string $body="")
+    private function buildRequest(string $baseURL, string $endpoint, string $method, array $additionalHeaders = [], string $body = '')
     {
         $headers = [
             'Accept' => 'application/json',
-            'Content-type' => 'application/json'
+            'Content-type' => 'application/json',
         ];
 
         if (count($additionalHeaders) > 0) {
             $headers = array_merge($headers, $additionalHeaders);
         }
 
-        $url = sprintf("%s/%s/%s", $baseURL, 'v2', $endpoint);
+        $url = sprintf('%s/%s/%s', $baseURL, 'v2', $endpoint);
 
         return new Request($method, $url, $headers, $body);
     }


### PR DESCRIPTION
## Purpose

![image](https://user-images.githubusercontent.com/58939809/128046987-a860f5f4-7200-4c1f-a842-e13e5feb8e82.png)

believe timeouts are causing healthcheck to fail even though we're seeing 200s despite sirius being down (as we had expected and fixed in a previous ticket months ago)

![image](https://user-images.githubusercontent.com/58939809/128047152-1f084954-73ca-44b0-b35e-ea04cf397599.png)

Pretty sure that going for timeouts under 2 secs is the way to go here. Doesn't really matter if occasionally says it's offline when it isn't as this doesnt affect our availability but it will stop us getting alerts when sirius is down and we're not (I hope).
