### PR TITLE
Added date feature flag for additional benefits questions

### DIFF
--- a/api/scripts/localstack-init.php
+++ b/api/scripts/localstack-init.php
@@ -72,7 +72,7 @@ $ssmClient->putParameter([
 $ssmClient->putParameter([
      'Name' => '/default/parameter/benefits-questions',
      'Type' => 'String',
-     'Value' => '03-08-2021 14:00:00',
+     'Value' => '31-12-2030 00:00:00',
      'Overwrite' => true,
 ]);
 

--- a/api/scripts/localstack-init.php
+++ b/api/scripts/localstack-init.php
@@ -5,14 +5,15 @@ use Aws\S3\S3Client;
 use Aws\Ssm\SsmClient;
 use GuzzleHttp\Client;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__.'/../vendor/autoload.php';
 
 function isLocalstackAvailable()
 {
     try {
         $client = new Client();
         $response = $client->request('GET', 'http://localstack:8080');
-        return $response->getStatusCode() === 200;
+
+        return 200 === $response->getStatusCode();
     } catch (Throwable $e) {
         return false;
     }
@@ -20,14 +21,14 @@ function isLocalstackAvailable()
 
 do {
     sleep(1);
-} while (isLocalstackAvailable() === false);
+} while (false === isLocalstackAvailable());
 
 $ssmClient = new SsmClient([
-    'version'  => 'latest',
-    'region'  => 'eu-west-1',
-    'endpoint'  => 'http://localstack:4583',
-    'validate'  => false,
-    'credentials'  => [
+    'version' => 'latest',
+    'region' => 'eu-west-1',
+    'endpoint' => 'http://localstack:4583',
+    'validate' => false,
+    'credentials' => [
         'key' => 'FAKE_ID',
         'secret' => 'FAKE_KEY',
     ],
@@ -37,73 +38,80 @@ $ssmClient->putParameter([
     'Name' => '/default/flag/document-sync',
     'Type' => 'String',
     'Value' => '1',
-    'Overwrite' => true
+    'Overwrite' => true,
 ]);
 
 $ssmClient->putParameter([
     'Name' => '/default/parameter/document-sync-row-limit',
     'Type' => 'String',
     'Value' => '100',
-    'Overwrite' => true
+    'Overwrite' => true,
 ]);
 
 $ssmClient->putParameter([
     'Name' => '/default/parameter/document-sync-interval-minutes',
     'Type' => 'String',
     'Value' => '4.5',
-    'Overwrite' => true
+    'Overwrite' => true,
 ]);
 
 $ssmClient->putParameter([
     'Name' => '/default/flag/checklist-sync',
     'Type' => 'String',
     'Value' => '1',
-    'Overwrite' => true
+    'Overwrite' => true,
 ]);
 
 $ssmClient->putParameter([
     'Name' => '/default/parameter/checklist-sync-row-limit',
     'Type' => 'String',
     'Value' => '100',
-    'Overwrite' => true
+    'Overwrite' => true,
+]);
+
+$ssmClient->putParameter([
+     'Name' => '/default/parameter/benefits-questions',
+     'Type' => 'String',
+     'Value' => '03-08-2021 14:00:00',
+     'Overwrite' => true,
 ]);
 
 $cloudwatchLogsClient = new CloudWatchLogsClient([
-    'version'  => 'latest',
-    'region'  => 'eu-west-1',
-    'endpoint'  => 'http://localstack:4586',
-    'validate'  => false,
-    'credentials'  => [
+    'version' => 'latest',
+    'region' => 'eu-west-1',
+    'endpoint' => 'http://localstack:4586',
+    'validate' => false,
+    'credentials' => [
         'key' => 'FAKE_ID',
         'secret' => 'FAKE_KEY',
     ],
 ]);
 
-$logsResult = $cloudwatchLogsClient->describeLogGroups(['logGroupNamePrefix' => 'audit-local',]);
+$logsResult = $cloudwatchLogsClient->describeLogGroups(['logGroupNamePrefix' => 'audit-local']);
 
 if (empty($logsResult->get('logGroups'))) {
     $cloudwatchLogsClient->createLogGroup([
-        'logGroupName' => 'audit-local'
+        'logGroupName' => 'audit-local',
     ]);
 }
 
 $s3Client = new S3Client([
-    'version'  => 'latest',
-    'region'  => 'eu-west-1',
-    'endpoint'  => 'http://localstack:4572',
-    'validate'  => false,
+    'version' => 'latest',
+    'region' => 'eu-west-1',
+    'endpoint' => 'http://localstack:4572',
+    'validate' => false,
     'use_path_style_endpoint' => true,
-    'credentials'  => [
+    'credentials' => [
         'key' => 'FAKE_ID',
         'secret' => 'FAKE_KEY',
     ],
 ]);
 
-$s3Result = $s3Client->listBuckets(['logGroupNamePrefix' => 'audit-local',]);
+$s3Result = $s3Client->listBuckets(['logGroupNamePrefix' => 'audit-local']);
 
 if (empty($s3Result->get('Buckets'))) {
     $s3Client->createBucket([
-        'Bucket' => 'pa-uploads-local'
+        'Bucket' => 'pa-uploads-local',
     ]);
 
     $s3Client->putBucketVersioning([

--- a/api/scripts/localstack-init.php
+++ b/api/scripts/localstack-init.php
@@ -69,13 +69,6 @@ $ssmClient->putParameter([
     'Overwrite' => true,
 ]);
 
-$ssmClient->putParameter([
-     'Name' => '/default/parameter/benefits-questions',
-     'Type' => 'String',
-     'Value' => '31-12-2030 00:00:00',
-     'Overwrite' => true,
-]);
-
 $cloudwatchLogsClient = new CloudWatchLogsClient([
     'version' => 'latest',
     'region' => 'eu-west-1',

--- a/client/scripts/localstack-init.php
+++ b/client/scripts/localstack-init.php
@@ -72,7 +72,7 @@ $ssmClient->putParameter([
 $ssmClient->putParameter([
      'Name' => '/default/parameter/benefits-questions',
      'Type' => 'String',
-     'Value' => '03-08-2021 14:00:00',
+     'Value' => '31-12-2030 00:00:00',
      'Overwrite' => true,
 ]);
 

--- a/client/scripts/localstack-init.php
+++ b/client/scripts/localstack-init.php
@@ -5,14 +5,15 @@ use Aws\S3\S3Client;
 use Aws\Ssm\SsmClient;
 use GuzzleHttp\Client;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__.'/../vendor/autoload.php';
 
 function isLocalstackAvailable()
 {
     try {
         $client = new Client();
         $response = $client->request('GET', 'http://localstack:8080');
-        return $response->getStatusCode() === 200;
+
+        return 200 === $response->getStatusCode();
     } catch (Throwable $e) {
         return false;
     }
@@ -20,14 +21,14 @@ function isLocalstackAvailable()
 
 do {
     sleep(1);
-} while (isLocalstackAvailable() === false);
+} while (false === isLocalstackAvailable());
 
 $ssmClient = new SsmClient([
-    'version'  => 'latest',
-    'region'  => 'eu-west-1',
-    'endpoint'  => 'http://localstack:4583',
-    'validate'  => false,
-    'credentials'  => [
+    'version' => 'latest',
+    'region' => 'eu-west-1',
+    'endpoint' => 'http://localstack:4583',
+    'validate' => false,
+    'credentials' => [
         'key' => 'FAKE_ID',
         'secret' => 'FAKE_KEY',
     ],
@@ -37,73 +38,80 @@ $ssmClient->putParameter([
     'Name' => '/default/flag/document-sync',
     'Type' => 'String',
     'Value' => '1',
-    'Overwrite' => true
+    'Overwrite' => true,
 ]);
 
 $ssmClient->putParameter([
     'Name' => '/default/parameter/document-sync-row-limit',
     'Type' => 'String',
     'Value' => '100',
-    'Overwrite' => true
+    'Overwrite' => true,
 ]);
 
 $ssmClient->putParameter([
     'Name' => '/default/parameter/document-sync-interval-minutes',
     'Type' => 'String',
     'Value' => '4.5',
-    'Overwrite' => true
+    'Overwrite' => true,
 ]);
 
 $ssmClient->putParameter([
     'Name' => '/default/flag/checklist-sync',
     'Type' => 'String',
     'Value' => '1',
-    'Overwrite' => true
+    'Overwrite' => true,
 ]);
 
 $ssmClient->putParameter([
     'Name' => '/default/parameter/checklist-sync-row-limit',
     'Type' => 'String',
     'Value' => '100',
-    'Overwrite' => true
+    'Overwrite' => true,
+]);
+
+$ssmClient->putParameter([
+     'Name' => '/default/parameter/benefits-questions',
+     'Type' => 'String',
+     'Value' => '03-08-2021 14:00:00',
+     'Overwrite' => true,
 ]);
 
 $cloudwatchLogsClient = new CloudWatchLogsClient([
-    'version'  => 'latest',
-    'region'  => 'eu-west-1',
-    'endpoint'  => 'http://localstack:4586',
-    'validate'  => false,
-    'credentials'  => [
+    'version' => 'latest',
+    'region' => 'eu-west-1',
+    'endpoint' => 'http://localstack:4586',
+    'validate' => false,
+    'credentials' => [
         'key' => 'FAKE_ID',
         'secret' => 'FAKE_KEY',
     ],
 ]);
 
-$logsResult = $cloudwatchLogsClient->describeLogGroups(['logGroupNamePrefix' => 'audit-local',]);
+$logsResult = $cloudwatchLogsClient->describeLogGroups(['logGroupNamePrefix' => 'audit-local']);
 
 if (empty($logsResult->get('logGroups'))) {
     $cloudwatchLogsClient->createLogGroup([
-        'logGroupName' => 'audit-local'
+        'logGroupName' => 'audit-local',
     ]);
 }
 
 $s3Client = new S3Client([
-    'version'  => 'latest',
-    'region'  => 'eu-west-1',
-    'endpoint'  => 'http://localstack:4572',
-    'validate'  => false,
+    'version' => 'latest',
+    'region' => 'eu-west-1',
+    'endpoint' => 'http://localstack:4572',
+    'validate' => false,
     'use_path_style_endpoint' => true,
-    'credentials'  => [
+    'credentials' => [
         'key' => 'FAKE_ID',
         'secret' => 'FAKE_KEY',
     ],
 ]);
 
-$s3Result = $s3Client->listBuckets(['logGroupNamePrefix' => 'audit-local',]);
+$s3Result = $s3Client->listBuckets(['logGroupNamePrefix' => 'audit-local']);
 
 if (empty($s3Result->get('Buckets'))) {
     $s3Client->createBucket([
-        'Bucket' => 'pa-uploads-local'
+        'Bucket' => 'pa-uploads-local',
     ]);
 
     $s3Client->putBucketVersioning([

--- a/client/src/Controller/Report/ReportController.php
+++ b/client/src/Controller/Report/ReportController.php
@@ -21,6 +21,7 @@ use App\Service\Client\Internal\SatisfactionApi;
 use App\Service\Client\Internal\UserApi;
 use App\Service\Client\RestClient;
 use App\Service\Csv\TransactionsCsvGenerator;
+use App\Service\ParameterStoreService;
 use App\Service\Redirector;
 use App\Service\ReportSubmissionService;
 use DateTime;
@@ -257,7 +258,7 @@ class ReportController extends AbstractController
      *
      * @return RedirectResponse|Response|null
      */
-    public function overviewAction(Redirector $redirector, $reportId)
+    public function overviewAction(Redirector $redirector, $reportId, ParameterStoreService $parameterStore)
     {
         $reportJmsGroup = ['status', 'balance', 'user', 'client', 'client-reports', 'balance-state'];
         // redirect if user has missing details or is on wrong page
@@ -296,11 +297,22 @@ class ReportController extends AbstractController
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, $reportJmsGroup);
         $activeReport = $activeReportId ? $this->reportApi->getReportIfNotSubmitted($activeReportId, $reportJmsGroup) : null;
 
+        $additionalBenefitsQuestions = false;
+        $dateTimeFormat = 'd-m-Y H:i:s';
+
+        $flagDate = DateTime::createFromFormat($dateTimeFormat, $parameterStore->getFeatureFlag(ParameterStoreService::FLAG_BENEFITS_QUESTIONS));
+        $currentDate = DateTime::createFromFormat($dateTimeFormat, date($dateTimeFormat));
+
+        if ($flagDate <= $currentDate) {
+            $additionalBenefitsQuestions = true;
+        }
+
         return $this->render($template, [
             'user' => $user,
             'client' => $client,
             'report' => $report,
             'activeReport' => $activeReport,
+            'additionalBenefitsQuestions' => $additionalBenefitsQuestions,
         ]);
     }
 

--- a/client/src/Controller/Report/ReportController.php
+++ b/client/src/Controller/Report/ReportController.php
@@ -304,12 +304,23 @@ class ReportController extends AbstractController
         $additionalBenefitsQuestions = false;
         $dateTimeFormat = 'd-m-Y H:i:s';
 
-        $flagDate = DateTime::createFromFormat($dateTimeFormat, $parameterStore->getFeatureFlag(ParameterStoreService::FLAG_BENEFITS_QUESTIONS));
+        var_dump('Phase 1');
+
+        $date = $parameterStore->getFeatureFlag(ParameterStoreService::FLAG_BENEFITS_QUESTIONS);
+
+        var_dump('Phase 2');
+        var_dump($date);
+
+        $flagDate = DateTime::createFromFormat($dateTimeFormat, $date);
         $currentDate = DateTime::createFromFormat($dateTimeFormat, date($dateTimeFormat));
+
+        var_dump('Phase 3');
 
         if ($flagDate <= $currentDate) {
             $additionalBenefitsQuestions = true;
         }
+
+        var_dump('Phase 4');
 
         return $this->render($template, [
             'user' => $user,

--- a/client/src/Controller/Report/ReportController.php
+++ b/client/src/Controller/Report/ReportController.php
@@ -301,26 +301,17 @@ class ReportController extends AbstractController
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, $reportJmsGroup);
         $activeReport = $activeReportId ? $this->reportApi->getReportIfNotSubmitted($activeReportId, $reportJmsGroup) : null;
 
-        $additionalBenefitsQuestions = false;
+        $benefitsSection = false;
         $dateTimeFormat = 'd-m-Y H:i:s';
 
-        var_dump('Phase 1');
+        $featureFlag = $parameterStore->getFeatureFlag(ParameterStoreService::FLAG_BENEFITS_QUESTIONS);
 
-        $date = $parameterStore->getFeatureFlag(ParameterStoreService::FLAG_BENEFITS_QUESTIONS);
-
-        var_dump('Phase 2');
-        var_dump($date);
-
-        $flagDate = DateTime::createFromFormat($dateTimeFormat, $date);
+        $featureFlagDate = DateTime::createFromFormat($dateTimeFormat, $featureFlag);
         $currentDate = DateTime::createFromFormat($dateTimeFormat, date($dateTimeFormat));
 
-        var_dump('Phase 3');
-
-        if ($flagDate <= $currentDate) {
-            $additionalBenefitsQuestions = true;
+        if ($currentDate >= $featureFlagDate) {
+            $benefitsSection = true;
         }
-
-        var_dump('Phase 4');
 
         return $this->render($template, [
             'user' => $user,
@@ -328,7 +319,7 @@ class ReportController extends AbstractController
             'namedDeputy' => $namedDeputy,
             'report' => $report,
             'activeReport' => $activeReport,
-            'additionalBenefitsQuestions' => $additionalBenefitsQuestions,
+            'benefitsSection' => $benefitsSection,
         ]);
     }
 

--- a/client/src/Service/ParameterStoreService.php
+++ b/client/src/Service/ParameterStoreService.php
@@ -15,6 +15,8 @@ class ParameterStoreService
     public const FLAG_CHECKLIST_SYNC = 'checklist-sync';
     public const PARAMETER_CHECKLIST_SYNC_ROW_LIMIT = 'checklist-sync-row-limit';
 
+    public const FLAG_BENEFITS_QUESTIONS = 'benefits-questions';
+
     /** @var SsmClient */
     private $ssmClient;
 

--- a/client/src/Service/ParameterStoreService.php
+++ b/client/src/Service/ParameterStoreService.php
@@ -43,9 +43,7 @@ class ParameterStoreService
 
     public function getFeatureFlag(string $flagKey)
     {
-        var_dump($this->flagPrefix);
         $flagName = $this->flagPrefix.$flagKey;
-        var_dump($flagName);
         $flag = $this->ssmClient->getParameter(['Name' => $flagName]);
 
         return $flag['Parameter']['Value'];

--- a/client/src/Service/ParameterStoreService.php
+++ b/client/src/Service/ParameterStoreService.php
@@ -43,7 +43,9 @@ class ParameterStoreService
 
     public function getFeatureFlag(string $flagKey)
     {
+        var_dump($this->flagPrefix);
         $flagName = $this->flagPrefix.$flagKey;
+        var_dump($flagName);
         $flag = $this->ssmClient->getParameter(['Name' => $flagName]);
 
         return $flag['Parameter']['Value'];

--- a/environment/front.tf
+++ b/environment/front.tf
@@ -66,7 +66,8 @@ data "aws_iam_policy_document" "query_ssm" {
       aws_ssm_parameter.flag_document_sync.arn,
       aws_ssm_parameter.document_sync_row_limit.arn,
       aws_ssm_parameter.flag_checklist_sync.arn,
-      aws_ssm_parameter.checklist_sync_row_limit.arn
+      aws_ssm_parameter.checklist_sync_row_limit.arn,
+      aws_ssm_parameter.flag_benefits_questions.arn
     ]
   }
 }

--- a/environment/parameters.tf
+++ b/environment/parameters.tf
@@ -65,7 +65,7 @@ resource "aws_ssm_parameter" "flag_checklist_sync" {
 resource "aws_ssm_parameter" "flag_benefits_questions" {
   name  = "${local.feature_flag_prefix}benefits-questions"
   type  = "String"
-  value = "03-08-2021 14:00:00"
+  value = "31-12-2030 00:00:00"
 
   tags = local.default_tags
 

--- a/environment/parameters.tf
+++ b/environment/parameters.tf
@@ -61,3 +61,15 @@ resource "aws_ssm_parameter" "flag_checklist_sync" {
     ignore_changes = [value]
   }
 }
+
+resource "aws_ssm_parameter" "flag_benefits_questions" {
+  name  = "${local.feature_flag_prefix}benefits-questions"
+  type  = "String"
+  value = "03-08-2021 14:00:00"
+
+  tags = local.default_tags
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}


### PR DESCRIPTION
## Purpose
Adding a date-based feature flag to allow developers to show/hide certain features and functionality behind the flag.
Using a date as to accommodate certain scenarios such as hiding questions on reports which have submitted before said date.

Fixes DDPB-4038

## Approach
Update terraform to create additional feature flag in AWS Parameter Store.
Update AWS IAM Policy to allow reading of variable to role.
Update scripts to create flag for localstack.
Add feature flag to Parameter Store Service.
Update Report and NDR controllers to pull in feature flag.

## Learning
Not only do you need to create a feature flag in `parameters.tf`, but you will also need to ensure you update the policy for the aws role to allow for reading in `front.tf`.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
