### PR TITLE
DDPB-4062: Create the entities and migrations for the new report section

### DIFF
--- a/api/src/Entity/Report/ClientBenefitsCheck.php
+++ b/api/src/Entity/Report/ClientBenefitsCheck.php
@@ -1,0 +1,141 @@
+<?php
+
+ declare(strict_types=1);
+
+namespace App\Entity\Report;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Ramsey\Uuid\Doctrine\UuidGenerator;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * @ORM\Table(name="client_benefits_check")
+ * @ORM\Entity
+ */
+class ClientBenefitsCheck
+{
+    public function __construct(?UuidInterface $id = null)
+    {
+        $this->id = $id ?? Uuid::uuid4();
+        $this->created = new DateTime();
+    }
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(name="id", type="uuid")
+     * @ORM\GeneratedValue(strategy="NONE")
+     * @ORM\CustomIdGenerator(class=UuidGenerator::class)
+     */
+    private UuidInterface $id;
+
+    /**
+     * @ORM\Column(name="created_at", type="datetime",nullable=true)
+     * @Gedmo\Timestampable(on="create")
+     */
+    private DateTime $created;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="App\Entity\Report\Report", inversedBy="clientBenefitsCheck")
+     * @ORM\JoinColumn(name="report_id", referencedColumnName="id", onDelete="CASCADE")
+     */
+    private Report $report;
+
+    /**
+     * @var string one of either [date in format MM/YYYY, currentlyChecking, neverChecked]
+     *
+     * @ORM\Column(name="when_last_checked_entitlement", type="string", nullable=false)
+     */
+    private $whenLastCheckedEntitlement;
+
+    /**
+     * @var string one of either [yes, no, doNotKnow]
+     *
+     * @ORM\Column(name="do_others_receive_income_on_clients_behalf", type="string", nullable=false)
+     */
+    private $doOthersReceiveIncomeOnClientsBehalf;
+
+    /**
+     * @ORM\OneToMany(targetEntity="App\Entity\Report\IncomeReceivedOnClientsBehalf", mappedBy="clientBenefitsCheck", cascade={"persist", "remove"}, fetch="EXTRA_LAZY")
+     */
+    private ArrayCollection $typesOfIncomeReceivedOnClientsBehalf;
+
+    public function getId(): UuidInterface
+    {
+        return $this->id;
+    }
+
+    public function setId(UuidInterface $id): ClientBenefitsCheck
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getReport(): Report
+    {
+        return $this->report;
+    }
+
+    public function setReport(Report $report): ClientBenefitsCheck
+    {
+        $this->report = $report;
+
+        return $this;
+    }
+
+    public function getWhenLastCheckedEntitlement(): string
+    {
+        return $this->whenLastCheckedEntitlement;
+    }
+
+    public function setWhenLastCheckedEntitlement(string $whenLastCheckedEntitlement): ClientBenefitsCheck
+    {
+        $this->whenLastCheckedEntitlement = $whenLastCheckedEntitlement;
+
+        return $this;
+    }
+
+    public function getDoOthersReceiveIncomeOnClientsBehalf(): string
+    {
+        return $this->doOthersReceiveIncomeOnClientsBehalf;
+    }
+
+    public function setDoOthersReceiveIncomeOnClientsBehalf(string $doOthersReceiveIncomeOnClientsBehalf): ClientBenefitsCheck
+    {
+        $this->doOthersReceiveIncomeOnClientsBehalf = $doOthersReceiveIncomeOnClientsBehalf;
+
+        return $this;
+    }
+
+    public function getTypesOfIncomeReceivedOnClientsBehalf(): ArrayCollection
+    {
+        return $this->typesOfIncomeReceivedOnClientsBehalf;
+    }
+
+    /**
+     * @param ArrayCollection $typesOfIncomeReceivedOnClientsBehalf
+     */
+    public function addTypesOfIncomeReceivedOnClientsBehalf(IncomeReceivedOnClientsBehalf $incomeReceivedOnClientsBehalf): ClientBenefitsCheck
+    {
+        if (!$this->typesOfIncomeReceivedOnClientsBehalf->contains($incomeReceivedOnClientsBehalf)) {
+            $this->typesOfIncomeReceivedOnClientsBehalf->add($incomeReceivedOnClientsBehalf);
+        }
+
+        return $this;
+    }
+
+    public function getCreated(): DateTime
+    {
+        return $this->created;
+    }
+
+    public function setCreated(DateTime $created): ClientBenefitsCheck
+    {
+        $this->created = $created;
+
+        return $this;
+    }
+}

--- a/api/src/Entity/Report/ClientBenefitsCheck.php
+++ b/api/src/Entity/Report/ClientBenefitsCheck.php
@@ -4,6 +4,7 @@
 
 namespace App\Entity\Report;
 
+use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;

--- a/api/src/Entity/Report/IncomeReceivedOnClientsBehalf.php
+++ b/api/src/Entity/Report/IncomeReceivedOnClientsBehalf.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity\Report;
+
+use DateTime;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * @ORM\Table(name="income_received_on_clients_behalf")
+ * @ORM\Entity
+ */
+class IncomeReceivedOnClientsBehalf
+{
+    public function __construct(?UuidInterface $id = null)
+    {
+        $this->id = $id ?? Uuid::uuid4();
+        $this->created = new DateTime();
+    }
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(name="id", type="uuid")
+     * @ORM\GeneratedValue(strategy="NONE")
+     * @ORM\CustomIdGenerator(class=UuidGenerator::class)
+     */
+    private UuidInterface $id;
+
+    /**
+     * @ORM\Column(name="created_at", type="datetime",nullable=true)
+     * @Gedmo\Timestampable(on="create")
+     */
+    private DateTime $created;
+
+    /**
+     * @ORM\OneToOne(targetEntity="App\Entity\Report\ClientBenefitsCheck", inversedBy="incomeReceivedOnClientsBehalf", cascade={"persist", "remove"})
+     */
+    private ClientBenefitsCheck $clientBenefitsCheck;
+
+    /**
+     * @ORM\Column(name="income_type", type="string", nullable=false)
+     */
+    private string $incomeType;
+
+    /**
+     * @ORM\Column(name="amount", type="decimal", precision=14, scale=2, nullable=true)
+     */
+    private float $amount;
+
+    public function getClientBenefitsCheck(): ClientBenefitsCheck
+    {
+        return $this->clientBenefitsCheck;
+    }
+
+    public function setClientBenefitsCheck(ClientBenefitsCheck $clientBenefitsCheck): IncomeReceivedOnClientsBehalf
+    {
+        $this->clientBenefitsCheck = $clientBenefitsCheck;
+
+        return $this;
+    }
+
+    public function getIncomeType(): string
+    {
+        return $this->incomeType;
+    }
+
+    public function setIncomeType(string $incomeType): IncomeReceivedOnClientsBehalf
+    {
+        $this->incomeType = $incomeType;
+
+        return $this;
+    }
+
+    public function getAmount(): float
+    {
+        return $this->amount;
+    }
+
+    public function setAmount(float $amount): IncomeReceivedOnClientsBehalf
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+
+    public function getId(): UuidInterface
+    {
+        return $this->id;
+    }
+
+    public function setId(UuidInterface $id): IncomeReceivedOnClientsBehalf
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getCreated(): DateTime
+    {
+        return $this->created;
+    }
+
+    public function setCreated(DateTime $created): IncomeReceivedOnClientsBehalf
+    {
+        $this->created = $created;
+
+        return $this;
+    }
+}

--- a/api/src/Entity/UserResearch/UserResearchResponse.php
+++ b/api/src/Entity/UserResearch/UserResearchResponse.php
@@ -79,7 +79,6 @@ class UserResearchResponse
     private DateTime $created;
 
     /**
-     * @var DateTime
      * @JMS\Type("App\Entity\Satisfaction")
      * @JMS\Groups({"user-research", "satisfaction"})
      *

--- a/api/src/Migrations/Version254.php
+++ b/api/src/Migrations/Version254.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version254 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add migrations for ClientBenefitsCheck';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE client_benefits_check (id UUID NOT NULL, report_id INT DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, when_last_checked_entitlement VARCHAR(255) NOT NULL, do_others_receive_income_on_clients_behalf VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_B0206BD54BD2A4C0 ON client_benefits_check (report_id)');
+        $this->addSql('COMMENT ON COLUMN client_benefits_check.id IS \'(DC2Type:uuid)\'');
+        $this->addSql('CREATE TABLE income_received_on_clients_behalf (id UUID NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, income_type VARCHAR(255) NOT NULL, amount NUMERIC(14, 2) DEFAULT NULL, clientBenefitsCheck_id UUID DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_2F551CA35606E920 ON income_received_on_clients_behalf (clientBenefitsCheck_id)');
+        $this->addSql('COMMENT ON COLUMN income_received_on_clients_behalf.id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN income_received_on_clients_behalf.clientBenefitsCheck_id IS \'(DC2Type:uuid)\'');
+        $this->addSql('ALTER TABLE client_benefits_check ADD CONSTRAINT FK_B0206BD54BD2A4C0 FOREIGN KEY (report_id) REFERENCES report (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE income_received_on_clients_behalf ADD CONSTRAINT FK_2F551CA35606E920 FOREIGN KEY (clientBenefitsCheck_id) REFERENCES client_benefits_check (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE income_received_on_clients_behalf DROP CONSTRAINT FK_2F551CA35606E920');
+        $this->addSql('DROP TABLE client_benefits_check');
+        $this->addSql('DROP TABLE income_received_on_clients_behalf');
+    }
+}

--- a/docs/ADDING_REPORT_SECTIONS.md
+++ b/docs/ADDING_REPORT_SECTIONS.md
@@ -1,0 +1,65 @@
+#Adding Report Sections
+
+Complete the Deputy Report service comprises a number of sections of a larger form that deputies use to report on how they have carried out their deputyship details over a 12-month period. In code, this is modelled on the `Report` entity with each subsection defined as separate entities and linked to the report in one-to-one relationships.
+
+In order to add a new section to the report carry out the following steps:
+
+##API
+* Decide on a descriptive name for the report section and create a new entity class in `api/src/entity/`
+* Add the relevant annotations to signal to Doctrine that the entity class is an entity and should have a corresponding database table:
+
+```phpt
+/**
+ * @ORM\Table(name="lifestyle")
+ * @ORM\Entity
+ */
+class Lifestyle
+{}
+```
+
+* Map the questions included in the form section to properties on the entity class including any required Doctrine notations related to the expected response types. For example, a question asking if a client undertakes social activities could be mapped as follows:
+
+```phpt
+    /**
+     * @var string yes|no|null
+     *
+     * @JMS\Type("string")
+     * @JMS\Groups({"lifestyle"})
+     * @ORM\Column( name="does_client_undertake_social_activities", type="string", length=4, nullable=true)
+     */
+    private $doesClientUndertakeSocialActivities;
+```
+
+* When all questions are mapped to properties, exec in to the api docker container and generate a new migration file using the Symfony console:
+
+```
+> docker-compose exec api sh
+
+> php app/console doctrine:migrations:diff
+```
+
+* Check the contents of the migration file generated to ensure it captures the required database changes and amend if necessary. Rename the migration file following the naming convention in `api/src/Migrations` and, still inside the api docker container, run the migration:
+
+```
+> php app/console doctrine:migrations:migrate
+```
+
+* Inspect the database to ensure the new tables and changes are as expected
+
+##Client
+
+* Create a representation of the `api` report section entity in `client` including all the properties and link to the `Report` entity. Ensure the entity includes the `HasReportTrait` added to it:
+
+```phpt
+class Lifestyle
+{
+    use HasReportTrait;
+    ...
+}
+```
+
+* Create a new form class and map the report section entity properties to the form questions as required (see examples in `client/src/Form/Report`)
+
+* Add a new section to the report overview template (`App/Report/Report/overview.html.twig`) by including a new `App/Report/Report/_subsection.html.twig` partial. If required for NDR reports also include in `App/Ndr/Ndr/overview.html.twig`
+
+* Create a corresponding controller and implement the form logic as required using the newly created form type


### PR DESCRIPTION
## Purpose
Creates the entities and migration for the new form section 'Benefits check'.

Fixes DDPB-4062

## Approach
Following on from comments made in various retros and health checks I've ensured the ids of the two entities are UUIDs to protect against users trying to access resources incrementally. 

There may be some tweaks to the entities when we come to implement the forms - especially `ClientBenefitsCheck::whenLastCheckedEntitlement` as this can be either a string or DateTime so some type of conversion will need to happen after checking if the value is a DateTime (e.g. `DateTime::createFromFormat('m/Y', '01/2021')`).

The readme I added is a first stab and will evolve as we implement the rest of this form section.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
