### PR TITLE
Adds javascript disabled tracking for logged in users

### DIFF
--- a/client/config/services.yml
+++ b/client/config/services.yml
@@ -327,6 +327,11 @@ services:
         arguments:
             $environment: '@twig'
 
+    App\Twig\ComponentsExtension:
+        class: App\Twig\ComponentsExtension
+        arguments:
+            $environment: '@twig'
+
     # Logtash formatter for Kibana
     logstash_formatter:
         class: Monolog\Formatter\LogstashFormatter

--- a/client/src/Twig/FormFieldsExtension.php
+++ b/client/src/Twig/FormFieldsExtension.php
@@ -331,7 +331,7 @@ class FormFieldsExtension extends AbstractExtension
             $gaTrackingAction,
             $gaTrackingLabel,
             $gaTrackingValue,
-            $vars['attr']
+            $vars['attr'] ?? []
         );
 
         return $this->renderFormSubmit($element, $elementName, $vars);

--- a/client/templates/Components/GoogleAnalytics/hiddenEvent.html.twig
+++ b/client/templates/Components/GoogleAnalytics/hiddenEvent.html.twig
@@ -1,0 +1,3 @@
+{% if (ga is defined) and (app.user is defined) and (dt is defined) %}
+    <img src="http://www.google-analytics.com/collect?v=1&t=pageview&tid={{ ga.default }}&uid={{ app.user.id }}&dl={{ app.request.uri | url_encode }}&dt={{ dt }}">
+{% endif %}

--- a/client/templates/Org/Index/dashboard.html.twig
+++ b/client/templates/Org/Index/dashboard.html.twig
@@ -157,4 +157,8 @@
         }
     } %}
 
+    <noscript>
+        {{ hidden_ga_event('Javascript Disabled') }}
+    </noscript>
+
 {% endblock %}

--- a/client/templates/Report/Report/index.html.twig
+++ b/client/templates/Report/Report/index.html.twig
@@ -99,4 +99,7 @@
 
     {% endif %}
 
+    <noscript>
+        {{ hidden_ga_event('Javascript Disabled') }}
+    </noscript>
 {% endblock %}

--- a/client/tests/phpunit/Twig/ComponentsExtensionTest.php
+++ b/client/tests/phpunit/Twig/ComponentsExtensionTest.php
@@ -12,7 +12,8 @@ class ComponentsExtensionTest extends TestCase
     {
         $this->translator = m::mock('Symfony\Contracts\Translation\TranslatorInterface');
         $this->reportSectionsLinkService = m::mock('App\Service\ReportSectionsLinkService');
-        $this->object = new \App\Twig\ComponentsExtension($this->translator, $this->reportSectionsLinkService);
+        $this->twigEnvironment = m::mock('Twig\Environment');
+        $this->object = new \App\Twig\ComponentsExtension($this->translator, $this->reportSectionsLinkService, $this->twigEnvironment);
     }
 
     public static function accordionLinksProvider()
@@ -123,7 +124,7 @@ class ComponentsExtensionTest extends TestCase
      * @test
      * @dataProvider pad_day_monthProvider
      */
-    public function pad_day_month($input, $expected)
+    public function padDayMonth($input, $expected)
     {
         $f = $this->object->getFilters()['pad_day_month']->getCallable();
 
@@ -144,7 +145,7 @@ class ComponentsExtensionTest extends TestCase
      * @test
      * @dataProvider behat_namifyProvider
      */
-    public function behat_namify($input, $expected)
+    public function behatNamify($input, $expected)
     {
         $f = $this->object->getFilters()['behat_namify']->getCallable();
 
@@ -164,7 +165,7 @@ class ComponentsExtensionTest extends TestCase
      * @test
      * @dataProvider money_formatProvider
      */
-    public function money_format($input, $expected)
+    public function moneyFormat($input, $expected)
     {
         $f = $this->object->getFilters()['money_format']->getCallable();
 
@@ -184,7 +185,7 @@ class ComponentsExtensionTest extends TestCase
     /**
      * @test
      */
-    public function class_name()
+    public function className()
     {
         $f = $this->object->getFilters()['class_name']->getCallable();
 


### PR DESCRIPTION
## Purpose
Following on from recent conversations we needed a way to track how many of our users have JS disabled in their browsers so we can make more informed decisions on how we design the app. This adds tracking for for lays and org users when they log in so we can breakdown how many users there are in Google Analytics.
