### PR TITLE
DDPB-4030 - Add feature flag for paper reports

### DIFF
--- a/api/scripts/localstack-init.php
+++ b/api/scripts/localstack-init.php
@@ -76,6 +76,20 @@ $ssmClient->putParameter([
     'Overwrite' => true,
 ]);
 
+$ssmClient->putParameter([
+     'Name' => '/default/flag/benefits-questions',
+     'Type' => 'String',
+     'Value' => '31-12-2030 00:00:00',
+     'Overwrite' => true,
+]);
+
+$ssmClient->putParameter([
+     'Name' => '/default/flag/paper-reports',
+     'Type' => 'String',
+     'Value' => '1',
+     'Overwrite' => true,
+]);
+
 $cloudwatchLogsClient = new CloudWatchLogsClient([
     'version' => 'latest',
     'region' => 'eu-west-1',

--- a/client/scripts/localstack-init.php
+++ b/client/scripts/localstack-init.php
@@ -70,10 +70,17 @@ $ssmClient->putParameter([
 ]);
 
 $ssmClient->putParameter([
-     'Name' => '/default/flag/benefits-questions',
-     'Type' => 'String',
-     'Value' => '31-12-2030 00:00:00',
-     'Overwrite' => true,
+    'Name' => '/default/flag/benefits-questions',
+    'Type' => 'String',
+    'Value' => '31-12-2030 00:00:00',
+    'Overwrite' => true,
+]);
+
+$ssmClient->putParameter([
+    'Name' => '/default/flag/paper-reports',
+    'Type' => 'String',
+    'Value' => '1',
+    'Overwrite' => true,
 ]);
 
 $cloudwatchLogsClient = new CloudWatchLogsClient([

--- a/client/src/Service/ParameterStoreService.php
+++ b/client/src/Service/ParameterStoreService.php
@@ -17,6 +17,8 @@ class ParameterStoreService
 
     public const FLAG_BENEFITS_QUESTIONS = 'benefits-questions';
 
+    public const FLAG_PAPER_REPORTS = 'paper-reports';
+
     /** @var SsmClient */
     private $ssmClient;
 

--- a/environment/front.tf
+++ b/environment/front.tf
@@ -67,7 +67,8 @@ data "aws_iam_policy_document" "query_ssm" {
       aws_ssm_parameter.document_sync_row_limit.arn,
       aws_ssm_parameter.flag_checklist_sync.arn,
       aws_ssm_parameter.checklist_sync_row_limit.arn,
-      aws_ssm_parameter.flag_benefits_questions.arn
+      aws_ssm_parameter.flag_benefits_questions.arn,
+      aws_ssm_parameter.flag_paper_reports.arn
     ]
   }
 }

--- a/environment/parameters.tf
+++ b/environment/parameters.tf
@@ -73,3 +73,15 @@ resource "aws_ssm_parameter" "flag_benefits_questions" {
     ignore_changes = [value]
   }
 }
+
+resource "aws_ssm_parameter" "flag_paper_reports" {
+  name  = "${local.feature_flag_prefix}paper-reports"
+  type  = "String"
+  value = "0"
+
+  tags = local.default_tags
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}


### PR DESCRIPTION
## Purpose
Adding a feature flag to allow developers to show/hide certain features and functionality behind the flag.

Fixes DDPB-4030

## Approach
Update terraform to create additional feature flag in AWS Parameter Store.
Update AWS IAM Policy to allow reading of variable to role.
Update scripts to create flag for localstack.
Add feature flag to Parameter Store Service.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [x] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
