### PR TITLE
DDPB-4131: Start persisting dep type and add one time dep type update

### DIFF
--- a/api/src/v2/Assembler/NamedDeputyAssembler.php
+++ b/api/src/v2/Assembler/NamedDeputyAssembler.php
@@ -39,6 +39,7 @@ class NamedDeputyAssembler
             ->setAddress3($dto->getDeputyAddress3())
             ->setAddress4($dto->getDeputyAddress4())
             ->setAddress5($dto->getDeputyAddress5())
-            ->setAddressPostcode($dto->getDeputyPostcode());
+            ->setAddressPostcode($dto->getDeputyPostcode())
+            ->setDeputyType($dto->getDeputyType());
     }
 }

--- a/api/src/v2/Registration/Assembler/CasRecToOrgDeputyshipDtoAssembler.php
+++ b/api/src/v2/Registration/Assembler/CasRecToOrgDeputyshipDtoAssembler.php
@@ -75,6 +75,7 @@ class CasRecToOrgDeputyshipDtoAssembler
             ->setReportType($reportType)
             ->setReportStartDate($reportStartDate)
             ->setReportEndDate($reportEndDate)
-            ->setDeputyAddressNumber($deputyAddressNumber);
+            ->setDeputyAddressNumber($deputyAddressNumber)
+            ->setDeputyType($row['Dep Type']);
     }
 }

--- a/api/src/v2/Registration/DTO/OrgDeputyshipDto.php
+++ b/api/src/v2/Registration/DTO/OrgDeputyshipDto.php
@@ -9,10 +9,6 @@ use DateTime;
 class OrgDeputyshipDto
 {
     /** @var string */
-    private $deputyNumber;
-    private $deputyLastname;
-    private $deputyAddress1;
-    private $deputyAddress2;
     private $caseNumber;
     private $clientFirstname;
     private $clientLastname;
@@ -20,6 +16,11 @@ class OrgDeputyshipDto
     private $clientAddress2;
     private $clientCounty;
     private $clientPostCode;
+    private $deputyAddress1;
+    private $deputyAddress2;
+    private $deputyLastname;
+    private $deputyNumber;
+    private $deputyType;
     private $reportType;
 
     /** @var string|null */
@@ -372,6 +373,21 @@ class OrgDeputyshipDto
     public function setDeputyAddress5(?string $deputyAddress5): OrgDeputyshipDto
     {
         $this->deputyAddress5 = $deputyAddress5;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDeputyType(): string
+    {
+        return $this->deputyType;
+    }
+
+    public function setDeputyType(string $deputyType)
+    {
+        $this->deputyType = $deputyType;
 
         return $this;
     }

--- a/api/src/v2/Registration/Uploader/OrgDeputyshipUploader.php
+++ b/api/src/v2/Registration/Uploader/OrgDeputyshipUploader.php
@@ -91,6 +91,11 @@ class OrgDeputyshipUploader
             ]
         );
 
+        // Temporary fix to generate dep types for all existing named deps - remove once CSVs have been uploaded
+        if (!is_null($namedDeputy)) {
+            $namedDeputy->setDeputyType($dto->getDeputyType());
+        }
+
         if (is_null($namedDeputy)) {
             $namedDeputy = $this->namedDeputyAssembler->assembleFromOrgDeputyshipDto($dto);
 

--- a/api/tests/Unit/v2/Registration/TestHelpers/OrgDeputyshipDTOTestHelper.php
+++ b/api/tests/Unit/v2/Registration/TestHelpers/OrgDeputyshipDTOTestHelper.php
@@ -264,7 +264,8 @@ class OrgDeputyshipDTOTestHelper
             ->setAddress3($dto->getDeputyAddress3())
             ->setAddress4($dto->getDeputyAddress4())
             ->setAddress5($dto->getDeputyAddress5())
-            ->setAddressPostcode($dto->getDeputyPostcode());
+            ->setAddressPostcode($dto->getDeputyPostcode())
+            ->setDeputyType($dto->getDeputyType());
 
         $em->persist($namedDeputy);
         $em->flush();


### PR DESCRIPTION
## Purpose
WE've receveid reports of some professional users unable to submit reports. Cloudwatch logs have shown we rely on a `NamedDeputy` having `DeputyType` set to determine the next years report type but we aren't currently persisting this as part of CSV upload. I've not got to the bottom of why this isn't stopping everyone from submitting but it definitely feels like deputy type is an important piece of data to be persisting so this will fix the issue until we can investigate further and write some more robust tests for the whole end to end journey from ingest to submission/re-submission.

Fixes DDPB-4131
Fixes DDPB-4130

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
