### PR TITLE
Ensure we have layer.tar ready for apply integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,6 +406,9 @@ workflows:
           cron: "00 05 * * 0"
           filters: { branches: { only: [ main ] } }
     jobs:
+      - lambda-unit-test:
+            name: lambda unit test
+            filters: { branches: { only: [ main ] } }
       - build:
           name: build integration
           filters: { branches: { only: [ main ] } }


### PR DESCRIPTION
## Purpose
Our weekly integration test run looks to have been broken for a long time - https://app.circleci.com/pipelines/github/ministryofjustice/opg-digideps/7657/workflows/96b587e6-5aeb-4569-8632-054b7937d195. It looks like we're missing a required step to ensure `layer.tar` is available when we run an apply so adding in now.

@xaithe @jamesrwarren - let me know if I've oversimplified this solution 😅 
