### PR TITLE
DDPB-4077 - Show joint accounts on the checklist 

### DIFF
--- a/client/templates/Admin/Client/Report/partials/_money-in-and-out.html.twig
+++ b/client/templates/Admin/Client/Report/partials/_money-in-and-out.html.twig
@@ -59,6 +59,7 @@
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
                         <th scope="col" class="govuk-table__header">{{ 'bankAccount' | trans({}, 'common') }}</th>
+                        <th scope="col" class="govuk-table__header">{{ 'joint' | trans({}, 'common') }}</th>
                         <th scope="col" class="govuk-table__header govuk-table__header--numeric">{{ 'amount' | trans({}, 'common') }}</th>
                     </tr>
                 </thead>
@@ -66,11 +67,12 @@
                     {% for account in report.bankAccounts %}
                         <tr class="govuk-table__row">
                             <td class="govuk-table__cell">{{ account.getNameOneLine() }}</td>
+                            <td class="govuk-table__cell">{{ account.getIsJointAccount() == 'yes' ? 'Yes' : 'No'}}</td>
                             <td class="govuk-table__cell govuk-table__cell--numeric">£{{ account.openingBalance | money_format }}</td>
                         </tr>
                     {% endfor %}
                     <tr class="govuk-table__row">
-                        <th scope="row" class="govuk-table__header">{{ 'totalAmount' | trans({}, 'common') }}</th>
+                        <th scope="row" colspan='2' class="govuk-table__header">{{ 'totalAmount' | trans({}, 'common') }}</th>
                         <td class="govuk-table__cell govuk-table__cell--numeric">
                             <strong class="behat-region-checklist-accounts-opening-total">
                                 £{{ report.accountsOpeningBalanceTotal | money_format }}
@@ -99,6 +101,7 @@
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
                         <th class="govuk-table__header">{{ 'bankAccount' | trans({}, 'common') }}</th>
+                        <th class="govuk-table__header">{{ 'joint' | trans({}, 'common') }}</th>
                         <th class="govuk-table__header govuk-table__header--numeric">{{ 'amount' | trans({}, 'common') }}</th>
                     </tr>
                 </thead>
@@ -106,11 +109,12 @@
                     {% for account in report.bankAccounts %}
                         <tr class="govuk-table__row">
                             <td class="govuk-table__cell">{{ account.getNameOneLine() }}</td>
+                            <td class="govuk-table__cell">{{ account.getIsJointAccount() == 'yes' ? 'Yes' : 'No'}}</td>
                             <td class="govuk-table__cell govuk-table__cell--numeric">£{{ account.closingBalance | money_format }}</td>
                         </tr>
                     {% endfor %}
                     <tr class="govuk-table__row">
-                        <th scope="row" class="govuk-table__header">{{ 'totalAmount' | trans({}, 'common') }}</th>
+                        <th scope="row" colspan='2' class="govuk-table__header">{{ 'totalAmount' | trans({}, 'common') }}</th>
                         <td class="govuk-table__cell govuk-table__cell--numeric">
                             <strong class="behat-region-checklist-accounts-closing-total">£{{ report.accountsClosingBalanceTotal | money_format }}</strong>
                         </td>

--- a/client/translations/common.en.yml
+++ b/client/translations/common.en.yml
@@ -78,6 +78,7 @@ typeOfAccount: Type of account
 sortCode: Sort code
 accountNumber: Account number
 bankAccount: Bank account
+joint: Joint
 notApplicable: Not applicable
 savedBy: Saved by
 date: Date


### PR DESCRIPTION
## Purpose
Currently on the checklist, accounts are not flagged to show whether they are joint accounts or not.
This fix adds in a new column to the account balance table to flag joint accounts.

Fixes DDPB-4077

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
