### PR TITLE
Updated CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@ministryofjustice/digideps
+*@ministryofjustice/digideps


### PR DESCRIPTION
`*` is needed to indicate its on all files because you can path filter as well