### PR TITLE
DDPB-4162: Drop optional destroy from CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,18 +169,6 @@ workflows:
           requires: [ unprotect environment approval ]
           filters: { branches: { ignore: [ main ] } }
           protect_time: "0"
-      # Optional manual destruction of environment
-      - cleanup:
-          name: optional destroy environment approval
-          type: approval
-          requires: [ cancel redundant builds ]
-          filters: { branches: { ignore: [ main ] } }
-
-      - terraform-command:
-          name: destroy environment
-          requires: [ optional destroy environment approval ]
-          filters: { branches: { ignore: [ main ] } }
-          tf_command: destroy
 
   integration:
     jobs:


### PR DESCRIPTION
## Purpose
Dropping this step from the pipeline as no one is using it.
