### PR TITLE
[DDPB-3884] Remove password hashes from api responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ else
 	docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm test sh ./tests/Behat/run-tests.sh --profile v2-tests-goutte --tags @v2
 endif
 
-behat-tests-v2-goutte-parallel: up-app-integration-tests reset-fixtures disable-debug
+behat-tests-v2-goutte-parallel: up-app-integration-tests reset-fixtures disable-debug ##@behat Run the integration tests in parallel
 	docker-compose -f docker-compose.yml -f docker-compose.dev.yml run --rm test sh ./tests/Behat/run-tests-parallel.sh --tags @v2
 
 behat-tests-v2-browserstack: up-app-integration-tests reset-fixtures disable-debug

--- a/api/src/Controller/AuthController.php
+++ b/api/src/Controller/AuthController.php
@@ -127,7 +127,7 @@ class AuthController extends RestController
      */
     public function getLoggedUser(TokenStorageInterface $tokenStorage)
     {
-        $this->formatter->setJmsSerialiserGroups(['user']);
+        $this->formatter->setJmsSerialiserGroups(['user', 'user-login']);
 
         return $tokenStorage->getToken()->getUser();
     }

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -120,6 +120,7 @@ class User implements UserInterface
      * @var string
      * @ORM\Column(name="password", type="string", length=100, nullable=false)
      * @JMS\Groups({ "user-login"})
+     * @JMS\Exclude
      */
     private $password;
 

--- a/api/tests/Unit/Controller/AuthControllerTest.php
+++ b/api/tests/Unit/Controller/AuthControllerTest.php
@@ -196,6 +196,20 @@ class AuthControllerTest extends AbstractTestController
         ]);
     }
 
+    public function testPasswordHashNotInResponse()
+    {
+        $authToken = $this->login('deputy@example.org', 'DigidepsPass1234', API_TOKEN_DEPUTY);
+
+        // assert succeed with token
+        $data = $this->assertJsonRequest('GET', '/auth/get-logged-user', [
+                'mustSucceed' => true,
+                'AuthToken' => $authToken,
+            ])['data'];
+
+        $this->assertEquals('deputy@example.org', $data['email']);
+        $this->assertNull($data['password'], 'No password is returned');
+    }
+
     public function testBruteForceSameEmail()
     {
         $this->resetAttempts('email'.'deputy@example.org');

--- a/client/src/Controller/SettingsController.php
+++ b/client/src/Controller/SettingsController.php
@@ -121,9 +121,7 @@ class SettingsController extends AbstractController
             ]));
             $request->getSession()->set('login-context', 'password-update');
 
-            $successRoute = $this->getUser()->isDeputyOrg() ? 'org_settings' : 'account_settings';
-
-            return $this->redirect($this->generateUrl($successRoute));
+            return $this->redirect('/logout');
         }
 
         return [

--- a/client/tests/phpunit/Service/Client/Internal/UserApiTest.php
+++ b/client/tests/phpunit/Service/Client/Internal/UserApiTest.php
@@ -1,16 +1,16 @@
-<?php declare(strict_types=1);
+<?php
 
+declare(strict_types=1);
 
+use App\Event\AdminUserCreatedEvent;
 use App\Event\CoDeputyCreatedEvent;
 use App\Event\CoDeputyInvitedEvent;
 use App\Event\DeputyInvitedEvent;
 use App\Event\DeputySelfRegisteredEvent;
 use App\Event\OrgUserCreatedEvent;
-use App\Event\UserPasswordResetEvent;
-use App\Event\AdminUserCreatedEvent;
 use App\Event\UserDeletedEvent;
+use App\Event\UserPasswordResetEvent;
 use App\Event\UserUpdatedEvent;
-use App\EventDispatcher\EventDispatcherMock;
 use App\EventDispatcher\ObservableEventDispatcher;
 use App\Model\SelfRegisterData;
 use App\Service\Client\Internal\UserApi;
@@ -96,7 +96,7 @@ class UserApiTest extends TestCase
     {
         $userToCreate = UserHelpers::createUser();
 
-        $this->restClient->post('user', $userToCreate, ["admin_add_user"], 'User')->shouldBeCalled()->willReturn($userToCreate);
+        $this->restClient->post('user', $userToCreate, ['admin_add_user'], 'User')->shouldBeCalled()->willReturn($userToCreate);
 
         $userCreatedEvent = new AdminUserCreatedEvent($userToCreate);
         $this->eventDispatcher->dispatch($userCreatedEvent, 'admin.user.created')->shouldBeCalled();
@@ -218,7 +218,7 @@ class UserApiTest extends TestCase
     {
         $userToCreate = UserHelpers::createUser();
 
-        $this->restClient->post('user', $userToCreate, ["org_team_add"], 'User')->shouldBeCalled()->willReturn($userToCreate);
+        $this->restClient->post('user', $userToCreate, ['org_team_add'], 'User')->shouldBeCalled()->willReturn($userToCreate);
 
         $userCreatedEvent = new OrgUserCreatedEvent($userToCreate);
         $this->eventDispatcher->dispatch($userCreatedEvent, 'org.user.created')->shouldBeCalled();


### PR DESCRIPTION
## Purpose
Remove password hashes from being returned in an API response that holds user data. There was 1 issue with this where when a user changes their password it would no longer log them out afterwards. To solve this we just redirect the user to the logout page after submitting a password change and the form is valid

Fixes DDPB-3884