### PR TITLE
DDPB-3851: Allow discharge of org deputies without associated named deputies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,12 @@
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v4.0.1
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
 -   repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.19.0
+    rev: v1.56.0
     hooks:
     -   id: terraform_fmt
     -   id: terraform_validate

--- a/api/src/Entity/Client.php
+++ b/api/src/Entity/Client.php
@@ -829,7 +829,7 @@ class Client implements ClientInterface
     /**
      * @return Client
      */
-    public function setNamedDeputy(NamedDeputy $namedDeputy)
+    public function setNamedDeputy(?NamedDeputy $namedDeputy)
     {
         $this->namedDeputy = $namedDeputy;
 

--- a/api/tests/Behat/bootstrap/v2/ClientManagement/ClientManagementTrait.php
+++ b/api/tests/Behat/bootstrap/v2/ClientManagement/ClientManagementTrait.php
@@ -344,7 +344,7 @@ MESSAGE;
     {
         $this->assertInteractingWithUserIsSet();
 
-        $this->iVisitAdminLayClientDetailsPage();
+        $this->iVisitAdminClientDetailsPageForDeputyInteractingWith();
 
         $dischargedOnSelector = "//dt[normalize-space() = 'Discharged on']/..";
         $dischargedOnVisible = $this->getSession()->getPage()->find('xpath', $dischargedOnSelector);

--- a/api/tests/Behat/bootstrap/v2/ClientManagement/ClientManagementTrait.php
+++ b/api/tests/Behat/bootstrap/v2/ClientManagement/ClientManagementTrait.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Tests\Behat\v2\ClientManagement;
 
 use App\Entity\Client;
-use App\Entity\NamedDeputy;
 use App\Tests\Behat\BehatException;
 use App\Tests\Behat\v2\Common\UserDetails;
 use DateTime;
@@ -364,9 +363,7 @@ MESSAGE;
     {
         $this->assertInteractingWithUserIsSet();
 
-//        $namedDeputy = $this->em->getRepository(NamedDeputy::class)->findBy(['email1' => $this->interactingWithUserDetails->getNamedDeputyEmail()]);
         $client = $this->em->find(Client::class, $this->interactingWithUserDetails->getClientId());
-
         $client->setNamedDeputy(null);
 
         $this->em->persist($client);

--- a/api/tests/Behat/features-v2/client-management/admin/discharge.lay.feature
+++ b/api/tests/Behat/features-v2/client-management/admin/discharge.lay.feature
@@ -1,0 +1,23 @@
+@v2 @v2_admin @admin-client-discharge
+Feature: Admin - Client Discharge
+
+    @super-admin @lay-pfa-high-submitted
+    Scenario: A super admin user discharges a client
+        Given a super admin user accesses the admin app
+        When I visit the admin client details page for an existing client linked to a Lay deputy
+        And I attempt to discharge the client
+        Then the client should be discharged
+
+    @admin-manager @lay-pfa-high-submitted
+    Scenario: An admin manager user can discharge a client
+        Given an admin manager user accesses the admin app
+        When I visit the admin client details page for an existing client linked to a Lay deputy
+        And I attempt to discharge the client
+        Then the client should be discharged
+
+    @admin @lay-pfa-high-submitted
+    Scenario: An admin user cannot discharge a client
+        Given an admin user accesses the admin app
+        When I visit the admin client details page for an existing client linked to a Lay deputy
+        And I attempt to discharge the client
+        Then the client should not be discharged

--- a/api/tests/Behat/features-v2/client-management/admin/discharge.org.feature
+++ b/api/tests/Behat/features-v2/client-management/admin/discharge.org.feature
@@ -2,22 +2,31 @@
 Feature: Admin - Client Discharge
 
 @super-admin @prof-admin-health-welfare-submitted
-  Scenario: A super admin user discharges a client
+  Scenario: A super admin user discharges an org client
     Given a super admin user accesses the admin app
     When I visit the admin client details page for an existing client linked to a deputy in an Organisation
     And I attempt to discharge the client
     Then the client should be discharged
 
 @admin-manager @prof-admin-health-welfare-submitted
-  Scenario: An admin manager user can discharge a client
+  Scenario: An admin manager user discharges an org client
     Given an admin manager user accesses the admin app
     When I visit the admin client details page for an existing client linked to a deputy in an Organisation
     And I attempt to discharge the client
     Then the client should be discharged
 
 @admin @prof-admin-health-welfare-submitted
-  Scenario: An admin user cannot discharge a client
+  Scenario: An admin user discharges an org client
     Given an admin user accesses the admin app
     When I visit the admin client details page for an existing client linked to a deputy in an Organisation
     And I attempt to discharge the client
     Then the client should not be discharged
+
+@admin-manager @prof-admin-health-welfare-submitted @acs
+Scenario: An admin manager user discharges an org client without a named deputy
+    Given a Professional Deputy has submitted a Health and Welfare report
+    And an admin manager user accesses the admin app
+    And the client does not have a named deputy associated with them
+    When I visit the admin client details page for an existing client linked to a deputy in an Organisation
+    And I attempt to discharge the client
+    Then the client should be discharged

--- a/api/tests/Behat/features-v2/client-management/admin/discharge.org.feature
+++ b/api/tests/Behat/features-v2/client-management/admin/discharge.org.feature
@@ -1,21 +1,21 @@
 @v2 @v2_admin @admin-client-discharge
 Feature: Admin - Client Discharge
 
-@super-admin @lay-pfa-high-submitted
+@super-admin @prof-admin-health-welfare-submitted
   Scenario: A super admin user discharges a client
     Given a super admin user accesses the admin app
-    When I visit the admin client details page for an existing client linked to a Lay deputy
+    When I visit the admin client details page for an existing client linked to a deputy in an Organisation
     And I attempt to discharge the client
     Then the client should be discharged
 
-@admin-manager @lay-pfa-high-submitted
+@admin-manager @prof-admin-health-welfare-submitted
   Scenario: An admin manager user can discharge a client
     Given an admin manager user accesses the admin app
-    When I visit the admin client details page for an existing client linked to a Lay deputy
+    When I visit the admin client details page for an existing client linked to a deputy in an Organisation
     And I attempt to discharge the client
     Then the client should be discharged
 
-@admin @prof-admin-health-welfare-submitted @lay-pfa-high-submitted
+@admin @prof-admin-health-welfare-submitted
   Scenario: An admin user cannot discharge a client
     Given an admin user accesses the admin app
     When I visit the admin client details page for an existing client linked to a deputy in an Organisation

--- a/client/templates/Admin/Client/Client/details.html.twig
+++ b/client/templates/Admin/Client/Client/details.html.twig
@@ -105,15 +105,16 @@
                 {{ 'alternativeEmail' | trans({}, 'common') }}: {{ namedDeputy.email3 }}<br />
             {% endif %}
         </p>
-        {% if is_granted('ROLE_ADMIN_MANAGER') %}
-            {% if not client.isDeleted %}
-                <a href="{{ path('admin_client_discharge', {id: client.id}) }}" role="button" data-module="govuk-button" class="govuk-button govuk-button--secondary">
-                    Discharge deputy
-                </a>
-            {% endif %}
-        {% endif %}
     </div>
 </details>
+{% endif %}
+
+{% if is_granted('ROLE_ADMIN_MANAGER') %}
+    {% if not client.isDeleted %}
+        <a href="{{ path('admin_client_discharge', {id: client.id}) }}" role="button" data-module="govuk-button" class="govuk-button govuk-button--secondary">
+            Discharge deputy
+        </a>
+    {% endif %}
 {% endif %}
 
 {% set allReports = client.reports|merge([client.ndr])|filter(r => (r is not null)) %}


### PR DESCRIPTION
## Purpose
In the templates for the org client details page we hide the button for discharging a deputy behind a check on if a named deputy is associated with the client. While this makes logical sense we have over 7000 deputies without a named deputy associated with them since we dropped the named deputy table and rebuilt via the CSV. The reason behind this high number is due to the fact we don't remove a client/deputy from digideps when they drop off the CSV. This means in the rare cases where auto discharge doesn't happen on CSV upload we are unable to discharge a deputy and allow a new deputy to be associated with a client.

This change moves the discharge deputy button outside of the check on named deputy so we can discharge when needed. This may be a little confusing for users so we should link in with the teams responsible for this for feedback. There may be no end users actively using the button as currently only super admins and admin managers have access to the button.

Fixes DDPB-3851.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [x] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
