### PR TITLE
DDPB-4171: Fix redis and add service health integration tests

### DIFF
--- a/api/tests/Behat/behat.yml
+++ b/api/tests/Behat/behat.yml
@@ -363,6 +363,12 @@ v2-tests-goutte:
             contexts:
                 - App\Tests\Behat\v2\Reporting\Sections\ReportingSectionsFeatureContext
 
+        service-helath:
+            description: Covering service health monitoring features of the app
+            paths: [ "%paths.base%/features-v2/service-health" ]
+            contexts:
+                - App\Tests\Behat\v2\ServiceHealth\ServiceHealthFeatureContext
+
         user-management:
             description: Covering the user management features of the app (admin)
             paths: [ "%paths.base%/features-v2/user-management" ]

--- a/api/tests/Behat/behat.yml
+++ b/api/tests/Behat/behat.yml
@@ -363,7 +363,7 @@ v2-tests-goutte:
             contexts:
                 - App\Tests\Behat\v2\Reporting\Sections\ReportingSectionsFeatureContext
 
-        service-helath:
+        service-health:
             description: Covering service health monitoring features of the app
             paths: [ "%paths.base%/features-v2/service-health" ]
             contexts:

--- a/api/tests/Behat/bootstrap/v2/ServiceHealth/ServiceHealthFeatureContext.php
+++ b/api/tests/Behat/bootstrap/v2/ServiceHealth/ServiceHealthFeatureContext.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Behat\v2\ServiceHealth;
+
+use App\Tests\Behat\v2\Common\BaseFeatureContext;
+
+class ServiceHealthFeatureContext extends BaseFeatureContext
+{
+}

--- a/api/tests/Behat/features-v2/service-health/external-dependecy-checks.feature
+++ b/api/tests/Behat/features-v2/service-health/external-dependecy-checks.feature
@@ -1,4 +1,4 @@
-@service-health @v2_admin
+@v2 @service-health @v2_admin
 Feature: Overview of external dependencies the application requires to function
 
     @infra @smoke

--- a/api/tests/Behat/features-v2/service-health/external-dependecy-checks.feature
+++ b/api/tests/Behat/features-v2/service-health/external-dependecy-checks.feature
@@ -1,0 +1,12 @@
+@service-health @v2_admin
+Feature: Overview of external dependencies the application requires to function
+
+    @infra @smoke
+    Scenario: check maintenance page checks
+        When I go to "/manage/availability"
+        Then I should see "Sirius: OK"
+        And I should see "Api: OK"
+        And I should see "Redis: OK"
+        And I should see "Notify: OK"
+        And I should see "ClamAV: OK"
+        And I should see "htmlToPdf: OK"

--- a/client/config/services.yml
+++ b/client/config/services.yml
@@ -29,6 +29,8 @@ parameters:
             registration: [1,2,3]
             registration_admin: [1,2]
 
+    fallback_notify_base_uri: false
+
 services:
     _defaults:
         autowire: true
@@ -193,7 +195,6 @@ services:
             $config:
                 httpClient: '@Http\Adapter\Guzzle7\Client'
                 apiKey: '%env(NOTIFY_API_KEY)%'
-                baseUrl: 'http://mock-notify-api:4010'
 
     App\Service\Mailer\NotifyClientMock:
         class: App\Service\Mailer\NotifyClientMock
@@ -201,7 +202,8 @@ services:
             $config:
                 httpClient: '@Http\Adapter\Guzzle7\Client'
                 apiKey: '%env(NOTIFY_API_KEY)%'
-                baseUrl: 'http://mock-notify-api:4010'
+#                Setting the URI to false defaults to the uri defined in the package
+                baseUrl: '%env(default:fallback_notify_base_uri:NOTIFY_API_BASE_URI)%'
             $logger: '@logger'
 
     Http\Adapter\Guzzle7\Client:

--- a/client/config/services.yml
+++ b/client/config/services.yml
@@ -193,6 +193,7 @@ services:
             $config:
                 httpClient: '@Http\Adapter\Guzzle7\Client'
                 apiKey: '%env(NOTIFY_API_KEY)%'
+                baseUrl: 'http://mock-notify-api:4010'
 
     App\Service\Mailer\NotifyClientMock:
         class: App\Service\Mailer\NotifyClientMock
@@ -200,6 +201,7 @@ services:
             $config:
                 httpClient: '@Http\Adapter\Guzzle7\Client'
                 apiKey: '%env(NOTIFY_API_KEY)%'
+                baseUrl: 'http://mock-notify-api:4010'
             $logger: '@logger'
 
     Http\Adapter\Guzzle7\Client:

--- a/client/config/services.yml
+++ b/client/config/services.yml
@@ -29,7 +29,7 @@ parameters:
             registration: [1,2,3]
             registration_admin: [1,2]
 
-    fallback_notify_base_uri: false
+    fallback_notify_base_uri: null
 
 services:
     _defaults:
@@ -195,6 +195,8 @@ services:
             $config:
                 httpClient: '@Http\Adapter\Guzzle7\Client'
                 apiKey: '%env(NOTIFY_API_KEY)%'
+#                Setting the URI to null defaults to the uri defined in the package
+                baseUrl: '%env(default:fallback_notify_base_uri:NOTIFY_API_BASE_URI)%'
 
     App\Service\Mailer\NotifyClientMock:
         class: App\Service\Mailer\NotifyClientMock
@@ -202,7 +204,7 @@ services:
             $config:
                 httpClient: '@Http\Adapter\Guzzle7\Client'
                 apiKey: '%env(NOTIFY_API_KEY)%'
-#                Setting the URI to false defaults to the uri defined in the package
+#                Setting the URI to null defaults to the uri defined in the package
                 baseUrl: '%env(default:fallback_notify_base_uri:NOTIFY_API_BASE_URI)%'
             $logger: '@logger'
 

--- a/client/frontend.env
+++ b/client/frontend.env
@@ -18,7 +18,7 @@ NONADMIN_HOST=https://digideps.local
 ADMIN_HOST=https://admin.digideps.local
 
 # Due to validation checks when instantiating Notify client this needs to be in a valid JWT format - the value is fake
-NOTIFY_API_KEY=testkey-3256fbd6-df6e-43ea-862c-7120440ba955-fedc4684-3084-4376-8e6a-338701de2beb
+NOTIFY_API_KEY=fakekey-1234fbd6-df6e-43ea-862c-7120440ba955-42e755b4-752b-437d-aafa-9939773bf7e4
 NOTIFY_API_BASE_URI=http://mock-notify-api:4010
 
 # use simple alpha and underscore for bucketname. Fakes3 failing otherwise

--- a/client/frontend.env
+++ b/client/frontend.env
@@ -18,7 +18,7 @@ NONADMIN_HOST=https://digideps.local
 ADMIN_HOST=https://admin.digideps.local
 
 # Due to validation checks when instantiating Notify client this needs to be in a valid JWT format - the value is fake
-NOTIFY_API_KEY=fakekey-1234fbd6-df6e-43ea-862c-7120440ba955-42e755b4-752b-437d-aafa-9939773bf7e4
+NOTIFY_API_KEY=fakekey-6457aff8-dd8e-43ca-872e-6452298ad541-beef2296-6402-9456-1d3e-465110ae2beb
 NOTIFY_API_BASE_URI=http://mock-notify-api:4010
 
 # use simple alpha and underscore for bucketname. Fakes3 failing otherwise

--- a/client/frontend.env
+++ b/client/frontend.env
@@ -18,7 +18,8 @@ NONADMIN_HOST=https://digideps.local
 ADMIN_HOST=https://admin.digideps.local
 
 # Due to validation checks when instantiating Notify client this needs to be in a valid JWT format - the value is fake
-NOTIFY_API_KEY=fakekey-1234fbd6-df6e-43ea-862c-7120440ba955-42e755b4-752b-437d-aafa-9939773bf7e4
+NOTIFY_API_KEY=testkey-3256fbd6-df6e-43ea-862c-7120440ba955-fedc4684-3084-4376-8e6a-338701de2beb
+NOTIFY_API_BASE_URI=http://mock-notify-api:4010
 
 # use simple alpha and underscore for bucketname. Fakes3 failing otherwise
 S3_BUCKETNAME=pa-uploads-local

--- a/client/govuk-notifications.yaml
+++ b/client/govuk-notifications.yaml
@@ -1,0 +1,220 @@
+---
+openapi: 3.0.0
+info:
+    version: 2.0.0
+    title: govuk-notifications
+    description: "Specifications for the v2 public endpoints used by Notify clients"
+
+tags:
+    - name: govuk-notifications
+      description: Public API operations relating used by Notify clients
+
+security:
+    - bearerAuth: []
+
+paths:
+    /v2/templates:
+        description: Get all templates
+        get:
+            summary: Get all templates
+            description: Returns the latest version of all templates.
+            tags:
+                - "templates"
+            responses:
+                200:
+                    description: Get all templates
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ArrayOfTemplates'
+                400:
+                    description: Incorrect API key or service in trial mode
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error4XX-5XX'
+                403:
+                    description: System clock innaccurate or invalid API key
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error4XX-5XX'
+                429:
+                    description: Too many requests
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error4XX-5XX'
+                500:
+                    description: Something unexpected happened and it is the API's fault
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error4XX-5XX'
+
+    /v2/notifications/email:
+        description: Send an email
+        post:
+            summary: Send an email
+            description: Sends an email with optional personalisations
+            tags:
+                - "email"
+            requestBody:
+                content:
+                    'application/json':
+                        schema:
+                            properties:
+                                template_id:
+                                    description: UID that refers to an existing template in Notify
+                                    type: string
+                                    example:
+                                        $ref: '#/components/schemas/UUID'
+                                personalisation:
+                                    description: Metadata to personalise the email template
+                                    type: object
+                                    example:
+                                        $ref: '#/components/schemas/Personalisation'
+                            required:
+                                - status
+            responses:
+                201:
+                    description: Success response from client
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    content:
+                                        type: object
+                                        properties:
+                                            body:
+                                                type: string
+                                                example: "The email body content"
+                                            from_email:
+                                                type: string
+                                                example: "complete.the.deputy.report@notifications.service.gov.uk"
+                                            subject:
+                                                type: string
+                                                example: "Reset your password"
+                                    id:
+                                        type: string
+                                        nullable: true
+                                        example:
+                                            $ref: '#/components/schemas/UUID'
+                                    reference:
+                                        type: string
+                                        format: nullable
+                                    scheduled_for:
+                                        type: string
+                                        format: nullable
+                                    template:
+                                        type: object
+                                        properties:
+                                            id:
+                                                type: string
+                                                example:
+                                                    $ref: '#/components/schemas/UUID'
+                                            uri:
+                                                type: string
+                                                example: "https://api.notifications.service.gov.uk/services/3256fbd6-df6e-43ea-862c-7120440ba955/templates/827555cc-498a-43ef-957a-63fa387065e3"
+                                            version:
+                                                type: integer
+                                                example: 11
+                                    uri:
+                                        type: string
+                                        example: "https://api.notifications.service.gov.uk/v2/notifications/baaa3c44-ff89-4943-b80d-7ceaeecc878a"
+                400:
+                    description: Incorrect API key or service in trial mode
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error4XX-5XX'
+                403:
+                    description: System clock innaccurate or invalid API key
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error4XX-5XX'
+                429:
+                    description: Too many requests
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error4XX-5XX'
+                500:
+                    description: Something unexpected happened and it is the API's fault
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error4XX-5XX'
+
+components:
+    securitySchemes:
+        bearerAuth: # arbitrary name for the security scheme
+            type: http
+            scheme: bearer
+            bearerFormat: JWT    # optional, arbitrary value for documentation purposes
+    schemas:
+        UUID:
+            type: string
+            readOnly: true
+            description: A unique identifier
+            pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'
+            example: '5a8b1a26-8296-4373-ae61-f8d0b250e773'
+        Personalisation:
+            type: object
+            properties:
+                first_name:
+                    type: string
+                    pattern: '.*'
+                    example: 'Alex'
+                application_date:
+                    type: string
+                    example: "2019-12-31"
+            required: false
+        ArrayOfTemplates:
+            type: array
+            items:
+                $ref: '#components/schemas/Template'
+        Template:
+            properties:
+                body:
+                    type: string
+                created_at:
+                    type: string
+                created_by:
+                    type: string
+                id:
+                    type: string
+                letter_contact_block:
+                    type: string
+                    format: nullable
+                name:
+                    type: string
+                personalisation:
+                    type: object
+                    properties:
+                        deletionDate:
+                            type: object
+                            properties:
+                                required:
+                                    type: boolean
+                postage:
+                    type: string
+                    format: nullable
+                subject:
+                    type: string
+                type:
+                    type: string
+                updated_at:
+                    type: string
+                version:
+                    type: integer
+                    format: int32
+        Error4XX-5XX:
+            type: object
+            properties:
+                error:
+                    type: string
+                message:
+                    type: string

--- a/client/govuk-notifications.yaml
+++ b/client/govuk-notifications.yaml
@@ -64,18 +64,31 @@ paths:
                     'application/json':
                         schema:
                             properties:
+                                email_address:
+                                    description: The email address of the recipient.
+                                    type: string
+                                    example: 'testAccount@example.org'
                                 template_id:
-                                    description: UID that refers to an existing template in Notify
+                                    description: UID that refers to an existing template in Notify.
                                     type: string
                                     example:
                                         $ref: '#/components/schemas/UUID'
                                 personalisation:
-                                    description: Metadata to personalise the email template
+                                    description: Metadata to personalise the email template.
                                     type: object
                                     example:
                                         $ref: '#/components/schemas/Personalisation'
+                                reference:
+                                    description: identifies a single notification or a batch of notifications.
+                                    type: string
+                                    example: 'ref123'
+                                email_reply_to_id:
+                                    description: The email address to receive replies from your users.
+                                    type: string
+                                    example: 'reply-only@example.org'
                             required:
-                                - status
+                                - email_address
+                                - template_id
             responses:
                 201:
                     description: Success response from client

--- a/client/src/Service/Availability/RedisAvailability.php
+++ b/client/src/Service/Availability/RedisAvailability.php
@@ -2,6 +2,7 @@
 
 namespace App\Service\Availability;
 
+use Predis\ClientInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class RedisAvailability extends ServiceAvailabilityAbstract
@@ -9,21 +10,21 @@ class RedisAvailability extends ServiceAvailabilityAbstract
     const TEST_KEY = 'RedisAvailabilityTestKey';
 
     private ContainerInterface $container;
+    private ClientInterface $redis;
 
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container, ClientInterface $redis)
     {
         $this->isHealthy = false;
         $this->container = $container;
+        $this->redis = $redis;
     }
 
     public function ping()
     {
         try {
-            // get the redis service, save and read a key
-            $redis = $this->container->get('snc_redis.default');
-            $redis->set(self::TEST_KEY, 'valueSaved');
+            $this->redis->set(self::TEST_KEY, 'valueSaved');
 
-            if ('valueSaved' == $redis->get(self::TEST_KEY)) {
+            if ('valueSaved' == $this->redis->get(self::TEST_KEY)) {
                 $this->isHealthy = true;
             }
         } catch (\Throwable $e) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
             - htmltopdf
             - router
             - localstack
+            - mock-notify-api
         environment:
             VIRTUAL_HOST: www.digideps.local,digideps.local
             VIRTUAL_PROTO: https
@@ -87,6 +88,7 @@ services:
             - api
             - redis-frontend
             - mock-sirius-integration
+            - mock-notify-api
         environment:
             VIRTUAL_HOST: admin.digideps.local
             VIRTUAL_PROTO: https
@@ -188,3 +190,16 @@ services:
             - 6060:8080
         environment:
             - OPENAPI_MOCK_SPECIFICATION_URL=https://raw.githubusercontent.com/ministryofjustice/opg-data-deputy-reporting/master/lambda_functions/v2/openapi/deputy-reporting-openapi.yml
+
+    mock-notify-api:
+        image: stoplight/prism:4.4.1
+        ports:
+            - 4010:4010
+        volumes:
+            - ./client/govuk-notifications.yaml:/tmp/govuk-notifications.yaml
+        command:
+            - mock
+            - /tmp/govuk-notifications.yaml
+            - -h
+            - 0.0.0.0
+            - --dynamic


### PR DESCRIPTION
## Purpose
Fixes the Redis health check on /manage/availability along with adding a missing integration test for overall service health.

Fixes DDPB-4171

## Approach
It turns out Redis wasn't broken - the RedisAvailability class was still using the old skool approach of getting Redis directly from the container after it was built rather than via dependency injection.

## Learning
As a side adventure (and in order to make the integration tests pass locally) I drafted up a super quick open API spec for the two Notify endpoints we use in the app so we could have a real mock Notify to call out to. It could be a little more dynamic but for the purpose of getting the integration tests to pass it's serviceable! The logic is a little backwards in that we only ever provide the base URI locally via frontend.env. If that env var is missing (which it will be in branch envs, preprod and prod) then it defaults to false which uses the hardcoded real API endpoint that's in the Notify PHP client:

```
Local:
    API key: fake (although doesn't matter as the API is mocked)
    URI: http://mock-notify-api:4010
Branch env:
    API key: dev
    URI: false
Integration/Preprod env:
    API key: dev
    URI: false
Live env:
    API key: live
    URI: false
```

I also saw that when we send an email to notify the response from them contains the full email body which could mean we could fully test our email sending on branches. This is currently not possible as templates are stored only within Notify itself so we can never be sure we're passing all the required personalisation values. A future ticket...

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes
