### PR TITLE
DDPB-4173: Ensure benefits check is required in formatted report rather than money in

### DIFF
--- a/client/templates/Report/Formatted/formatted_body.html.twig
+++ b/client/templates/Report/Formatted/formatted_body.html.twig
@@ -45,7 +45,7 @@
             } %}
         {% endif %}
 
-        {% if report.hasSection('moneyIn') %}
+        {% if report.hasSection('clientBenefitsCheck') %}
             {% include '@App/Report/Formatted/_client_benefits_check.html.twig' with {
                 'clientBenefitsCheck': report.clientBenefitsCheck
             } %}


### PR DESCRIPTION
## Purpose
We're showing the new report section on report previews and PDFs as we check if the report contains the `moneyIn` section rather than `clientBenefitsCheck`.

Fixes DDPB-4173.

## Learning
Copy and paste is rarely a good thing.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
