### PR TITLE
DDPB-4170: Bump PHP alpine images to use busybox v3.14

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -16,7 +16,7 @@ RUN composer run-script post-install-cmd --no-interaction
 
 RUN composer dump-autoload --optimize
 
-FROM php:7.4.23-fpm-alpine
+FROM php:7.4.26-fpm-alpine3.14
 WORKDIR /var/www
 EXPOSE 80
 EXPOSE 443

--- a/api/composer.json
+++ b/api/composer.json
@@ -15,7 +15,7 @@
     }
   },
   "require": {
-    "php": "7.4.23",
+    "php": "7.4.26",
     "aws/aws-sdk-php": "^3.100.9",
     "doctrine/doctrine-bundle": "^2.2",
     "doctrine/doctrine-migrations-bundle": "^3.0",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b85abb3b710e29697ca05117e4d259dd",
+    "content-hash": "121756527e6b84308cff54eaef479f45",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -8205,8 +8205,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "7.4.19"
+        "php": "7.4.26"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -38,7 +38,7 @@ COPY src src
 RUN composer run-script post-install-cmd --no-interaction
 RUN composer dump-autoload --optimize
 
-FROM php:8.0.12-fpm-alpine
+FROM php:8.0.12-fpm-alpine3.14
 WORKDIR /var/www
 EXPOSE 80
 EXPOSE 443


### PR DESCRIPTION
## Purpose
Fixes https://nvd.nist.gov/vuln/detail/CVE-2021-42383 by bumping busybox to 3.14 (hopefully).

Fixes DDPB-4170