### PR TITLE
Simplify composer tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,3 +143,11 @@ phpstan-api:
 
 phpstan-frontend:
 	docker-compose run --rm frontend vendor/phpstan/phpstan/phpstan analyse src --memory-limit=0 --level=max
+
+composer-api:
+	docker-compose exec api sh install-composer.sh
+	docker-compose exec api sh
+
+composer-frontend:
+	docker-compose exec frontend sh install-composer.sh
+	docker-compose exec frontend sh

--- a/Makefile
+++ b/Makefile
@@ -144,10 +144,10 @@ phpstan-api:
 phpstan-frontend:
 	docker-compose run --rm frontend vendor/phpstan/phpstan/phpstan analyse src --memory-limit=0 --level=max
 
-composer-api:
+composer-api: ##@application Drops you into the API container with composer installed
 	docker-compose exec api sh install-composer.sh
 	docker-compose exec api sh
 
-composer-frontend:
+composer-frontend: ##@application Drops you into the frontend container with composer installed
 	docker-compose exec frontend sh install-composer.sh
 	docker-compose exec frontend sh

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -13,6 +13,9 @@ services:
       - ./client/translations:/var/www/translations
       - ./client/phpstan.neon:/var/www/phpstan.neon
       - ./client/bin:/var/www/vendor/bin
+      - ./client/composer.json:/var/www/composer.json
+      - ./client/composer.lock:/var/www/composer.lock
+      - ./docker/install-composer.sh:/var/www/install-composer.sh
 
   api:
     volumes:
@@ -28,6 +31,9 @@ services:
       - ./api/postgres.env:/var/www/postgres.env
       - ./api/phpstan.neon:/var/www/phpstan.neon
       - ./api/bin:/var/www/vendor/bin
+      - ./api/composer.json:/var/www/composer.json
+      - ./api/composer.lock:/var/www/composer.lock
+      - ./docker/install-composer.sh:/var/www/install-composer.sh
 
   frontend:
     volumes:
@@ -39,6 +45,9 @@ services:
       - ./client/translations:/var/www/translations
       - ./client/phpstan.neon:/var/www/phpstan.neon
       - ./client/bin:/var/www/vendor/bin
+      - ./client/composer.json:/var/www/composer.json
+      - ./client/composer.lock:/var/www/composer.lock
+      - ./docker/install-composer.sh:/var/www/install-composer.sh
 
   htmltopdf:
     volumes:

--- a/docker/install-composer.sh
+++ b/docker/install-composer.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]
+then
+    >&2 echo 'ERROR: Invalid installer checksum'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet
+RESULT=$?
+rm composer-setup.php
+
+mv composer.phar /usr/local/bin/composer
+
+exit $RESULT


### PR DESCRIPTION
## Purpose
As part of #731 I got sick of having to either switch PHP version locally or manually install composer each time I exec-ed into a container in order to install or update packages so I've added a couple of helper commands to achieve this. 

