### PR TITLE
DDPB-4138 - Update TLS 1.2 to remove out of date cypher suites

### DIFF
--- a/environment/admin_elb.tf
+++ b/environment/admin_elb.tf
@@ -14,7 +14,7 @@ resource "aws_lb_listener" "admin" {
   load_balancer_arn = aws_lb.admin.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
   certificate_arn   = aws_acm_certificate_validation.wildcard.certificate_arn
 
   default_action {

--- a/environment/front_elb.tf
+++ b/environment/front_elb.tf
@@ -15,7 +15,7 @@ resource "aws_lb_listener" "front_https" {
   load_balancer_arn = aws_lb.front.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
   certificate_arn   = aws_acm_certificate_validation.wildcard.certificate_arn
 
   default_action {


### PR DESCRIPTION
## Purpose
Our current TLS listeners on our load balancers have some weak or insecure cypher suites.
To remove these, we have updated the listener to use a more update to date version: `ELBSecurityPolicy-FS-1-2-Res-2020-10`

This listener contains no weak or insecure policies.

Fixes DDPB-4138

## Approach
Updated ssl_policy on both Frontend and Admin ELBs to use the new listener.

Tested the changes on [BrowserStack](https://live.browserstack.com/) to confirm that the [browsers we should be compatible with](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices) are working as expected.

## Learning
Development branch is publicly accessible, which meant it was really easy to test against using BrowserStack. Possible to make use of the dev branch more often for tickets like this.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
