### PR TITLE
DDPB-4202: Fix client PHPUnit Deprecations

### DIFF
--- a/api/src/TestHelpers/ClientTestHelper.php
+++ b/api/src/TestHelpers/ClientTestHelper.php
@@ -8,12 +8,16 @@ use App\Entity\Client;
 use App\Entity\Organisation;
 use App\Entity\Report\Report;
 use App\Entity\User;
+use DateTime;
 use Doctrine\ORM\EntityManager;
 use Faker\Factory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class ClientTestHelper extends TestCase
 {
+    use ProphecyTrait;
+
     public function createClientMock(int $id, bool $hasReports)
     {
         $report = $hasReports ? (self::prophesize(Report::class))->reveal() : null;
@@ -34,7 +38,7 @@ class ClientTestHelper extends TestCase
             ->setLastname($faker->lastName)
             ->setCaseNumber($caseNumber ?: self::createValidCaseNumber())
             ->setEmail($faker->safeEmail.mt_rand(1, 100000))
-            ->setCourtDate(new \DateTime('09-Aug-2018'))
+            ->setCourtDate(new DateTime('09-Aug-2018'))
             ->setAddress($faker->streetAddress)
             ->setPostcode($faker->postcode);
 

--- a/api/src/TestHelpers/ClientTestHelper.php
+++ b/api/src/TestHelpers/ClientTestHelper.php
@@ -12,12 +12,9 @@ use DateTime;
 use Doctrine\ORM\EntityManager;
 use Faker\Factory;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 
 class ClientTestHelper extends TestCase
 {
-    use ProphecyTrait;
-
     public function createClientMock(int $id, bool $hasReports)
     {
         $report = $hasReports ? (self::prophesize(Report::class))->reveal() : null;

--- a/api/src/TestHelpers/UserTestHelper.php
+++ b/api/src/TestHelpers/UserTestHelper.php
@@ -10,12 +10,9 @@ use DateTime;
 use Doctrine\ORM\EntityManager;
 use Faker\Factory;
 use PHPUnit\Framework\TestCase;
-use Prophecy\PhpUnit\ProphecyTrait;
 
 class UserTestHelper extends TestCase
 {
-    use ProphecyTrait;
-
     public function createUserMock(string $roleName, bool $hasReports, bool $hasClients, int $id)
     {
         $clientTestHelper = new ClientTestHelper();

--- a/api/src/TestHelpers/UserTestHelper.php
+++ b/api/src/TestHelpers/UserTestHelper.php
@@ -10,9 +10,12 @@ use DateTime;
 use Doctrine\ORM\EntityManager;
 use Faker\Factory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class UserTestHelper extends TestCase
 {
+    use ProphecyTrait;
+
     public function createUserMock(string $roleName, bool $hasReports, bool $hasClients, int $id)
     {
         $clientTestHelper = new ClientTestHelper();
@@ -26,6 +29,20 @@ class UserTestHelper extends TestCase
         $user->getId()->willReturn($id);
 
         return $user->reveal();
+    }
+
+    public function createAndPersistUser(EntityManager $em, ?Client $client = null, ?string $roleName = User::ROLE_LAY_DEPUTY, ?string $email = null)
+    {
+        $user = $this->createUser($client, $roleName, $email);
+
+        if (!is_null($client)) {
+            $em->persist($client);
+        }
+
+        $em->persist($user);
+        $em->flush();
+
+        return $user;
     }
 
     public function createUser(?Client $client = null, ?string $roleName = User::ROLE_LAY_DEPUTY, ?string $email = null)
@@ -49,20 +66,6 @@ class UserTestHelper extends TestCase
         if (!is_null($client)) {
             $user->addClient($client);
         }
-
-        return $user;
-    }
-
-    public function createAndPersistUser(EntityManager $em, ?Client $client = null, ?string $roleName = User::ROLE_LAY_DEPUTY, ?string $email = null)
-    {
-        $user = $this->createUser($client, $roleName, $email);
-
-        if (!is_null($client)) {
-            $em->persist($client);
-        }
-
-        $em->persist($user);
-        $em->flush();
 
         return $user;
     }

--- a/api/tests/Unit/Security/ClientVoterTest.php
+++ b/api/tests/Unit/Security/ClientVoterTest.php
@@ -11,7 +11,6 @@ use App\Security\ClientVoter;
 use App\TestHelpers\ClientTestHelper;
 use App\TestHelpers\UserTestHelper;
 use PHPUnit\Framework\MockObject\MockObject;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -19,8 +18,6 @@ use Symfony\Component\Security\Core\Security;
 
 class ClientVoterTest extends KernelTestCase
 {
-    use ProphecyTrait;
-
     /** @var ClientVoter */
     private $voter;
 

--- a/api/tests/Unit/Security/OrganisationVoterTest.php
+++ b/api/tests/Unit/Security/OrganisationVoterTest.php
@@ -8,15 +8,12 @@ use App\Entity\Organisation;
 use App\Entity\User;
 use App\Security\OrganisationVoter;
 use DateTime;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Security;
 
 class OrganisationVoterTest extends KernelTestCase
 {
-    use ProphecyTrait;
-
     public function setUp(): void
     {
         $this->user = new User();

--- a/api/tests/Unit/Security/OrganisationVoterTest.php
+++ b/api/tests/Unit/Security/OrganisationVoterTest.php
@@ -8,12 +8,15 @@ use App\Entity\Organisation;
 use App\Entity\User;
 use App\Security\OrganisationVoter;
 use DateTime;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Security;
 
 class OrganisationVoterTest extends KernelTestCase
 {
+    use ProphecyTrait;
+
     public function setUp(): void
     {
         $this->user = new User();

--- a/api/tests/Unit/Service/ReportServiceTest.php
+++ b/api/tests/Unit/Service/ReportServiceTest.php
@@ -24,15 +24,12 @@ use Mockery;
 use MockeryStub as m;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use RuntimeException;
 use Throwable;
 
 class ReportServiceTest extends TestCase
 {
-    use ProphecyTrait;
-
     /**
      * @var ReportService
      */

--- a/api/tests/Unit/Service/ReportServiceTest.php
+++ b/api/tests/Unit/Service/ReportServiceTest.php
@@ -15,33 +15,36 @@ use App\Entity\User;
 use App\Repository\DocumentRepository;
 use App\Repository\ReportRepository;
 use App\Service\ReportService;
+use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\Persistence\ObjectRepository;
+use Mockery;
 use MockeryStub as m;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use RuntimeException;
 use Throwable;
 
 class ReportServiceTest extends TestCase
 {
-    /**
-     * @var EntityDir\User
-     */
-    private $user;
-
-    /**
-     * @var Report
-     */
-    private $report;
+    use ProphecyTrait;
 
     /**
      * @var ReportService
      */
     protected $sut;
+    /**
+     * @var EntityDir\User
+     */
+    private $user;
+    /**
+     * @var Report
+     */
+    private $report;
 
     public function setUp(): void
     {
@@ -49,13 +52,13 @@ class ReportServiceTest extends TestCase
         $client = new Client();
         $client->addUser($this->user);
         $client->setCaseNumber('12345678');
-        $client->setCourtDate(new \DateTime('2014-06-06'));
+        $client->setCourtDate(new DateTime('2014-06-06'));
 
         $this->bank1 = (new BankAccount())->setAccountNumber('1234');
         $this->asset1 = (new AssetProperty())
             ->setAddress('SW1')
             ->setOwned(AssetProperty::OWNED_FULLY);
-        $this->report = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new \DateTime('2015-01-01'), new \DateTime('2015-12-31'));
+        $this->report = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new DateTime('2015-01-01'), new DateTime('2015-12-31'));
         $this->report
             ->setNoAssetToAdd(false)
             ->addAsset($this->asset1)
@@ -104,8 +107,8 @@ class ReportServiceTest extends TestCase
     public function testSubmitInvalid()
     {
         $this->report->setAgreedBehalfDeputy(false);
-        $this->expectException(\RuntimeException::class);
-        $this->sut->submit($this->report, $this->user, new \DateTime('2016-01-15'));
+        $this->expectException(RuntimeException::class);
+        $this->sut->submit($this->report, $this->user, new DateTime('2016-01-15'));
     }
 
     public function testSubmitValid()
@@ -113,25 +116,25 @@ class ReportServiceTest extends TestCase
         $report = $this->report;
 
         // Create partial mock of ReportService
-        $reportService = \Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
+        $reportService = Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
 
         // mocks
         $this->em->shouldReceive('detach');
         $this->em->shouldReceive('flush');
         // assert persists on report and submission record
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($report) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($report) {
             return $report instanceof Report;
         }));
         // assert persists on report and submission record
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($report) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($report) {
             return $report instanceof EntityDir\Report\ReportSubmission;
         }));
 
         // clonePersistentResources should be called
-        $reportService->shouldReceive('clonePersistentResources')->with(\Mockery::type(Report::class), $report);
+        $reportService->shouldReceive('clonePersistentResources')->with(Mockery::type(Report::class), $report);
 
         $report->setAgreedBehalfDeputy(true);
-        $newYearReport = $reportService->submit($report, $this->user, new \DateTime('2016-01-15'));
+        $newYearReport = $reportService->submit($report, $this->user, new DateTime('2016-01-15'));
 
         // assert current report
         $this->assertTrue($report->getSubmitted());
@@ -150,20 +153,20 @@ class ReportServiceTest extends TestCase
     public function testResubmit()
     {
         $report = $this->report;
-        $report->setUnSubmitDate(new \DateTime('2018-02-14'));
+        $report->setUnSubmitDate(new DateTime('2018-02-14'));
 
         // A report for the next report period should already exist
         $client = $this->report->getClient();
-        $nextReport = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new \DateTime('2016-01-01'), new \DateTime('2016-12-31'));
+        $nextReport = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new DateTime('2016-01-01'), new DateTime('2016-12-31'));
         $client->addReport($nextReport);
 
         // Create partial mock of ReportService
-        $reportService = \Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
+        $reportService = Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
 
         // mocks
         $this->em->shouldReceive('detach');
         // assert persists on report and submission record
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($report) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($report) {
             return $report instanceof EntityDir\Report\ReportSubmission;
         }));
         $this->em->shouldReceive('flush')->with()->once(); //last in createNextYearReport
@@ -172,7 +175,7 @@ class ReportServiceTest extends TestCase
         $reportService->shouldReceive('clonePersistentResources')->with($nextReport, $report);
 
         $report->setAgreedBehalfDeputy(true);
-        $newYearReport = $reportService->submit($report, $this->user, new \DateTime());
+        $newYearReport = $reportService->submit($report, $this->user, new DateTime());
 
         // assert current report
         $this->assertTrue($report->getSubmitted());
@@ -190,60 +193,33 @@ class ReportServiceTest extends TestCase
 
     public function testSubmitNotAgreedNdrThrowsException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $this->ndr->setAgreedBehalfDeputy(null);
-        $submitDate = new \DateTime('2018-04-05');
+        $submitDate = new DateTime('2018-04-05');
 
         $ndrDoccumentId = 999;
 
         $this->sut->submit($this->ndr, $this->user, $submitDate, $ndrDoccumentId);
     }
 
-    private function getFilledInNdr()
-    {
-        $client = new EntityDir\Client();
-        $client->addUser($this->user);
-        $client->setCaseNumber('12345678');
-        $client->setCourtDate(new \DateTime('2014-06-06'));
-
-        $ndr = new EntityDir\Ndr\Ndr($client);
-
-        $ndrBank = new EntityDir\Ndr\BankAccount();
-        $ndrBank->setAccountNumber('4321')
-            ->setNdr($ndr);
-
-        $ndrAsset = new EntityDir\Ndr\AssetProperty();
-        $ndrAsset->setAddress('SW1')
-            ->setOwned(EntityDir\Report\AssetProperty::OWNED_FULLY)
-            ->setNdr($ndr);
-
-        $ndr->setNoAssetToAdd(false);
-        $ndr->addAsset($ndrAsset);
-        $ndr->setBankAccounts([$ndrBank]);
-        $ndr->setAgreedBehalfDeputy(true);
-        $ndr->setClient($client);
-
-        return $ndr;
-    }
-
     public function testSubmitValidNdr()
     {
         $ndr = $this->getFilledInNdr();
 
-        $submitDate = new \DateTime('2018-04-05');
+        $submitDate = new DateTime('2018-04-05');
 
         // assert persists on report and submission record
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($ndr) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($ndr) {
             return $ndr instanceof EntityDir\Report\ReportSubmission;
         }));
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($report) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($report) {
             return $report instanceof EntityDir\Report\Report;
         }));
         $this->em->shouldReceive('flush')->with()->once(); //last in createNextYearReport
 
         // Create partial mock of ReportService
-        $reportService = \Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
+        $reportService = Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
         $this->em->shouldReceive('detach');
         $this->em->shouldReceive('persist');
         $this->em->shouldReceive('flush');
@@ -269,26 +245,53 @@ class ReportServiceTest extends TestCase
         $this->assertEquals('4321', $newAccount->getAccountNumber());
     }
 
+    private function getFilledInNdr()
+    {
+        $client = new EntityDir\Client();
+        $client->addUser($this->user);
+        $client->setCaseNumber('12345678');
+        $client->setCourtDate(new DateTime('2014-06-06'));
+
+        $ndr = new EntityDir\Ndr\Ndr($client);
+
+        $ndrBank = new EntityDir\Ndr\BankAccount();
+        $ndrBank->setAccountNumber('4321')
+            ->setNdr($ndr);
+
+        $ndrAsset = new EntityDir\Ndr\AssetProperty();
+        $ndrAsset->setAddress('SW1')
+            ->setOwned(EntityDir\Report\AssetProperty::OWNED_FULLY)
+            ->setNdr($ndr);
+
+        $ndr->setNoAssetToAdd(false);
+        $ndr->addAsset($ndrAsset);
+        $ndr->setBankAccounts([$ndrBank]);
+        $ndr->setAgreedBehalfDeputy(true);
+        $ndr->setClient($client);
+
+        return $ndr;
+    }
+
     public function testSubmitNdrWithExistingReport()
     {
         $ndr = $this->getFilledInNdr();
 
-        $report = new Report($ndr->getClient(), Report::LAY_PFA_HIGH_ASSETS_TYPE, new \DateTime('2018-06-06'), new \DateTime('2019-06-05'));
+        $report = new Report($ndr->getClient(), Report::LAY_PFA_HIGH_ASSETS_TYPE, new DateTime('2018-06-06'), new DateTime('2019-06-05'));
         $ndr->getClient()->addReport($report);
 
-        $submitDate = new \DateTime('2018-04-05');
+        $submitDate = new DateTime('2018-04-05');
 
         // assert persists on report and submission record
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($ndr) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($ndr) {
             return $ndr instanceof EntityDir\Report\ReportSubmission;
         }));
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($report) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($report) {
             return $report instanceof EntityDir\Report\Report;
         }));
         $this->em->shouldReceive('flush')->with()->once(); //last in createNextYearReport
 
         // Create partial mock of ReportService
-        $reportService = \Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
+        $reportService = Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
         $this->em->shouldReceive('detach');
         $this->em->shouldReceive('persist');
         $this->em->shouldReceive('flush');
@@ -316,11 +319,11 @@ class ReportServiceTest extends TestCase
     public function testResubmitPersistenceRequiresReport()
     {
         $report = $this->report;
-        $report->setUnSubmitDate(new \DateTime('2018-02-14'));
+        $report->setUnSubmitDate(new DateTime('2018-02-14'));
         $report->setAgreedBehalfDeputy(true);
 
         // Create partial mock of ReportService
-        $reportService = \Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
+        $reportService = Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
         $this->em->shouldReceive('detach');
         $this->em->shouldReceive('persist');
         $this->em->shouldReceive('flush');
@@ -329,17 +332,17 @@ class ReportServiceTest extends TestCase
         $reportService->shouldNotReceive('clonePersistentResources');
 
         // Submit a report without one set up for next year
-        $reportService->submit($report, $this->user, new \DateTime());
+        $reportService->submit($report, $this->user, new DateTime());
 
         // Submit a report where next year's dates don't match
         $client = $this->report->getClient();
-        $nextReport = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new \DateTime('2016-01-17'), new \DateTime('2017-01-16'));
+        $nextReport = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new DateTime('2016-01-17'), new DateTime('2017-01-16'));
         $client->addReport($nextReport);
 
-        $report->setUnSubmitDate(new \DateTime('2018-02-14'));
+        $report->setUnSubmitDate(new DateTime('2018-02-14'));
         $report->setAgreedBehalfDeputy(true);
 
-        $reportService->submit($report, $this->user, new \DateTime());
+        $reportService->submit($report, $this->user, new DateTime());
     }
 
     /**
@@ -348,17 +351,17 @@ class ReportServiceTest extends TestCase
     public function testPersistentResourcesCloned()
     {
         $client = $this->report->getClient();
-        $newReport = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new \DateTime('2016-01-01'), new \DateTime('2016-12-31'));
+        $newReport = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new DateTime('2016-01-01'), new DateTime('2016-12-31'));
 
         // Assert asset is cloned
         $this->em->shouldReceive('detach')->once();
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($asset) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($asset) {
             return $asset instanceof EntityDir\Report\AssetProperty
                 && 'SW1' === $asset->getAddress();
         }))->once();
 
         // Assert bank account is cloned, with opening/closing balance modified
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($bankAccount) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($bankAccount) {
             return $bankAccount instanceof EntityDir\Report\BankAccount
                 && '1234' === $bankAccount->getAccountNumber()
                 && $bankAccount->getOpeningBalance() === $this->report->getBankAccounts()[0]->getClosingBalance()
@@ -376,7 +379,7 @@ class ReportServiceTest extends TestCase
     public function testDuplicateResourcesNotPersisted()
     {
         $client = $this->report->getClient();
-        $newReport = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new \DateTime('2016-01-01'), new \DateTime('2016-12-31'));
+        $newReport = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new DateTime('2016-01-01'), new DateTime('2016-12-31'));
 
         $newAsset = clone $this->report->getAssets()[0];
         $newReport->addAsset($newAsset);
@@ -394,13 +397,13 @@ class ReportServiceTest extends TestCase
 
     public function testSubmitAdditionalDocuments()
     {
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($report) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($report) {
             return $report instanceof EntityDir\Report\ReportSubmission;
         }));
         $this->em->shouldReceive('flush')->with()->once();
 
         $this->assertEmpty($this->report->getReportSubmissions());
-        $currentReport = $this->sut->submitAdditionalDocuments($this->report, $this->user, new \DateTime('2016-01-15'));
+        $currentReport = $this->sut->submitAdditionalDocuments($this->report, $this->user, new DateTime('2016-01-15'));
         $submission = $currentReport->getReportSubmissions()->first();
 
         $this->assertContains($submission, $this->report->getReportSubmissions());
@@ -412,7 +415,7 @@ class ReportServiceTest extends TestCase
     {
         $this->assertEquals(false, ReportService::isDue(null));
 
-        $todayMidnight = new \DateTime('today midnight');
+        $todayMidnight = new DateTime('today midnight');
 
         $oneMinuteBeforeLastMidnight = clone $todayMidnight;
         $oneMinuteBeforeLastMidnight->modify('-1 minute');
@@ -421,12 +424,12 @@ class ReportServiceTest extends TestCase
         $oneMinuteAfterLastMidnight->modify('+1 minute');
 
         // end date is past (before midnight) => due
-        $this->assertEquals(true, ReportService::isDue(new \DateTime('last week')));
+        $this->assertEquals(true, ReportService::isDue(new DateTime('last week')));
         $this->assertEquals(true, ReportService::isDue($oneMinuteBeforeLastMidnight));
 
         // otherwise not due
         $this->assertEquals(false, ReportService::isDue($oneMinuteAfterLastMidnight));
-        $this->assertEquals(false, ReportService::isDue(new \DateTime('next week')));
+        $this->assertEquals(false, ReportService::isDue(new DateTime('next week')));
     }
 
     /**

--- a/client/composer.json
+++ b/client/composer.json
@@ -63,13 +63,14 @@
         "jangregor/phpstan-prophecy": "^1.0.0",
         "mockery/mockery": "^1.0.0",
         "pact-foundation/pact-php": "^7.1",
+        "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/phpstan": "^1.0.0",
         "phpstan/phpstan-mockery": "^1.0.0",
         "phpstan/phpstan-phpunit": "^1.0.0",
         "phpunit/phpcov": "8.2.0",
         "phpunit/phpunit": "^9.5.10",
-        "symfony/phpunit-bridge": "^5.2",
         "symfony/maker-bundle": "^1.29",
+        "symfony/phpunit-bridge": "^5.2",
         "symfony/var-dumper": "^4.0"
     }
 }

--- a/client/composer.lock
+++ b/client/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "61f542a6e66f57ac54601034afd27a71",
+    "content-hash": "0e0efebba09f8e5de41e7351ecef30eb",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -6721,6 +6721,58 @@
             "time": "2021-09-10T09:02:12+00:00"
         },
         {
+            "name": "phpspec/prophecy-phpunit",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy-phpunit.git",
+                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy-phpunit/zipball/2d7a9df55f257d2cba9b1d0c0963a54960657177",
+                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8",
+                "phpspec/prophecy": "^1.3",
+                "phpunit/phpunit": "^9.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\PhpUnit\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christophe Coevoet",
+                    "email": "stof@notk.org"
+                }
+            ],
+            "description": "Integrating the Prophecy mocking library in PHPUnit test cases",
+            "homepage": "http://phpspec.net",
+            "keywords": [
+                "phpunit",
+                "prophecy"
+            ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy-phpunit/issues",
+                "source": "https://github.com/phpspec/prophecy-phpunit/tree/v2.0.1"
+            },
+            "time": "2020-07-09T08:33:42+00:00"
+        },
+        {
             "name": "phpstan/phpstan",
             "version": "1.2.0",
             "source": {
@@ -8628,5 +8680,5 @@
         "php": "8.0.12"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/client/src/Controller/Report/MoneyInController.php
+++ b/client/src/Controller/Report/MoneyInController.php
@@ -75,7 +75,7 @@ class MoneyInController extends AbstractController
      *
      * @return array|RedirectResponse
      */
-    public function stepAction(Request $request, $reportId, $step, $transactionId = null, AuthorizationCheckerInterface $authorizationChecker)
+    public function stepAction(Request $request, $reportId, $step, AuthorizationCheckerInterface $authorizationChecker, $transactionId = null)
     {
         $totalSteps = 2;
         if ($step < 1 || $step > $totalSteps) {

--- a/client/tests/phpunit/Command/ChecklistSyncCommandTest.php
+++ b/client/tests/phpunit/Command/ChecklistSyncCommandTest.php
@@ -184,27 +184,42 @@ class ChecklistSyncCommandTest extends KernelTestCase
      */
     public function doesNotAttemptToSyncFailedPdfGenerations()
     {
+        $apiCallArguments = [
+            [
+                'get',
+                'report/all-with-queued-checklists',
+                ['row_limit' => '30'],
+                'Report\Report[]',
+                [],
+                false,
+            ],
+            [
+                'put',
+                'checklist/3923',
+                json_encode([
+                    'syncStatus' => Checklist::SYNC_STATUS_PERMANENT_ERROR,
+                    'syncError' => 'Failed to generate PDF',
+                ]),
+                'raw',
+                [],
+                false,
+            ],
+        ];
+
+        $returnValues = [
+            [],
+            [
+                $this->buildReport(),
+                $this->buildReport(),
+            ],
+        ];
+
         $this
             ->ensureFeatureIsEnabled()
-            ->ensureRestClientReturnsRows()
+            ->assertApiCallsAreMade($apiCallArguments, $returnValues)
             ->ensurePdfGenerationWillFailWith(new PdfGenerationFailedException('Failed to generate PDF'))
             ->assertSyncServiceIsNotInvoked()
             ->invokeTest();
-    }
-
-    private function ensureRestClientReturnsRows(): ChecklistSyncCommandTest
-    {
-        $this->restClient
-            ->expects($this->once())
-            ->method('apiCall')
-            ->withConsecutive([])
-            ->with('get', 'report/all-with-queued-checklists', ['row_limit' => '30'], 'Report\Report[]', [], false)
-            ->willReturnOnConsecutiveCalls([
-                $this->buildReport(),
-                $this->buildReport(),
-            ]);
-
-        return $this;
     }
 
     /**
@@ -212,9 +227,40 @@ class ChecklistSyncCommandTest extends KernelTestCase
      */
     public function fetchesAndSendsQueuedChecklistsToSyncService()
     {
+        $apiCallArguments = [
+            [
+                'get',
+                'report/all-with-queued-checklists',
+                ['row_limit' => '30'],
+                'Report\Report[]',
+                [],
+                false,
+            ],
+            [
+                'put',
+                'checklist/3923',
+                json_encode([
+                    'syncStatus' => Checklist::SYNC_STATUS_PERMANENT_ERROR,
+                    'syncError' => 'Failed to generate PDF',
+                ]),
+                'raw',
+                [],
+                false,
+            ],
+        ];
+
+        $returnValues = [
+            [],
+            [
+                $this->buildReport(),
+                $this->buildReport(),
+            ],
+        ];
+
         $this
             ->ensureFeatureIsEnabled()
-            ->ensureRestClientReturnsRows()
+            ->assertApiCallsAreMade($apiCallArguments, $returnValues)
+//            ->ensureRestClientReturnsRows()
             ->ensurePdfGenerationWillSucceed()
             ->assertEachRowWillBeTransformedAndSentToSyncService()
             ->invokeTest();

--- a/client/tests/phpunit/Command/ChecklistSyncCommandTest.php
+++ b/client/tests/phpunit/Command/ChecklistSyncCommandTest.php
@@ -1,27 +1,31 @@
 <?php
+
 namespace App\Tests\Command;
 
 use App\Command\ChecklistSyncCommand;
 use App\Entity\Client;
 use App\Entity\Report\Checklist;
 use App\Entity\Report\Report;
+use App\Entity\User;
 use App\Exception\PdfGenerationFailedException;
 use App\Exception\SiriusDocumentSyncFailedException;
-use App\Entity\User;
 use App\Model\Sirius\QueuedChecklistData;
 use App\Service\ChecklistPdfGenerator;
 use App\Service\ChecklistSyncService;
 use App\Service\Client\RestClient;
 use App\Service\ParameterStoreService;
+use DateTime;
 use PHPUnit\Framework\MockObject\MockObject;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Throwable;
 
 class ChecklistSyncCommandTest extends KernelTestCase
 {
+    use ProphecyTrait;
+
     /** @var MockObject */
     private $syncService;
     private $parameterStore;
@@ -30,7 +34,6 @@ class ChecklistSyncCommandTest extends KernelTestCase
 
     /** @var CommandTester */
     private $commandTester;
-
 
     public function setUp(): void
     {
@@ -59,17 +62,121 @@ class ChecklistSyncCommandTest extends KernelTestCase
             ->invokeTest();
     }
 
+    private function invokeTest(): void
+    {
+        $this->commandTester->execute([]);
+    }
+
+    private function assertSyncServiceIsNotInvoked(): ChecklistSyncCommandTest
+    {
+        $this->syncService
+            ->expects($this->never())
+            ->method('sync');
+
+        return $this;
+    }
+
+    private function ensureFeatureIsDisabled(): ChecklistSyncCommandTest
+    {
+        $this->parameterStore
+            ->method('getFeatureFlag')
+            ->willReturn('0');
+
+        return $this;
+    }
+
     /**
      * @test
      */
     public function updatesSyncStatusOnFailedPdfGenerations()
     {
+        $apiCallArguments = [
+            [
+                'get',
+                'report/all-with-queued-checklists',
+                ['row_limit' => '30'],
+                'Report\Report[]',
+                [],
+                false,
+            ],
+            [
+                'put',
+                'checklist/3923',
+                json_encode([
+                    'syncStatus' => Checklist::SYNC_STATUS_PERMANENT_ERROR,
+                    'syncError' => 'Failed to generate PDF',
+                ]),
+                'raw',
+                [],
+                false,
+            ],
+        ];
+
+        $returnValues = [
+            [],
+            [
+                $this->buildReport(),
+                $this->buildReport(),
+            ],
+        ];
+
         $this
             ->ensureFeatureIsEnabled()
-            ->ensureRestClientReturnsRows()
+            ->assertApiCallsAreMade($apiCallArguments, $returnValues)
             ->ensurePdfGenerationWillFailWith(new PdfGenerationFailedException('Failed to generate PDF'))
-            ->assertChecklistStatusWillBeUpdatedWithError('Failed to generate PDF')
             ->invokeTest();
+    }
+
+    private function buildReport()
+    {
+        $user = (new User())->setEmail('test@test.com');
+
+        $report = (new Report())
+            ->setStartDate(new DateTime())
+            ->setEndDate(new DateTime())
+            ->setReportSubmissions([])
+            ->setType(Report::TYPE_PROPERTY_AND_AFFAIRS_HIGH_ASSETS);
+
+        $checklist = (new Checklist($report))->setSubmittedBy($user);
+        $checklist->setId(3923);
+
+        $report->setChecklist($checklist);
+
+        $client = new Client();
+        $client->setCaseNumber('case-number');
+
+        $report->setClient($client);
+
+        return $report;
+    }
+
+    private function ensurePdfGenerationWillFailWith(Throwable $e): ChecklistSyncCommandTest
+    {
+        $this->pdfGenerator
+            ->method('generate')
+            ->willThrowException($e);
+
+        return $this;
+    }
+
+    private function assertApiCallsAreMade(array $arguments, array $returnValues): ChecklistSyncCommandTest
+    {
+        $this->restClient
+            ->expects($this->once())
+            ->method('apiCall')
+            ->withConsecutive(...$arguments)
+            ->willReturnOnConsecutiveCalls(...$returnValues);
+
+        return $this;
+    }
+
+    private function ensureFeatureIsEnabled(): ChecklistSyncCommandTest
+    {
+        $this->parameterStore
+            ->method('getFeatureFlag')
+            ->willReturn('1');
+
+        return $this;
     }
 
     /**
@@ -85,6 +192,21 @@ class ChecklistSyncCommandTest extends KernelTestCase
             ->invokeTest();
     }
 
+    private function ensureRestClientReturnsRows(): ChecklistSyncCommandTest
+    {
+        $this->restClient
+            ->expects($this->once())
+            ->method('apiCall')
+            ->withConsecutive([])
+            ->with('get', 'report/all-with-queued-checklists', ['row_limit' => '30'], 'Report\Report[]', [], false)
+            ->willReturnOnConsecutiveCalls([
+                $this->buildReport(),
+                $this->buildReport(),
+            ]);
+
+        return $this;
+    }
+
     /**
      * @test
      */
@@ -96,6 +218,29 @@ class ChecklistSyncCommandTest extends KernelTestCase
             ->ensurePdfGenerationWillSucceed()
             ->assertEachRowWillBeTransformedAndSentToSyncService()
             ->invokeTest();
+    }
+
+    private function assertEachRowWillBeTransformedAndSentToSyncService(): ChecklistSyncCommandTest
+    {
+        $this->syncService
+            ->expects($this->exactly(2))
+            ->method('sync')
+            ->withConsecutive(
+                [$this->isInstanceOf(QueuedChecklistData::class)],
+                [$this->isInstanceOf(QueuedChecklistData::class)]
+            )
+            ->willReturnOnConsecutiveCalls('uuid-1', 'uuid-2');
+
+        return $this;
+    }
+
+    private function ensurePdfGenerationWillSucceed(): ChecklistSyncCommandTest
+    {
+        $this->pdfGenerator
+            ->method('generate')
+            ->willReturn('file-contents');
+
+        return $this;
     }
 
     /**
@@ -111,6 +256,30 @@ class ChecklistSyncCommandTest extends KernelTestCase
             ->invokeTest();
     }
 
+    private function assertChecklistsAreFetchedWithLimitOf(string $limit)
+    {
+        $this->restClient
+            ->expects($this->at(0))
+            ->method('apiCall')
+            ->with('get', 'report/all-with-queued-checklists', ['row_limit' => $limit], 'Report\Report[]', [], false)
+            ->willReturn([
+                $this->buildReport(),
+                $this->buildReport(),
+            ]);
+
+        return $this;
+    }
+
+    private function ensureConfigurableRowLimitIsSetTo(string $limit): ChecklistSyncCommandTest
+    {
+        $this->parameterStore
+            ->method('getParameter')
+            ->with(ParameterStoreService::PARAMETER_CHECKLIST_SYNC_ROW_LIMIT)
+            ->willReturn($limit);
+
+        return $this;
+    }
+
     /**
      * @test
      */
@@ -122,6 +291,30 @@ class ChecklistSyncCommandTest extends KernelTestCase
             ->ensurePdfGenerationWillSucceed()
             ->assertChecklistsAreFetchedWithDefaultLimit()
             ->invokeTest();
+    }
+
+    private function assertChecklistsAreFetchedWithDefaultLimit()
+    {
+        $this->restClient
+            ->expects($this->at(0))
+            ->method('apiCall')
+            ->with('get', 'report/all-with-queued-checklists', ['row_limit' => ChecklistSyncCommand::FALLBACK_ROW_LIMITS], 'Report\Report[]', [], false)
+            ->willReturn([
+                $this->buildReport(),
+                $this->buildReport(),
+            ]);
+
+        return $this;
+    }
+
+    private function ensureConfigurableRowLimitIsNotSet(): ChecklistSyncCommandTest
+    {
+        $this->parameterStore
+            ->method('getParameter')
+            ->with(ParameterStoreService::PARAMETER_CHECKLIST_SYNC_ROW_LIMIT)
+            ->willReturn(null);
+
+        return $this;
     }
 
     /**
@@ -136,6 +329,25 @@ class ChecklistSyncCommandTest extends KernelTestCase
             ->assertChecklistsAreFetchedWithDefaultLimit()
             ->assertChecklistStatusWillBeUpdatedWithSuccess()
             ->invokeTest();
+    }
+
+    private function assertChecklistStatusWillBeUpdatedWithSuccess(): ChecklistSyncCommandTest
+    {
+        $this->restClient
+            ->expects($this->at(1))
+            ->method('apiCall')
+            ->with(
+                'put',
+                'checklist/3923',
+                json_encode([
+                    'syncStatus' => Checklist::SYNC_STATUS_SUCCESS,
+                ]),
+                'raw',
+                [],
+                false
+            );
+
+        return $this;
     }
 
     /**
@@ -153,119 +365,7 @@ class ChecklistSyncCommandTest extends KernelTestCase
             ->invokeTest();
     }
 
-    private function ensureFeatureIsEnabled(): ChecklistSyncCommandTest
-    {
-        $this->parameterStore
-            ->method('getFeatureFlag')
-            ->willReturn('1');
-
-        return $this;
-    }
-
-    private function ensureFeatureIsDisabled(): ChecklistSyncCommandTest
-    {
-        $this->parameterStore
-            ->method('getFeatureFlag')
-            ->willReturn('0');
-
-        return $this;
-    }
-
-    private function ensurePdfGenerationWillFailWith(\Throwable $e): ChecklistSyncCommandTest
-    {
-        $this->pdfGenerator
-            ->method('generate')
-            ->willThrowException($e);
-
-        return $this;
-    }
-
-    private function ensurePdfGenerationWillSucceed(): ChecklistSyncCommandTest
-    {
-        $this->pdfGenerator
-            ->method('generate')
-            ->willReturn('file-contents');
-
-        return $this;
-    }
-
-    private function ensureConfigurableRowLimitIsSetTo(string $limit): ChecklistSyncCommandTest
-    {
-        $this->parameterStore
-            ->method('getParameter')
-            ->with(ParameterStoreService::PARAMETER_CHECKLIST_SYNC_ROW_LIMIT)
-            ->willReturn($limit);
-
-        return $this;
-    }
-
-    private function ensureConfigurableRowLimitIsNotSet(): ChecklistSyncCommandTest
-    {
-        $this->parameterStore
-            ->method('getParameter')
-            ->with(ParameterStoreService::PARAMETER_CHECKLIST_SYNC_ROW_LIMIT)
-            ->willReturn(null);
-
-        return $this;
-    }
-
-    private function ensureRestClientReturnsRows(): ChecklistSyncCommandTest
-    {
-        $this->restClient
-            ->expects($this->at(0))
-            ->method('apiCall')
-            ->with('get', 'report/all-with-queued-checklists', ['row_limit' => '30'], 'Report\Report[]', [], false)
-            ->willReturn([
-                $this->buildReport(),
-                $this->buildReport()
-            ]);
-
-        return $this;
-    }
-
-    private function assertChecklistsAreFetchedWithLimitOf(string $limit)
-    {
-        $this->restClient
-            ->expects($this->at(0))
-            ->method('apiCall')
-            ->with('get', 'report/all-with-queued-checklists', ['row_limit' => $limit], 'Report\Report[]', [], false)
-            ->willReturn([
-                $this->buildReport(),
-                $this->buildReport()
-            ]);
-
-        return $this;
-    }
-
-    private function assertChecklistsAreFetchedWithDefaultLimit()
-    {
-        $this->restClient
-            ->expects($this->at(0))
-            ->method('apiCall')
-            ->with('get', 'report/all-with-queued-checklists', ['row_limit' => ChecklistSyncCommand::FALLBACK_ROW_LIMITS], 'Report\Report[]', [], false)
-            ->willReturn([
-                $this->buildReport(),
-                $this->buildReport()
-            ]);
-
-        return $this;
-    }
-
-    private function assertEachRowWillBeTransformedAndSentToSyncService(): ChecklistSyncCommandTest
-    {
-        $this->syncService
-            ->expects($this->exactly(2))
-            ->method('sync')
-            ->withConsecutive(
-                [$this->isInstanceOf(QueuedChecklistData::class)],
-                [$this->isInstanceOf(QueuedChecklistData::class)]
-            )
-            ->willReturnOnConsecutiveCalls('uuid-1', 'uuid-2');
-
-        return $this;
-    }
-
-    private function ensureSyncWillFailWith(\Throwable $e): ChecklistSyncCommandTest
+    private function ensureSyncWillFailWith(Throwable $e): ChecklistSyncCommandTest
     {
         $this->syncService
             ->expects($this->exactly(2))
@@ -277,80 +377,5 @@ class ChecklistSyncCommandTest extends KernelTestCase
             ->willThrowException($e);
 
         return $this;
-    }
-
-    private function assertChecklistStatusWillBeUpdatedWithError($error): ChecklistSyncCommandTest
-    {
-        $this->restClient
-            ->expects($this->at(1))
-            ->method('apiCall')
-            ->with(
-                'put',
-                'checklist/3923',
-                json_encode([
-                    'syncStatus' => Checklist::SYNC_STATUS_PERMANENT_ERROR,
-                    'syncError' => $error
-                ]),
-                'raw',
-                [],
-                false
-            );
-
-        return $this;
-    }
-
-    private function assertChecklistStatusWillBeUpdatedWithSuccess(): ChecklistSyncCommandTest
-    {
-        $this->restClient
-            ->expects($this->at(1))
-            ->method('apiCall')
-            ->with(
-                'put',
-                'checklist/3923',
-                json_encode([
-                    'syncStatus' => Checklist::SYNC_STATUS_SUCCESS
-                ]),
-                'raw',
-                [],
-                false
-            );
-
-        return $this;
-    }
-
-    private function assertSyncServiceIsNotInvoked(): ChecklistSyncCommandTest
-    {
-        $this->syncService
-            ->expects($this->never())
-            ->method('sync');
-
-        return $this;
-    }
-
-    private function buildReport()
-    {
-        $user = (new User())->setEmail('test@test.com');
-
-        $report = (new Report())
-            ->setStartDate(new \DateTime())
-            ->setEndDate(new \DateTime())
-            ->setReportSubmissions([])
-            ->setType(Report::TYPE_PROPERTY_AND_AFFAIRS_HIGH_ASSETS);
-
-        $checklist = (new Checklist($report))->setSubmittedBy($user);
-        $checklist->setId(3923);
-
-        $report->setChecklist($checklist);
-
-        $client = new Client();
-        $client->setCaseNumber('case-number');
-
-        $report->setClient($client);
-        return $report;
-    }
-
-    private function invokeTest(): void
-    {
-        $this->commandTester->execute([]);
     }
 }

--- a/client/tests/phpunit/Command/DocumentSyncCommandTest.php
+++ b/client/tests/phpunit/Command/DocumentSyncCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Tests\Command;
 
 use App\Command\DocumentSyncCommand;
@@ -8,8 +9,8 @@ use App\Service\DocumentSyncService;
 use App\Service\ParameterStoreService;
 use DateTime;
 use DateTimeZone;
-use PHPUnit\Framework\MockObject\MockObject;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -19,35 +20,32 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 class DocumentSyncCommandTest extends KernelTestCase
 {
-    /**
-     * @var DocumentSyncService
-     */
-    private $syncService;
-
-    /**
-     * @var RestClient
-     */
-    private $restClient;
-
-    /**
-     * @var SerializerInterface
-     */
-    private $serializer;
-
-    /**
-     * @var ParameterStoreService
-     */
-    private $parameterStore;
-
-    /**
-     * @var CommandTester
-     */
-    private $commandTester;
+    use ProphecyTrait;
 
     /**
      * @var ContainerInterface
      */
     protected static $container;
+    /**
+     * @var DocumentSyncService
+     */
+    private $syncService;
+    /**
+     * @var RestClient
+     */
+    private $restClient;
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+    /**
+     * @var ParameterStoreService
+     */
+    private $parameterStore;
+    /**
+     * @var CommandTester
+     */
+    private $commandTester;
 
     public function setUp(): void
     {
@@ -79,8 +77,8 @@ class DocumentSyncCommandTest extends KernelTestCase
                 'report_start_date' => '2017-02-01',
                 'report_end_date' => '2018-01-31',
                 'report_submit_date' => '2020-04-29 15:05:23',
-                'report_type' => '104'
-            ]
+                'report_type' => '104',
+            ],
         ]);
 
         $queuedDocumentData = (new QueuedDocumentData())
@@ -152,46 +150,45 @@ class DocumentSyncCommandTest extends KernelTestCase
         $this->assertStringContainsString('Feature disabled, sleeping', $output);
     }
 
-    public function testExecute_with_sync_error_submission_ids(): void
+    public function testExecuteWithSyncErrorSubmissionIds(): void
     {
         $this->parameterStore
-           ->getFeatureFlag(ParameterStoreService::FLAG_DOCUMENT_SYNC)
-           ->shouldBeCalled()
-           ->willReturn('1');
+            ->getFeatureFlag(ParameterStoreService::FLAG_DOCUMENT_SYNC)
+            ->shouldBeCalled()
+            ->willReturn('1');
 
         $this->parameterStore
-           ->getParameter(ParameterStoreService::PARAMETER_DOCUMENT_SYNC_ROW_LIMIT)
-           ->shouldBeCalled()
-           ->willReturn('100');
+            ->getParameter(ParameterStoreService::PARAMETER_DOCUMENT_SYNC_ROW_LIMIT)
+            ->shouldBeCalled()
+            ->willReturn('100');
 
         $this->restClient
-           ->apiCall('get', 'document/queued', ['row_limit' => '100'], 'array', Argument::type('array'), false)
-           ->shouldBeCalled()
-           ->willReturn(json_encode([]));
+            ->apiCall('get', 'document/queued', ['row_limit' => '100'], 'array', Argument::type('array'), false)
+            ->shouldBeCalled()
+            ->willReturn(json_encode([]));
 
-        /** @var DocumentSyncService|ObjectProphecy $documentSyncService */
+        /* @var DocumentSyncService|ObjectProphecy $documentSyncService */
         $this->syncService
-           ->getSyncErrorSubmissionIds()
-           ->shouldBeCalled()
-           ->willReturn([1]);
-
-        $this->syncService
-           ->setSubmissionsDocumentsToPermanentError()
-           ->shouldBeCalled();
+            ->getSyncErrorSubmissionIds()
+            ->shouldBeCalled()
+            ->willReturn([1]);
 
         $this->syncService
-           ->getDocsNotSyncedCount()
-           ->shouldBeCalled()
-           ->willReturn(6);
+            ->setSubmissionsDocumentsToPermanentError()
+            ->shouldBeCalled();
 
         $this->syncService
-           ->setSyncErrorSubmissionIds([])
-           ->shouldBeCalled();
+            ->getDocsNotSyncedCount()
+            ->shouldBeCalled()
+            ->willReturn(6);
 
         $this->syncService
-           ->setDocsNotSyncedCount(0)
-           ->shouldBeCalled();
+            ->setSyncErrorSubmissionIds([])
+            ->shouldBeCalled();
 
+        $this->syncService
+            ->setDocsNotSyncedCount(0)
+            ->shouldBeCalled();
 
         $this->commandTester->execute([]);
 

--- a/client/tests/phpunit/EventSubscriber/AdminUserCreatedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/AdminUserCreatedSubscriberTest.php
@@ -1,5 +1,6 @@
-<?php declare(strict_types=1);
+<?php
 
+declare(strict_types=1);
 
 namespace Tests\App\EventListener;
 
@@ -8,9 +9,12 @@ use App\EventSubscriber\AdminUserCreatedSubscriber;
 use App\Service\Mailer\Mailer;
 use App\TestHelpers\UserHelpers;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class AdminUserCreatedSubscriberTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @test */
     public function getSubscribedEvents()
     {

--- a/client/tests/phpunit/EventSubscriber/ClientDeletedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/ClientDeletedSubscriberTest.php
@@ -1,5 +1,6 @@
-<?php declare(strict_types=1);
+<?php
 
+declare(strict_types=1);
 
 use App\Entity\Client;
 use App\Event\ClientDeletedEvent;
@@ -10,15 +11,18 @@ use App\TestHelpers\ClientHelpers;
 use App\TestHelpers\NamedDeputyHelper;
 use App\TestHelpers\UserHelpers;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 
 class ClientDeletedSubscriberTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @test */
     public function getSubscribedEvents()
     {
         self::assertEquals([
-            ClientDeletedEvent::NAME => 'logEvent'
+            ClientDeletedEvent::NAME => 'logEvent',
         ], ClientDeletedSubscriber::getSubscribedEvents());
     }
 
@@ -47,10 +51,9 @@ class ClientDeletedSubscriberTest extends TestCase
             'deputy_name' => $deputy->getFullName(),
             'discharged_on' => $now->format(DateTime::ATOM),
             'deputyship_start_date' => $clientWithUsers->getCourtDate()->format(DateTime::ATOM),
-            'event' => AuditEvents::EVENT_CLIENT_DISCHARGED,
-            'type' => 'audit'
+            'event' => AuditEvents::EVENT_CLIENT_DELETED,
+            'type' => 'audit',
         ];
-        ;
 
         $logger->notice('', $expectedEvent)->shouldBeCalled();
         $sut->logEvent($clientDeletedEvent);

--- a/client/tests/phpunit/EventSubscriber/ClientUpdatedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/ClientUpdatedSubscriberTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Tests\App\EventListener;
 
@@ -15,11 +17,14 @@ use DateTime;
 use Faker\Factory;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
 
 class ClientUpdatedSubscriberTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ObjectProphecy */
     private $logger;
 
@@ -78,7 +83,7 @@ class ClientUpdatedSubscriberTest extends TestCase
             'subject_full_name' => $postUpdateClient->getFullName(),
             'subject_role' => 'CLIENT',
             'event' => AuditEvents::EVENT_CLIENT_EMAIL_CHANGED,
-            'type' => 'audit'
+            'type' => 'audit',
         ];
 
         $this->logger->notice($expectedLogMessage, $expectedEvent)->shouldBeCalled();
@@ -96,7 +101,7 @@ class ClientUpdatedSubscriberTest extends TestCase
     }
 
     /** @test */
-    public function logEvent_only_logs_on_email_change()
+    public function logEventOnlyLogsOnEmailChange()
     {
         $preUpdateClient = ClientHelpers::createClient();
         $postUpdateClient = (ClientHelpers::createClient())->setEmail($preUpdateClient->getEmail());
@@ -145,7 +150,7 @@ class ClientUpdatedSubscriberTest extends TestCase
     }
 
     /** @test */
-    public function sendEmail_client_details_not_changed()
+    public function sendEmailClientDetailsNotChanged()
     {
         $preUpdateClient = ClientHelpers::createClient();
         $postUpdateClient = clone $preUpdateClient;
@@ -159,7 +164,7 @@ class ClientUpdatedSubscriberTest extends TestCase
     }
 
     /** @test */
-    public function sendEmail_email_not_sent_when_details_changed_but_clients_are_different()
+    public function sendEmailEmailNotSentWhenDetailsChangedButClientsAreDifferent()
     {
         $preUpdateClient = ClientHelpers::createClient();
         $postUpdateClient = (ClientHelpers::createClient())->setId(12345);

--- a/client/tests/phpunit/EventSubscriber/CoDeputyCreationSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/CoDeputyCreationSubscriberTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Tests\App\EventListener;
 
@@ -8,9 +10,12 @@ use App\EventSubscriber\CoDeputyCreationSubscriber;
 use App\Service\Mailer\Mailer;
 use App\TestHelpers\UserHelpers;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class CoDeputyCreationSubscriberTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @test */
     public function getSubscribedEvents()
     {

--- a/client/tests/phpunit/EventSubscriber/DeputyInvitedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/DeputyInvitedSubscriberTest.php
@@ -1,5 +1,6 @@
-<?php declare(strict_types=1);
+<?php
 
+declare(strict_types=1);
 
 namespace Tests\App\EventListener;
 
@@ -8,9 +9,12 @@ use App\EventSubscriber\DeputyInvitedSubscriber;
 use App\Service\Mailer\Mailer;
 use App\TestHelpers\UserHelpers;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class DeputyInvitedSubscriberTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @test */
     public function getSubscribedEvents()
     {

--- a/client/tests/phpunit/EventSubscriber/DeputySelfRegisteredSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/DeputySelfRegisteredSubscriberTest.php
@@ -1,5 +1,6 @@
-<?php declare(strict_types=1);
+<?php
 
+declare(strict_types=1);
 
 namespace Tests\App\EventListener;
 
@@ -8,9 +9,12 @@ use App\EventSubscriber\DeputySelfRegisteredSubscriber;
 use App\Service\Mailer\Mailer;
 use App\TestHelpers\UserHelpers;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class DeputySelfRegisteredSubscriberTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @test */
     public function getSubscribedEvents()
     {

--- a/client/tests/phpunit/EventSubscriber/FeedbackSubmittedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/FeedbackSubmittedSubscriberTest.php
@@ -1,5 +1,6 @@
-<?php declare(strict_types=1);
+<?php
 
+declare(strict_types=1);
 
 namespace Tests\App\EventListener;
 
@@ -10,16 +11,19 @@ use App\Model\FeedbackReport;
 use App\Service\Mailer\Mailer;
 use App\TestHelpers\UserHelpers;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class FeedbackSubmittedSubscriberTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @test */
     public function getSubscribedEvents()
     {
         self::assertEquals(
             [
                 GeneralFeedbackSubmittedEvent::NAME => 'sendGeneralFeedbackEmail',
-                PostSubmissionFeedbackSubmittedEvent::NAME => 'sendPostSubmissionFeedbackEmail'
+                PostSubmissionFeedbackSubmittedEvent::NAME => 'sendPostSubmissionFeedbackEmail',
             ],
             FeedbackSubmittedSubscriber::getSubscribedEvents()
         );

--- a/client/tests/phpunit/EventSubscriber/NdrSubmittedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/NdrSubmittedSubscriberTest.php
@@ -1,5 +1,6 @@
-<?php declare(strict_types=1);
+<?php
 
+declare(strict_types=1);
 
 namespace Tests\App\EventListener;
 
@@ -9,10 +10,13 @@ use App\Service\Mailer\Mailer;
 use App\TestHelpers\NdrHelpers;
 use App\TestHelpers\ReportHelpers;
 use App\TestHelpers\UserHelpers;
-use PHPStan\Testing\TestCase;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class NdrSubmittedSubscriberTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @test */
     public function getSubscribedEvents()
     {

--- a/client/tests/phpunit/EventSubscriber/OrgUserCreatedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/OrgUserCreatedSubscriberTest.php
@@ -1,5 +1,6 @@
-<?php declare(strict_types=1);
+<?php
 
+declare(strict_types=1);
 
 namespace Tests\App\EventListener;
 
@@ -8,9 +9,12 @@ use App\EventSubscriber\OrgUserCreatedSubscriber;
 use App\Service\Mailer\Mailer;
 use App\TestHelpers\UserHelpers;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class OrgUserCreatedSubscriberTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @test */
     public function getSubscribedEvents()
     {

--- a/client/tests/phpunit/EventSubscriber/OrgUserMembershipSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/OrgUserMembershipSubscriberTest.php
@@ -1,28 +1,31 @@
-<?php declare(strict_types=1);
+<?php
 
+declare(strict_types=1);
 
 namespace Tests\App\EventListener;
 
 use App\Event\UserAddedToOrganisationEvent;
 use App\Event\UserRemovedFromOrganisationEvent;
 use App\EventSubscriber\OrgUserMembershipSubscriber;
-use App\Service\Audit\AuditEvents;
 use App\Service\Time\DateTimeProvider;
 use App\TestHelpers\OrganisationHelpers;
 use App\TestHelpers\UserHelpers;
 use DateTime;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 
 class OrgUserMembershipSubscriberTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @test */
     public function getSubscribedEvents()
     {
         self::assertEquals(
             [
                 UserAddedToOrganisationEvent::NAME => 'logUserAddedEvent',
-                UserRemovedFromOrganisationEvent::NAME => 'logUserRemovedEvent'
+                UserRemovedFromOrganisationEvent::NAME => 'logUserRemovedEvent',
             ],
             OrgUserMembershipSubscriber::getSubscribedEvents()
         );
@@ -49,7 +52,7 @@ class OrgUserMembershipSubscriberTest extends TestCase
             'added_on' => $now->format(DateTime::ATOM),
             'added_by' => $currentUser->getEmail(),
             'event' => $expectedEventName,
-            'type' => 'audit'
+            'type' => 'audit',
         ];
 
         $logger = self::prophesize(LoggerInterface::class);
@@ -85,7 +88,7 @@ class OrgUserMembershipSubscriberTest extends TestCase
             'removed_on' => $now->format(DateTime::ATOM),
             'removed_by' => $currentUser->getEmail(),
             'event' => $expectedEventName,
-            'type' => 'audit'
+            'type' => 'audit',
         ];
 
         $logger = self::prophesize(LoggerInterface::class);

--- a/client/tests/phpunit/EventSubscriber/ReportSubmittedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/ReportSubmittedSubscriberTest.php
@@ -1,5 +1,6 @@
-<?php declare(strict_types=1);
+<?php
 
+declare(strict_types=1);
 
 namespace Tests\App\EventListener;
 
@@ -7,17 +8,20 @@ use App\Event\ReportSubmittedEvent;
 use App\EventSubscriber\ReportSubmittedSubscriber;
 use App\Service\Audit\AuditEvents;
 use App\Service\Client\Internal\ReportApi;
-use App\Service\Time\DateTimeProvider;
 use App\Service\Mailer\Mailer;
+use App\Service\Time\DateTimeProvider;
 use App\TestHelpers\ReportHelpers;
 use App\TestHelpers\UserHelpers;
 use DateTime;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Psr\Log\LoggerInterface;
 
 class ReportSubmittedSubscriberTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */
@@ -61,7 +65,7 @@ class ReportSubmittedSubscriberTest extends TestCase
     /**
      * @test
      */
-    public function sendEmail_email_not_sent_for_resubmissions()
+    public function sendEmailEmailNotSentForResubmissions()
     {
         $reportApi = self::prophesize(ReportApi::class);
         $mailer = self::prophesize(Mailer::class);
@@ -94,7 +98,10 @@ class ReportSubmittedSubscriberTest extends TestCase
         $dateTimeProvider = self::prophesize(DateTimeProvider::class);
         $reportApi = self::prophesize(ReportApi::class);
         $mailer = self::prophesize(Mailer::class);
-        $submittedReport = ReportHelpers::createReport();
+
+        $submittedReport = (ReportHelpers::createReport())
+            ->setUnSubmitDate(new DateTime());
+
         $nextYearReport = ReportHelpers::createReport();
 
         $now = new DateTime();
@@ -112,7 +119,7 @@ class ReportSubmittedSubscriberTest extends TestCase
             'report_id' => $submittedReport->getId(),
             'date_resubmitted' => $submittedReport->getSubmitDate(),
             'event' => AuditEvents::EVENT_REPORT_RESUBMITTED,
-            'type' => 'audit'
+            'type' => 'audit',
         ];
 
         $logger->notice('', $expectedEvent)->shouldBeCalled();

--- a/client/tests/phpunit/EventSubscriber/ReportUnsubmittedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/ReportUnsubmittedSubscriberTest.php
@@ -1,5 +1,6 @@
-<?php declare(strict_types=1);
+<?php
 
+declare(strict_types=1);
 
 namespace Tests\App\EventListener;
 
@@ -11,10 +12,13 @@ use App\TestHelpers\ReportHelpers;
 use App\TestHelpers\UserHelpers;
 use DateTime;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 
 class ReportUnsubmittedSubscriberTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */
@@ -41,7 +45,6 @@ class ReportUnsubmittedSubscriberTest extends TestCase
         $currentUser = UserHelpers::createUser();
         $trigger = 'UNSUBMIT_REPORT';
 
-
         $submittedReport = ReportHelpers::createSubmittedReport();
 
         $sut = new ReportUnsubmittedSubscriber($logger->reveal(), $dateTimeProvider->reveal());
@@ -54,7 +57,7 @@ class ReportUnsubmittedSubscriberTest extends TestCase
             'report_id' => $submittedReport->getId(),
             'date_unsubmitted' => $submittedReport->getUnSubmitDate(),
             'event' => AuditEvents::EVENT_REPORT_UNSUBMITTED,
-            'type' => 'audit'
+            'type' => 'audit',
         ];
 
         $logger->notice('', $expectedEvent)->shouldBeCalled();

--- a/client/tests/phpunit/EventSubscriber/UserActivatedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/UserActivatedSubscriberTest.php
@@ -1,18 +1,20 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Tests\App\EventListener;
 
 use App\Event\UserActivatedEvent;
 use App\EventSubscriber\UserActivatedSubscriber;
 use App\Service\Mailer\Mailer;
-use App\Service\Mailer\MailFactory;
-use App\Service\Mailer\MailSender;
-use App\TestHelpers\EmailHelpers;
 use App\TestHelpers\UserHelpers;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class UserActivatedSubscriberTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @test */
     public function getSubscribedEvents()
     {

--- a/client/tests/phpunit/EventSubscriber/UserDeletedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/UserDeletedSubscriberTest.php
@@ -1,5 +1,6 @@
-<?php declare(strict_types=1);
+<?php
 
+declare(strict_types=1);
 
 namespace Tests\App\EventListener;
 
@@ -11,10 +12,13 @@ use App\Service\Time\DateTimeProvider;
 use App\TestHelpers\UserHelpers;
 use DateTime;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Log\LoggerInterface;
 
 class UserDeletedSubscriberTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @test */
     public function getSubscribedEvents()
     {
@@ -50,7 +54,7 @@ class UserDeletedSubscriberTest extends TestCase
             'subject_email' => $deletedUser->getEmail(),
             'subject_role' => $deletedUser->getRoleName(),
             'event' => $expectedEventName,
-            'type' => 'audit'
+            'type' => 'audit',
         ];
 
         $logger->notice('', $expectedEvent)->shouldBeCalled();

--- a/client/tests/phpunit/EventSubscriber/UserPasswordResetSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/UserPasswordResetSubscriberTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Tests\App\EventListener;
 
@@ -7,9 +9,12 @@ use App\EventSubscriber\UserPasswordResetSubscriber;
 use App\Service\Mailer\Mailer;
 use App\TestHelpers\UserHelpers;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class UserPasswordResetSubscriberTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @test */
     public function getSubscribedEvents()
     {

--- a/client/tests/phpunit/Security/ClientVoterTest.php
+++ b/client/tests/phpunit/Security/ClientVoterTest.php
@@ -8,12 +8,15 @@ use App\Entity\Client;
 use App\Entity\User;
 use App\TestHelpers\ClientHelpers;
 use App\TestHelpers\UserHelpers;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Security;
 
 class ClientVoterTest extends KernelTestCase
 {
+    use ProphecyTrait;
+
     /**
      * @dataProvider deleteClientProvider
      * @test

--- a/client/tests/phpunit/Security/UserVoterTest.php
+++ b/client/tests/phpunit/Security/UserVoterTest.php
@@ -9,12 +9,15 @@ use App\Entity\Report\Report;
 use App\Entity\User;
 use App\TestHelpers\UserHelpers;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 
 class UserVoterTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @dataProvider deleteUserProvider
      * @test

--- a/client/tests/phpunit/Service/AWS/RequestSignerTest.php
+++ b/client/tests/phpunit/Service/AWS/RequestSignerTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Service\Client\AWS;
 
@@ -6,21 +8,23 @@ use App\Service\AWS\DefaultCredentialProvider;
 use App\Service\AWS\RequestSigner;
 use App\Service\AWS\SignatureV4Signer;
 use Aws\Credentials\Credentials;
-use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 
 class RequestSignerTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @test */
     public function signRequest()
     {
         $headers['X-Amz-Content-Sha256'] = 'A payload';
         $headers['Authorization'] = [
-            "AWS4-HMAC-SHA256 "
-            . "Credential=abc123/some/scope, "
-            . "SignedHeaders={['header' => 'signed']}, Signature={aSignature}"
+            'AWS4-HMAC-SHA256 '
+            .'Credential=abc123/some/scope, '
+            ."SignedHeaders={['header' => 'signed']}, Signature={aSignature}",
         ];
 
         $originalRequest = new Request('GET', 'some.url');
@@ -36,7 +40,6 @@ class RequestSignerTest extends TestCase
         /** @var SignatureV4Signer&ObjectProphecy $signer */
         $signer = self::prophesize(SignatureV4Signer::class);
         $signer->signRequest($originalRequest, $credentials, $service)->shouldBeCalled()->willReturn($signedRequest);
-
 
         $sut = new RequestSigner($provider, $signer->reveal());
         $sut->signRequest($originalRequest, $service);

--- a/client/tests/phpunit/Service/Audit/AuditEventsTest.php
+++ b/client/tests/phpunit/Service/Audit/AuditEventsTest.php
@@ -1,16 +1,21 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Service\Audit;
 
 use App\Entity\User;
 use App\Service\Time\DateTimeProvider;
-use App\Service\Time\FakeClock;
 use DateTime;
+use DateTimeZone;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 
 class AuditEventsTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      * @dataProvider startDateProvider
@@ -30,7 +35,7 @@ class AuditEventsTest extends TestCase
             'discharged_on' => $now->format(DateTime::ATOM),
             'deputyship_start_date' => $expectedStartDate,
             'event' => 'CLIENT_DELETED',
-            'type' => 'audit'
+            'type' => 'audit',
         ];
 
         $actual = (new AuditEvents($dateTimeProvider->reveal()))->clientDischarged(
@@ -47,12 +52,12 @@ class AuditEventsTest extends TestCase
     public function startDateProvider()
     {
         return [
-             'Start date present' => [
-                 '2019-07-08T09:36:00+01:00',
-                 new DateTime('2019-07-08T09:36', new \DateTimeZone('+0100'))
-             ],
-             'Null start date' => [null, null]
-         ];
+            'Start date present' => [
+                '2019-07-08T09:36:00+01:00',
+                new DateTime('2019-07-08T09:36', new DateTimeZone('+0100')),
+            ],
+            'Null start date' => [null, null],
+        ];
     }
 
     /**
@@ -75,7 +80,7 @@ class AuditEventsTest extends TestCase
             'subject_full_name' => 'Panda Bear',
             'subject_role' => 'ROLE_LAY_DEPUTY',
             'event' => 'USER_EMAIL_CHANGED',
-            'type' => 'audit'
+            'type' => 'audit',
         ];
 
         $actual = (new AuditEvents($dateTimeProvider->reveal()))->userEmailChanged(
@@ -110,7 +115,7 @@ class AuditEventsTest extends TestCase
             'subject_full_name' => 'Panda Bear',
             'subject_role' => 'CLIENT',
             'event' => 'CLIENT_EMAIL_CHANGED',
-            'type' => 'audit'
+            'type' => 'audit',
         ];
 
         $actual = (new AuditEvents($dateTimeProvider->reveal()))->clientEmailChanged(
@@ -128,8 +133,8 @@ class AuditEventsTest extends TestCase
     {
         return [
             'Email changed' => ['me@test.com', 'you@test.com'],
-            'Email removed' =>  ['me@test.com', null],
-            'Email added' => [null, 'you@test.com']
+            'Email removed' => ['me@test.com', null],
+            'Email added' => [null, 'you@test.com'],
         ];
     }
 
@@ -152,7 +157,7 @@ class AuditEventsTest extends TestCase
             'user_changed' => $userChanged,
             'changed_on' => $now->format(DateTime::ATOM),
             'event' => AuditEvents::EVENT_ROLE_CHANGED,
-            'type' => 'audit'
+            'type' => 'audit',
         ];
 
         $actual = (new AuditEvents($dateTimeProvider->reveal()))->roleChanged(
@@ -177,7 +182,7 @@ class AuditEventsTest extends TestCase
     /**
      * @test
      */
-    public function userDeleted_deputy(): void
+    public function userDeletedDeputy(): void
     {
         $now = new DateTime();
 
@@ -193,7 +198,7 @@ class AuditEventsTest extends TestCase
             'subject_email' => 'r.murphy@email.com',
             'subject_role' => 'ROLE_LAY_DEPUTY',
             'event' => 'DEPUTY_DELETED',
-            'type' => 'audit'
+            'type' => 'audit',
         ];
 
         $actual = (new AuditEvents($dateTimeProvider->reveal()))->userDeleted(
@@ -211,7 +216,7 @@ class AuditEventsTest extends TestCase
      * @test
      * @dataProvider adminRoleProvider
      */
-    public function userDeleted_admin(string $role): void
+    public function userDeletedAdmin(string $role): void
     {
         $now = new DateTime();
 
@@ -227,7 +232,7 @@ class AuditEventsTest extends TestCase
             'subject_email' => 'r.konichiwa@email.com',
             'subject_role' => $role,
             'event' => 'ADMIN_DELETED',
-            'type' => 'audit'
+            'type' => 'audit',
         ];
 
         $actual = (new AuditEvents($dateTimeProvider->reveal()))->userDeleted(

--- a/client/tests/phpunit/Service/Client/Internal/ClientApiTest.php
+++ b/client/tests/phpunit/Service/Client/Internal/ClientApiTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DigidepsTests\Service\Client\Internal;
 
@@ -13,6 +15,8 @@ use App\TestHelpers\ClientHelpers;
 use App\TestHelpers\UserHelpers;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -20,38 +24,40 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class ClientApiTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
-     * @var \Prophecy\Prophecy\ObjectProphecy
+     * @var ObjectProphecy
      */
     private $restClient;
 
     /**
-     * @var \Prophecy\Prophecy\ObjectProphecy
+     * @var ObjectProphecy
      */
     private $router;
 
     /**
-     * @var \Prophecy\Prophecy\ObjectProphecy
+     * @var ObjectProphecy
      */
     private $logger;
 
     /**
-     * @var \Prophecy\Prophecy\ObjectProphecy
+     * @var ObjectProphecy
      */
     private $userApi;
 
     /**
-     * @var \Prophecy\Prophecy\ObjectProphecy
+     * @var ObjectProphecy
      */
     private $dateTimeProvider;
 
     /**
-     * @var \Prophecy\Prophecy\ObjectProphecy
+     * @var ObjectProphecy
      */
     private $tokenStorage;
 
     /**
-     * @var \Prophecy\Prophecy\ObjectProphecy
+     * @var ObjectProphecy
      */
     private $eventDispatcher;
 

--- a/client/tests/phpunit/Service/Client/Internal/NdrApiTest.php
+++ b/client/tests/phpunit/Service/Client/Internal/NdrApiTest.php
@@ -1,5 +1,6 @@
-<?php declare(strict_types=1);
+<?php
 
+declare(strict_types=1);
 
 namespace DigidepsTests\Service\Client\Internal;
 
@@ -14,9 +15,12 @@ use App\TestHelpers\NdrHelpers;
 use App\TestHelpers\ReportHelpers;
 use App\TestHelpers\UserHelpers;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class NdrApiTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @test */
     public function submit()
     {

--- a/client/tests/phpunit/Service/Client/Internal/OrganisationApiTest.php
+++ b/client/tests/phpunit/Service/Client/Internal/OrganisationApiTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace DigidepsTests\Service\Client\Internal;
 
@@ -11,10 +13,13 @@ use App\TestHelpers\OrganisationHelpers;
 use App\TestHelpers\UserHelpers;
 use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 
 class OrganisationApiTest extends TestCase
 {
+    use ProphecyTrait;
+
     private ObjectProphecy $restClient;
     private ObjectProphecy $eventDispatcher;
     private OrganisationApi $sut;

--- a/client/tests/phpunit/Service/Client/Internal/ReportApiTest.php
+++ b/client/tests/phpunit/Service/Client/Internal/ReportApiTest.php
@@ -1,19 +1,24 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Tests\App\Service\Client\Internal;
 
 use App\Event\ReportSubmittedEvent;
+use App\Event\ReportUnsubmittedEvent;
 use App\EventDispatcher\ObservableEventDispatcher;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\TestHelpers\ReportHelpers;
 use App\TestHelpers\UserHelpers;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
-use App\Event\ReportUnsubmittedEvent;
 
 class ReportApiTest extends TestCase
 {
+    use ProphecyTrait;
+
     private ObjectProphecy $restClient;
     private ObjectProphecy $eventDispatcher;
     private ReportApi $sut;
@@ -59,7 +64,7 @@ class ReportApiTest extends TestCase
         $submittedReport = ReportHelpers::createSubmittedReport();
 
         $this->restClient
-            ->put('report/' . $submittedReport->getId() . '/unsubmit', $submittedReport, ['submitted', 'unsubmit_date', 'report_unsubmitted_sections_list', 'startEndDates', 'report_due_date'])
+            ->put('report/'.$submittedReport->getId().'/unsubmit', $submittedReport, ['submitted', 'unsubmit_date', 'report_unsubmitted_sections_list', 'startEndDates', 'report_due_date'])
             ->shouldBeCalled();
 
         $reportUnsubmittedEvent = new ReportUnsubmittedEvent(
@@ -79,7 +84,7 @@ class ReportApiTest extends TestCase
     {
         return [
             'Id returned' => ['1'],
-            'Id not returned' => [null]
+            'Id not returned' => [null],
         ];
     }
 }

--- a/client/tests/phpunit/Service/Client/Internal/SatisfactionApiTest.php
+++ b/client/tests/phpunit/Service/Client/Internal/SatisfactionApiTest.php
@@ -1,5 +1,6 @@
-<?php declare(strict_types=1);
+<?php
 
+declare(strict_types=1);
 
 namespace DigidepsTests\Service\Client\Internal;
 
@@ -12,12 +13,16 @@ use App\Service\Client\Internal\SatisfactionApi;
 use App\Service\Client\RestClient;
 use App\TestHelpers\UserHelpers;
 use Faker\Factory;
+use Faker\Generator;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 
 class SatisfactionApiTest extends TestCase
 {
-    /** @var \Faker\Generator */
+    use ProphecyTrait;
+
+    /** @var Generator */
     private $faker;
 
     /** @var RestClient&ObjectProphecy */
@@ -26,7 +31,7 @@ class SatisfactionApiTest extends TestCase
     /** @var ObservableEventDispatcher&ObjectProphecy */
     private $eventDisaptcher;
 
-    /**  @var SatisfactionApi */
+    /** @var SatisfactionApi */
     private $sut;
 
     public function setUp(): void
@@ -42,7 +47,7 @@ class SatisfactionApiTest extends TestCase
      */
     public function createGeneralFeedback()
     {
-        $score = $this->faker->randomElement([1,2,3,4,5]);
+        $score = $this->faker->randomElement([1, 2, 3, 4, 5]);
         $comments = $this->faker->realText();
 
         $this->restClient->post(
@@ -56,7 +61,7 @@ class SatisfactionApiTest extends TestCase
             'phone' => $this->faker->phoneNumber,
             'page' => $this->faker->url,
             'email' => $this->faker->email,
-            'satisfactionLevel' => $score
+            'satisfactionLevel' => $score,
         ];
 
         $event = (new GeneralFeedbackSubmittedEvent())->setFeedbackFormResponse($formData);
@@ -71,7 +76,7 @@ class SatisfactionApiTest extends TestCase
      */
     public function createPostSubmissionFeedback(?string $comments, string $expectedCommentsInPostRequest, ?int $reportId, ?int $ndrId)
     {
-        $score = $this->faker->randomElement([1,2,3,4,5]);
+        $score = $this->faker->randomElement([1, 2, 3, 4, 5]);
         $submittedByUser = UserHelpers::createUser();
         $reportType = $this->faker->randomElement([
             Report::TYPE_COMBINED_HIGH_ASSETS,
@@ -79,7 +84,7 @@ class SatisfactionApiTest extends TestCase
             Report::TYPE_ABBREVIATION_COMBINED,
             Report::TYPE_COMBINED_LOW_ASSETS,
             Report::TYPE_PROPERTY_AND_AFFAIRS_LOW_ASSETS,
-            Report::TYPE_HEALTH_WELFARE
+            Report::TYPE_HEALTH_WELFARE,
         ]);
 
         $this->restClient->post(
@@ -89,7 +94,7 @@ class SatisfactionApiTest extends TestCase
                 'comments' => $expectedCommentsInPostRequest,
                 'reportType' => $reportType,
                 'reportId' => $reportId,
-                'ndrId' => $ndrId
+                'ndrId' => $ndrId,
             ]
         )
             ->shouldBeCalled()

--- a/client/tests/phpunit/Service/Client/Internal/UserApiTest.php
+++ b/client/tests/phpunit/Service/Client/Internal/UserApiTest.php
@@ -18,12 +18,15 @@ use App\Service\Client\RestClient;
 use App\TestHelpers\UserHelpers;
 use Faker\Factory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class UserApiTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ObjectProphecy */
     private $restClient;
 

--- a/client/tests/phpunit/Service/Client/Sirius/SiriusApiGatewayClientTest.php
+++ b/client/tests/phpunit/Service/Client/Sirius/SiriusApiGatewayClientTest.php
@@ -8,6 +8,7 @@ use App\Service\AWS\RequestSigner;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -15,6 +16,8 @@ use Symfony\Component\Serializer\Serializer;
 
 class SiriusApiGatewayClientTest extends KernelTestCase
 {
+    use ProphecyTrait;
+
     /** @var string */
     private $baseURL;
 

--- a/client/tests/phpunit/Service/DocumentDownloaderTest.php
+++ b/client/tests/phpunit/Service/DocumentDownloaderTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Service;
 
@@ -10,6 +12,7 @@ use App\Model\RetrievedDocument;
 use App\Service\File\DocumentsZipFileCreator;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -18,6 +21,8 @@ use ZipArchive;
 
 class DocumentDownloaderTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var ObjectProphecy|DocumentService
      */
@@ -33,32 +38,18 @@ class DocumentDownloaderTest extends TestCase
      */
     private $zipFileCreator;
 
-    public function setUp():void
+    public function setUp(): void
     {
         $this->documentService = self::prophesize(DocumentService::class);
         $this->reportSubmissionService = self::prophesize(ReportSubmissionService::class);
         $this->zipFileCreator = self::prophesize(DocumentsZipFileCreator::class);
     }
 
-    private function generateReportSubmission(string $caseNumber): ReportSubmission
-    {
-        $client = new Client();
-        $client->setCaseNumber($caseNumber);
-
-        $report = new Report();
-        $report->setClient($client);
-
-        $reportSubmission = new ReportSubmission();
-        $reportSubmission->setReport($report);
-
-        return $reportSubmission;
-    }
-
     public function testGenerateDownloadResponse(): void
     {
         $sut = new DocumentDownloader($this->documentService->reveal(), $this->reportSubmissionService->reveal(), $this->zipFileCreator->reveal());
 
-        $zipFile = "/tmp/test-file.zip";
+        $zipFile = '/tmp/test-file.zip';
         file_put_contents($zipFile, 'some content');
 
         $response = $sut->generateDownloadResponse($zipFile);
@@ -136,6 +127,20 @@ class DocumentDownloaderTest extends TestCase
 
         self::assertEquals($expectedRetrievedDocuments, $retrievedDocuments);
         self::assertEquals($missingDocument, $missingDocument);
+    }
+
+    private function generateReportSubmission(string $caseNumber): ReportSubmission
+    {
+        $client = new Client();
+        $client->setCaseNumber($caseNumber);
+
+        $report = new Report();
+        $report->setClient($client);
+
+        $reportSubmission = new ReportSubmission();
+        $reportSubmission->setReport($report);
+
+        return $reportSubmission;
     }
 
     public function testSetMissingDocsFlashMessage(): void

--- a/client/tests/phpunit/Service/DocumentServiceTest.php
+++ b/client/tests/phpunit/Service/DocumentServiceTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Service;
 
@@ -15,6 +17,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
 use Twig\Environment;
@@ -22,6 +25,8 @@ use Twig\Loader\FilesystemLoader;
 
 class DocumentServiceTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var DocumentService
      */
@@ -66,7 +71,6 @@ class DocumentServiceTest extends TestCase
      * @var ObjectProphecy|Document
      */
     private $doc4;
-
 
     public function setUp(): void
     {
@@ -120,7 +124,7 @@ class DocumentServiceTest extends TestCase
             ->willReturn([]);
 
         $this->restClient
-            ->delete('document/' . $docId)
+            ->delete('document/'.$docId)
             ->shouldBeCalled()
             ->willReturn(true);
 
@@ -180,7 +184,7 @@ class DocumentServiceTest extends TestCase
     {
         $this->s3Storage->retrieve('ref-1')->shouldBeCalled()->willReturn('doc1 contents');
         $this->s3Storage->retrieve('ref-2')->shouldBeCalled()
-            ->willThrow(new FileNotFoundException("Cannot find file with reference ref-2"));
+            ->willThrow(new FileNotFoundException('Cannot find file with reference ref-2'));
 
         /** @var ObjectProphecy|ReportSubmission $reportSubmission */
         $reportSubmission = self::prophesize(ReportSubmission::class);
@@ -248,9 +252,9 @@ class DocumentServiceTest extends TestCase
     {
         $this->s3Storage->retrieve('ref-1')->shouldBeCalled()->willReturn('doc1 contents');
         $this->s3Storage->retrieve('ref-2')->shouldBeCalled()
-            ->willThrow(new FileNotFoundException("Cannot find file with reference ref-2"));
+            ->willThrow(new FileNotFoundException('Cannot find file with reference ref-2'));
         $this->s3Storage->retrieve('ref-3')->shouldBeCalled()
-            ->willThrow(new FileNotFoundException("Cannot find file with reference ref-3"));
+            ->willThrow(new FileNotFoundException('Cannot find file with reference ref-3'));
         $this->s3Storage->retrieve('ref-4')->shouldBeCalled()->willReturn('doc4 contents');
 
         /** @var ObjectProphecy|ReportSubmission $reportSubmission */
@@ -309,20 +313,6 @@ class DocumentServiceTest extends TestCase
         self::assertEquals($expectedFlash, $actualFlash);
     }
 
-    private function generateReportSubmission(string $caseNumber): ReportSubmission
-    {
-        $client = new Client();
-        $client->setCaseNumber($caseNumber);
-
-        $report = new Report();
-        $report->setClient($client);
-
-        $reportSubmission = new ReportSubmission();
-        $reportSubmission->setReport($report);
-
-        return $reportSubmission;
-    }
-
     public function testTwigTemplate(): void
     {
         $reportSubmission1 = $this->generateReportSubmission('CaseNumber1');
@@ -343,7 +333,7 @@ class DocumentServiceTest extends TestCase
         $missingDocuments = [$missingDoc1, $missingDoc2, $missingDoc3];
         $missingDocumentCaseNumbers = ['CaseNumber1', 'CaseNumber2', 'CaseNumber1'];
 
-        $loader = new FilesystemLoader([__DIR__ . '/../../../templates/FlashMessages']);
+        $loader = new FilesystemLoader([__DIR__.'/../../../templates/FlashMessages']);
 
         $sut = new Environment($loader);
 
@@ -358,5 +348,19 @@ class DocumentServiceTest extends TestCase
             $expectedListItem = "<li>${caseNumber} - ${fileName}</li>";
             self::assertStringContainsString($expectedListItem, $renderedTwig);
         }
+    }
+
+    private function generateReportSubmission(string $caseNumber): ReportSubmission
+    {
+        $client = new Client();
+        $client->setCaseNumber($caseNumber);
+
+        $report = new Report();
+        $report->setClient($client);
+
+        $reportSubmission = new ReportSubmission();
+        $reportSubmission->setReport($report);
+
+        return $reportSubmission;
     }
 }

--- a/client/tests/phpunit/Service/DocumentSyncServiceTest.php
+++ b/client/tests/phpunit/Service/DocumentSyncServiceTest.php
@@ -19,12 +19,15 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use JMS\Serializer\Serializer;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 class DocumentSyncServiceTest extends KernelTestCase
 {
+    use ProphecyTrait;
+
     /** @var S3Storage&ObjectProphecy */
     private $s3Storage;
 
@@ -304,7 +307,7 @@ class DocumentSyncServiceTest extends KernelTestCase
                 'document/6789',
                 json_encode(
                     ['syncStatus' => Document::SYNC_STATUS_PERMANENT_ERROR,
-                    'syncError' => 'OPGDATA-API-FORBIDDEN: Credentials used for integration lack correct permissions',
+                        'syncError' => 'OPGDATA-API-FORBIDDEN: Credentials used for integration lack correct permissions',
                     ]
                 ),
                 'Report\\Document',

--- a/client/tests/phpunit/Service/File/DocumentZipFileCreatorTest.php
+++ b/client/tests/phpunit/Service/File/DocumentZipFileCreatorTest.php
@@ -1,15 +1,20 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Service\File;
 
 use App\Entity\Report\ReportSubmission;
 use App\Model\RetrievedDocument;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use ZipArchive;
 
 class DocumentZipFileCreatorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testCreateZipFilesFromRetrievedDocuments()
     {
         /** @var ObjectProphecy|ReportSubmission $reportSubmission1 */

--- a/client/tests/phpunit/Service/File/S3FileUploaderTest.php
+++ b/client/tests/phpunit/Service/File/S3FileUploaderTest.php
@@ -1,5 +1,6 @@
-<?php declare(strict_types=1);
+<?php
 
+declare(strict_types=1);
 
 namespace App\Service\File;
 
@@ -12,12 +13,15 @@ use App\TestHelpers\ReportHelpers;
 use DateTime;
 use Exception;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class S3FileUploaderTest extends KernelTestCase
 {
+    use ProphecyTrait;
+
     private string $projectDir;
     private ObjectProphecy $storage;
     private ObjectProphecy $restClient;
@@ -67,7 +71,7 @@ class S3FileUploaderTest extends KernelTestCase
     }
 
     /** @test */
-    public function uploadSupportingFilesAndPersistDocuments_single_file()
+    public function uploadSupportingFilesAndPersistDocumentsSingleFile()
     {
         $filePath = sprintf('%s/tests/phpunit/TestData/good-jpeg', $this->projectDir);
         $fileBody = file_get_contents($filePath);
@@ -87,7 +91,7 @@ class S3FileUploaderTest extends KernelTestCase
     }
 
     /** @test */
-    public function uploadSupportingFilesAndPersistDocuments_multiple_files()
+    public function uploadSupportingFilesAndPersistDocumentsMultipleFiles()
     {
         $jpeg = new UploadedFile(sprintf('%s/tests/phpunit/TestData/good-jpeg', $this->projectDir), 'good-jpeg');
         $png = new UploadedFile(sprintf('%s/tests/phpunit/TestData/good-png', $this->projectDir), 'good-png');
@@ -118,7 +122,7 @@ class S3FileUploaderTest extends KernelTestCase
     }
 
     /** @test */
-    public function removeFileFromS3_missing_storage_ref()
+    public function removeFileFromS3MissingStorageRef()
     {
         self::expectException(Exception::class);
 

--- a/client/tests/phpunit/Service/Mailer/MailSenderTest.php
+++ b/client/tests/phpunit/Service/Mailer/MailSenderTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Service\Mailer;
 
@@ -6,12 +8,16 @@ use Alphagov\Notifications\Client as NotifyClient;
 use Alphagov\Notifications\Exception\NotifyException;
 use App\Model\Email;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 //class MailSenderTest extends \PHPUnit_Framework_TestCase
-class MailSenderTest extends \Symfony\Bundle\FrameworkBundle\Test\WebTestCase
+class MailSenderTest extends WebTestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var ObjectProphecy&LoggerInterface
      */
@@ -33,7 +39,7 @@ class MailSenderTest extends \Symfony\Bundle\FrameworkBundle\Test\WebTestCase
     /**
      * @test
      */
-    public function send_notify()
+    public function sendNotify()
     {
         $email = $this->generateEmail();
         $this->notifyClient->sendEmail('to@email.address', '123-template-id', ['param' => 'param value'], '', 'fake-id')->shouldBeCalled();
@@ -41,30 +47,30 @@ class MailSenderTest extends \Symfony\Bundle\FrameworkBundle\Test\WebTestCase
     }
 
     /**
-     * @test
-     */
-    public function send_notify_exceptions_are_logged()
-    {
-        $email = $this->generateEmail();
-        $this->logger->error('Error message')->shouldBeCalled();
-        $this->notifyClient->sendEmail(Argument::cetera())->willThrow(new NotifyException('Error message'));
-
-        self::assertFalse($this->sut->send($email));
-    }
-
-    /**
      * @return Email
      */
     private function generateEmail(
-        string $toEmail='to@email.address',
-        string $templateID='123-template-id',
-        array $parameters=['param' => 'param value'],
-        string $fromEmailNotifyID='fake-id'
+        string $toEmail = 'to@email.address',
+        string $templateID = '123-template-id',
+        array $parameters = ['param' => 'param value'],
+        string $fromEmailNotifyID = 'fake-id'
     ) {
         return (new Email())
             ->setToEmail($toEmail)
             ->setTemplate($templateID)
             ->setParameters($parameters)
             ->setFromEmailNotifyID($fromEmailNotifyID);
+    }
+
+    /**
+     * @test
+     */
+    public function sendNotifyExceptionsAreLogged()
+    {
+        $email = $this->generateEmail();
+        $this->logger->error('Error message')->shouldBeCalled();
+        $this->notifyClient->sendEmail(Argument::cetera())->willThrow(new NotifyException('Error message'));
+
+        self::assertFalse($this->sut->send($email));
     }
 }

--- a/client/tests/phpunit/Service/Mailer/MailerTest.php
+++ b/client/tests/phpunit/Service/Mailer/MailerTest.php
@@ -1,8 +1,9 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Tests\App\Service\Mailer;
 
-use App\Model\Email;
 use App\Model\FeedbackReport;
 use App\Service\Mailer\Mailer;
 use App\Service\Mailer\MailFactory;
@@ -11,23 +12,25 @@ use App\TestHelpers\ClientHelpers;
 use App\TestHelpers\EmailHelpers;
 use App\TestHelpers\NdrHelpers;
 use App\TestHelpers\ReportHelpers;
-use App\TestHelpers\ReportTestHelper;
 use App\TestHelpers\UserHelpers;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 
 class MailerTest extends TestCase
 {
-    /** @var \Prophecy\Prophecy\ObjectProphecy */
+    use ProphecyTrait;
+
+    /** @var ObjectProphecy */
     private $mailFactory;
 
-    /** @var \Prophecy\Prophecy\ObjectProphecy */
+    /** @var ObjectProphecy */
     private $mailSender;
 
     /** @var Mailer */
     private $sut;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         $this->mailFactory = self::prophesize(MailFactory::class);
         $this->mailSender = self::prophesize(MailSender::class);
@@ -65,7 +68,7 @@ class MailerTest extends TestCase
     {
         return [
             'Name' => ['Poppy'],
-            'Null' => [null]
+            'Null' => [null],
         ];
     }
 
@@ -87,11 +90,11 @@ class MailerTest extends TestCase
         $formResponse = [
             'specificPage' => true,
             'page' => null,
-            'comments' => "Some comment here",
-            'name' => "Shygirl",
-            'email' => "shygirl@nuxxe.com",
-            'phone' => "01211234567",
-            'satisfactionLevel' => 5
+            'comments' => 'Some comment here',
+            'name' => 'Shygirl',
+            'email' => 'shygirl@nuxxe.com',
+            'phone' => '01211234567',
+            'satisfactionLevel' => 5,
         ];
         $generalFeedbackEmail = EmailHelpers::createEmail();
 

--- a/client/tests/phpunit/Service/NotifyAvailabilityTest.php
+++ b/client/tests/phpunit/Service/NotifyAvailabilityTest.php
@@ -7,10 +7,13 @@ use Alphagov\Notifications\Exception\ApiException as NotifyAPIException;
 use App\Service\Availability\NotifyAvailability;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 
 class NotifyAvailabilityTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @test
      */

--- a/client/tests/phpunit/Service/ParameterStoreServiceTest.php
+++ b/client/tests/phpunit/Service/ParameterStoreServiceTest.php
@@ -4,9 +4,12 @@ namespace App\Service;
 
 use Aws\Ssm\SsmClient;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class ParameterStoreServiceTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @test */
     public function getFeatureFlag()
     {

--- a/client/tests/phpunit/Service/ReportSubmissionServiceTest.php
+++ b/client/tests/phpunit/Service/ReportSubmissionServiceTest.php
@@ -17,6 +17,7 @@ use App\Service\Mailer\MailSender;
 use MockeryStub as m;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Bridge\Monolog\Logger;
 use Symfony\Component\DependencyInjection\Container;
@@ -24,6 +25,8 @@ use Twig\Environment;
 
 class ReportSubmissionServiceTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var ReportSubmissionService
      */
@@ -83,49 +86,6 @@ class ReportSubmissionServiceTest extends TestCase
     }
 
     /**
-     * Generates System Under Test.
-     *
-     * @return ReportSubmissionService
-     */
-    private function generateSut()
-    {
-        $mockContainer = m::mock(Container::class);
-
-        $mockContainer->shouldReceive('get')->with('file_uploader')->andReturn($this->mockFileUploader);
-        $mockContainer->shouldReceive('get')->with('rest_client')->andReturn($this->mockRestClient);
-        $mockContainer->shouldReceive('get')->with('App\Service\Mailer\MailSender')->andReturn($this->mockMailSender);
-        $mockContainer->shouldReceive('get')->with('App\Service\Mailer\MailFactory')->andReturn($this->mockMailFactory);
-        $mockContainer->shouldReceive('get')->with('templating')->andReturn($this->mockTemplatingEngine);
-        $mockContainer->shouldReceive('get')->with('logger')->andReturn($this->mockLogger);
-        $mockContainer->shouldReceive('get')->with('csv_generator_service')->andReturn($this->mockCsvGenerator);
-
-        return new ReportSubmissionService(
-            $this->mockCsvGenerator,
-            $this->mockTemplatingEngine,
-            $this->mockFileUploader,
-            $this->mockRestClient,
-            $this->mockLogger,
-            $this->mockMailFactory,
-            $this->mockMailSender,
-            $this->mockPdfGenerator
-        );
-    }
-
-    private function generateProphecySut()
-    {
-        return new ReportSubmissionService(
-            $this->csvGenerator->reveal(),
-            $this->twig->reveal(),
-            $this->fileUploader->reveal(),
-            $this->restClient->reveal(),
-            $this->logger->reveal(),
-            $this->mailFactory->reveal(),
-            $this->mailSender->reveal(),
-            $this->pdfGenerator->reveal(),
-        );
-    }
-
-    /**
      * @test
      * @dataProvider lowOrNoAssetsReportTypeProvider
      */
@@ -146,6 +106,20 @@ class ReportSubmissionServiceTest extends TestCase
 
         $sut = $this->generateProphecySut();
         $sut->generateReportDocuments($report->reveal());
+    }
+
+    private function generateProphecySut()
+    {
+        return new ReportSubmissionService(
+            $this->csvGenerator->reveal(),
+            $this->twig->reveal(),
+            $this->fileUploader->reveal(),
+            $this->restClient->reveal(),
+            $this->logger->reveal(),
+            $this->mailFactory->reveal(),
+            $this->mailSender->reveal(),
+            $this->pdfGenerator->reveal(),
+        );
     }
 
     public function lowOrNoAssetsReportTypeProvider()
@@ -208,6 +182,35 @@ class ReportSubmissionServiceTest extends TestCase
         $this->sut = $this->generateSut();
 
         $this->assertEquals('PDF CONTENT', $this->sut->getPdfBinaryContent($this->mockReport, true));
+    }
+
+    /**
+     * Generates System Under Test.
+     *
+     * @return ReportSubmissionService
+     */
+    private function generateSut()
+    {
+        $mockContainer = m::mock(Container::class);
+
+        $mockContainer->shouldReceive('get')->with('file_uploader')->andReturn($this->mockFileUploader);
+        $mockContainer->shouldReceive('get')->with('rest_client')->andReturn($this->mockRestClient);
+        $mockContainer->shouldReceive('get')->with('App\Service\Mailer\MailSender')->andReturn($this->mockMailSender);
+        $mockContainer->shouldReceive('get')->with('App\Service\Mailer\MailFactory')->andReturn($this->mockMailFactory);
+        $mockContainer->shouldReceive('get')->with('templating')->andReturn($this->mockTemplatingEngine);
+        $mockContainer->shouldReceive('get')->with('logger')->andReturn($this->mockLogger);
+        $mockContainer->shouldReceive('get')->with('csv_generator_service')->andReturn($this->mockCsvGenerator);
+
+        return new ReportSubmissionService(
+            $this->mockCsvGenerator,
+            $this->mockTemplatingEngine,
+            $this->mockFileUploader,
+            $this->mockRestClient,
+            $this->mockLogger,
+            $this->mockMailFactory,
+            $this->mockMailSender,
+            $this->mockPdfGenerator
+        );
     }
 
     /**

--- a/client/tests/phpunit/phpunit.xml
+++ b/client/tests/phpunit/phpunit.xml
@@ -14,49 +14,51 @@
     stopOnRisky="false"
     stopOnWarning="false"
 >
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">../../src</directory>
-    </include>
-  </coverage>
-  <testsuites>
-    <testsuite name="Client unit tests">
-      <directory>./Command</directory>
-      <directory>./Entity</directory>
-      <directory>./EventListener</directory>
-      <directory>./Form</directory>
-      <directory>./Mapper</directory>
-      <directory>./Model</directory>
-      <directory>./Resolver</directory>
-      <directory>./Security</directory>
-      <directory>./Service</directory>
-      <directory>./Transformer</directory>
-      <directory>./Twig</directory>
-      <directory>./Validator</directory>
-    </testsuite>
-    <testsuite name="Pact contract tests">
-      <directory>./Pact</directory>
-    </testsuite>
-  </testsuites>
-  <php>
-    <ini name="error_log" value="/dev/stdout"/>
-    <ini name="memory_limit" value="512M"/>
-    <env name="PACT_MOCK_SERVER_HOST" value="pact-mock"/>
-    <env name="PACT_MOCK_SERVER_PORT" value="80"/>
-    <env name="PACT_CONSUMER_NAME" value="Complete the deputy report"/>
-    <env name="PACT_PROVIDER_NAME" value="OPG Data"/>
-    <env name="KERNEL_CLASS" value="App\Kernel"/>
-    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
-  </php>
-  <listeners>
-    <listener class="App\Pact\Listener\PactTestListener" file="./Pact/Listener/PactTestListener.php">
-      <arguments>
-        <array>
-          <element key="0">
-            <string>Pact contract tests</string>
-          </element>
-        </array>
-      </arguments>
-    </listener>
-  </listeners>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">../../src</directory>
+        </include>
+    </coverage>
+    <testsuites>
+        <testsuite name="Client unit tests">
+            <directory>./Command</directory>
+            <directory>./Entity</directory>
+            <directory>./EventListener</directory>
+            <directory>./EventSubscriber</directory>
+            <directory>./Form</directory>
+            <directory>./Mapper</directory>
+            <directory>./Model</directory>
+            <directory>./Pact</directory>
+            <directory>./Resolver</directory>
+            <directory>./Security</directory>
+            <directory>./Service</directory>
+            <directory>./Transformer</directory>
+            <directory>./Twig</directory>
+            <directory>./Validator</directory>
+        </testsuite>
+        <testsuite name="Pact contract tests">
+            <directory>./Pact</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <ini name="error_log" value="/dev/stdout"/>
+        <ini name="memory_limit" value="512M"/>
+        <env name="PACT_MOCK_SERVER_HOST" value="pact-mock"/>
+        <env name="PACT_MOCK_SERVER_PORT" value="80"/>
+        <env name="PACT_CONSUMER_NAME" value="Complete the deputy report"/>
+        <env name="PACT_PROVIDER_NAME" value="OPG Data"/>
+        <env name="KERNEL_CLASS" value="App\Kernel"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+    </php>
+    <listeners>
+        <listener class="App\Pact\Listener\PactTestListener" file="./Pact/Listener/PactTestListener.php">
+            <arguments>
+                <array>
+                    <element key="0">
+                        <string>Pact contract tests</string>
+                    </element>
+                </array>
+            </arguments>
+        </listener>
+    </listeners>
 </phpunit>


### PR DESCRIPTION
## Purpose
Since upgrading PHP and PHPUnit we've had very noisy unit tests with lots of deprecation warnings. Leaving these as is would mean when we come to update either PHP or PHPUnit we would have work to do to avoid breaking changes. This PR fixes the client deprecation warnings - API to follow.

Fixes DDPB-####

## Approach
It was a case of working through each deprecation to see what the issue was. The main change here is PHPUnit 9 deprecates having PHPSpec Prophecy as a bundled dependency. The recommended fix is to import a trait and explicitly call it at the start of the test.

There was also a deprecation for the PHPUnit `at()` method which required a full rewrite of the ChecklistSyncCommand test. Its not as readable but trying to chain multiple consecutive calls didn't seem possible so putting all expected API calls and returns together seemed like an OK compromise. Happy for any suggestions of other ways of doing this.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes
