### PR TITLE
DDPB-3880: Filename sanitisation

### DIFF
--- a/client/src/Service/File/FileNameFixer.php
+++ b/client/src/Service/File/FileNameFixer.php
@@ -235,9 +235,11 @@ class FileNameFixer
         return true === isset($mime_map[$mime]) ? $mime_map[$mime] : false;
     }
 
-    public function removeUnusualCharacters(string $fileName)
+    public function removeUnusualCharacters(string $fileName): array | string | null
     {
         $fileNameSpacesToUnderscores = str_replace(' ', '_', $fileName);
-        return preg_replace('/[^A-Za-z0-9\_\.]/', '', $fileNameSpacesToUnderscores);
+        $specialCharsRemoved = preg_replace('/[^A-Za-z0-9_.]/', '', $fileNameSpacesToUnderscores);
+
+        return preg_replace('/[.](?=.*[.])/', '_', $specialCharsRemoved);
     }
 }

--- a/client/src/Service/File/FileNameFixer.php
+++ b/client/src/Service/File/FileNameFixer.php
@@ -1,6 +1,5 @@
 <?php
 
-
 declare(strict_types=1);
 
 namespace App\Service\File;
@@ -236,9 +235,11 @@ class FileNameFixer
         return true === isset($mime_map[$mime]) ? $mime_map[$mime] : false;
     }
 
-    public function removeUnusualCharacters()
+    public function removeUnusualCharacters(string $fileName)
     {
-        return "My_File_1_2nd_revision.pdf";
-    }
+        $fileName = str_replace(' ', '_', $fileName);
+        $fileName = str_replace('(', '', $fileName);
 
+        return str_replace(')', '', $fileName);
+    }
 }

--- a/client/src/Service/File/FileNameFixer.php
+++ b/client/src/Service/File/FileNameFixer.php
@@ -1,5 +1,6 @@
 <?php
 
+
 declare(strict_types=1);
 
 namespace App\Service\File;
@@ -234,4 +235,10 @@ class FileNameFixer
 
         return true === isset($mime_map[$mime]) ? $mime_map[$mime] : false;
     }
+
+    public function removeUnusualCharacters()
+    {
+        return "My_File_1_2nd_revision.pdf";
+    }
+
 }

--- a/client/src/Service/File/FileNameFixer.php
+++ b/client/src/Service/File/FileNameFixer.php
@@ -237,9 +237,7 @@ class FileNameFixer
 
     public function removeUnusualCharacters(string $fileName)
     {
-        $fileName = str_replace(' ', '_', $fileName);
-        $fileName = str_replace('(', '', $fileName);
-
-        return str_replace(')', '', $fileName);
+        $fileNameSpacesToUnderscores = str_replace(' ', '_', $fileName);
+        return preg_replace('/[^A-Za-z0-9\_\.]/', '', $fileNameSpacesToUnderscores);
     }
 }

--- a/client/src/Service/File/S3FileUploader.php
+++ b/client/src/Service/File/S3FileUploader.php
@@ -10,6 +10,7 @@ use App\Entity\ReportInterface;
 use App\Service\Client\RestClient;
 use App\Service\File\Storage\StorageInterface;
 use App\Service\Time\DateTimeProvider;
+use Exception;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class S3FileUploader
@@ -53,6 +54,7 @@ class S3FileUploader
 
         $fileName = $this->fileNameFixer->addMissingFileExtension($file, $body);
         $fileName = $this->fileNameFixer->removeWhiteSpaceBeforeFileExtension($fileName);
+        $fileName = $this->fileNameFixer->removeUnusualCharacters($fileName);
 
         return [$body, $fileName];
     }
@@ -95,13 +97,13 @@ class S3FileUploader
     /**
      * Removes a file from S3.
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function removeFileFromS3(Document $document)
     {
         $storageReference = $document->getStorageReference();
         if (empty($storageReference)) {
-            throw new \Exception('Document could not be removed. No Reference.');
+            throw new Exception('Document could not be removed. No Reference.');
         }
 
         $this->storage->removeFromS3($storageReference);

--- a/client/tests/phpunit/Service/File/FileNameFixerTest.php
+++ b/client/tests/phpunit/Service/File/FileNameFixerTest.php
@@ -1,4 +1,5 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 
 
 namespace App\Service\File;
@@ -59,6 +60,25 @@ class FileNameFixerTest extends KernelTestCase
             'pdf' => ['tests/phpunit/TestData/good-pdf', 'good-pdf', 'good-pdf.pdf'],
             'png' => ['tests/phpunit/TestData/good-png', 'good-png', 'good-png.png'],
             'Already has an extension' => ['tests/phpunit/TestData/good-jpeg.jpeg', 'good-jpeg.jpeg', 'good-jpeg.jpeg'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider unusualCharactersProvider
+     */
+    public function removeUnusualCharacters($fileName, $expectedFileName)
+    {
+        $actualFileName = $this->sut->removeUnusualCharacters($fileName);
+
+        self::assertEquals($expectedFileName, $actualFileName);
+    }
+
+    public function unusualCharactersProvider()
+    {
+        return [
+            'white space is transformed to underscores' => ['My File 1 2nd revision.pdf', 'My_File_1_2nd_revision.pdf'],
+            'special characters are removed' => ['My File 1 (3rd revision).pdf', 'My_File_1_3rd_revision.pdf'],
         ];
     }
 }

--- a/client/tests/phpunit/Service/File/FileNameFixerTest.php
+++ b/client/tests/phpunit/Service/File/FileNameFixerTest.php
@@ -78,8 +78,8 @@ class FileNameFixerTest extends KernelTestCase
     {
         return [
             'white space is transformed to underscores' => ['My File 1 2nd revision.pdf', 'My_File_1_2nd_revision.pdf'],
-            'opening and closing parenthesis are removed' => ['My File 1 (3rd revision).pdf', 'My_File_1_3rd_revision.pdf'],
-            'all special characters are removed' => ['$%/[]My {}{}{}File_+=<>1.pdf', 'My_File_1.pdf'],
+            'all special characters are removed' => ['$%/[]My {}{}|{}File_+()=<>1.pdf', 'My_File_1.pdf'],
+            'file extension dot remains, any others transformed to underscores' => ['My_File.png.pdf','My_File_png.pdf']
         ];
     }
 }

--- a/client/tests/phpunit/Service/File/FileNameFixerTest.php
+++ b/client/tests/phpunit/Service/File/FileNameFixerTest.php
@@ -1,6 +1,6 @@
 <?php
-declare(strict_types=1);
 
+declare(strict_types=1);
 
 namespace App\Service\File;
 
@@ -78,7 +78,8 @@ class FileNameFixerTest extends KernelTestCase
     {
         return [
             'white space is transformed to underscores' => ['My File 1 2nd revision.pdf', 'My_File_1_2nd_revision.pdf'],
-            'special characters are removed' => ['My File 1 (3rd revision).pdf', 'My_File_1_3rd_revision.pdf'],
+            'opening and closing parenthesis are removed' => ['My File 1 (3rd revision).pdf', 'My_File_1_3rd_revision.pdf'],
+            'all special characters are removed' => ['$%/[]My {}{}{}File_+=<>1.pdf', 'My_File_1.pdf'],
         ];
     }
 }

--- a/client/tests/phpunit/Service/File/FileNameFixerTest.php
+++ b/client/tests/phpunit/Service/File/FileNameFixerTest.php
@@ -79,7 +79,9 @@ class FileNameFixerTest extends KernelTestCase
         return [
             'white space is transformed to underscores' => ['My File 1 2nd revision.pdf', 'My_File_1_2nd_revision.pdf'],
             'all special characters are removed' => ['$%/[]My {}{}|{}File_+()=<>1.pdf', 'My_File_1.pdf'],
-            'file extension dot remains, any others transformed to underscores' => ['My_File.png.pdf','My_File_png.pdf']
+            'file extension dot remains, any others transformed to underscores' => ['My_File.png.pdf', 'My_File_png.pdf'],
+            'HTML constructs are not allowed' => ['<a href="myhostilefile.exe">Report</a>.pdf', 'a_hrefmyhostilefile_exeReporta.pdf'],
+            'Directory constructs are not allowed' => ['../../', '___.'],
         ];
     }
 }

--- a/client/tests/phpunit/Service/File/S3FileUploaderTest.php
+++ b/client/tests/phpunit/Service/File/S3FileUploaderTest.php
@@ -1,5 +1,6 @@
-<?php declare(strict_types=1);
+<?php
 
+declare(strict_types=1);
 
 namespace App\Service\File;
 
@@ -67,7 +68,7 @@ class S3FileUploaderTest extends KernelTestCase
     }
 
     /** @test */
-    public function uploadSupportingFilesAndPersistDocuments_single_file()
+    public function uploadSupportingFilesAndPersistDocumentsSingleFile()
     {
         $filePath = sprintf('%s/tests/phpunit/TestData/good-jpeg', $this->projectDir);
         $fileBody = file_get_contents($filePath);
@@ -79,6 +80,8 @@ class S3FileUploaderTest extends KernelTestCase
 
         $this->fileNameFixer->addMissingFileExtension($uploadedFile, $fileBody)->shouldBeCalled()->willReturn('good-jpeg.jpeg');
         $this->fileNameFixer->removeWhiteSpaceBeforeFileExtension('good-jpeg.jpeg')->shouldBeCalled()->willReturn('good-jpeg.jpeg');
+        $this->fileNameFixer->removeUnusualCharacters('good-jpeg.jpeg')->shouldBeCalled()->willReturn('good_jpeg.jpeg');
+
         $this->dateTimeProvider->getDateTime()->willReturn($now);
         $this->storage->store(Argument::cetera())->shouldBeCalled();
         $this->restClient->post(Argument::cetera())->shouldBeCalled();
@@ -87,7 +90,7 @@ class S3FileUploaderTest extends KernelTestCase
     }
 
     /** @test */
-    public function uploadSupportingFilesAndPersistDocuments_multiple_files()
+    public function uploadSupportingFilesAndPersistDocumentsMultipleFiles()
     {
         $jpeg = new UploadedFile(sprintf('%s/tests/phpunit/TestData/good-jpeg', $this->projectDir), 'good-jpeg');
         $png = new UploadedFile(sprintf('%s/tests/phpunit/TestData/good-png', $this->projectDir), 'good-png');
@@ -99,6 +102,7 @@ class S3FileUploaderTest extends KernelTestCase
 
         $this->fileNameFixer->addMissingFileExtension(Argument::cetera())->shouldBeCalledTimes(3)->willReturn('the-fixed-file-name');
         $this->fileNameFixer->removeWhiteSpaceBeforeFileExtension('the-fixed-file-name')->shouldBeCalledTimes(3)->willReturn('the-fixed-file-name');
+        $this->fileNameFixer->removeUnusualCharacters('the-fixed-file-name')->shouldBeCalledTimes(3)->willReturn('the_fixed_file_name');
 
         $this->dateTimeProvider->getDateTime()->willReturn($now);
         $this->storage->store(Argument::cetera())->shouldBeCalledTimes(3);
@@ -118,7 +122,7 @@ class S3FileUploaderTest extends KernelTestCase
     }
 
     /** @test */
-    public function removeFileFromS3_missing_storage_ref()
+    public function removeFileFromS3MissingStorageRef()
     {
         self::expectException(Exception::class);
 


### PR DESCRIPTION
## Purpose
An output of the IT health check identified a vulnerability with our file upload service, where users could potentially provide malicious filenames, that could be executed by our app. This PR will sanitise filenames to ensure this cannot happen.

Fixes DDPB-3880

## Approach
We were already manipulating some filenames as part of the S3 uploader, so we extended the functionality in this class to remove and replace suspicious characters.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes
