### PR TITLE
DDPB-4205: Fix API PHPUnit deprecations

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -25,6 +25,7 @@
     "jms/serializer-bundle": "^4.0.1",
     "league/csv": "^9.5",
     "monolog/monolog": "^1.25.1",
+    "phpspec/prophecy-phpunit": "^2.0",
     "predis/predis": "^1.1.1",
     "ramsey/uuid": "^4.2",
     "ramsey/uuid-doctrine": "^1.6",

--- a/api/composer.json
+++ b/api/composer.json
@@ -47,7 +47,7 @@
     "acsauk/mink-extension": "^2.5.2",
     "friends-of-behat/symfony-extension": "^2.2",
     "fakerphp/faker": "^1.16",
-    "liuggio/fastest": "^1.8",
+    "liuggio/fastest": "^1.9",
     "mockery/mockery": "^1.0.0",
     "phpstan/phpstan": "^1.0.0",
     "phpstan/phpstan-mockery": "^1.0.0",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "842bec106f6f7e968e2bb5c4668428e5",
+    "content-hash": "404bca0f6e49ebe41c35c2cfcf07e9da",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -8102,29 +8102,29 @@
         },
         {
             "name": "liuggio/fastest",
-            "version": "v1.8.0",
+            "version": "v1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liuggio/fastest.git",
-                "reference": "2f8fb336aa75fa2e475594e5ec256f8efd34a075"
+                "reference": "ea33a99058a43ffa9a4c9e2787defa85fe513b0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liuggio/fastest/zipball/2f8fb336aa75fa2e475594e5ec256f8efd34a075",
-                "reference": "2f8fb336aa75fa2e475594e5ec256f8efd34a075",
+                "url": "https://api.github.com/repos/liuggio/fastest/zipball/ea33a99058a43ffa9a4c9e2787defa85fe513b0b",
+                "reference": "ea33a99058a43ffa9a4c9e2787defa85fe513b0b",
                 "shasum": ""
             },
             "require": {
                 "doctrine/collections": "^1.2",
                 "php": "^7.3 || ^8.0",
-                "symfony/console": "^3.4|^4.4|^5.0",
-                "symfony/process": "^3.4|^4.4|^5.0",
-                "symfony/stopwatch": "^3.4|^4.4|^5.0"
+                "symfony/console": "^4.4|^5.0",
+                "symfony/process": "^4.4.35|^5.0",
+                "symfony/stopwatch": "^4.4|^5.0"
             },
             "require-dev": {
                 "behat/behat": "^3.6",
-                "phpstan/phpstan": "^0.12.78",
-                "phpstan/phpstan-phpunit": "^0.12.17"
+                "phpstan/phpstan": "^0.12.99",
+                "phpstan/phpstan-phpunit": "^0.12.22"
             },
             "suggest": {
                 "behat/behat": "Install it if you want to run tests with the provided Behat extension"
@@ -8135,7 +8135,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8-dev"
+                    "dev-master": "1.9-dev"
                 }
             },
             "autoload": {
@@ -8159,9 +8159,9 @@
             "description": "Simple parallel testing execution... with some goodies for functional tests.",
             "support": {
                 "issues": "https://github.com/liuggio/fastest/issues",
-                "source": "https://github.com/liuggio/fastest/tree/v1.8.0"
+                "source": "https://github.com/liuggio/fastest/tree/v1.9.0"
             },
-            "time": "2021-02-25T12:59:08+00:00"
+            "time": "2021-12-17T07:56:59+00:00"
         },
         {
             "name": "mockery/mockery",

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e866b25f0d3c7ad9ba7e9aaa7c6e2742",
+    "content-hash": "842bec106f6f7e968e2bb5c4668428e5",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -2784,6 +2784,510 @@
             "time": "2021-06-14T00:11:39+00:00"
         },
         {
+            "name": "myclabs/deep-copy",
+            "version": "1.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T09:40:50+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.13.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
+            },
+            "time": "2021-11-30T19:35:32+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+            },
+            "time": "2021-07-20T11:28:43+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.1.0"
+            },
+            "time": "2021-02-23T14:00:09+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.3",
+                "webmozart/assert": "^1.9.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.2",
+                "psalm/phar": "^4.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
+            },
+            "time": "2021-10-19T17:43:47+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/a12f7e301eb7258bb68acd89d4aefa05c2906cae",
+                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "psalm/phar": "^4.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.5.1"
+            },
+            "time": "2021-10-02T14:08:47+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.2",
+                "php": "^7.2 || ~8.0, <8.2",
+                "phpdocumentor/reflection-docblock": "^5.2",
+                "sebastian/comparator": "^3.0 || ^4.0",
+                "sebastian/recursion-context": "^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^6.0 || ^7.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy/issues",
+                "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
+            },
+            "time": "2021-09-10T09:02:12+00:00"
+        },
+        {
+            "name": "phpspec/prophecy-phpunit",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy-phpunit.git",
+                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy-phpunit/zipball/2d7a9df55f257d2cba9b1d0c0963a54960657177",
+                "reference": "2d7a9df55f257d2cba9b1d0c0963a54960657177",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8",
+                "phpspec/prophecy": "^1.3",
+                "phpunit/phpunit": "^9.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\PhpUnit\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christophe Coevoet",
+                    "email": "stof@notk.org"
+                }
+            ],
+            "description": "Integrating the Prophecy mocking library in PHPUnit test cases",
+            "homepage": "http://phpspec.net",
+            "keywords": [
+                "phpunit",
+                "prophecy"
+            ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy-phpunit/issues",
+                "source": "https://github.com/phpspec/prophecy-phpunit/tree/v2.0.1"
+            },
+            "time": "2020-07-09T08:33:42+00:00"
+        },
+        {
             "name": "phpstan/phpdoc-parser",
             "version": "1.2.0",
             "source": {
@@ -2831,6 +3335,427 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/1.2.0"
             },
             "time": "2021-09-16T20:46:02+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d5850aaf931743067f4bfc1ae4cbd06468400687",
+                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.13.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.3",
+                "phpunit/php-text-template": "^2.0.2",
+                "sebastian/code-unit-reverse-lookup": "^2.0.2",
+                "sebastian/complexity": "^2.0",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/lines-of-code": "^1.0.3",
+                "sebastian/version": "^3.0.1",
+                "theseer/tokenizer": "^1.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcov": "*",
+                "ext-xdebug": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-05T09:12:13+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.5.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
+                "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.3.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.1",
+                "phar-io/manifest": "^2.0.3",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.3",
+                "phpspec/prophecy": "^1.12.1",
+                "phpunit/php-code-coverage": "^9.2.7",
+                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.3",
+                "phpunit/php-timer": "^5.0.2",
+                "sebastian/cli-parser": "^1.0.1",
+                "sebastian/code-unit": "^1.0.6",
+                "sebastian/comparator": "^4.0.5",
+                "sebastian/diff": "^4.0.3",
+                "sebastian/environment": "^5.1.3",
+                "sebastian/exporter": "^4.0.3",
+                "sebastian/global-state": "^5.0.1",
+                "sebastian/object-enumerator": "^4.0.3",
+                "sebastian/resource-operations": "^3.0.3",
+                "sebastian/type": "^2.3.4",
+                "sebastian/version": "^3.0.2"
+            },
+            "require-dev": {
+                "ext-pdo": "*",
+                "phpspec/prophecy-phpunit": "^2.0.1"
+            },
+            "suggest": {
+                "ext-soap": "*",
+                "ext-xdebug": "*"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.5-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ],
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.10"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/donate.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-09-25T07:38:51+00:00"
         },
         {
             "name": "predis/predis",
@@ -3438,6 +4363,970 @@
                 }
             ],
             "time": "2021-11-08T03:04:18+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:08:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55f4261989e546dc112258c7a75935a81a7ce382",
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:49:45+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.7",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:52:27+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:10:38+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "388b6ced16caa751030f6a69e588299fa09200ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/388b6ced16caa751030f6a69e588299fa09200ac",
+                "reference": "388b6ced16caa751030f6a69e588299fa09200ac",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:52:38+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-11-11T14:18:36+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-06-11T13:31:12+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.6",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-28T06:42:11+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:17:30+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:45:17+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "2.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-06-15T12:49:02+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
         },
         {
             "name": "sensio/framework-extra-bundle",
@@ -4908,6 +6797,56 @@
             "time": "2021-11-24T08:40:37+00:00"
         },
         {
+            "name": "theseer/tokenizer",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-28T10:34:58+00:00"
+        },
+        {
             "name": "twig/twig",
             "version": "v3.3.4",
             "source": {
@@ -4982,6 +6921,64 @@
                 }
             ],
             "time": "2021-11-25T13:46:55+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.13"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
+            },
+            "time": "2021-03-09T10:59:23+00:00"
         }
     ],
     "packages-dev": [
@@ -6239,458 +8236,6 @@
             "time": "2021-09-13T15:28:59+00:00"
         },
         {
-            "name": "myclabs/deep-copy",
-            "version": "1.10.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
-            },
-            "require-dev": {
-                "doctrine/collections": "^1.0",
-                "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^7.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
-                "files": [
-                    "src/DeepCopy/deep_copy.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Create deep copies (clones) of your objects",
-            "keywords": [
-                "clone",
-                "copy",
-                "duplicate",
-                "object",
-                "object graph"
-            ],
-            "support": {
-                "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
-            },
-            "funding": [
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-11-13T09:40:50+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "v4.13.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
-                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.0"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
-            },
-            "time": "2021-11-30T19:35:32+00:00"
-        },
-        {
-            "name": "phar-io/manifest",
-            "version": "2.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/manifest.git",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-phar": "*",
-                "ext-xmlwriter": "*",
-                "phar-io/version": "^3.0.1",
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "support": {
-                "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
-            },
-            "time": "2021-07-20T11:28:43+00:00"
-        },
-        {
-            "name": "phar-io/version",
-            "version": "3.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/version.git",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
-                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Library for handling version information and constraints",
-            "support": {
-                "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.1.0"
-            },
-            "time": "2021-02-23T14:00:09+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-common",
-            "version": "2.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-2.x": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
-            },
-            "time": "2020-06-27T09:03:43+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "5.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
-                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
-                "shasum": ""
-            },
-            "require": {
-                "ext-filter": "*",
-                "php": "^7.2 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^1.3",
-                "webmozart/assert": "^1.9.1"
-            },
-            "require-dev": {
-                "mockery/mockery": "~1.3.2",
-                "psalm/phar": "^4.8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                },
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "account@ijaap.nl"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
-            },
-            "time": "2021-10-19T17:43:47+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "1.5.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/a12f7e301eb7258bb68acd89d4aefa05c2906cae",
-                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0",
-                "phpdocumentor/reflection-common": "^2.0"
-            },
-            "require-dev": {
-                "ext-tokenizer": "*",
-                "psalm/phar": "^4.8"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-            "support": {
-                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.5.1"
-            },
-            "time": "2021-10-02T14:08:47+00:00"
-        },
-        {
-            "name": "phpspec/prophecy",
-            "version": "1.14.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
-                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.2",
-                "phpdocumentor/reflection-docblock": "^5.2",
-                "sebastian/comparator": "^3.0 || ^4.0",
-                "sebastian/recursion-context": "^3.0 || ^4.0"
-            },
-            "require-dev": {
-                "phpspec/phpspec": "^6.0 || ^7.0",
-                "phpunit/phpunit": "^8.0 || ^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Prophecy\\": "src/Prophecy"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
-                },
-                {
-                    "name": "Marcello Duarte",
-                    "email": "marcello.duarte@gmail.com"
-                }
-            ],
-            "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "https://github.com/phpspec/prophecy",
-            "keywords": [
-                "Double",
-                "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
-            ],
-            "support": {
-                "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
-            },
-            "time": "2021-09-10T09:02:12+00:00"
-        },
-        {
             "name": "phpstan/phpstan",
             "version": "1.2.0",
             "source": {
@@ -6863,324 +8408,6 @@
             "time": "2021-10-14T08:03:54+00:00"
         },
         {
-            "name": "phpunit/php-code-coverage",
-            "version": "9.2.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d5850aaf931743067f4bfc1ae4cbd06468400687",
-                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-libxml": "*",
-                "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.13.0",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
-                "theseer/tokenizer": "^1.2.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-pcov": "*",
-                "ext-xdebug": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "9.2-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
-            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
-            "keywords": [
-                "coverage",
-                "testing",
-                "xunit"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.10"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2021-12-05T09:12:13+00:00"
-        },
-        {
-            "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
-            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
-            "keywords": [
-                "filesystem",
-                "iterator"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2021-12-02T12:48:52+00:00"
-        },
-        {
-            "name": "phpunit/php-invoker",
-            "version": "3.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-pcntl": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Invoke callables with a timeout",
-            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
-            "keywords": [
-                "process"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T05:58:55+00:00"
-        },
-        {
-            "name": "phpunit/php-text-template",
-            "version": "2.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Simple template engine.",
-            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
-            "keywords": [
-                "template"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T05:33:50+00:00"
-        },
-        {
-            "name": "phpunit/php-timer",
-            "version": "5.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Utility class for timing",
-            "homepage": "https://github.com/sebastianbergmann/php-timer/",
-            "keywords": [
-                "timer"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T13:16:10+00:00"
-        },
-        {
             "name": "phpunit/phpcov",
             "version": "8.2.0",
             "source": {
@@ -7241,1073 +8468,6 @@
                 }
             ],
             "time": "2020-10-02T03:40:10+00:00"
-        },
-        {
-            "name": "phpunit/phpunit",
-            "version": "9.5.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
-                "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.3.1",
-                "ext-dom": "*",
-                "ext-json": "*",
-                "ext-libxml": "*",
-                "ext-mbstring": "*",
-                "ext-xml": "*",
-                "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
-                "php": ">=7.3",
-                "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2.7",
-                "phpunit/php-file-iterator": "^3.0.5",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.5",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.3",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^2.3.4",
-                "sebastian/version": "^3.0.2"
-            },
-            "require-dev": {
-                "ext-pdo": "*",
-                "phpspec/prophecy-phpunit": "^2.0.1"
-            },
-            "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
-            },
-            "bin": [
-                "phpunit"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "9.5-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ],
-                "files": [
-                    "src/Framework/Assert/Functions.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "The PHP Unit Testing framework.",
-            "homepage": "https://phpunit.de/",
-            "keywords": [
-                "phpunit",
-                "testing",
-                "xunit"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.10"
-            },
-            "funding": [
-                {
-                    "url": "https://phpunit.de/donate.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2021-09-25T07:38:51+00:00"
-        },
-        {
-            "name": "sebastian/cli-parser",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library for parsing CLI options",
-            "homepage": "https://github.com/sebastianbergmann/cli-parser",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T06:08:49+00:00"
-        },
-        {
-            "name": "sebastian/code-unit",
-            "version": "1.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Collection of value objects that represent the PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/code-unit",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T13:08:54+00:00"
-        },
-        {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T05:30:19+00:00"
-        },
-        {
-            "name": "sebastian/comparator",
-            "version": "4.0.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "55f4261989e546dc112258c7a75935a81a7ce382"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55f4261989e546dc112258c7a75935a81a7ce382",
-                "reference": "55f4261989e546dc112258c7a75935a81a7ce382",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Volker Dusch",
-                    "email": "github@wallbash.com"
-                },
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                }
-            ],
-            "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "https://github.com/sebastianbergmann/comparator",
-            "keywords": [
-                "comparator",
-                "compare",
-                "equality"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.6"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T15:49:45+00:00"
-        },
-        {
-            "name": "sebastian/complexity",
-            "version": "2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^4.7",
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library for calculating the complexity of PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/complexity",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T15:52:27+00:00"
-        },
-        {
-            "name": "sebastian/diff",
-            "version": "4.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "symfony/process": "^4.2 || ^5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                }
-            ],
-            "description": "Diff implementation",
-            "homepage": "https://github.com/sebastianbergmann/diff",
-            "keywords": [
-                "diff",
-                "udiff",
-                "unidiff",
-                "unified diff"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T13:10:38+00:00"
-        },
-        {
-            "name": "sebastian/environment",
-            "version": "5.1.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "388b6ced16caa751030f6a69e588299fa09200ac"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/388b6ced16caa751030f6a69e588299fa09200ac",
-                "reference": "388b6ced16caa751030f6a69e588299fa09200ac",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-posix": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
-            "keywords": [
-                "Xdebug",
-                "environment",
-                "hhvm"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T05:52:38+00:00"
-        },
-        {
-            "name": "sebastian/exporter",
-            "version": "4.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
-                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
-            },
-            "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Volker Dusch",
-                    "email": "github@wallbash.com"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                },
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "https://www.github.com/sebastianbergmann/exporter",
-            "keywords": [
-                "export",
-                "exporter"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2021-11-11T14:18:36+00:00"
-        },
-        {
-            "name": "sebastian/global-state",
-            "version": "5.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
-                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
-            },
-            "require-dev": {
-                "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
-            "keywords": [
-                "global state"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2021-06-11T13:31:12+00:00"
-        },
-        {
-            "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^4.6",
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library for counting the lines of code in PHP source code",
-            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-11-28T06:42:11+00:00"
-        },
-        {
-            "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
-            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T13:12:34+00:00"
-        },
-        {
-            "name": "sebastian/object-reflector",
-            "version": "2.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Allows reflection of object attributes, including inherited and non-public ones",
-            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T13:14:26+00:00"
-        },
-        {
-            "name": "sebastian/recursion-context",
-            "version": "4.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                }
-            ],
-            "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T13:17:30+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T06:45:17+00:00"
-        },
-        {
-            "name": "sebastian/type",
-            "version": "2.3.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
-                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.3-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Collection of value objects that represent the types of the PHP type system",
-            "homepage": "https://github.com/sebastianbergmann/type",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2021-06-15T12:49:02+00:00"
-        },
-        {
-            "name": "sebastian/version",
-            "version": "3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
-            "homepage": "https://github.com/sebastianbergmann/version",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T06:39:44+00:00"
         },
         {
             "name": "symfony/maker-bundle",
@@ -8479,114 +8639,6 @@
                 }
             ],
             "time": "2021-11-29T15:30:56+00:00"
-        },
-        {
-            "name": "theseer/tokenizer",
-            "version": "1.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "support": {
-                "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/theseer",
-                    "type": "github"
-                }
-            ],
-            "time": "2021-07-28T10:34:58+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.10.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
-                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<4.6.1 || 4.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.13"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
-            },
-            "time": "2021-03-09T10:59:23+00:00"
         }
     ],
     "aliases": [],

--- a/api/config/packages/test/framework.yml
+++ b/api/config/packages/test/framework.yml
@@ -1,4 +1,6 @@
 framework:
+    session:
+        handler_id: null
     test: ~
     profiler:
         collect: false

--- a/api/scripts/apiunittest.sh
+++ b/api/scripts/apiunittest.sh
@@ -30,16 +30,16 @@ export PGUSER=${DATABASE_USERNAME:=api}
 
 # Run each folder of unit tests individually. If we were to run them all
 # individually it would cause a memory leak.
-#php vendor/bin/phpunit -c tests/Unit tests/Unit/Command/ --coverage-php tests/coverage/Command.cov
-#php vendor/bin/phpunit -c tests/Unit tests/Unit/Controller/ --coverage-php tests/coverage/Controller.cov
-#php vendor/bin/phpunit -c tests/Unit tests/Unit/ControllerReport/ --coverage-php tests/coverage/ControllerReport.cov
-#php vendor/bin/phpunit -c tests/Unit tests/Unit/Controller-Ndr/ --coverage-php tests/coverage/Controller-Ndr.cov
-#php vendor/bin/phpunit -c tests/Unit tests/Unit/Entity/ --coverage-php tests/coverage/Entity.cov
-#php vendor/bin/phpunit -c tests/Unit tests/Unit/Factory/ --coverage-php tests/coverage/Factory.cov
-#php vendor/bin/phpunit -c tests/Unit tests/Unit/Security/ --coverage-php tests/coverage/Security.cov
-#php vendor/bin/phpunit -c tests/Unit tests/Unit/Service/ --coverage-php tests/coverage/Service.cov
-#php vendor/bin/phpunit -c tests/Unit tests/Unit/Stats/ --coverage-php tests/coverage/Stats.cov
-#php vendor/bin/phpunit -c tests/Unit tests/Unit/Transformer/ --coverage-php tests/coverage/Transformer.cov
+php vendor/bin/phpunit -c tests/Unit tests/Unit/Command/ --coverage-php tests/coverage/Command.cov
+php vendor/bin/phpunit -c tests/Unit tests/Unit/Controller/ --coverage-php tests/coverage/Controller.cov
+php vendor/bin/phpunit -c tests/Unit tests/Unit/ControllerReport/ --coverage-php tests/coverage/ControllerReport.cov
+php vendor/bin/phpunit -c tests/Unit tests/Unit/Controller-Ndr/ --coverage-php tests/coverage/Controller-Ndr.cov
+php vendor/bin/phpunit -c tests/Unit tests/Unit/Entity/ --coverage-php tests/coverage/Entity.cov
+php vendor/bin/phpunit -c tests/Unit tests/Unit/Factory/ --coverage-php tests/coverage/Factory.cov
+php vendor/bin/phpunit -c tests/Unit tests/Unit/Security/ --coverage-php tests/coverage/Security.cov
+php vendor/bin/phpunit -c tests/Unit tests/Unit/Service/ --coverage-php tests/coverage/Service.cov
+php vendor/bin/phpunit -c tests/Unit tests/Unit/Stats/ --coverage-php tests/coverage/Stats.cov
+php vendor/bin/phpunit -c tests/Unit tests/Unit/Transformer/ --coverage-php tests/coverage/Transformer.cov
 php vendor/bin/phpunit -c tests/Unit tests/Unit/v2/ --coverage-php tests/coverage/v2.cov
 
 php vendor/phpunit/phpcov/phpcov merge --clover "./tests/coverage/api-unit-tests.xml" "./tests/coverage"

--- a/api/scripts/apiunittest.sh
+++ b/api/scripts/apiunittest.sh
@@ -30,16 +30,16 @@ export PGUSER=${DATABASE_USERNAME:=api}
 
 # Run each folder of unit tests individually. If we were to run them all
 # individually it would cause a memory leak.
-php vendor/bin/phpunit -c tests/Unit tests/Unit/Command/ --coverage-php tests/coverage/Command.cov
-php vendor/bin/phpunit -c tests/Unit tests/Unit/Controller/ --coverage-php tests/coverage/Controller.cov
-php vendor/bin/phpunit -c tests/Unit tests/Unit/ControllerReport/ --coverage-php tests/coverage/ControllerReport.cov
-php vendor/bin/phpunit -c tests/Unit tests/Unit/Controller-Ndr/ --coverage-php tests/coverage/Controller-Ndr.cov
-php vendor/bin/phpunit -c tests/Unit tests/Unit/Entity/ --coverage-php tests/coverage/Entity.cov
-php vendor/bin/phpunit -c tests/Unit tests/Unit/Factory/ --coverage-php tests/coverage/Factory.cov
-php vendor/bin/phpunit -c tests/Unit tests/Unit/Security/ --coverage-php tests/coverage/Security.cov
-php vendor/bin/phpunit -c tests/Unit tests/Unit/Service/ --coverage-php tests/coverage/Service.cov
-php vendor/bin/phpunit -c tests/Unit tests/Unit/Stats/ --coverage-php tests/coverage/Stats.cov
-php vendor/bin/phpunit -c tests/Unit tests/Unit/Transformer/ --coverage-php tests/coverage/Transformer.cov
+#php vendor/bin/phpunit -c tests/Unit tests/Unit/Command/ --coverage-php tests/coverage/Command.cov
+#php vendor/bin/phpunit -c tests/Unit tests/Unit/Controller/ --coverage-php tests/coverage/Controller.cov
+#php vendor/bin/phpunit -c tests/Unit tests/Unit/ControllerReport/ --coverage-php tests/coverage/ControllerReport.cov
+#php vendor/bin/phpunit -c tests/Unit tests/Unit/Controller-Ndr/ --coverage-php tests/coverage/Controller-Ndr.cov
+#php vendor/bin/phpunit -c tests/Unit tests/Unit/Entity/ --coverage-php tests/coverage/Entity.cov
+#php vendor/bin/phpunit -c tests/Unit tests/Unit/Factory/ --coverage-php tests/coverage/Factory.cov
+#php vendor/bin/phpunit -c tests/Unit tests/Unit/Security/ --coverage-php tests/coverage/Security.cov
+#php vendor/bin/phpunit -c tests/Unit tests/Unit/Service/ --coverage-php tests/coverage/Service.cov
+#php vendor/bin/phpunit -c tests/Unit tests/Unit/Stats/ --coverage-php tests/coverage/Stats.cov
+#php vendor/bin/phpunit -c tests/Unit tests/Unit/Transformer/ --coverage-php tests/coverage/Transformer.cov
 php vendor/bin/phpunit -c tests/Unit tests/Unit/v2/ --coverage-php tests/coverage/v2.cov
 
 php vendor/phpunit/phpcov/phpcov merge --clover "./tests/coverage/api-unit-tests.xml" "./tests/coverage"

--- a/api/src/Controller/UserResearchController.php
+++ b/api/src/Controller/UserResearchController.php
@@ -37,7 +37,7 @@ class UserResearchController extends RestController
 
     /**
      * @Route("/user-research", name="create_user_research", methods={"POST"})
-     * @Security("has_role('ROLE_DEPUTY') or has_role('ROLE_ORG')")
+     * @Security("is_granted('ROLE_DEPUTY') or is_granted('ROLE_ORG')")
      */
     public function create(Request $request)
     {

--- a/api/src/Controller/UserResearchController.php
+++ b/api/src/Controller/UserResearchController.php
@@ -44,7 +44,9 @@ class UserResearchController extends RestController
         try {
             $formData = json_decode($request->getContent(), true);
 
-            $formData['satisfaction'] = $this->satisfactionRepository->find($formData['satisfaction']);
+            $satisfactionId = $formData['satisfaction'] ?? null;
+            $formData['satisfaction'] = $satisfactionId ? $this->satisfactionRepository->find($satisfactionId) : null;
+
             $userResearchResponse = $this->factory->generateFromFormData($formData);
             $this->userResearchResponseRepository->create($userResearchResponse, $this->getUser());
 

--- a/api/src/Entity/CasRec.php
+++ b/api/src/Entity/CasRec.php
@@ -3,7 +3,10 @@
 namespace App\Entity;
 
 use App\Entity\Report\Report;
+use DateTime;
 use Doctrine\ORM\Mapping as ORM;
+use Exception;
+use InvalidArgumentException;
 use JMS\Serializer\Annotation as JMS;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -58,128 +61,6 @@ class CasRec
         [true, self::REALM_PROF, ['hw'], 'opg103', Report::PROF_COMBINED_LOW_ASSETS],
         [true, self::REALM_PROF, ['hw'], 'opg102', Report::PROF_COMBINED_HIGH_ASSETS],
     ];
-
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="id", type="integer", nullable=false)
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
-     * @ORM\SequenceGenerator(sequenceName="casrec_id_seq", allocationSize=1, initialValue=1)
-     */
-    private $id;
-
-    /**
-     * @var string
-     *
-     * @JMS\Type("string")
-     *
-     * @Assert\NotBlank()
-     *
-     * @ORM\Column(name="client_case_number", type="string", length=20, nullable=false)
-     */
-    private $caseNumber;
-
-    /**
-     * @var string
-     *
-     * @JMS\Type("string")
-     *
-     * @Assert\NotBlank()
-     *
-     * @ORM\Column(name="client_lastname", type="string", length=50, nullable=false)
-     */
-    private $clientLastname;
-
-    /**
-     * @var string
-     *
-     * @JMS\Type("string")
-     *
-     * @Assert\NotBlank()
-     *
-     * @ORM\Column(name="deputy_no", type="string", length=100, nullable=false)
-     */
-    private $deputyNo;
-
-    /**
-     * @var string
-     *
-     * @Assert\NotBlank()
-     *
-     * @ORM\Column(name="deputy_lastname", type="string", length=100, nullable=true)
-     *
-     * @JMS\Type("string")
-     */
-    private $deputySurname;
-
-    /**
-     * @var string
-     *
-     * @JMS\Type("string")
-     *
-     * @ORM\Column(name="deputy_postcode", type="string", length=10, nullable=true)
-     *
-     * @Assert\Length(min=2, max=10, minMessage="postcode too short", maxMessage="postcode too long" )
-     */
-    private $deputyPostCode;
-
-    /**
-     * @var string OPG102|OPG103|empty string
-     *
-     * @JMS\Type("string")
-     *
-     * @ORM\Column(name="type_of_report", type="string", length=10, nullable=true)
-     */
-    private $typeOfReport;
-
-    /**
-     * @var string A2|C1|HW|L2|L2A|L3|L3G|P2A|PGA|PGC|S1A|S1N|empty
-     *
-     * typeOfReport=OPG103 only have
-     *
-     * @JMS\Type("string")
-     *
-     * @ORM\Column(name="corref", type="string", length=10, nullable=true)
-     */
-    private $corref;
-
-    /**
-     * @JMS\Type("string")
-     *
-     * @ORM\Column(name="other_columns", type="text", nullable=true)
-     */
-    private $otherColumns;
-
-    /**
-     * @var \DateTime
-     * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
-     *
-     * @ORM\Column(name="uploaded_at", type="datetime", nullable=true)
-     */
-    private $createdAt;
-
-    /**
-     * @var \DateTime
-     * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
-     *
-     * @ORM\Column(name="updated_at", type="datetime", nullable=true)
-     */
-    private $updatedAt;
-
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="source", type="string", nullable=true, options={"default" : "casrec"})
-     */
-    private $source;
-
-    /**
-     * @var \DateTime
-     * @ORM\Column(name="order_date", type="datetime", nullable=true)
-     */
-    private $orderDate;
-
     /**
      * Filled from cron.
      *
@@ -197,6 +78,114 @@ class CasRec
         'ú' => 'u', 'ü' => 'u', 'û' => 'u', 'ý' => 'y', 'ý' => 'y', 'þ' => 'b', 'ÿ' => 'y', 'ƒ' => 'f',
         'ă' => 'a', 'î' => 'i', 'â' => 'a', 'ș' => 's', 'ț' => 't', 'Ă' => 'A', 'Î' => 'I', 'Â' => 'A', 'Ș' => 'S', 'Ț' => 'T',
     ];
+    /**
+     * @var int
+     *
+     * @ORM\Column(name="id", type="integer", nullable=false)
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     * @ORM\SequenceGenerator(sequenceName="casrec_id_seq", allocationSize=1, initialValue=1)
+     */
+    private $id;
+    /**
+     * @var string
+     *
+     * @JMS\Type("string")
+     *
+     * @Assert\NotBlank()
+     *
+     * @ORM\Column(name="client_case_number", type="string", length=20, nullable=false)
+     */
+    private $caseNumber;
+    /**
+     * @var string
+     *
+     * @JMS\Type("string")
+     *
+     * @Assert\NotBlank()
+     *
+     * @ORM\Column(name="client_lastname", type="string", length=50, nullable=false)
+     */
+    private $clientLastname;
+    /**
+     * @var string
+     *
+     * @JMS\Type("string")
+     *
+     * @Assert\NotBlank()
+     *
+     * @ORM\Column(name="deputy_no", type="string", length=100, nullable=false)
+     */
+    private $deputyNo;
+    /**
+     * @var string
+     *
+     * @Assert\NotBlank()
+     *
+     * @ORM\Column(name="deputy_lastname", type="string", length=100, nullable=true)
+     *
+     * @JMS\Type("string")
+     */
+    private $deputySurname;
+    /**
+     * @var string
+     *
+     * @JMS\Type("string")
+     *
+     * @ORM\Column(name="deputy_postcode", type="string", length=10, nullable=true)
+     *
+     * @Assert\Length(min=2, max=10, minMessage="postcode too short", maxMessage="postcode too long" )
+     */
+    private $deputyPostCode;
+    /**
+     * @var string OPG102|OPG103|empty string
+     *
+     * @JMS\Type("string")
+     *
+     * @ORM\Column(name="type_of_report", type="string", length=10, nullable=true)
+     */
+    private $typeOfReport;
+    /**
+     * @var string A2|C1|HW|L2|L2A|L3|L3G|P2A|PGA|PGC|S1A|S1N|empty
+     *
+     * typeOfReport=OPG103 only have
+     *
+     * @JMS\Type("string")
+     *
+     * @ORM\Column(name="corref", type="string", length=10, nullable=true)
+     */
+    private $corref;
+    /**
+     * @JMS\Type("string")
+     *
+     * @ORM\Column(name="other_columns", type="text", nullable=true)
+     */
+    private $otherColumns;
+    /**
+     * @var DateTime
+     * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
+     *
+     * @ORM\Column(name="uploaded_at", type="datetime", nullable=true)
+     */
+    private $createdAt;
+    /**
+     * @var DateTime
+     * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
+     *
+     * @ORM\Column(name="updated_at", type="datetime", nullable=true)
+     */
+    private $updatedAt;
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="source", type="string", nullable=true, options={"default" : "casrec"})
+     */
+    private $source;
+    /**
+     * @var DateTime
+     * @ORM\Column(name="order_date", type="datetime", nullable=true)
+     */
+    private $orderDate;
 
     public function __construct(array $row)
     {
@@ -207,19 +196,24 @@ class CasRec
         $this->deputyPostCode = self::normaliseSurname($row['Dep Postcode']);
         $this->typeOfReport = self::normaliseCorrefAndTypeOfRep($row['Typeofrep']);
         $this->corref = self::normaliseCorrefAndTypeOfRep($row['Corref']);
-        $this->orderDate = $row['OrderDate'];
+        $this->orderDate = $row['OrderDate'] ?? null;
 
-        $source = isset($row['Source']) ? $row['Source'] : self::CASREC_SOURCE;
+        $source = $row['Source'] ?? self::CASREC_SOURCE;
         $this->setSource($source);
 
         $this->otherColumns = serialize($row);
-        $this->createdAt = new \DateTime();
+        $this->createdAt = new DateTime();
         $this->updatedAt = null;
     }
 
-    private static function normaliseCorrefAndTypeOfRep($value)
+    /** @deprecated use App\Service\DataNormaliser */
+    public static function normaliseCaseNumber($value)
     {
-        return trim(strtolower($value));
+        $value = trim($value);
+        $value = strtolower($value);
+        $value = preg_replace('#^([a-z0-9]+/)#i', '', $value);
+
+        return $value;
     }
 
     /** @deprecated use App\Service\DataNormaliser */
@@ -237,22 +231,17 @@ class CasRec
     }
 
     /** @deprecated use App\Service\DataNormaliser */
-    public static function normaliseCaseNumber($value)
-    {
-        $value = trim($value);
-        $value = strtolower($value);
-        $value = preg_replace('#^([a-z0-9]+/)#i', '', $value);
-
-        return $value;
-    }
-
-    /** @deprecated use App\Service\DataNormaliser */
     public static function normaliseDeputyNo($value)
     {
         $value = trim($value);
         $value = strtolower($value);
 
         return $value;
+    }
+
+    private static function normaliseCorrefAndTypeOfRep($value)
+    {
+        return trim(strtolower($value));
     }
 
     /** @deprecated use App\Service\DataNormaliser */
@@ -266,6 +255,56 @@ class CasRec
         $value = preg_replace('/([^a-z0-9])/i', '', $value);
 
         return $value;
+    }
+
+    /**
+     * Determine type of report based on 'Typeofrep' and 'Corref' columns in the Casrec CSV
+     * 103: when corref = l3/l3g and typeofRep = opg103
+     * 104: when corref == hw and typeofRep empty (104 CURRENTLY DISABLED)
+     * 103: all the other cases;.
+     *
+     * @param string $typeOfRep e.g. opg103
+     * @param string $corref    e.g. l3, l3g
+     * @param string $realm     e.g. REALM_PROF
+     *
+     * @return string Report::TYPE_*
+     */
+    public static function getTypeBasedOnTypeofRepAndCorref($typeOfRep, $corref, $realm)
+    {
+        $typeOfRep = trim(strtolower($typeOfRep));
+        $corref = trim(strtolower($corref));
+
+        // find report type
+        $reportType = null;
+        foreach (self::$csvToReportTypeMap as $row) {
+            list($enabled, $currentUserRole, $currentCorrefs, $currentTypeOfRep, $outputType) = $row;
+            if ($enabled && $realm === $currentUserRole && in_array($corref, $currentCorrefs) && $typeOfRep === $currentTypeOfRep) {
+                return $outputType;
+            }
+        }
+
+        // default report type if no entry mached above
+        switch ($realm) {
+            case self::REALM_LAY:
+                return Report::LAY_PFA_HIGH_ASSETS_TYPE;
+            case self::REALM_PA:
+                return Report::PA_PFA_HIGH_ASSETS_TYPE;
+            case self::REALM_PROF:
+                return Report::PROF_PFA_HIGH_ASSETS_TYPE;
+        }
+
+        throw new Exception(__METHOD__.': realm not recognised to determine report type');
+    }
+
+    /**
+     * @return array
+     */
+    public static function validSources()
+    {
+        return [
+            self::CASREC_SOURCE,
+            self::SIRIUS_SOURCE,
+        ];
     }
 
     public function getCaseNumber()
@@ -310,45 +349,6 @@ class CasRec
     }
 
     /**
-     * Determine type of report based on 'Typeofrep' and 'Corref' columns in the Casrec CSV
-     * 103: when corref = l3/l3g and typeofRep = opg103
-     * 104: when corref == hw and typeofRep empty (104 CURRENTLY DISABLED)
-     * 103: all the other cases;.
-     *
-     * @param string $typeOfRep e.g. opg103
-     * @param string $corref    e.g. l3, l3g
-     * @param string $realm     e.g. REALM_PROF
-     *
-     * @return string Report::TYPE_*
-     */
-    public static function getTypeBasedOnTypeofRepAndCorref($typeOfRep, $corref, $realm)
-    {
-        $typeOfRep = trim(strtolower($typeOfRep));
-        $corref = trim(strtolower($corref));
-
-        // find report type
-        $reportType = null;
-        foreach (self::$csvToReportTypeMap as $row) {
-            list($enabled, $currentUserRole, $currentCorrefs, $currentTypeOfRep, $outputType) = $row;
-            if ($enabled && $realm === $currentUserRole && in_array($corref, $currentCorrefs) && $typeOfRep === $currentTypeOfRep) {
-                return $outputType;
-            }
-        }
-
-        // default report type if no entry mached above
-        switch ($realm) {
-            case self::REALM_LAY:
-                return Report::LAY_PFA_HIGH_ASSETS_TYPE;
-            case self::REALM_PA:
-                return Report::PA_PFA_HIGH_ASSETS_TYPE;
-            case self::REALM_PROF:
-                return Report::PROF_PFA_HIGH_ASSETS_TYPE;
-        }
-
-        throw new \Exception(__METHOD__.': realm not recognised to determine report type');
-    }
-
-    /**
      * @return array
      */
     public function getOtherColumns()
@@ -369,7 +369,15 @@ class CasRec
     }
 
     /**
-     * @param \DateTime $updatedAt
+     * @return DateTime|null
+     */
+    public function getUpdatedAt()
+    {
+        return $this->updatedAt;
+    }
+
+    /**
+     * @param DateTime $updatedAt
      *
      * @return CasRec
      */
@@ -378,14 +386,6 @@ class CasRec
         $this->updatedAt = $updatedAt;
 
         return $this;
-    }
-
-    /**
-     * @return \DateTime|null
-     */
-    public function getUpdatedAt()
-    {
-        return $this->updatedAt;
     }
 
     /**
@@ -405,7 +405,7 @@ class CasRec
     {
         $source = strtolower($source);
         if (!in_array($source, self::validSources())) {
-            throw new \InvalidArgumentException(sprintf('Attempting to set invalid source: %s given', $source));
+            throw new InvalidArgumentException(sprintf('Attempting to set invalid source: %s given', $source));
         }
 
         $this->source = $source;
@@ -414,18 +414,7 @@ class CasRec
     }
 
     /**
-     * @return array
-     */
-    public static function validSources()
-    {
-        return [
-            self::CASREC_SOURCE,
-            self::SIRIUS_SOURCE,
-        ];
-    }
-
-    /**
-     * @return \DateTime
+     * @return DateTime
      */
     public function getOrderDate()
     {
@@ -435,7 +424,7 @@ class CasRec
     /**
      * @return CasRec
      */
-    public function setOrderDate(\DateTime $orderDate)
+    public function setOrderDate(DateTime $orderDate)
     {
         $this->orderDate = $orderDate;
 

--- a/api/src/Entity/CasRec.php
+++ b/api/src/Entity/CasRec.php
@@ -189,13 +189,13 @@ class CasRec
 
     public function __construct(array $row)
     {
-        $this->caseNumber = self::normaliseCaseNumber($row['Case']);
-        $this->clientLastname = self::normaliseSurname($row['Surname']);
-        $this->deputyNo = self::normaliseDeputyNo($row['Deputy No']);
-        $this->deputySurname = self::normaliseSurname($row['Dep Surname']);
-        $this->deputyPostCode = self::normaliseSurname($row['Dep Postcode']);
-        $this->typeOfReport = self::normaliseCorrefAndTypeOfRep($row['Typeofrep']);
-        $this->corref = self::normaliseCorrefAndTypeOfRep($row['Corref']);
+        $this->caseNumber = self::normaliseCaseNumber($row['Case'] ?? '');
+        $this->clientLastname = self::normaliseSurname($row['Surname'] ?? '');
+        $this->deputyNo = self::normaliseDeputyNo($row['Deputy No'] ?? '');
+        $this->deputySurname = self::normaliseSurname($row['Dep Surname'] ?? '');
+        $this->deputyPostCode = self::normaliseSurname($row['Dep Postcode'] ?? '');
+        $this->typeOfReport = self::normaliseCorrefAndTypeOfRep($row['Typeofrep'] ?? '');
+        $this->corref = self::normaliseCorrefAndTypeOfRep($row['Corref'] ?? '');
         $this->orderDate = $row['OrderDate'] ?? null;
 
         $source = $row['Source'] ?? self::CASREC_SOURCE;

--- a/api/src/FixtureFactory/ClientFactory.php
+++ b/api/src/FixtureFactory/ClientFactory.php
@@ -41,12 +41,12 @@ class ClientFactory
 
         $client = (new Client())
             ->setCaseNumber($faker->unique()->randomNumber(8))
-            ->setFirstname($faker->firstName)
-            ->setLastname($faker->lastName)
+            ->setFirstname($faker->firstName())
+            ->setLastname($faker->lastName())
             ->setPhone('0212112345')
             ->setAddress('1 Fake road')
-            ->setAddress2($faker->city)
-            ->setPostcode($faker->postcode)
+            ->setAddress2($faker->city())
+            ->setPostcode($faker->postcode())
             ->setCounty('West Midlands')
             ->setCountry('GB')
             ->setCourtDate($courtDate ? new DateTime($courtDate) : new DateTime());

--- a/api/src/FixtureFactory/UserFactory.php
+++ b/api/src/FixtureFactory/UserFactory.php
@@ -5,6 +5,8 @@ namespace App\FixtureFactory;
 use App\Entity\Client;
 use App\Entity\Organisation;
 use App\Entity\User;
+use DateTime;
+use Exception;
 use Faker\Factory;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 
@@ -19,7 +21,7 @@ class UserFactory
     }
 
     /**
-     * @throws \Exception
+     * @throws Exception
      */
     public function create(array $data): User
     {
@@ -36,7 +38,7 @@ class UserFactory
             ->setLastname(isset($data['lastName']) ? $data['lastName'] : 'User')
             ->setEmail(isset($data['email']) ? $data['email'] : 'behat-'.strtolower($data['deputyType']).'-deputy-'.$data['id'].'@publicguardian.gov.uk')
             ->setActive(true)
-            ->setRegistrationDate(new \DateTime())
+            ->setRegistrationDate(new DateTime())
             ->setNdrEnabled($ndrEnabled)
             ->setCoDeputyClientConfirmed(isset($data['codeputyEnabled']))
             ->setPhoneMain('07911111111111')
@@ -51,53 +53,6 @@ class UserFactory
         } else {
             $user->setActive(false);
         }
-
-        return $user;
-    }
-
-    /**
-     * @throws \Exception
-     */
-    public function createAdmin(array $data): User
-    {
-        $user = (new User())
-            ->setFirstname(isset($data['firstName']) ? $data['firstName'] : ucfirst($data['adminType']).' Admin '.$data['email'])
-            ->setLastname(isset($data['lastName']) ? $data['lastName'] : 'User')
-            ->setEmail($data['email'])
-            ->setRegistrationDate(new \DateTime())
-            ->setRoleName($data['adminType']);
-
-        if ('true' === $data['activated']) {
-            $user->setPassword($this->encoder->encodePassword($user, 'DigidepsPass1234'))->setActive(true);
-        }
-
-        return $user;
-    }
-
-    /**
-     * @return User|void
-     */
-    public function createGenericOrgUser(Organisation $organisation)
-    {
-        $faker = Factory::create();
-
-        $email = sprintf('%s.%s@%s', $faker->firstName, $faker->lastName, $organisation->getEmailIdentifier());
-        $trimmedEmail = substr($email, 0, 59);
-
-        $user = (new User())
-            ->setFirstname($faker->firstName)
-            ->setLastname($faker->lastName)
-            ->setEmail($trimmedEmail)
-            ->setActive(true)
-            ->setRegistrationDate(new \DateTime())
-            ->setNdrEnabled(false)
-            ->setPhoneMain('07911111111111')
-            ->setAddress1('Victoria Road')
-            ->setAddressPostcode('SW1')
-            ->setAddressCountry('GB')
-            ->setRoleName('ROLE_PROF_TEAM_MEMBER');
-
-        $user->setPassword($this->encoder->encodePassword($user, 'DigidepsPass1234'));
 
         return $user;
     }
@@ -124,6 +79,53 @@ class UserFactory
         }
     }
 
+    /**
+     * @throws Exception
+     */
+    public function createAdmin(array $data): User
+    {
+        $user = (new User())
+            ->setFirstname(isset($data['firstName']) ? $data['firstName'] : ucfirst($data['adminType']).' Admin '.$data['email'])
+            ->setLastname(isset($data['lastName']) ? $data['lastName'] : 'User')
+            ->setEmail($data['email'])
+            ->setRegistrationDate(new DateTime())
+            ->setRoleName($data['adminType']);
+
+        if ('true' === $data['activated']) {
+            $user->setPassword($this->encoder->encodePassword($user, 'DigidepsPass1234'))->setActive(true);
+        }
+
+        return $user;
+    }
+
+    /**
+     * @return User|void
+     */
+    public function createGenericOrgUser(Organisation $organisation)
+    {
+        $faker = Factory::create();
+
+        $email = sprintf('%s.%s@%s', $faker->firstName(), $faker->lastName(), $organisation->getEmailIdentifier());
+        $trimmedEmail = substr($email, 0, 59);
+
+        $user = (new User())
+            ->setFirstname($faker->firstName())
+            ->setLastname($faker->lastName())
+            ->setEmail($trimmedEmail)
+            ->setActive(true)
+            ->setRegistrationDate(new DateTime())
+            ->setNdrEnabled(false)
+            ->setPhoneMain('07911111111111')
+            ->setAddress1('Victoria Road')
+            ->setAddressPostcode('SW1')
+            ->setAddressCountry('GB')
+            ->setRoleName('ROLE_PROF_TEAM_MEMBER');
+
+        $user->setPassword($this->encoder->encodePassword($user, 'DigidepsPass1234'));
+
+        return $user;
+    }
+
     public function createCoDeputy(User $originalDeputy, Client $client, array $data)
     {
         $user2 = clone $originalDeputy;
@@ -137,7 +139,7 @@ class UserFactory
             )
             ->addClient($client)
             ->setActive($data['activated'])
-            ->setRegistrationDate(new \DateTime())
+            ->setRegistrationDate(new DateTime())
             ->setCoDeputyClientConfirmed(true)
             ->setActive(true);
 

--- a/api/src/TestHelpers/ClientTestHelper.php
+++ b/api/src/TestHelpers/ClientTestHelper.php
@@ -8,6 +8,7 @@ use App\Entity\Client;
 use App\Entity\Organisation;
 use App\Entity\Report\Report;
 use App\Entity\User;
+use DateTime;
 use Doctrine\ORM\EntityManager;
 use Faker\Factory;
 use PHPUnit\Framework\TestCase;
@@ -30,13 +31,13 @@ class ClientTestHelper extends TestCase
         $faker = Factory::create('en_GB');
 
         $client = (new Client())
-            ->setFirstname($faker->firstName)
-            ->setLastname($faker->lastName)
+            ->setFirstname($faker->firstName())
+            ->setLastname($faker->lastName())
             ->setCaseNumber($caseNumber ?: self::createValidCaseNumber())
-            ->setEmail($faker->safeEmail.mt_rand(1, 100000))
-            ->setCourtDate(new \DateTime('09-Aug-2018'))
-            ->setAddress($faker->streetAddress)
-            ->setPostcode($faker->postcode);
+            ->setEmail($faker->safeEmail().mt_rand(1, 100000))
+            ->setCourtDate(new DateTime('09-Aug-2018'))
+            ->setAddress($faker->streetAddress())
+            ->setPostcode($faker->postcode());
 
         if (!is_null($user) && User::ROLE_LAY_DEPUTY === $user->getRoleName()) {
             return $client->addUser($user ?: (new UserTestHelper())->createAndPersistUser($em));

--- a/api/src/TestHelpers/NamedDeputyTestHelper.php
+++ b/api/src/TestHelpers/NamedDeputyTestHelper.php
@@ -17,14 +17,14 @@ class NamedDeputyTestHelper
         $faker = Factory::create('en_GB');
 
         return (new NamedDeputy())
-            ->setFirstname($faker->firstName)
-            ->setLastname($faker->lastName)
-            ->setEmail1($email ?: $faker->safeEmail.rand(1, 100000))
-            ->setAddress1($faker->streetAddress)
+            ->setFirstname($faker->firstName())
+            ->setLastname($faker->lastName())
+            ->setEmail1($email ?: $faker->safeEmail().rand(1, 100000))
+            ->setAddress1($faker->streetAddress())
             ->setAddress2($faker->city())
             ->setAddress3($faker->county)
-            ->setAddressPostcode($faker->postcode)
+            ->setAddressPostcode($faker->postcode())
             ->setDeputyNo($deputyNumber ?: $faker->randomNumber(8))
-            ->setPhoneMain($faker->phoneNumber);
+            ->setPhoneMain($faker->phoneNumber());
     }
 }

--- a/api/src/TestHelpers/NamedDeputyTestHelper.php
+++ b/api/src/TestHelpers/NamedDeputyTestHelper.php
@@ -21,7 +21,7 @@ class NamedDeputyTestHelper
             ->setLastname($faker->lastName)
             ->setEmail1($email ?: $faker->safeEmail.rand(1, 100000))
             ->setAddress1($faker->streetAddress)
-            ->setAddress2($faker->city)
+            ->setAddress2($faker->city())
             ->setAddress3($faker->county)
             ->setAddressPostcode($faker->postcode)
             ->setDeputyNo($deputyNumber ?: $faker->randomNumber(8))

--- a/api/src/TestHelpers/UserTestHelper.php
+++ b/api/src/TestHelpers/UserTestHelper.php
@@ -28,31 +28,6 @@ class UserTestHelper extends TestCase
         return $user->reveal();
     }
 
-    public function createUser(?Client $client = null, ?string $roleName = User::ROLE_LAY_DEPUTY, ?string $email = null)
-    {
-        $faker = Factory::create('en_GB');
-
-        $user = (new User())
-            ->setFirstname($faker->firstName)
-            ->setLastname($faker->lastName)
-            ->setEmail($email ? $email : $faker->safeEmail)
-            ->setRoleName($roleName)
-            ->setPhoneMain($faker->phoneNumber)
-            ->setRegistrationDate(new DateTime())
-            ->setLastLoggedIn(new DateTime())
-            ->setActive(true)
-            ->setAddress1($faker->streetAddress)
-            ->setAddressCountry('GB')
-            ->setAddressPostcode($faker->postcode)
-            ->setAgreeTermsUse(true);
-
-        if (!is_null($client)) {
-            $user->addClient($client);
-        }
-
-        return $user;
-    }
-
     public function createAndPersistUser(EntityManager $em, ?Client $client = null, ?string $roleName = User::ROLE_LAY_DEPUTY, ?string $email = null)
     {
         $user = $this->createUser($client, $roleName, $email);
@@ -63,6 +38,31 @@ class UserTestHelper extends TestCase
 
         $em->persist($user);
         $em->flush();
+
+        return $user;
+    }
+
+    public function createUser(?Client $client = null, ?string $roleName = User::ROLE_LAY_DEPUTY, ?string $email = null)
+    {
+        $faker = Factory::create('en_GB');
+
+        $user = (new User())
+            ->setFirstname($faker->firstName())
+            ->setLastname($faker->lastName())
+            ->setEmail($email ?: $faker->safeEmail())
+            ->setRoleName($roleName)
+            ->setPhoneMain($faker->phoneNumber())
+            ->setRegistrationDate(new DateTime())
+            ->setLastLoggedIn(new DateTime())
+            ->setActive(true)
+            ->setAddress1($faker->streetAddress())
+            ->setAddressCountry('GB')
+            ->setAddressPostcode($faker->postcode())
+            ->setAgreeTermsUse(true);
+
+        if (!is_null($client)) {
+            $user->addClient($client);
+        }
 
         return $user;
     }

--- a/api/src/v2/Controller/ClientController.php
+++ b/api/src/v2/Controller/ClientController.php
@@ -89,7 +89,7 @@ class ClientController extends RestController
 
     /**
      * @Route("/case-number/{caseNumber}", methods={"GET"})
-     * @Security("is_granted('ROLE_ADMIN') or has_role('ROLE_AD') or has_role('ROLE_DEPUTY')")
+     * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD') or is_granted('ROLE_DEPUTY')")
      */
     public function getByCaseNumber(string $caseNumber): JsonResponse
     {

--- a/api/tests/Behat/bootstrap/v2/Reporting/Sections/ContactsSectionTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Reporting/Sections/ContactsSectionTrait.php
@@ -81,13 +81,13 @@ trait ContactsSectionTrait
      */
     public function iEnterValidContactDetails()
     {
-        $this->fillInField('contact_contactName', $this->faker->name, 'contactDetails');
+        $this->fillInField('contact_contactName', $this->faker->name(), 'contactDetails');
         $this->fillInField('contact_relationship', $this->faker->text(50), 'contactDetails');
         $this->fillInField('contact_explanation', $this->faker->text(200), 'contactDetails');
-        $this->fillInField('contact_address', $this->faker->streetName, 'contactDetails');
+        $this->fillInField('contact_address', $this->faker->streetName(), 'contactDetails');
         $this->fillInField('contact_address2', $this->faker->city(), 'contactDetails');
         $this->fillInField('contact_county', $this->faker->county, 'contactDetails');
-        $this->fillInField('contact_postcode', $this->faker->postcode, 'contactDetails');
+        $this->fillInField('contact_postcode', $this->faker->postcode(), 'contactDetails');
         $this->chooseOption('contact_country', 'United Kingdom', 'contactDetails');
 
         $this->pressButton('Save and continue');

--- a/api/tests/Behat/bootstrap/v2/Reporting/Sections/ContactsSectionTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Reporting/Sections/ContactsSectionTrait.php
@@ -11,6 +11,16 @@ trait ContactsSectionTrait
     private bool $hasContacts = false;
 
     /**
+     * @Given I view and start the contacts report section
+     */
+    public function iViewAndStartContactsSection()
+    {
+        $this->iViewContactsSection();
+
+        $this->clickLink('Start contacts');
+    }
+
+    /**
      * @Given I view the contacts report section
      */
     public function iViewContactsSection()
@@ -26,16 +36,6 @@ trait ContactsSectionTrait
         if (!$onSummaryPage) {
             throw new BehatException(sprintf('Not on contacts start page. Current URL is: %s', $currentUrl));
         }
-    }
-
-    /**
-     * @Given I view and start the contacts report section
-     */
-    public function iViewAndStartContactsSection()
-    {
-        $this->iViewContactsSection();
-
-        $this->clickLink('Start contacts');
     }
 
     /**
@@ -62,25 +62,6 @@ trait ContactsSectionTrait
     }
 
     /**
-     * @When I enter valid contact details
-     */
-    public function iEnterValidContactDetails()
-    {
-        $this->fillInField('contact_contactName', $this->faker->name, 'contactDetails');
-        $this->fillInField('contact_relationship', $this->faker->text(50), 'contactDetails');
-        $this->fillInField('contact_explanation', $this->faker->text(200), 'contactDetails');
-        $this->fillInField('contact_address', $this->faker->streetName, 'contactDetails');
-        $this->fillInField('contact_address2', $this->faker->city, 'contactDetails');
-        $this->fillInField('contact_county', $this->faker->county, 'contactDetails');
-        $this->fillInField('contact_postcode', $this->faker->postcode, 'contactDetails');
-        $this->chooseOption('contact_country', 'United Kingdom', 'contactDetails');
-
-        $this->pressButton('Save and continue');
-
-        $this->iAmOnContactsAddAnotherPage();
-    }
-
-    /**
      * @When I enter another contacts details
      */
     public function iEnterAnotherContactsDetails()
@@ -91,6 +72,25 @@ trait ContactsSectionTrait
         $this->iAmOnAddAContactPage();
 
         $this->iEnterValidContactDetails();
+
+        $this->iAmOnContactsAddAnotherPage();
+    }
+
+    /**
+     * @When I enter valid contact details
+     */
+    public function iEnterValidContactDetails()
+    {
+        $this->fillInField('contact_contactName', $this->faker->name, 'contactDetails');
+        $this->fillInField('contact_relationship', $this->faker->text(50), 'contactDetails');
+        $this->fillInField('contact_explanation', $this->faker->text(200), 'contactDetails');
+        $this->fillInField('contact_address', $this->faker->streetName, 'contactDetails');
+        $this->fillInField('contact_address2', $this->faker->city(), 'contactDetails');
+        $this->fillInField('contact_county', $this->faker->county, 'contactDetails');
+        $this->fillInField('contact_postcode', $this->faker->postcode, 'contactDetails');
+        $this->chooseOption('contact_country', 'United Kingdom', 'contactDetails');
+
+        $this->pressButton('Save and continue');
 
         $this->iAmOnContactsAddAnotherPage();
     }

--- a/api/tests/Unit/Controller-Ndr/AssetControllerTest.php
+++ b/api/tests/Unit/Controller-Ndr/AssetControllerTest.php
@@ -2,6 +2,8 @@
 
 namespace App\Tests\Unit\Controller\Ndr;
 
+use App\Entity\Ndr\AssetOther;
+use App\Entity\Ndr\AssetProperty;
 use App\Tests\Unit\Controller\AbstractTestController;
 
 class AssetControllerTest extends AbstractTestController
@@ -17,6 +19,16 @@ class AssetControllerTest extends AbstractTestController
     private static $asset2;
     private static $tokenAdmin = null;
     private static $tokenDeputy = null;
+
+    /**
+     * clear fixtures.
+     */
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+
+        self::fixtures()->clear();
+    }
 
     public function setUp(): void
     {
@@ -43,16 +55,6 @@ class AssetControllerTest extends AbstractTestController
         self::fixtures()->flush()->clear();
     }
 
-    /**
-     * clear fixtures.
-     */
-    public static function tearDownAfterClass(): void
-    {
-        parent::tearDownAfterClass();
-
-        self::fixtures()->clear();
-    }
-
     public function testgetAssetsAuth()
     {
         $url = '/ndr/'.self::$ndr1->getId().'/assets';
@@ -74,13 +76,13 @@ class AssetControllerTest extends AbstractTestController
 
         // assert get
         $data = $this->assertJsonRequest('GET', $url, [
-                'mustSucceed' => true,
-                'AuthToken' => self::$tokenDeputy,
-            ])['data'];
+            'mustSucceed' => true,
+            'AuthToken' => self::$tokenDeputy,
+        ])['data'];
 
         // order by id ASC (insert order)
         usort($data, function ($a, $b) {
-            return $a['id'] > $b['id'];
+            return $a['id'] > $b['id'] ? 1 : 0;
         });
 
         $this->assertCount(2, $data);
@@ -114,9 +116,9 @@ class AssetControllerTest extends AbstractTestController
 
         // assert get
         $data = $this->assertJsonRequest('GET', $url, [
-                'mustSucceed' => true,
-                'AuthToken' => self::$tokenDeputy,
-            ])['data'];
+            'mustSucceed' => true,
+            'AuthToken' => self::$tokenDeputy,
+        ])['data'];
 
         $this->assertEquals(self::$asset1->getId(), $data['id']);
         $this->assertEquals(self::$asset1->getTitle(), $data['title']);
@@ -155,7 +157,8 @@ class AssetControllerTest extends AbstractTestController
 
         self::fixtures()->clear();
 
-        $asset = self::fixtures()->getRepo('Ndr\Asset')->find($return['data']['id']); /* @var $asset \App\Entity\Ndr\AssetOther */
+        $asset = self::fixtures()->getRepo('Ndr\Asset')->find($return['data']['id']);
+        /* @var $asset AssetOther */
         $this->assertInstanceOf('App\Entity\Ndr\AssetOther', $asset);
         $this->assertEquals(123, $asset->getValue());
         $this->assertEquals('de', $asset->getDescription());
@@ -193,7 +196,8 @@ class AssetControllerTest extends AbstractTestController
 
         self::fixtures()->clear();
 
-        $asset = self::fixtures()->getRepo('Ndr\Asset')->find($return['data']['id']); /* @var $asset \App\Entity\Ndr\AssetProperty */
+        $asset = self::fixtures()->getRepo('Ndr\Asset')->find($return['data']['id']);
+        /* @var $asset AssetProperty */
 
         $this->assertInstanceOf('App\Entity\Ndr\AssetProperty', $asset);
         $this->assertEquals('me', $asset->getOccupants());

--- a/api/tests/Unit/Controller/AuthControllerTest.php
+++ b/api/tests/Unit/Controller/AuthControllerTest.php
@@ -5,19 +5,12 @@ namespace App\Tests\Unit\Controller;
 use App\Entity\User;
 use App\Service\BruteForce\AttemptsIncrementalWaitingChecker;
 use App\Service\BruteForce\AttemptsInTimeChecker;
-use Mockery as m;
 
 class AuthControllerTest extends AbstractTestController
 {
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
-    }
-
-    private function resetAttempts($key)
-    {
-        self::$container->get(AttemptsInTimeChecker::class)->resetAttempts($key);
-        self::$container->get(AttemptsIncrementalWaitingChecker::class)->resetAttempts($key);
     }
 
     /**
@@ -64,6 +57,12 @@ class AuthControllerTest extends AbstractTestController
         $this->assertJsonRequest('GET', '/auth/get-logged-user', [
             'mustFail' => true,
         ]);
+    }
+
+    private function resetAttempts($key)
+    {
+        self::$container->get(AttemptsInTimeChecker::class)->resetAttempts($key);
+        self::$container->get(AttemptsIncrementalWaitingChecker::class)->resetAttempts($key);
     }
 
     public function testLoginFailSecretPermissions()
@@ -116,9 +115,9 @@ class AuthControllerTest extends AbstractTestController
 
         // assert succeed with token
         $data = $this->assertJsonRequest('GET', '/auth/get-logged-user', [
-                'mustSucceed' => true,
-                'AuthToken' => $authToken,
-            ])['data'];
+            'mustSucceed' => true,
+            'AuthToken' => $authToken,
+        ])['data'];
 
         $this->assertEquals(User::ROLE_LAY_DEPUTY, $data['role_name']);
         $this->assertEquals('deputy@example.org', $data['email']);
@@ -153,16 +152,16 @@ class AuthControllerTest extends AbstractTestController
 
         // assert deputy can access
         $data = $this->assertJsonRequest('GET', '/auth/get-logged-user', [
-                'mustSucceed' => true,
-                'AuthToken' => $authTokenDeputy,
-            ])['data'];
+            'mustSucceed' => true,
+            'AuthToken' => $authTokenDeputy,
+        ])['data'];
         $this->assertEquals('deputy@example.org', $data['email']);
 
         // assert admin can access
         $data = $this->assertJsonRequest('GET', '/auth/get-logged-user', [
-                'mustSucceed' => true,
-                'AuthToken' => $authTokenAdmin,
-            ])['data'];
+            'mustSucceed' => true,
+            'AuthToken' => $authTokenAdmin,
+        ])['data'];
         $this->assertEquals('admin@example.org', $data['email']);
 
         //logout admin and test deputy can still acess
@@ -175,9 +174,9 @@ class AuthControllerTest extends AbstractTestController
             'AuthToken' => $authTokenAdmin,
         ]);
         $data = $this->assertJsonRequest('GET', '/auth/get-logged-user', [
-                'mustSucceed' => true,
-                'AuthToken' => $authTokenDeputy,
-            ])['data'];
+            'mustSucceed' => true,
+            'AuthToken' => $authTokenDeputy,
+        ])['data'];
         $this->assertEquals('deputy@example.org', $data['email']);
     }
 
@@ -202,12 +201,12 @@ class AuthControllerTest extends AbstractTestController
 
         // assert succeed with token
         $data = $this->assertJsonRequest('GET', '/auth/get-logged-user', [
-                'mustSucceed' => true,
-                'AuthToken' => $authToken,
-            ])['data'];
+            'mustSucceed' => true,
+            'AuthToken' => $authToken,
+        ])['data'];
 
         $this->assertEquals('deputy@example.org', $data['email']);
-        $this->assertNull($data['password'], 'No password is returned');
+        $this->assertFalse(isset($data['password']), 'A password was returned when it should not have been returned');
     }
 
     public function testBruteForceSameEmail()
@@ -272,14 +271,14 @@ class AuthControllerTest extends AbstractTestController
 
         // assert it's now locked, even if the password is correct
         $data = $this->assertJsonRequest('POST', '/auth/login', [
-                'mustFail' => true,
-                'data' => [
-                    'email' => 'deputy@example.org',
-                    'password' => 'DigidepsPass1234',
-                ],
-                'ClientSecret' => API_TOKEN_DEPUTY,
-                'assertCode' => 423,
-                'assertResponseCode' => 423,
+            'mustFail' => true,
+            'data' => [
+                'email' => 'deputy@example.org',
+                'password' => 'DigidepsPass1234',
+            ],
+            'ClientSecret' => API_TOKEN_DEPUTY,
+            'assertCode' => 423,
+            'assertResponseCode' => 423,
         ])['data'];
 
         $expectedTimeStamp = time() + 600;

--- a/api/tests/Unit/Entity/Repository/DocumentRepositoryTest.php
+++ b/api/tests/Unit/Entity/Repository/DocumentRepositoryTest.php
@@ -35,33 +35,6 @@ class DocumentRepositoryTest extends KernelTestCase
     private $thirdJulyAm;
     private $thirdJulyPm;
 
-    protected function setUp(): void
-    {
-        $kernel = self::bootKernel();
-
-        $this->entityManager = $kernel->getContainer()
-            ->get('doctrine')
-            ->getManager();
-
-        $this->documentRepository = $this->entityManager
-            ->getRepository(Document::class);
-
-        $this->purgeDatabase();
-
-        $this->firstJulyAm = DateTime::createFromFormat('d/m/Y', '01/07/2020', new DateTimeZone('UTC'));
-        $this->firstJulyPm = clone $this->firstJulyAm->add(new DateInterval('PT20H'));
-        $this->secondJulyAm = DateTime::createFromFormat('d/m/Y', '02/07/2020', new DateTimeZone('UTC'));
-        $this->secondJulyPm = clone $this->secondJulyAm->add(new DateInterval('PT20H'));
-        $this->thirdJulyAm = DateTime::createFromFormat('d/m/Y', '03/07/2020', new DateTimeZone('UTC'));
-        $this->thirdJulyPm = clone $this->thirdJulyAm->add(new DateInterval('PT20H'));
-    }
-
-    private function purgeDatabase()
-    {
-        $purger = new ORMPurger($this->entityManager);
-        $purger->purge();
-    }
-
     /**
      * @test
      */
@@ -81,6 +54,141 @@ class DocumentRepositoryTest extends KernelTestCase
         self::assertEquals(Document::SYNC_STATUS_IN_PROGRESS, $supportingDoc->getSynchronisationStatus());
     }
 
+    private function createAndSubmitReportWithSupportingDoc(DateTime $submittedOn)
+    {
+        $client = $this->generateAndPersistClient('abc-123');
+        $report = $this->generateAndPersistReport($client, false);
+        $reportPdfDoc = $this->generateAndPersistDocument($report, true, 'QUEUED', $this->firstJulyPm, false);
+        $supportingDoc = $this->generateAndPersistDocument($report, false, 'QUEUED', $this->firstJulyAm, false);
+
+        $reportSubmission = $this->submitReport($report, $submittedOn, $reportPdfDoc, $supportingDoc);
+
+        $this->entityManager->flush();
+
+        return [$client, $report, $reportPdfDoc, $supportingDoc, $reportSubmission];
+    }
+
+    private function generateAndPersistClient(string $caseNumber)
+    {
+        $client = (new Client())->setCaseNumber($caseNumber);
+
+        $this->entityManager->persist($client);
+
+        return $client;
+    }
+
+    private function generateAndPersistReport(Client $client, bool $isNdr)
+    {
+        if ($isNdr) {
+            $report = (new Ndr($client))->setStartDate($this->firstJulyAm);
+        } else {
+            $report = (new Report(
+                $client,
+                Report::TYPE_PROPERTY_AND_AFFAIRS_HIGH_ASSETS,
+                $this->firstJulyAm,
+                $this->firstJulyAm->add(new DateInterval('P364D'))
+            )
+            );
+        }
+
+        $this->entityManager->persist($report);
+
+        return $report;
+    }
+
+    private function generateAndPersistDocument(ReportInterface $report, bool $isReportPdf, string $syncStatus, DateTime $createdOn, bool $isResubmission)
+    {
+        $fileName = $isReportPdf ? 'report' : 'supporting-document';
+        $storageRef = $isReportPdf ? 'storage-ref-report' : 'storage-ref-supporting-document';
+
+        $fileName .= $isResubmission ? '-resubmission.pdf' : '.pdf';
+        $storageRef .= $isResubmission ? '-resubmission.pdf' : '.pdf';
+
+        $doc = (new Document($report))
+            ->setFileName($fileName)
+            ->setStorageReference($storageRef)
+            ->setIsReportPdf($isReportPdf)
+            ->setSynchronisationStatus($syncStatus)
+            ->setCreatedOn($createdOn);
+
+        $this->entityManager->persist($doc);
+
+        return $doc;
+    }
+
+    private function submitReport(ReportInterface $report, DateTime $submittedOn, Document $reportPdf, ?Document $supportingDocument)
+    {
+        $report->setSubmitDate($submittedOn);
+
+        $reportSubmission = $this->generateAndPersistReportSubmission($report, $submittedOn);
+        $reportSubmission->addDocument($reportPdf);
+
+        $reportPdf->setReportSubmission($reportSubmission);
+
+        if ($supportingDocument) {
+            $reportSubmission->addDocument($supportingDocument);
+            $supportingDocument->setReportSubmission($reportSubmission);
+
+            $this->entityManager->persist($supportingDocument);
+        }
+
+        $this->entityManager->persist($reportPdf);
+        $this->entityManager->persist($reportSubmission);
+
+        return $reportSubmission;
+    }
+
+    private function generateAndPersistReportSubmission(ReportInterface $report, DateTime $createdOn)
+    {
+        $submission = (new ReportSubmission($report, $this->generateAndPersistUser()))->setCreatedOn($createdOn);
+
+        $this->entityManager->persist($submission);
+
+        return $submission;
+    }
+
+    private function generateAndPersistUser()
+    {
+        $user = (new User())
+            ->setFirstname('Test')
+            ->setLastname('User')
+            ->setPassword('password123');
+
+        $datePostFix = (string) (new DateTime())->getTimestamp();
+        $user->setEmail(sprintf('test-user%s%s@test.com', $datePostFix, rand(0, 100000)));
+
+        $this->entityManager->persist($user);
+
+        return $user;
+    }
+
+    /**
+     * @param Report|Ndr $report
+     */
+    private function assertDataMatchesEntity(
+        array $documents,
+        Document $document,
+        Client $client,
+        ReportSubmission $submission,
+                         $report
+    ) {
+        $docId = $document->getId();
+
+        self::assertEquals($document->getId(), $documents[$docId]['document_id']);
+        self::assertEquals($submission->getId(), $documents[$docId]['report_submission_id']);
+        self::assertEquals($client->getCaseNumber(), $documents[$docId]['case_number']);
+        self::assertEquals($document->isReportPdf(), $documents[$docId]['is_report_pdf']);
+        self::assertEquals($document->getStorageReference(), $documents[$docId]['storage_reference']);
+        self::assertEquals($report->getStartDate()->format('Y-m-d'), $documents[$docId]['report_start_date']);
+        self::assertEquals($report->getSubmitDate()->format('Y-m-d H:i:s'), $documents[$docId]['report_submit_date']);
+        self::assertEquals($submission->getUuid(), $documents[$docId]['report_submission_uuid']);
+
+        if ($report instanceof Report) {
+            self::assertEquals($report->getEndDate()->format('Y-m-d'), $documents[$docId]['report_end_date']);
+            self::assertEquals($report->getType(), $documents[$docId]['report_type']);
+        }
+    }
+
     /**
      * @test
      */
@@ -92,6 +200,20 @@ class DocumentRepositoryTest extends KernelTestCase
         $documents = $this->documentRepository->getQueuedDocumentsAndSetToInProgress('100');
 
         self::assertEquals('abc-123-abc-123', $documents[$supportingDoc->getId()]['report_submission_uuid']);
+    }
+
+    private function syncDocuments(array $documents, ?ReportSubmission $submission, ?string $uuid)
+    {
+        if ($submission) {
+            $this->entityManager->persist($submission->setUuid($uuid));
+        }
+
+        foreach ($documents as $document) {
+            $document->setSynchronisationStatus('SUCCESS');
+            $this->entityManager->persist($document);
+        }
+
+        $this->entityManager->flush();
     }
 
     /**
@@ -108,6 +230,19 @@ class DocumentRepositoryTest extends KernelTestCase
         $this->entityManager->refresh($reportPdfDoc);
 
         self::assertEquals(Document::SYNC_STATUS_IN_PROGRESS, $reportPdfDoc->getSynchronisationStatus());
+    }
+
+    private function createAndSubmitNdr()
+    {
+        $client = $this->generateAndPersistClient('abc-123');
+        $ndr = $this->generateAndPersistReport($client, true);
+        $reportPdfDoc = $this->generateAndPersistDocument($ndr, true, 'QUEUED', $this->firstJulyAm, false);
+
+        $reportSubmission = $this->submitReport($ndr, $this->secondJulyPm, $reportPdfDoc, null);
+
+        $this->entityManager->flush();
+
+        return [$client, $ndr, $reportPdfDoc, $reportSubmission];
     }
 
     /**
@@ -130,6 +265,20 @@ class DocumentRepositoryTest extends KernelTestCase
         self::assertEquals($additionalSubmission->getId(), $documents[$additionalSupportingDoc->getId()]['report_submission_id']);
     }
 
+    private function createAndSubmitAdditionalDocuments(ReportInterface $report, DateTime $submittedOn)
+    {
+        $additionalSubmission = $this->generateAndPersistReportSubmission($report, $submittedOn);
+        $additionalSupportingDoc = $this->generateAndPersistDocument($report, false, 'QUEUED', $submittedOn, false);
+
+        $additionalSubmission->addDocument($additionalSupportingDoc);
+        $additionalSupportingDoc->setReportSubmission($additionalSubmission);
+
+        $this->entityManager->persist($additionalSupportingDoc);
+        $this->entityManager->persist($additionalSubmission);
+
+        return [$additionalSubmission, $additionalSupportingDoc];
+    }
+
     /**
      * @test
      */
@@ -150,6 +299,18 @@ class DocumentRepositoryTest extends KernelTestCase
         self::assertEquals($reportResubmission->getId(), $documents[$resubmissionSupportingDoc->getId()]['report_submission_id']);
     }
 
+    private function createAndSubmitResubmissionWithSupportingDoc(ReportInterface $report, DateTime $submittedOn)
+    {
+        $resubmissionReportPdfDoc = $this->generateAndPersistDocument($report, true, 'QUEUED', $this->secondJulyAm, true);
+        $resubmissionSupportingDoc = $this->generateAndPersistDocument($report, false, 'QUEUED', $this->secondJulyAm, true);
+
+        $reportResubmission = $this->submitReport($report, $submittedOn, $resubmissionReportPdfDoc, $resubmissionSupportingDoc);
+
+        $this->entityManager->flush();
+
+        return [$resubmissionReportPdfDoc, $resubmissionSupportingDoc, $reportResubmission];
+    }
+
     /**
      * @test
      */
@@ -163,7 +324,15 @@ class DocumentRepositoryTest extends KernelTestCase
 
         [$additionalSubmission, $additionalSupportingDoc] = $this->createAndSubmitAdditionalDocuments($report, $this->thirdJulyPm);
 
+        $this->entityManager->flush();
+
         $documents = $this->documentRepository->getQueuedDocumentsAndSetToInProgress('100');
+
+        $this->syncDocuments([$additionalSupportingDoc], $additionalSubmission, 'def-456-def-456');
+
+        $this->entityManager->refresh($additionalSubmission);
+        $this->entityManager->refresh($additionalSupportingDoc);
+
         self::assertEquals($additionalSubmission->getUuid(), $documents[$additionalSupportingDoc->getId()]['report_submission_uuid']);
     }
 
@@ -266,192 +435,31 @@ class DocumentRepositoryTest extends KernelTestCase
         self::assertTrue($reportPdf2Returned, '$reportPdf2Returned was not returned');
     }
 
-    /**
-     * @param Report|Ndr $report
-     */
-    private function assertDataMatchesEntity(
-        array $documents,
-        Document $document,
-        Client $client,
-        ReportSubmission $submission,
-        $report
-    ) {
-        $docId = $document->getId();
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
 
-        self::assertEquals($document->getId(), $documents[$docId]['document_id']);
-        self::assertEquals($submission->getId(), $documents[$docId]['report_submission_id']);
-        self::assertEquals($client->getCaseNumber(), $documents[$docId]['case_number']);
-        self::assertEquals($document->isReportPdf(), $documents[$docId]['is_report_pdf']);
-        self::assertEquals($document->getStorageReference(), $documents[$docId]['storage_reference']);
-        self::assertEquals($report->getStartDate()->format('Y-m-d'), $documents[$docId]['report_start_date']);
-        self::assertEquals($report->getSubmitDate()->format('Y-m-d H:i:s'), $documents[$docId]['report_submit_date']);
-        self::assertEquals($submission->getUuid(), $documents[$docId]['report_submission_uuid']);
+        $this->entityManager = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
 
-        if ($report instanceof Report) {
-            self::assertEquals($report->getEndDate()->format('Y-m-d'), $documents[$docId]['report_end_date']);
-            self::assertEquals($report->getType(), $documents[$docId]['report_type']);
-        }
+        $this->documentRepository = $this->entityManager
+            ->getRepository(Document::class);
+
+        $this->purgeDatabase();
+
+        $this->firstJulyAm = DateTime::createFromFormat('d/m/Y', '01/07/2020', new DateTimeZone('UTC'));
+        $this->firstJulyPm = clone $this->firstJulyAm->add(new DateInterval('PT20H'));
+        $this->secondJulyAm = DateTime::createFromFormat('d/m/Y', '02/07/2020', new DateTimeZone('UTC'));
+        $this->secondJulyPm = clone $this->secondJulyAm->add(new DateInterval('PT20H'));
+        $this->thirdJulyAm = DateTime::createFromFormat('d/m/Y', '03/07/2020', new DateTimeZone('UTC'));
+        $this->thirdJulyPm = clone $this->thirdJulyAm->add(new DateInterval('PT20H'));
     }
 
-    private function createAndSubmitReportWithSupportingDoc(DateTime $submittedOn)
+    private function purgeDatabase()
     {
-        $client = $this->generateAndPersistClient('abc-123');
-        $report = $this->generateAndPersistReport($client, false);
-        $reportPdfDoc = $this->generateAndPersistDocument($report, true, 'QUEUED', $this->firstJulyPm, false);
-        $supportingDoc = $this->generateAndPersistDocument($report, false, 'QUEUED', $this->firstJulyAm, false);
-
-        $reportSubmission = $this->submitReport($report, $submittedOn, $reportPdfDoc, $supportingDoc);
-
-        $this->entityManager->flush();
-
-        return [$client, $report, $reportPdfDoc, $supportingDoc, $reportSubmission];
-    }
-
-    private function createAndSubmitNdr()
-    {
-        $client = $this->generateAndPersistClient('abc-123');
-        $ndr = $this->generateAndPersistReport($client, true);
-        $reportPdfDoc = $this->generateAndPersistDocument($ndr, true, 'QUEUED', $this->firstJulyAm, false);
-
-        $reportSubmission = $this->submitReport($ndr, $this->secondJulyPm, $reportPdfDoc, null);
-
-        $this->entityManager->flush();
-
-        return [$client, $ndr, $reportPdfDoc, $reportSubmission];
-    }
-
-    private function submitReport(ReportInterface $report, DateTime $submittedOn, Document $reportPdf, ?Document $supportingDocument)
-    {
-        $report->setSubmitDate($submittedOn);
-
-        $reportSubmission = $this->generateAndPersistReportSubmission($report, $submittedOn);
-        $reportSubmission->addDocument($reportPdf);
-
-        $reportPdf->setReportSubmission($reportSubmission);
-
-        if ($supportingDocument) {
-            $reportSubmission->addDocument($supportingDocument);
-            $supportingDocument->setReportSubmission($reportSubmission);
-
-            $this->entityManager->persist($supportingDocument);
-        }
-
-        $this->entityManager->persist($reportPdf);
-        $this->entityManager->persist($reportSubmission);
-
-        return $reportSubmission;
-    }
-
-    private function generateAndPersistReport(Client $client, bool $isNdr)
-    {
-        if ($isNdr) {
-            $report = (new Ndr($client))->setStartDate($this->firstJulyAm);
-        } else {
-            $report = (new Report(
-                $client,
-                Report::TYPE_PROPERTY_AND_AFFAIRS_HIGH_ASSETS,
-                $this->firstJulyAm,
-                $this->firstJulyAm->add(new DateInterval('P364D'))
-            )
-            );
-        }
-
-        $this->entityManager->persist($report);
-
-        return $report;
-    }
-
-    private function generateAndPersistClient(string $caseNumber)
-    {
-        $client = (new Client())->setCaseNumber($caseNumber);
-
-        $this->entityManager->persist($client);
-
-        return $client;
-    }
-
-    private function generateAndPersistUser()
-    {
-        $user = (new User())
-            ->setFirstname('Test')
-            ->setLastname('User')
-            ->setPassword('password123');
-
-        $datePostFix = (string) (new DateTime())->getTimestamp();
-        $user->setEmail(sprintf('test-user%s%s@test.com', $datePostFix, rand(0, 100000)));
-
-        $this->entityManager->persist($user);
-
-        return $user;
-    }
-
-    private function generateAndPersistReportSubmission(ReportInterface $report, DateTime $createdOn)
-    {
-        $submission = (new ReportSubmission($report, $this->generateAndPersistUser()))->setCreatedOn($createdOn);
-
-        $this->entityManager->persist($submission);
-
-        return $submission;
-    }
-
-    private function generateAndPersistDocument(ReportInterface $report, bool $isReportPdf, string $syncStatus, DateTime $createdOn, bool $isResubmission)
-    {
-        $fileName = $isReportPdf ? 'report' : 'supporting-document';
-        $storageRef = $isReportPdf ? 'storage-ref-report' : 'storage-ref-supporting-document';
-
-        $fileName .= $isResubmission ? '-resubmission.pdf' : '.pdf';
-        $storageRef .= $isResubmission ? '-resubmission.pdf' : '.pdf';
-
-        $doc = (new Document($report))
-            ->setFileName($fileName)
-            ->setStorageReference($storageRef)
-            ->setIsReportPdf($isReportPdf)
-            ->setSynchronisationStatus($syncStatus)
-            ->setCreatedOn($createdOn);
-
-        $this->entityManager->persist($doc);
-
-        return $doc;
-    }
-
-    private function syncDocuments(array $documents, ?ReportSubmission $submission, ?string $uuid)
-    {
-        if ($submission) {
-            $this->entityManager->persist($submission->setUuid($uuid));
-        }
-
-        foreach ($documents as $document) {
-            $document->setSynchronisationStatus('SUCCESS');
-            $this->entityManager->persist($document);
-        }
-
-        $this->entityManager->flush();
-    }
-
-    private function createAndSubmitAdditionalDocuments(ReportInterface $report, DateTime $submittedOn)
-    {
-        $additionalSubmission = $this->generateAndPersistReportSubmission($report, $submittedOn);
-        $additionalSupportingDoc = $this->generateAndPersistDocument($report, false, 'QUEUED', $submittedOn, false);
-
-        $additionalSubmission->addDocument($additionalSupportingDoc);
-        $additionalSupportingDoc->setReportSubmission($additionalSubmission);
-
-        $this->entityManager->persist($additionalSupportingDoc);
-        $this->entityManager->persist($additionalSubmission);
-
-        return [$additionalSubmission, $additionalSupportingDoc];
-    }
-
-    private function createAndSubmitResubmissionWithSupportingDoc(ReportInterface $report, DateTime $submittedOn)
-    {
-        $resubmissionReportPdfDoc = $this->generateAndPersistDocument($report, true, 'QUEUED', $this->secondJulyAm, true);
-        $resubmissionSupportingDoc = $this->generateAndPersistDocument($report, false, 'QUEUED', $this->secondJulyAm, true);
-
-        $reportResubmission = $this->submitReport($report, $submittedOn, $resubmissionReportPdfDoc, $resubmissionSupportingDoc);
-
-        $this->entityManager->flush();
-
-        return [$resubmissionReportPdfDoc, $resubmissionSupportingDoc, $reportResubmission];
+        $purger = new ORMPurger($this->entityManager);
+        $purger->purge();
     }
 
     protected function tearDown(): void

--- a/api/tests/Unit/Entity/Repository/OrganisationRepositoryTest.php
+++ b/api/tests/Unit/Entity/Repository/OrganisationRepositoryTest.php
@@ -3,15 +3,20 @@
 namespace App\Tests\Unit\Entity\Repository;
 
 use App\Entity\Organisation;
+use App\Entity\User;
 use App\Repository\OrganisationRepository;
 use App\Tests\Unit\Fixtures;
+use DateTime;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class OrganisationRepositoryTest extends WebTestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var OrganisationRepository
      */
@@ -21,25 +26,6 @@ class OrganisationRepositoryTest extends WebTestCase
      * @var EntityManagerInterface
      */
     private $em;
-
-    protected function setUp(): void
-    {
-        $kernel = self::bootKernel();
-
-        $this->em = $kernel->getContainer()
-            ->get('doctrine')
-            ->getManager();
-
-        $this->fixtures = new Fixtures($this->em);
-
-        $metaClass = self::prophesize(ClassMetadata::class);
-        $metaClass->name = Organisation::class;
-
-        $this->sut = $this->em->getRepository(Organisation::class);
-
-        $purger = new ORMPurger($this->em);
-        $purger->purge();
-    }
 
     /** @test */
     public function testGetAllArray()
@@ -82,8 +68,8 @@ class OrganisationRepositoryTest extends WebTestCase
     public function testHasActiveEntitiesSoftDeletedClientInOrgReturnsFalse()
     {
         $orgs = $this->fixtures->createOrganisations(1);
-        $user = $this->fixtures->createUser()->setRoleName(\App\Entity\User::ROLE_PA);
-        $clientDeleted = $this->fixtures->createClient($user, ['setDeletedAt' => new \DateTime()]);
+        $user = $this->fixtures->createUser()->setRoleName(User::ROLE_PA);
+        $clientDeleted = $this->fixtures->createClient($user, ['setDeletedAt' => new DateTime()]);
         $this->em->flush();
 
         $this->fixtures->addClientToOrganisation($clientDeleted->getId(), $orgs[0]->getId());
@@ -96,8 +82,8 @@ class OrganisationRepositoryTest extends WebTestCase
     public function testHasActiveEntitiesArchivedClientInOrgReturnsFalse()
     {
         $orgs = $this->fixtures->createOrganisations(1);
-        $user = $this->fixtures->createUser()->setRoleName(\App\Entity\User::ROLE_PA);
-        $clientArchived = $this->fixtures->createClient($user, ['setArchivedAt' => new \DateTime()]);
+        $user = $this->fixtures->createUser()->setRoleName(User::ROLE_PA);
+        $clientArchived = $this->fixtures->createClient($user, ['setArchivedAt' => new DateTime()]);
         $this->em->flush();
 
         $this->fixtures->addClientToOrganisation($clientArchived->getId(), $orgs[0]->getId());
@@ -110,9 +96,9 @@ class OrganisationRepositoryTest extends WebTestCase
     public function testHasActiveEntitiesArchivedAndSoftDeletedClientsInOrgReturnsFalse()
     {
         $orgs = $this->fixtures->createOrganisations(1);
-        $user = $this->fixtures->createUser()->setRoleName(\App\Entity\User::ROLE_PA);
-        $clientDeleted = $this->fixtures->createClient($user, ['setDeletedAt' => new \DateTime()]);
-        $clientArchived = $this->fixtures->createClient($user, ['setArchivedAt' => new \DateTime()]);
+        $user = $this->fixtures->createUser()->setRoleName(User::ROLE_PA);
+        $clientDeleted = $this->fixtures->createClient($user, ['setDeletedAt' => new DateTime()]);
+        $clientArchived = $this->fixtures->createClient($user, ['setArchivedAt' => new DateTime()]);
         $this->em->flush();
 
         $this->fixtures->addClientToOrganisation($clientDeleted->getId(), $orgs[0]->getId());
@@ -126,10 +112,10 @@ class OrganisationRepositoryTest extends WebTestCase
     public function testHasActiveEntitiesArchivedAndSoftDeletedAndActiveClientsInOrgReturnsTrue()
     {
         $orgs = $this->fixtures->createOrganisations(1);
-        $user = $this->fixtures->createUser()->setRoleName(\App\Entity\User::ROLE_PA);
+        $user = $this->fixtures->createUser()->setRoleName(User::ROLE_PA);
         $clientActive = $this->fixtures->createClient($user);
-        $clientDeleted = $this->fixtures->createClient($user, ['setDeletedAt' => new \DateTime()]);
-        $clientArchived = $this->fixtures->createClient($user, ['setArchivedAt' => new \DateTime()]);
+        $clientDeleted = $this->fixtures->createClient($user, ['setDeletedAt' => new DateTime()]);
+        $clientArchived = $this->fixtures->createClient($user, ['setArchivedAt' => new DateTime()]);
         $this->em->flush();
 
         $this->fixtures->addClientToOrganisation($clientActive->getId(), $orgs[0]->getId());
@@ -144,9 +130,9 @@ class OrganisationRepositoryTest extends WebTestCase
     public function testHasActiveEntitiesArchivedAndSoftDeletedClientsAndUserInOrgReturnsTrue()
     {
         $orgs = $this->fixtures->createOrganisations(1);
-        $user = $this->fixtures->createUser()->setRoleName(\App\Entity\User::ROLE_PA);
-        $clientDeleted = $this->fixtures->createClient($user, ['setDeletedAt' => new \DateTime()]);
-        $clientArchived = $this->fixtures->createClient($user, ['setArchivedAt' => new \DateTime()]);
+        $user = $this->fixtures->createUser()->setRoleName(User::ROLE_PA);
+        $clientDeleted = $this->fixtures->createClient($user, ['setDeletedAt' => new DateTime()]);
+        $clientArchived = $this->fixtures->createClient($user, ['setArchivedAt' => new DateTime()]);
         $this->em->flush();
 
         $this->fixtures->addUserToOrganisation($user->getId(), $orgs[0]->getId());
@@ -161,7 +147,7 @@ class OrganisationRepositoryTest extends WebTestCase
     public function testHasActiveEntitiesActiveClientAndUserInOrgReturnsTrue()
     {
         $orgs = $this->fixtures->createOrganisations(1);
-        $user = $this->fixtures->createUser()->setRoleName(\App\Entity\User::ROLE_PA);
+        $user = $this->fixtures->createUser()->setRoleName(User::ROLE_PA);
         $clientActive = $this->fixtures->createClient($user);
         $this->em->flush();
 
@@ -180,6 +166,25 @@ class OrganisationRepositoryTest extends WebTestCase
 
         $result = $this->sut->findByEmailIdentifier($orgs[0]->getEmailIdentifier());
         self::assertEquals($orgs[0], $result);
+    }
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+
+        $this->em = $kernel->getContainer()
+            ->get('doctrine')
+            ->getManager();
+
+        $this->fixtures = new Fixtures($this->em);
+
+        $metaClass = self::prophesize(ClassMetadata::class);
+        $metaClass->name = Organisation::class;
+
+        $this->sut = $this->em->getRepository(Organisation::class);
+
+        $purger = new ORMPurger($this->em);
+        $purger->purge();
     }
 
     protected function tearDown(): void

--- a/api/tests/Unit/Factory/ClientBenefitsCheckFactoryTest.php
+++ b/api/tests/Unit/Factory/ClientBenefitsCheckFactoryTest.php
@@ -14,6 +14,7 @@ use App\Repository\ReportRepository;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
@@ -21,6 +22,8 @@ use ReflectionClass;
 
 class ClientBenefitsCheckFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     private ?ClientBenefitsCheck $incomeClientBenefitsCheck;
 
     private ?float $incomeAmount;
@@ -106,6 +109,40 @@ class ClientBenefitsCheckFactoryTest extends TestCase
         self::assertEquals($existingClientBenefitsCheck, $income->getClientBenefitsCheck());
         self::assertEquals($this->incomeType, $income->getIncomeType());
         self::assertEquals($this->incomeAmount, $income->getAmount());
+    }
+
+    private function generateValidFormData(bool $existingEntity): array
+    {
+        return [
+            'report_id' => $this->reportId,
+            'id' => $existingEntity ? $this->id : null,
+            'created' => $this->created,
+            'when_last_checked_entitlement' => $this->whenLastCheckedEntitlement,
+            'date_last_checked_entitlement' => $this->dateLastCheckedEntitlement,
+            'never_checked_explanation' => $this->neverCheckedExplanation,
+            'do_others_receive_income_on_clients_behalf' => $this->doOthersReceiveIncomeOnClientsBehalf,
+            'dont_know_income_explanation' => $this->dontKnowIncomeExplanation,
+            'types_of_income_received_on_clients_behalf' => [
+                0 => [
+                    'id' => $existingEntity ? $this->incomeId : null,
+                    'created' => $this->incomeCreated,
+                    'client_benefits_check' => $this->incomeClientBenefitsCheck,
+                    'income_type' => $this->incomeType,
+                    'amount' => $this->incomeAmount,
+                    'amount_dont_know' => $this->incomeAmountDontKnow,
+                ],
+            ],
+            'report' => [],
+        ];
+    }
+
+    private function set($entity, $value, $propertyName = 'id')
+    {
+        $class = new ReflectionClass($entity);
+        $property = $class->getProperty($propertyName);
+        $property->setAccessible(true);
+
+        $property->setValue($entity, $value);
     }
 
     /** @test */
@@ -194,45 +231,11 @@ class ClientBenefitsCheckFactoryTest extends TestCase
         self::assertEquals(0, $processedClientBenefitsCheck->getTypesOfIncomeReceivedOnClientsBehalf()->count());
     }
 
-    private function generateValidFormData(bool $existingEntity): array
-    {
-        return [
-            'report_id' => $this->reportId,
-            'id' => $existingEntity ? $this->id : null,
-            'created' => $this->created,
-            'when_last_checked_entitlement' => $this->whenLastCheckedEntitlement,
-            'date_last_checked_entitlement' => $this->dateLastCheckedEntitlement,
-            'never_checked_explanation' => $this->neverCheckedExplanation,
-            'do_others_receive_income_on_clients_behalf' => $this->doOthersReceiveIncomeOnClientsBehalf,
-            'dont_know_income_explanation' => $this->dontKnowIncomeExplanation,
-            'types_of_income_received_on_clients_behalf' => [
-                0 => [
-                    'id' => $existingEntity ? $this->incomeId : null,
-                    'created' => $this->incomeCreated,
-                    'client_benefits_check' => $this->incomeClientBenefitsCheck,
-                    'income_type' => $this->incomeType,
-                    'amount' => $this->incomeAmount,
-                    'amount_dont_know' => $this->incomeAmountDontKnow,
-                ],
-            ],
-            'report' => [],
-        ];
-    }
-
     private function generateValidFormDataRemoveIncomes()
     {
         $data = $this->generateValidFormData(true);
         $data['do_others_receive_income_on_clients_behalf'] = 'no';
 
         return $data;
-    }
-
-    private function set($entity, $value, $propertyName = 'id')
-    {
-        $class = new ReflectionClass($entity);
-        $property = $class->getProperty($propertyName);
-        $property->setAccessible(true);
-
-        $property->setValue($entity, $value);
     }
 }

--- a/api/tests/Unit/Security/OrganisationVoterTest.php
+++ b/api/tests/Unit/Security/OrganisationVoterTest.php
@@ -8,12 +8,15 @@ use App\Entity\Organisation;
 use App\Entity\User;
 use App\Security\OrganisationVoter;
 use DateTime;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Security;
 
 class OrganisationVoterTest extends KernelTestCase
 {
+    use ProphecyTrait;
+
     public function setUp(): void
     {
         $this->user = new User();

--- a/api/tests/Unit/Security/UserVoterTest.php
+++ b/api/tests/Unit/Security/UserVoterTest.php
@@ -33,8 +33,8 @@ class UserVoterTest extends KernelTestCase
         $clientTestHelp = new ClientTestHelper();
         $reportTestHelper = new ReportTestHelper();
 
-        $kernel = self::bootKernel();
-        $em = $kernel->getContainer()->get('em');
+        self::bootKernel();
+        $em = self::$container->get('em');
 
         $layNoReportsOrClients = $userTestHelper->createAndPersistUser($em, null, User::ROLE_LAY_DEPUTY);
 
@@ -227,7 +227,7 @@ class UserVoterTest extends KernelTestCase
             'Admin Manager deleted Prof Named Deputy' => [$adminManager, $profNamed, -1],
             'Admin Manager deleted Prof Admin Deputy' => [$adminManager, $profAdmin, -1],
             'Admin Manager deletes Prof Team Member' => [$adminManager, $profTeamMember, -1],
-            'Admin Manager deleted Admin user' => [$adminManager, $admin, -1],
+            'Admin Manager deleted Admin user' => [$adminManager, $admin, 1],
             'Admin Manager deletes Super Admin user' => [$adminManager, $superAdmin, -1],
             'Admin Manager deletes Admin Manager user' => [$adminManager, $adminManager2, 1],
             'Admin Manager deletes self' => [$adminManager, $adminManager, -1],
@@ -267,8 +267,8 @@ class UserVoterTest extends KernelTestCase
 
     public function addEditUserProvider()
     {
-        $kernel = self::bootKernel();
-        $em = $kernel->getContainer()->get('em');
+        self::bootKernel();
+        $em = self::$container->get('em');
 
         $userTestHelper = new UserTestHelper();
 

--- a/api/tests/Unit/Service/CasrecVerificationServiceTest.php
+++ b/api/tests/Unit/Service/CasrecVerificationServiceTest.php
@@ -5,11 +5,15 @@ namespace App\Tests\Unit\Service;
 use App\Service\CasrecVerificationService;
 use Doctrine\ORM\EntityManager;
 use Mockery as m;
+use Prophecy\PhpUnit\ProphecyTrait;
+use RuntimeException;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Serializer\SerializerInterface;
 
 class CasrecVerificationServiceTest extends WebTestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var CasrecVerificationService
      */
@@ -88,7 +92,6 @@ class CasrecVerificationServiceTest extends WebTestCase
             ->shouldReceive('findBy')->with(['caseNumber' => 'wrong678', 'clientLastname' => 'csurn', 'deputySurname' => 'dsurn'])->andReturn([])
             ->shouldReceive('findBy')->with(['caseNumber' => '11111111', 'clientLastname' => 'wrong', 'deputySurname' => 'dsurn'])->andReturn([])
             ->shouldReceive('findBy')->with(['caseNumber' => '11111111', 'clientLastname' => 'csurn', 'deputySurname' => 'wrong'])->andReturn([])
-
             ->shouldReceive('findBy')->with(['caseNumber' => '22222222', 'clientLastname' => 'csurn', 'deputySurname' => 'dsurn'])->andReturn([$crLayNoPC])
             ->shouldReceive('findBy')->with(['caseNumber' => '33333333', 'clientLastname' => 'csurn', 'deputySurname' => 'mldunique'])->andReturn([$casrecMLD1A])
             ->shouldReceive('findBy')->with(['caseNumber' => '33333333', 'clientLastname' => 'csurn', 'deputySurname' => 'sibling'])->andReturn([$casrecMLD1B, $casrecMLD1C])
@@ -131,7 +134,7 @@ class CasrecVerificationServiceTest extends WebTestCase
         $failMessage = '{"search_terms":{"caseNumber":"%s","clientLastname":"%s","deputySurname":"%s","deputyPostcode":"%s"},"case_number_matches":null}';
         try {
             $this->casrecVerificationService->validate('WRONG678', 'CSurn', 'DSurn', 'DPC123');
-        } catch (\RuntimeException $e) {
+        } catch (RuntimeException $e) {
             $this->assertStringContainsString(
                 sprintf($failMessage, 'wrong678', 'csurn', 'dsurn', 'dpc123'),
                 $e->getMessage()
@@ -140,7 +143,7 @@ class CasrecVerificationServiceTest extends WebTestCase
 
         try {
             $this->assertTrue($this->casrecVerificationService->validate('11111111', 'WRONG', 'DSurn', 'DPC123'));
-        } catch (\RuntimeException $e) {
+        } catch (RuntimeException $e) {
             $this->assertStringContainsString(
                 sprintf($failMessage, '11111111', 'wrong', 'dsurn', 'dpc123'),
                 $e->getMessage()
@@ -149,7 +152,7 @@ class CasrecVerificationServiceTest extends WebTestCase
 
         try {
             $this->assertTrue($this->casrecVerificationService->validate('11111111', 'CSurn', 'WRONG', 'DPC123'));
-        } catch (\RuntimeException $e) {
+        } catch (RuntimeException $e) {
             $this->assertStringContainsString(
                 sprintf($failMessage, '11111111', 'csurn', 'wrong', 'dpc123'),
                 $e->getMessage()
@@ -158,7 +161,7 @@ class CasrecVerificationServiceTest extends WebTestCase
 
         try {
             $this->assertTrue($this->casrecVerificationService->validate('11111111', 'CSurn', 'DSurn', 'WRONG'));
-        } catch (\RuntimeException $e) {
+        } catch (RuntimeException $e) {
             $this->assertStringContainsString(
                 sprintf($failMessage, '11111111', 'csurn', 'dsurn', 'wrong'),
                 $e->getMessage()
@@ -198,7 +201,7 @@ class CasrecVerificationServiceTest extends WebTestCase
         // if all MLD postcodes are in casrec, the postcode check is run
         try {
             $this->assertTrue($this->casrecVerificationService->validate('11111111', 'CSurn', 'DSurn', 'DOEsnT MatteR'));
-        } catch (\RuntimeException $e) {
+        } catch (RuntimeException $e) {
             $this->assertStringContainsString('{"search_terms":{"caseNumber":"11111111","clientLastname":"csurn","deputySurname":"dsurn","deputyPostcode":"doesntmatter"},"case_number_matches":null}', $e->getMessage());
         }
 

--- a/api/tests/Unit/Service/Formatter/RestFormatterTest.php
+++ b/api/tests/Unit/Service/Formatter/RestFormatterTest.php
@@ -9,12 +9,16 @@ use App\Service\Formatter\RestFormatter;
 use App\Service\Validator\RestArrayValidator;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\HttpFoundation\Request;
 
 class RestFormatterTest extends TestCase
 {
-    private \Prophecy\Prophecy\ObjectProphecy $inputOutputFormatter;
-    private \Prophecy\Prophecy\ObjectProphecy $validator;
+    use ProphecyTrait;
+
+    private ObjectProphecy $inputOutputFormatter;
+    private ObjectProphecy $validator;
     private RestFormatter $sut;
 
     public function setUp(): void

--- a/api/tests/Unit/Service/OrganisationRestHandlerTest.php
+++ b/api/tests/Unit/Service/OrganisationRestHandlerTest.php
@@ -12,11 +12,14 @@ use App\Service\RestHandler\OrganisationUpdateException;
 use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class OrganisationRestHandlerTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var ObjectProphecy|EntityManager
      */

--- a/api/tests/Unit/Service/ReportServiceTest.php
+++ b/api/tests/Unit/Service/ReportServiceTest.php
@@ -15,33 +15,36 @@ use App\Entity\User;
 use App\Repository\DocumentRepository;
 use App\Repository\ReportRepository;
 use App\Service\ReportService;
+use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\Persistence\ObjectRepository;
+use Mockery;
 use MockeryStub as m;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use RuntimeException;
 use Throwable;
 
 class ReportServiceTest extends TestCase
 {
-    /**
-     * @var EntityDir\User
-     */
-    private $user;
-
-    /**
-     * @var Report
-     */
-    private $report;
+    use ProphecyTrait;
 
     /**
      * @var ReportService
      */
     protected $sut;
+    /**
+     * @var EntityDir\User
+     */
+    private $user;
+    /**
+     * @var Report
+     */
+    private $report;
 
     public function setUp(): void
     {
@@ -49,13 +52,13 @@ class ReportServiceTest extends TestCase
         $client = new Client();
         $client->addUser($this->user);
         $client->setCaseNumber('12345678');
-        $client->setCourtDate(new \DateTime('2014-06-06'));
+        $client->setCourtDate(new DateTime('2014-06-06'));
 
         $this->bank1 = (new BankAccount())->setAccountNumber('1234');
         $this->asset1 = (new AssetProperty())
             ->setAddress('SW1')
             ->setOwned(AssetProperty::OWNED_FULLY);
-        $this->report = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new \DateTime('2015-01-01'), new \DateTime('2015-12-31'));
+        $this->report = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new DateTime('2015-01-01'), new DateTime('2015-12-31'));
         $this->report
             ->setNoAssetToAdd(false)
             ->addAsset($this->asset1)
@@ -104,8 +107,8 @@ class ReportServiceTest extends TestCase
     public function testSubmitInvalid()
     {
         $this->report->setAgreedBehalfDeputy(false);
-        $this->expectException(\RuntimeException::class);
-        $this->sut->submit($this->report, $this->user, new \DateTime('2016-01-15'));
+        $this->expectException(RuntimeException::class);
+        $this->sut->submit($this->report, $this->user, new DateTime('2016-01-15'));
     }
 
     public function testSubmitValid()
@@ -113,25 +116,25 @@ class ReportServiceTest extends TestCase
         $report = $this->report;
 
         // Create partial mock of ReportService
-        $reportService = \Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
+        $reportService = Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
 
         // mocks
         $this->em->shouldReceive('detach');
         $this->em->shouldReceive('flush');
         // assert persists on report and submission record
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($report) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($report) {
             return $report instanceof Report;
         }));
         // assert persists on report and submission record
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($report) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($report) {
             return $report instanceof EntityDir\Report\ReportSubmission;
         }));
 
         // clonePersistentResources should be called
-        $reportService->shouldReceive('clonePersistentResources')->with(\Mockery::type(Report::class), $report);
+        $reportService->shouldReceive('clonePersistentResources')->with(Mockery::type(Report::class), $report);
 
         $report->setAgreedBehalfDeputy(true);
-        $newYearReport = $reportService->submit($report, $this->user, new \DateTime('2016-01-15'));
+        $newYearReport = $reportService->submit($report, $this->user, new DateTime('2016-01-15'));
 
         // assert current report
         $this->assertTrue($report->getSubmitted());
@@ -150,20 +153,20 @@ class ReportServiceTest extends TestCase
     public function testResubmit()
     {
         $report = $this->report;
-        $report->setUnSubmitDate(new \DateTime('2018-02-14'));
+        $report->setUnSubmitDate(new DateTime('2018-02-14'));
 
         // A report for the next report period should already exist
         $client = $this->report->getClient();
-        $nextReport = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new \DateTime('2016-01-01'), new \DateTime('2016-12-31'));
+        $nextReport = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new DateTime('2016-01-01'), new DateTime('2016-12-31'));
         $client->addReport($nextReport);
 
         // Create partial mock of ReportService
-        $reportService = \Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
+        $reportService = Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
 
         // mocks
         $this->em->shouldReceive('detach');
         // assert persists on report and submission record
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($report) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($report) {
             return $report instanceof EntityDir\Report\ReportSubmission;
         }));
         $this->em->shouldReceive('flush')->with()->once(); //last in createNextYearReport
@@ -172,7 +175,7 @@ class ReportServiceTest extends TestCase
         $reportService->shouldReceive('clonePersistentResources')->with($nextReport, $report);
 
         $report->setAgreedBehalfDeputy(true);
-        $newYearReport = $reportService->submit($report, $this->user, new \DateTime());
+        $newYearReport = $reportService->submit($report, $this->user, new DateTime());
 
         // assert current report
         $this->assertTrue($report->getSubmitted());
@@ -190,60 +193,33 @@ class ReportServiceTest extends TestCase
 
     public function testSubmitNotAgreedNdrThrowsException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $this->ndr->setAgreedBehalfDeputy(null);
-        $submitDate = new \DateTime('2018-04-05');
+        $submitDate = new DateTime('2018-04-05');
 
         $ndrDoccumentId = 999;
 
         $this->sut->submit($this->ndr, $this->user, $submitDate, $ndrDoccumentId);
     }
 
-    private function getFilledInNdr()
-    {
-        $client = new EntityDir\Client();
-        $client->addUser($this->user);
-        $client->setCaseNumber('12345678');
-        $client->setCourtDate(new \DateTime('2014-06-06'));
-
-        $ndr = new EntityDir\Ndr\Ndr($client);
-
-        $ndrBank = new EntityDir\Ndr\BankAccount();
-        $ndrBank->setAccountNumber('4321')
-            ->setNdr($ndr);
-
-        $ndrAsset = new EntityDir\Ndr\AssetProperty();
-        $ndrAsset->setAddress('SW1')
-            ->setOwned(EntityDir\Report\AssetProperty::OWNED_FULLY)
-            ->setNdr($ndr);
-
-        $ndr->setNoAssetToAdd(false);
-        $ndr->addAsset($ndrAsset);
-        $ndr->setBankAccounts([$ndrBank]);
-        $ndr->setAgreedBehalfDeputy(true);
-        $ndr->setClient($client);
-
-        return $ndr;
-    }
-
     public function testSubmitValidNdr()
     {
         $ndr = $this->getFilledInNdr();
 
-        $submitDate = new \DateTime('2018-04-05');
+        $submitDate = new DateTime('2018-04-05');
 
         // assert persists on report and submission record
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($ndr) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($ndr) {
             return $ndr instanceof EntityDir\Report\ReportSubmission;
         }));
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($report) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($report) {
             return $report instanceof EntityDir\Report\Report;
         }));
         $this->em->shouldReceive('flush')->with()->once(); //last in createNextYearReport
 
         // Create partial mock of ReportService
-        $reportService = \Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
+        $reportService = Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
         $this->em->shouldReceive('detach');
         $this->em->shouldReceive('persist');
         $this->em->shouldReceive('flush');
@@ -269,26 +245,53 @@ class ReportServiceTest extends TestCase
         $this->assertEquals('4321', $newAccount->getAccountNumber());
     }
 
+    private function getFilledInNdr()
+    {
+        $client = new EntityDir\Client();
+        $client->addUser($this->user);
+        $client->setCaseNumber('12345678');
+        $client->setCourtDate(new DateTime('2014-06-06'));
+
+        $ndr = new EntityDir\Ndr\Ndr($client);
+
+        $ndrBank = new EntityDir\Ndr\BankAccount();
+        $ndrBank->setAccountNumber('4321')
+            ->setNdr($ndr);
+
+        $ndrAsset = new EntityDir\Ndr\AssetProperty();
+        $ndrAsset->setAddress('SW1')
+            ->setOwned(EntityDir\Report\AssetProperty::OWNED_FULLY)
+            ->setNdr($ndr);
+
+        $ndr->setNoAssetToAdd(false);
+        $ndr->addAsset($ndrAsset);
+        $ndr->setBankAccounts([$ndrBank]);
+        $ndr->setAgreedBehalfDeputy(true);
+        $ndr->setClient($client);
+
+        return $ndr;
+    }
+
     public function testSubmitNdrWithExistingReport()
     {
         $ndr = $this->getFilledInNdr();
 
-        $report = new Report($ndr->getClient(), Report::LAY_PFA_HIGH_ASSETS_TYPE, new \DateTime('2018-06-06'), new \DateTime('2019-06-05'));
+        $report = new Report($ndr->getClient(), Report::LAY_PFA_HIGH_ASSETS_TYPE, new DateTime('2018-06-06'), new DateTime('2019-06-05'));
         $ndr->getClient()->addReport($report);
 
-        $submitDate = new \DateTime('2018-04-05');
+        $submitDate = new DateTime('2018-04-05');
 
         // assert persists on report and submission record
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($ndr) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($ndr) {
             return $ndr instanceof EntityDir\Report\ReportSubmission;
         }));
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($report) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($report) {
             return $report instanceof EntityDir\Report\Report;
         }));
         $this->em->shouldReceive('flush')->with()->once(); //last in createNextYearReport
 
         // Create partial mock of ReportService
-        $reportService = \Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
+        $reportService = Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
         $this->em->shouldReceive('detach');
         $this->em->shouldReceive('persist');
         $this->em->shouldReceive('flush');
@@ -316,11 +319,11 @@ class ReportServiceTest extends TestCase
     public function testResubmitPersistenceRequiresReport()
     {
         $report = $this->report;
-        $report->setUnSubmitDate(new \DateTime('2018-02-14'));
+        $report->setUnSubmitDate(new DateTime('2018-02-14'));
         $report->setAgreedBehalfDeputy(true);
 
         // Create partial mock of ReportService
-        $reportService = \Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
+        $reportService = Mockery::mock(ReportService::class, [$this->em, $this->reportRepo])->makePartial();
         $this->em->shouldReceive('detach');
         $this->em->shouldReceive('persist');
         $this->em->shouldReceive('flush');
@@ -329,17 +332,17 @@ class ReportServiceTest extends TestCase
         $reportService->shouldNotReceive('clonePersistentResources');
 
         // Submit a report without one set up for next year
-        $reportService->submit($report, $this->user, new \DateTime());
+        $reportService->submit($report, $this->user, new DateTime());
 
         // Submit a report where next year's dates don't match
         $client = $this->report->getClient();
-        $nextReport = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new \DateTime('2016-01-17'), new \DateTime('2017-01-16'));
+        $nextReport = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new DateTime('2016-01-17'), new DateTime('2017-01-16'));
         $client->addReport($nextReport);
 
-        $report->setUnSubmitDate(new \DateTime('2018-02-14'));
+        $report->setUnSubmitDate(new DateTime('2018-02-14'));
         $report->setAgreedBehalfDeputy(true);
 
-        $reportService->submit($report, $this->user, new \DateTime());
+        $reportService->submit($report, $this->user, new DateTime());
     }
 
     /**
@@ -348,17 +351,17 @@ class ReportServiceTest extends TestCase
     public function testPersistentResourcesCloned()
     {
         $client = $this->report->getClient();
-        $newReport = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new \DateTime('2016-01-01'), new \DateTime('2016-12-31'));
+        $newReport = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new DateTime('2016-01-01'), new DateTime('2016-12-31'));
 
         // Assert asset is cloned
         $this->em->shouldReceive('detach')->once();
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($asset) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($asset) {
             return $asset instanceof EntityDir\Report\AssetProperty
                 && 'SW1' === $asset->getAddress();
         }))->once();
 
         // Assert bank account is cloned, with opening/closing balance modified
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($bankAccount) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($bankAccount) {
             return $bankAccount instanceof EntityDir\Report\BankAccount
                 && '1234' === $bankAccount->getAccountNumber()
                 && $bankAccount->getOpeningBalance() === $this->report->getBankAccounts()[0]->getClosingBalance()
@@ -376,7 +379,7 @@ class ReportServiceTest extends TestCase
     public function testDuplicateResourcesNotPersisted()
     {
         $client = $this->report->getClient();
-        $newReport = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new \DateTime('2016-01-01'), new \DateTime('2016-12-31'));
+        $newReport = new Report($client, Report::LAY_PFA_HIGH_ASSETS_TYPE, new DateTime('2016-01-01'), new DateTime('2016-12-31'));
 
         $newAsset = clone $this->report->getAssets()[0];
         $newReport->addAsset($newAsset);
@@ -394,13 +397,13 @@ class ReportServiceTest extends TestCase
 
     public function testSubmitAdditionalDocuments()
     {
-        $this->em->shouldReceive('persist')->with(\Mockery::on(function ($report) {
+        $this->em->shouldReceive('persist')->with(Mockery::on(function ($report) {
             return $report instanceof EntityDir\Report\ReportSubmission;
         }));
         $this->em->shouldReceive('flush')->with()->once();
 
         $this->assertEmpty($this->report->getReportSubmissions());
-        $currentReport = $this->sut->submitAdditionalDocuments($this->report, $this->user, new \DateTime('2016-01-15'));
+        $currentReport = $this->sut->submitAdditionalDocuments($this->report, $this->user, new DateTime('2016-01-15'));
         $submission = $currentReport->getReportSubmissions()->first();
 
         $this->assertContains($submission, $this->report->getReportSubmissions());
@@ -412,7 +415,7 @@ class ReportServiceTest extends TestCase
     {
         $this->assertEquals(false, ReportService::isDue(null));
 
-        $todayMidnight = new \DateTime('today midnight');
+        $todayMidnight = new DateTime('today midnight');
 
         $oneMinuteBeforeLastMidnight = clone $todayMidnight;
         $oneMinuteBeforeLastMidnight->modify('-1 minute');
@@ -421,12 +424,12 @@ class ReportServiceTest extends TestCase
         $oneMinuteAfterLastMidnight->modify('+1 minute');
 
         // end date is past (before midnight) => due
-        $this->assertEquals(true, ReportService::isDue(new \DateTime('last week')));
+        $this->assertEquals(true, ReportService::isDue(new DateTime('last week')));
         $this->assertEquals(true, ReportService::isDue($oneMinuteBeforeLastMidnight));
 
         // otherwise not due
         $this->assertEquals(false, ReportService::isDue($oneMinuteAfterLastMidnight));
-        $this->assertEquals(false, ReportService::isDue(new \DateTime('next week')));
+        $this->assertEquals(false, ReportService::isDue(new DateTime('next week')));
     }
 
     /**

--- a/api/tests/Unit/Service/ReportUtilsTest.php
+++ b/api/tests/Unit/Service/ReportUtilsTest.php
@@ -3,12 +3,53 @@
 namespace App\Tests\Unit\Service;
 
 use App\Service\ReportUtils;
+use DateTime;
 use PHPUnit\Framework\TestCase;
 
 class ReportUtilsTest extends TestCase
 {
+    public static function parseDateProvider()
+    {
+        return [
+            // d-M-y 20xx
+            ['05-Feb-15', '2015-02-05', '20'],
+            ['23-May-17', '2017-05-23', '20'],
+            ['15-Jul-17', '2017-07-15', '20'],
+            ['10-Jul-17', '2017-07-10', '20'],
+            ['10-Jul-98', '2098-07-10', '20'],
+            ['10-Jul-00', '2000-07-10', '20'],
+
+            // d-M-y 19xx
+            ['10-Jul-47', '1947-07-10', '19'],
+            ['10-Jul-65', '1965-07-10', '19'],
+            ['10-Jul-00', '1900-07-10', '19'],
+
+            //d/m/Y format
+            ['20-MAR-2003', '2003-03-20', '20'],
+            ['29-MAY-2013', '2013-05-29', '20'],
+            ['07-OCT-2016', '2016-10-07', '20'],
+            ['07-OCT-1945', '1945-10-07', '20'], //third param ignored if full year is given
+
+            // invalid days
+            ['00-MAY-2016', false, '20'],
+            ['32-MAY-2016', false, '20'],
+            // invalid month
+            ['07-xxx-2016', false, '20'],
+            ['07-janu-2016', false, '20'],
+            ['07-00-2016', false, '20'],
+            ['07-01-2016', false, '20'],
+            // invalid year
+            ['01-JAN-0', false, '20'],
+            ['01-JAN-1', false, '20'],
+            ['01-JAN-000', false, '20'],
+            ['01-JAN-001', false, '20'],
+            ['01-JAN-00000', false, '20'],
+            ['01-JAN-00001', false, '20'],
+        ];
+    }
+
     /**
-     * Data providor for reporting periods, end date and expected start date.
+     * Data provider for reporting periods, end date and expected start date.
      *
      * @return array
      */
@@ -52,50 +93,12 @@ class ReportUtilsTest extends TestCase
      */
     public function testGenerateStartDateFromEndDate($endDate, $expectedStartDate)
     {
-        $endDate = new \DateTime($endDate);
-        $startDate = ReportUtils::generateReportStartDateFromEndDate($endDate);
+        $sut = new ReportUtils();
+
+        $endDate = new DateTime($endDate);
+        $startDate = $sut->generateReportStartDateFromEndDate($endDate);
 
         $this->assertEquals($expectedStartDate, $startDate->format('Y-m-d'));
-    }
-
-    public static function parseDateProvider()
-    {
-        return [
-            // d-M-y 20xx
-            ['05-Feb-15', '2015-02-05', '20'],
-            ['23-May-17', '2017-05-23', '20'],
-            ['15-Jul-17', '2017-07-15', '20'],
-            ['10-Jul-17', '2017-07-10', '20'],
-            ['10-Jul-98', '2098-07-10', '20'],
-            ['10-Jul-00', '2000-07-10', '20'],
-
-            // d-M-y 19xx
-            ['10-Jul-47', '1947-07-10', '19'],
-            ['10-Jul-65', '1965-07-10', '19'],
-            ['10-Jul-00', '1900-07-10', '19'],
-
-            //d/m/Y format
-            ['20-MAR-2003', '2003-03-20', '20'],
-            ['29-MAY-2013', '2013-05-29', '20'],
-            ['07-OCT-2016', '2016-10-07', '20'],
-            ['07-OCT-1945', '1945-10-07', '20'], //third param ignored if full year is given
-
-            // invalid days
-            ['00-MAY-2016', false, '20'],
-            ['32-MAY-2016', false, '20'],
-            // invalid month
-            ['07-xxx-2016', false, '20'],
-            ['07-janu-2016', false, '20'],
-            ['07-00-2016', false, '20'],
-            ['07-01-2016', false, '20'],
-            // invalid year
-            ['01-JAN-0', false, '20'],
-            ['01-JAN-1', false, '20'],
-            ['01-JAN-000', false, '20'],
-            ['01-JAN-001', false, '20'],
-            ['01-JAN-00000', false, '20'],
-            ['01-JAN-00001', false, '20'],
-        ];
     }
 
     /**
@@ -103,7 +106,8 @@ class ReportUtilsTest extends TestCase
      */
     public function testparseDate($in, $expectedYmd, $century)
     {
-        $actual = ReportUtils::parseCsvDate($in, $century);
+        $sut = new ReportUtils();
+        $actual = $sut->parseCsvDate($in, $century);
 
         $this->assertEquals($expectedYmd, $actual ? $actual->format('Y-m-d') : $actual);
     }

--- a/api/tests/Unit/v2/Registration/Assembler/CasRecToOrgDeputyshipDtoAssemblerTest.php
+++ b/api/tests/Unit/v2/Registration/Assembler/CasRecToOrgDeputyshipDtoAssemblerTest.php
@@ -9,9 +9,12 @@ use App\Tests\Unit\v2\Registration\TestHelpers\OrgDeputyshipDTOTestHelper;
 use App\v2\Registration\Assembler\CasRecToOrgDeputyshipDtoAssembler;
 use DateTime;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class CasRecToOrgDeputyshipDtoAssemblerTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @test */
     public function assembleFromArrayDataIsSanitised()
     {

--- a/api/tests/Unit/v2/Registration/TestHelpers/OrgDeputyshipDTOTestHelper.php
+++ b/api/tests/Unit/v2/Registration/TestHelpers/OrgDeputyshipDTOTestHelper.php
@@ -50,31 +50,31 @@ class OrgDeputyshipDTOTestHelper
     public static function generateValidCasRecOrgDeputyshipArray()
     {
         $faker = Factory::create();
-        $courtOrderMadeDate = DateTimeImmutable::createFromMutable($faker->dateTimeThisYear);
+        $courtOrderMadeDate = DateTimeImmutable::createFromMutable($faker->dateTimeThisYear());
         $reportDueDate = $courtOrderMadeDate->modify('12 months - 1 day');
 
         return [
-            'Email' => sprintf('%s@%s%s.com', $faker->userName, $faker->randomNumber(8), $faker->domainWord),
+            'Email' => sprintf('%s@%s%s.com', $faker->userName(), $faker->randomNumber(8), $faker->domainWord()),
             'Deputy No' => (string) $faker->randomNumber(8),
             'Dep Postcode' => Address::postcode(),
-            'Dep Forename' => $faker->firstName,
-            'Dep Surname' => $faker->lastName,
+            'Dep Forename' => $faker->firstName(),
+            'Dep Surname' => $faker->lastName(),
             // Add 23 back in for PA tests
             'Dep Type' => (string) $faker->randomElement([21, 22, 24, 25, 26, 27, 29, 50, 63]),
-            'DepAddr No' => $faker->buildingNumber,
-            'Dep Adrs1' => $faker->streetName,
+            'DepAddr No' => $faker->buildingNumber(),
+            'Dep Adrs1' => $faker->streetName(),
             'Dep Adrs2' => Address::cityPrefix().' '.$faker->city(),
             'Dep Adrs3' => $faker->city(),
             'Dep Adrs4' => Address::county(),
             'Dep Adrs5' => 'UK',
             'Case' => (string) $faker->randomNumber(8),
-            'Forename' => $faker->firstName,
-            'Surname' => $faker->lastName,
+            'Forename' => $faker->firstName(),
+            'Surname' => $faker->lastName(),
             'Corref' => 'A3',
             'Report Due' => $reportDueDate->format('d-M-Y'),
-            'Forename' => $faker->firstName,
-            'Surname' => $faker->lastName,
-            'Client Adrs1' => $faker->buildingNumber.' '.$faker->streetName,
+            'Forename' => $faker->firstName(),
+            'Surname' => $faker->lastName(),
+            'Client Adrs1' => $faker->buildingNumber().' '.$faker->streetName(),
             'Client Adrs2' => Address::cityPrefix().' '.$faker->city(),
             'Client Adrs3' => Address::county(),
             'Client Adrs4' => null,
@@ -312,9 +312,9 @@ class OrgDeputyshipDTOTestHelper
 
         $layDeputy = (new User())
             ->setRoleName(User::ROLE_LAY_DEPUTY)
-            ->setFirstname($faker->firstName)
-            ->setLastname($faker->lastName)
-            ->setEmail($faker->email);
+            ->setFirstname($faker->firstName())
+            ->setLastname($faker->lastName())
+            ->setEmail($faker->email());
 
         $client = (new Client())
             ->setCaseNumber($dto->getCaseNumber())

--- a/api/tests/Unit/v2/Registration/TestHelpers/OrgDeputyshipDTOTestHelper.php
+++ b/api/tests/Unit/v2/Registration/TestHelpers/OrgDeputyshipDTOTestHelper.php
@@ -19,6 +19,7 @@ use App\v2\Registration\DTO\OrgDeputyshipDto;
 use DateTime;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManager;
+use Exception;
 use Faker\Factory;
 use Faker\Provider\en_GB\Address;
 
@@ -43,6 +44,74 @@ class OrgDeputyshipDTOTestHelper
         return base64_encode(gzcompress(json_encode($deputyships), 9));
     }
 
+    /**
+     * @return array
+     */
+    public static function generateValidCasRecOrgDeputyshipArray()
+    {
+        $faker = Factory::create();
+        $courtOrderMadeDate = DateTimeImmutable::createFromMutable($faker->dateTimeThisYear);
+        $reportDueDate = $courtOrderMadeDate->modify('12 months - 1 day');
+
+        return [
+            'Email' => sprintf('%s@%s%s.com', $faker->userName, $faker->randomNumber(8), $faker->domainWord),
+            'Deputy No' => (string) $faker->randomNumber(8),
+            'Dep Postcode' => Address::postcode(),
+            'Dep Forename' => $faker->firstName,
+            'Dep Surname' => $faker->lastName,
+            // Add 23 back in for PA tests
+            'Dep Type' => (string) $faker->randomElement([21, 22, 24, 25, 26, 27, 29, 50, 63]),
+            'DepAddr No' => $faker->buildingNumber,
+            'Dep Adrs1' => $faker->streetName,
+            'Dep Adrs2' => Address::cityPrefix().' '.$faker->city(),
+            'Dep Adrs3' => $faker->city(),
+            'Dep Adrs4' => Address::county(),
+            'Dep Adrs5' => 'UK',
+            'Case' => (string) $faker->randomNumber(8),
+            'Forename' => $faker->firstName,
+            'Surname' => $faker->lastName,
+            'Corref' => 'A3',
+            'Report Due' => $reportDueDate->format('d-M-Y'),
+            'Forename' => $faker->firstName,
+            'Surname' => $faker->lastName,
+            'Client Adrs1' => $faker->buildingNumber.' '.$faker->streetName,
+            'Client Adrs2' => Address::cityPrefix().' '.$faker->city(),
+            'Client Adrs3' => Address::county(),
+            'Client Adrs4' => null,
+            'Client Adrs5' => null,
+            'Client Postcode' => Address::postcode(),
+            'Client Date of Birth' => $faker->dateTime()->format('d-M-Y'),
+            'Made Date' => $courtOrderMadeDate->format('d-M-Y'),
+            'Typeofrep' => $faker->randomElement(['OPG102', 'OPG103']),
+            'Last Report Day' => '19-Jan-2021',
+        ];
+    }
+
+    private static function generateInvalidOrgDeputyshipArray()
+    {
+        $invalid = self::generateValidCasRecOrgDeputyshipArray();
+        $invalid['Email'] = '';
+
+        return $invalid;
+    }
+
+    /**
+     * @return OrgDeputyshipDto[]
+     */
+    public static function generateOrgDeputyshipDtos(int $validCount, int $invalidCount)
+    {
+        $json = self::generateCasRecOrgDeputyshipDecompressedJson($validCount, $invalidCount);
+        $dtos = [];
+        $reportUtils = new ReportUtils();
+        $assembler = new CasRecToOrgDeputyshipDtoAssembler($reportUtils);
+
+        foreach (json_decode($json, true) as $dtoArray) {
+            $dtos[] = $assembler->assembleSingleDtoFromArray($dtoArray);
+        }
+
+        return $dtos;
+    }
+
     public static function generateCasRecOrgDeputyshipDecompressedJson(int $validCount, int $invalidCount)
     {
         $deputyships = [];
@@ -63,26 +132,9 @@ class OrgDeputyshipDTOTestHelper
     }
 
     /**
-     * @return OrgDeputyshipDto[]
-     */
-    public static function generateOrgDeputyshipDtos(int $validCount, int $invalidCount)
-    {
-        $json = self::generateCasRecOrgDeputyshipDecompressedJson($validCount, $invalidCount);
-        $dtos = [];
-        $reportUtils = new ReportUtils();
-        $assembler = new CasRecToOrgDeputyshipDtoAssembler($reportUtils);
-
-        foreach (json_decode($json, true) as $dtoArray) {
-            $dtos[] = $assembler->assembleSingleDtoFromArray($dtoArray);
-        }
-
-        return $dtos;
-    }
-
-    /**
      * @return false|string
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public static function generateOrgDeputyshipResponseJson(int $clients, int $organisations, int $namedDeputies, int $reports, int $errors)
     {
@@ -141,57 +193,6 @@ class OrgDeputyshipDTOTestHelper
         }
 
         return $deputyships;
-    }
-
-    /**
-     * @return array
-     */
-    public static function generateValidCasRecOrgDeputyshipArray()
-    {
-        $faker = Factory::create();
-        $courtOrderMadeDate = DateTimeImmutable::createFromMutable($faker->dateTimeThisYear);
-        $reportDueDate = $courtOrderMadeDate->modify('12 months - 1 day');
-
-        return [
-            'Email' => sprintf('%s@%s%s.com', $faker->userName, $faker->randomNumber(8), $faker->domainWord),
-            'Deputy No' => (string) $faker->randomNumber(8),
-            'Dep Postcode' => Address::postcode(),
-            'Dep Forename' => $faker->firstName,
-            'Dep Surname' => $faker->lastName,
-            // Add 23 back in for PA tests
-            'Dep Type' => (string) $faker->randomElement([21, 22, 24, 25, 26, 27, 29, 50, 63]),
-            'DepAddr No' => $faker->buildingNumber,
-            'Dep Adrs1' => $faker->streetName,
-            'Dep Adrs2' => Address::cityPrefix().' '.$faker->city,
-            'Dep Adrs3' => $faker->city,
-            'Dep Adrs4' => Address::county(),
-            'Dep Adrs5' => 'UK',
-            'Case' => (string) $faker->randomNumber(8),
-            'Forename' => $faker->firstName,
-            'Surname' => $faker->lastName,
-            'Corref' => 'A3',
-            'Report Due' => $reportDueDate->format('d-M-Y'),
-            'Forename' => $faker->firstName,
-            'Surname' => $faker->lastName,
-            'Client Adrs1' => $faker->buildingNumber.' '.$faker->streetName,
-            'Client Adrs2' => Address::cityPrefix().' '.$faker->city,
-            'Client Adrs3' => Address::county(),
-            'Client Adrs4' => null,
-            'Client Adrs5' => null,
-            'Client Postcode' => Address::postcode(),
-            'Client Date of Birth' => $faker->dateTime->format('d-M-Y'),
-            'Made Date' => $courtOrderMadeDate->format('d-M-Y'),
-            'Typeofrep' => $faker->randomElement(['OPG102', 'OPG103']),
-            'Last Report Day' => '19-Jan-2021',
-        ];
-    }
-
-    private static function generateInvalidOrgDeputyshipArray()
-    {
-        $invalid = self::generateValidCasRecOrgDeputyshipArray();
-        $invalid['Email'] = '';
-
-        return $invalid;
     }
 
     public static function namedDeputyWasCreated(OrgDeputyshipDto $orgDeputyship, NamedDeputyRepository $namedDeputyRepository)


### PR DESCRIPTION
## Purpose
A continuation of #750 to remove deprecations from test outputs.

Fixes DDPB-4205

## Approach
API unit tests were pretty much unreadable due to there being deprecation outputs between each test case - now it's a see of `.` instead.

There was a final deprecation related to the auth component we're using in Symfony that will be removed in v5 that required a rewrite of the security config and implementation. We should switch to using the new [Symfony Security component](https://symfony.com/doc/current/security.html) when we upgrade to v6 - I'm not sure if this is possible while on 4 but its worth exploring so we can minimise upgrade PRs and potential risk.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes
