### PR TITLE
DDPB-4190 - Fix Scenario: A user adds one of each payment type

### DIFF
--- a/api/tests/Behat/bootstrap/v2/Reporting/Sections/MoneyOutSectionTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Reporting/Sections/MoneyOutSectionTrait.php
@@ -95,18 +95,30 @@ trait MoneyOutSectionTrait
     }
 
     /**
-     * @When I add one of each type of money out payment
+     * @When I add one type of money out payment from each category
      */
-    public function iAddOneOfEachTypeOfMoneyOutPayment()
+    public function iAddOneTypeOfMoneyOutPaymentFromEachCategory()
     {
         $this->iAmOnMoneyOutAddPaymentPage();
 
-        foreach ($this->paymentTypeDictionary as $radioPaymentValue => $translatedPaymentValue) {
-            $this->addPayment($radioPaymentValue, $translatedPaymentValue);
-            $this->addAnother('yes');
-        }
-
-        $this->clickLink('Back');
+        $this->addPayment('care-fees', $this->paymentTypeDictionary['care-fees']);
+        $this->addAnother('yes');
+        $this->addPayment('property-maintenance-improvement', $this->paymentTypeDictionary['property-maintenance-improvement']);
+        $this->addAnother('yes');
+        $this->addPayment('mortgage', $this->paymentTypeDictionary['mortgage']);
+        $this->addAnother('yes');
+        $this->addPayment('personal-allowance-pocket-money', $this->paymentTypeDictionary['personal-allowance-pocket-money']);
+        $this->addAnother('yes');
+        $this->addPayment('opg-fees', $this->paymentTypeDictionary['opg-fees']);
+        $this->addAnother('yes');
+        $this->addPayment('purchase-over-1000', $this->paymentTypeDictionary['purchase-over-1000']);
+        $this->addAnother('yes');
+        $this->addPayment('unpaid-care-fees', $this->paymentTypeDictionary['unpaid-care-fees']);
+        $this->addAnother('yes');
+        $this->addPayment('cash-withdrawn', $this->paymentTypeDictionary['cash-withdrawn']);
+        $this->addAnother('yes');
+        $this->addPayment('anything-else-paid-out', $this->paymentTypeDictionary['anything-else-paid-out']);
+        $this->addAnother('no');
     }
 
     /**

--- a/api/tests/Behat/features-v2/reporting/sections/money-out/money-out.feature
+++ b/api/tests/Behat/features-v2/reporting/sections/money-out/money-out.feature
@@ -14,10 +14,10 @@ Feature: Money Out
     Scenario: A user adds one of each payment type
         Given a Lay Deputy has not started a Pfa High Assets report
         When I view and start the money out report section
-        And I add one of each type of money out payment
+        And I add one type of money out payment from each category
         Then I should see the expected results on money out summary page
         When I follow link back to report overview page
-        Then I should see "money-out" as "39 items"
+        Then I should see "money-out" as "9 items"
 
     @lay-pfa-high-not-started
     Scenario: A user removes a payment


### PR DESCRIPTION
## Purpose
Occasionally when running a build, this particular test can sometimes fail.
It seems this is as a result of the steps falling out of sync with the browser, as the usual error message refers to the test step expecting the browser to be on a certain page and the browser actually being on a different one.

This ticket is to try and solve this issue.

Fixes DDPB-4190

## Approach
Ran this test a few times with various number of steps, and it did seem at a higher number of steps the error was more likely to occur.

Although it would be nice to test every type of money out payment as we currently do, all the types use the same layout and so just testing a few should prove the pages work as expected.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
