### PR TITLE
Exclude cross site scripting rule for now and add waf to all envs

### DIFF
--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -117,7 +117,7 @@
       "aurora_enabled": true,
       "s3_backup_replication": "Disabled",
       "s3_backup_kms_arn": "8d42ba9a-321c-43ac-a911-5f452d336da5",
-      "associate_alb_with_waf_web_acl_enabled": false
+      "associate_alb_with_waf_web_acl_enabled": true
     },
     "integration": {
       "name": "preproduction",
@@ -156,7 +156,7 @@
       "aurora_enabled": true,
       "s3_backup_replication": "Disabled",
       "s3_backup_kms_arn": "5875b77a-043c-41e3-a3c6-84bdd865fedf",
-      "associate_alb_with_waf_web_acl_enabled": false
+      "associate_alb_with_waf_web_acl_enabled": true
     },
     "development": {
       "name": "development",
@@ -198,7 +198,7 @@
       "aurora_enabled": true,
       "s3_backup_replication": "Enabled",
       "s3_backup_kms_arn": "f4dd7602-251f-48f8-accb-6d1bec57436f",
-      "associate_alb_with_waf_web_acl_enabled": false
+      "associate_alb_with_waf_web_acl_enabled": true
     },
     "default": {
       "name": "development",
@@ -238,7 +238,7 @@
       "aurora_enabled": true,
       "s3_backup_replication": "Disabled",
       "s3_backup_kms_arn": "f4dd7602-251f-48f8-accb-6d1bec57436f",
-      "associate_alb_with_waf_web_acl_enabled": false
+      "associate_alb_with_waf_web_acl_enabled": true
     }
   }
 }

--- a/shared/waf.tf
+++ b/shared/waf.tf
@@ -67,6 +67,10 @@ resource "aws_wafv2_web_acl" "main" {
           name = "SizeRestrictions_BODY"
         }
 
+        excluded_rule {
+          name = "CrossSiteScripting_BODY"
+        }
+
       }
     }
     visibility_config {


### PR DESCRIPTION
## Purpose
The WAF we applied to prod is currently blocking uploads of PDFs due to the cross-site scripting rule. We should disable this rule until we can work out a way to allow PDF uploads.

This PR also enables the WAF in all environments to ensure we pick these problems up in integration tests going forward.

Fixes DDPB-####
