### PR TITLE
DDPB-4188, DDPB-4207: New client benefits section markup fixes

### DIFF
--- a/client/assets/scss/digideps/_sections.scss
+++ b/client/assets/scss/digideps/_sections.scss
@@ -52,6 +52,7 @@
         // Currently need to use !important to override high-specificy margins from .status
         margin-top: 0 !important; // sass-lint:disable-line no-important
         margin-bottom: 0 !important; // sass-lint:disable-line no-important
+        white-space: nowrap;
     }
 
     &__link {

--- a/client/assets/scss/digideps/_tags.scss
+++ b/client/assets/scss/digideps/_tags.scss
@@ -1,5 +1,7 @@
 .opg-tag {
+
     &--small {
+        white-space: nowrap;
         @include govuk-font(14, $weight: bold);
     }
 

--- a/client/templates/Macros/macros.html.twig
+++ b/client/templates/Macros/macros.html.twig
@@ -625,3 +625,24 @@ C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.
         </fieldset>
     </div>
 {%- endmacro -%}
+
+{%- macro edit_remove_links_dd(editPathName, editOptions, removePathName, removeOptions, editLinkContextText, removeLinkContextText) -%}
+    <dd class="govuk-summary-list__value govuk-!-text-align-right">
+        <span>
+            <a
+                href="{{ path('client_benefits_check_step', editOptions) }}"
+                class="govuk-link"
+            >
+                {{ 'edit' | trans({}, 'common' ) }} <span class="govuk-visually-hidden">{{ editLinkContextText }}</span>
+            </a>
+        </span>
+        <span>
+            <a
+                href="{{ path(removePathName, removeOptions) }}"
+                class="govuk-link govuk-!-margin-left-1"
+            >
+                {{ 'remove' | trans({}, 'common' ) }} <span class="govuk-visually-hidden">{{ removeLinkContextText }}</span>
+            </a>
+        </span>
+    </dd>
+{%- endmacro -%}

--- a/client/templates/Report/ClientBenefitsCheck/_answers.html.twig
+++ b/client/templates/Report/ClientBenefitsCheck/_answers.html.twig
@@ -156,24 +156,19 @@
                             {% endif %}
                         </dd>
                         {% if showActions %}
-                            <dd class="govuk-summary-list__value govuk-!-text-align-right">
-                                <span>
-                                    <a
-                                        href="{{ path('client_benefits_check_step', { 'reportId': report.id, 'step': 3, 'reportOrNdr': reportOrNdr }) }}"
-                                        class="govuk-link"
-                                    >
-                                        {{ 'edit' | trans({}, 'common' ) }} <span class="govuk-visually-hidden">income type with description '{{ income.incomeType }}'</span>
-                                    </a>
-                                </span>
-                                    <span>
-                                    <a
-                                        href="{{ path('client_benefits_check_remove_income_type', { 'reportId': report.id, 'incomeTypeId': income.id, 'reportOrNdr': reportOrNdr }) }}"
-                                        class="govuk-link"
-                                    >
-                                        {{ 'remove' | trans({}, 'common' ) }} <span class="govuk-visually-hidden">income type with description '{{ income.incomeType }}'</span>
-                                    </a>
-                                </span>
-                            </dd>
+                            {% set editLinkContextText = 'income type with description ' ~ income.incomeType %}
+                            {% set removeLinkContextText = 'income type with description ' ~ income.incomeType %}
+
+                            {{
+                                macros.edit_remove_links_dd(
+                                    'client_benefits_check_step',
+                                    { 'reportId': report.id, 'step': 3, 'reportOrNdr': reportOrNdr },
+                                    'client_benefits_check_remove_income_type',
+                                    { 'reportId': report.id, 'incomeTypeId': income.id, 'reportOrNdr': reportOrNdr },
+                                    editLinkContextText,
+                                    removeLinkContextText
+                                )
+                            }}
                         {% endif %}
                     </div>
                 {% endfor %}


### PR DESCRIPTION
## Purpose
Fixes a couple of visual issues with the new benefits section:

* Ensures status tags remain on one line
* Adds spacing to edit/remove links (and moves to macro)

Fixes DDPB-4188, DDPB-4207

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [x] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
