### PR TITLE
DDPB-4138: Enforce TLSv1.2 as a minimum

### DIFF
--- a/api/docker/confd/templates/app.conf.tmpl
+++ b/api/docker/confd/templates/app.conf.tmpl
@@ -14,7 +14,11 @@ server {
 
     ssl_certificate         /etc/nginx/certs/app.crt;
     ssl_certificate_key     /etc/nginx/certs/app.key;
-    ssl_protocols           TLSv1.2 TLSv1.3;
+
+    # See https://ssl-config.mozilla.org/#server=nginx&version=1.17.7&config=intermediate&openssl=1.1.1d&guideline=5.4 for ref
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
 
     more_clear_headers X-Powered-By;
     more_clear_headers Server;

--- a/api/docker/confd/templates/app.conf.tmpl
+++ b/api/docker/confd/templates/app.conf.tmpl
@@ -14,6 +14,7 @@ server {
 
     ssl_certificate         /etc/nginx/certs/app.crt;
     ssl_certificate_key     /etc/nginx/certs/app.key;
+    ssl_protocols           TLSv1.2 TLSv1.3;
 
     more_clear_headers X-Powered-By;
     more_clear_headers Server;

--- a/api/docker/confd/templates/app.conf.tmpl
+++ b/api/docker/confd/templates/app.conf.tmpl
@@ -4,7 +4,7 @@ server {
 }
 
 server {
-    listen     443 ssl;
+    listen     443 ssl http2;
     root /var/www/public;
 
 
@@ -14,7 +14,7 @@ server {
 
     ssl_certificate         /etc/nginx/certs/app.crt;
     ssl_certificate_key     /etc/nginx/certs/app.key;
-    ssl_protocols           TLSv1.2;
+    ssl_protocols           TLSv1.2 TLSv1.3;
 
     more_clear_headers X-Powered-By;
     more_clear_headers Server;

--- a/api/docker/confd/templates/app.conf.tmpl
+++ b/api/docker/confd/templates/app.conf.tmpl
@@ -14,7 +14,7 @@ server {
 
     ssl_certificate         /etc/nginx/certs/app.crt;
     ssl_certificate_key     /etc/nginx/certs/app.key;
-    ssl_protocols           TLSv1.2 TLSv1.3;
+    ssl_protocols           TLSv1.2;
 
     more_clear_headers X-Powered-By;
     more_clear_headers Server;


### PR DESCRIPTION
## Purpose
Enforces TLS2 or 3 as a minimum and http2. I've been struggling to test this locally due to our self signed certificate returning an error when I curl with some tls options set using `curl -I -v --tlsv1.2 --tls-max 1.2 https://localhost:8090`. As the API is only available to services with AWS I can't run an SSL check on it from the open web. Everything is still working so I'm not too worried about misconfiguration, I just can't tell if this has fixed the problem 🤷 

Fixes DDPB-4138.

## Learning
This [config generator](https://ssl-config.mozilla.org/#server=nginx&version=1.17.7&config=intermediate&openssl=1.1.1d&guideline=5.4) was very useful in determining what to set for a broad range of compatibility.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes