### PR TITLE
DDPB-3832: Format the report review page to make it easier to submit a report 

### DIFF
--- a/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnFrontendTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnFrontendTrait.php
@@ -45,11 +45,27 @@ trait IShouldBeOnFrontendTrait
     }
 
     /**
+     * @Then I should be on the ndr declaration page
+     */
+    public function iAmOnNdrDeclarationPage(): bool
+    {
+        return $this->iAmOnPage('/ndr\/.*\/declaration$/');
+    }
+
+    /**
      * @Then I should be on the report submitted page
      */
     public function iAmOnReportSubmittedPage(): bool
     {
         return $this->iAmOnPage('/report\/.*\/submitted$/');
+    }
+
+    /**
+     * @Then I should be on the ndr submitted page
+     */
+    public function iAmOnNdrSubmittedPage(): bool
+    {
+        return $this->iAmOnPage('/ndr\/.*\/submitted$/');
     }
 
     /**

--- a/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnFrontendTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnFrontendTrait.php
@@ -21,6 +21,30 @@ trait IShouldBeOnFrontendTrait
     }
 
     /**
+     * @Then I should be on the report review page
+     */
+    public function iAmOnReportReviewPage(): bool
+    {
+        return $this->iAmOnPage('/report\/.*\/review$/');
+    }
+
+    /**
+     * @Then I should be on the ndr review page
+     */
+    public function iAmOnNdrReviewPage(): bool
+    {
+        return $this->iAmOnPage('/ndr\/.*\/review$/');
+    }
+
+    /**
+     * @Then I should be on the report declaration page
+     */
+    public function iAmOnReportDeclarationPage(): bool
+    {
+        return $this->iAmOnPage('/report\/.*\/declaration$/');
+    }
+
+    /**
      * @Then I should be on the report submitted page
      */
     public function iAmOnReportSubmittedPage(): bool

--- a/api/tests/Behat/bootstrap/v2/Common/ReportTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/ReportTrait.php
@@ -507,7 +507,11 @@ trait ReportTrait
     public function iContinueToDeclarationAndSubmission()
     {
         $this->clickLink('Continue to declaration and submission');
-        $this->iAmOnReportDeclarationPage();
+        if ('ndr' === strtolower($this->loggedInUserDetails->getCurrentReportNdrOrReport())) {
+            $this->iAmOnNdrDeclarationPage();
+        } else {
+            $this->iAmOnReportDeclarationPage();
+        }
     }
 
     /**
@@ -515,7 +519,11 @@ trait ReportTrait
      */
     public function iConfirmIAgreeToTheDeclaration()
     {
-        $this->checkOption('report_declaration[agree]');
+        if ('ndr' === strtolower($this->loggedInUserDetails->getCurrentReportNdrOrReport())) {
+            $this->checkOption('ndr_declaration[agree]');
+        } else {
+            $this->checkOption('report_declaration[agree]');
+        }
     }
 
     /**
@@ -523,7 +531,11 @@ trait ReportTrait
      */
     public function iConfirmIAmTheSoleDeputy()
     {
-        $this->selectOption('report_declaration[agreedBehalfDeputy]', 'only_deputy');
+        if ('ndr' === strtolower($this->loggedInUserDetails->getCurrentReportNdrOrReport())) {
+            $this->selectOption('ndr_declaration[agreedBehalfDeputy]', 'only_deputy');
+        } else {
+            $this->selectOption('report_declaration[agreedBehalfDeputy]', 'only_deputy');
+        }
     }
 
     /**
@@ -532,7 +544,11 @@ trait ReportTrait
     public function iSubmitMyReport()
     {
         $this->pressButton('Submit report');
-        $this->iAmOnReportSubmittedPage();
+        if ('ndr' === strtolower($this->loggedInUserDetails->getCurrentReportNdrOrReport())) {
+            $this->iAmOnNdrSubmittedPage();
+        } else {
+            $this->iAmOnReportSubmittedPage();
+        }
     }
 
     /**

--- a/api/tests/Behat/bootstrap/v2/Common/ReportTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/ReportTrait.php
@@ -458,7 +458,7 @@ trait ReportTrait
     public function endDateAndDueDateLoggedInUsersCurrentReportSetToDate(string $dateString, string $currentOrPrevious)
     {
         if (empty($this->loggedInUserDetails) ||
-           (empty($this->loggedInUserDetails->getCurrentReportId()) && empty($this->loggedInUserDetails->getPreviousReportId()))
+            (empty($this->loggedInUserDetails->getCurrentReportId()) && empty($this->loggedInUserDetails->getPreviousReportId()))
         ) {
             throw new BehatException('The logged in user does not have a report. Ensure a user with a report has logged in before using this step.');
         }
@@ -486,5 +486,60 @@ trait ReportTrait
             $this->loggedInUserDetails->setPreviousReportDueDate($newDate);
             $this->loggedInUserDetails->setPreviousReportEndDate($newDate);
         }
+    }
+
+    /**
+     * @When /^I preview and check the report$/
+     */
+    public function iPreviewAndCheckTheReport()
+    {
+        $this->pressButton('Preview and check report');
+        if ('ndr' === strtolower($this->loggedInUserDetails->getCurrentReportNdrOrReport())) {
+            $this->iAmOnNdrReviewPage();
+        } else {
+            $this->iAmOnReportReviewPage();
+        }
+    }
+
+    /**
+     * @Given /^I continue to declaration and submission$/
+     */
+    public function iContinueToDeclarationAndSubmission()
+    {
+        $this->clickLink('Continue to declaration and submission');
+        $this->iAmOnReportDeclarationPage();
+    }
+
+    /**
+     * @Given /^I confirm I agree to the declaration$/
+     */
+    public function iConfirmIAgreeToTheDeclaration()
+    {
+        $this->checkOption('report_declaration[agree]');
+    }
+
+    /**
+     * @Given /^I confirm I am the sole deputy$/
+     */
+    public function iConfirmIAmTheSoleDeputy()
+    {
+        $this->selectOption('report_declaration[agreedBehalfDeputy]', 'only_deputy');
+    }
+
+    /**
+     * @Given /^I submit my report$/
+     */
+    public function iSubmitMyReport()
+    {
+        $this->pressButton('Submit report');
+        $this->iAmOnReportSubmittedPage();
+    }
+
+    /**
+     * @Then /^my report should be submitted$/
+     */
+    public function myReportShouldBeSubmitted()
+    {
+        $this->assertPageContainsText('Your report has been sent to OPG');
     }
 }

--- a/api/tests/Behat/features-v2/report-submission/submitting-a-report.feature
+++ b/api/tests/Behat/features-v2/report-submission/submitting-a-report.feature
@@ -1,0 +1,13 @@
+@report-submissions @v2
+Feature: Report submissions dashboard
+
+    @lay-pfa-high-completed
+    Scenario: Submitting a completed report
+        Given a Lay Deputy has a completed report
+        And I visit the report overview page
+        When I preview and check the report
+        And I continue to declaration and submission
+        And I confirm I agree to the declaration
+        And I confirm I am the sole deputy
+        And I submit my report
+        Then my report should be submitted

--- a/api/tests/Behat/features-v2/report-submission/submitting-a-report.ndr.feature
+++ b/api/tests/Behat/features-v2/report-submission/submitting-a-report.ndr.feature
@@ -1,0 +1,13 @@
+@report-submissions @v2
+Feature: Report submissions dashboard
+
+    @ndr-completed @Mia
+    Scenario: Submitting a completed report
+        Given a Lay Deputy has a completed NDR report
+        And I visit the report overview page
+        When I preview and check the report
+        And I continue to declaration and submission
+        And I confirm I agree to the declaration
+        And I confirm I am the sole deputy
+        And I submit my report
+        Then my report should be submitted

--- a/api/tests/Behat/features-v2/report-submission/submitting-a-report.ndr.feature
+++ b/api/tests/Behat/features-v2/report-submission/submitting-a-report.ndr.feature
@@ -1,7 +1,7 @@
 @report-submissions @v2
 Feature: Report submissions dashboard
 
-    @ndr-completed @Mia
+    @ndr-completed
     Scenario: Submitting a completed report
         Given a Lay Deputy has a completed NDR report
         And I visit the report overview page

--- a/client/assets/scss/digideps/formatted_report/_main.scss
+++ b/client/assets/scss/digideps/formatted_report/_main.scss
@@ -438,4 +438,14 @@ $print-text: #454572;
             color: $print-text;
         }
     }
+
+
+}
+
+.opg-border--secondary {
+    border-width: thin;
+    border-style: solid;
+    border-color: $govuk-secondary-text-colour;
+    padding: 1rem;
+    width: 800px;
 }

--- a/client/templates/Macros/macros.html.twig
+++ b/client/templates/Macros/macros.html.twig
@@ -11,24 +11,26 @@
                     </a>
                 {% else %}
                     <a href="{{ path('homepage') }}" class="govuk-breadcrumbs__link">
-                        {{ 'yourReports' | trans({}, 'common' ) }}
+                        {{ 'yourReports' | trans({'deputyFirstname': app.user.firstname, 'deputyLastname': app.user.lastname}, 'common' ) }}
                     </a>
                 {% endif %}
             </li>
             <li class="govuk-breadcrumbs__list-item">
                 {% if report.type == 'ndr' %}
                     <a href="{{ path('ndr_overview', {'ndrId': report.id}) }}"
-                       class="govuk-breadcrumbs__link behat-link-breadcrumbs-ndr-overview" data-action="report.overview">
+                       class="govuk-breadcrumbs__link behat-link-breadcrumbs-ndr-overview"
+                       data-action="report.overview">
                         {{ 'newDeputyReportOverview' | trans({}, 'common' ) }}
                     </a>
 
                 {% else %}
                     <a href="{{ path('report_overview', {'reportId': report.id}) }}"
-                       class="govuk-breadcrumbs__link behat-link-breadcrumbs-report-overview" data-action="report.overview">
+                       class="govuk-breadcrumbs__link behat-link-breadcrumbs-report-overview"
+                       data-action="report.overview">
                         {% if isOrgUser %}
                             {{ 'clientProfile' | trans({}, 'common' ) }}
                         {% else %}
-                            {{ 'deputyReportOverview' | trans({}, 'common' ) }}
+                            {{ 'deputyReportOverview' | trans({ 'startYear': report.startDate | date('Y'),'endYear': report.endDate | date('Y') }, 'common' ) }}
                         {% endif %}
                     </a>
                 {% endif %}
@@ -110,7 +112,7 @@
             {% for item in items %}
                 <li class="govuk-breadcrumbs__list-item" {% if loop.last %}aria-current="page"{% endif %}>
                     {% if item.href is defined %}
-                        <a class="govuk-breadcrumbs__link" href="{{ item.href }}">{{ item.text  }}</a>
+                        <a class="govuk-breadcrumbs__link" href="{{ item.href }}">{{ item.text }}</a>
                     {% else %}
                         {{ item.text }}
                     {% endif %}
@@ -132,7 +134,7 @@
             'labelText': 'saveAndContinue',
             'labelTranslationDomain': 'common',
             'buttonClass': 'govuk-button govuk-!-margin-right-1 behat-link-save-and-continue',
-            }) }}
+        }) }}
     </div>
 {% endmacro %}
 
@@ -165,7 +167,8 @@
 
 {% macro icon(type, extraClass = '') %}
     {% if type in ['arrow-up'] %}
-        <svg role="presentation" focusable="false" class="opg-icon {{ extraClass }}" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
+        <svg role="presentation" focusable="false" class="opg-icon {{ extraClass }}" xmlns="http://www.w3.org/2000/svg"
+             width="13" height="17" viewBox="0 0 13 17">
             {% if type == 'arrow-up' %}
                 <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
             {% endif %}
@@ -210,7 +213,8 @@
             <div class="opg-alert opg-alert--info">
                 {{ _self.icon('information', 'opg-alert__icon') }}
                 <div class="behat-region-alert-message opg-alert__message">
-                    <p class="govuk-body govuk-!-margin-bottom-0">{{ message.textbeforemarkup }}<br><br>{{ message.textaftermarkup }}</p>
+                    <p class="govuk-body govuk-!-margin-bottom-0">{{ message.textbeforemarkup }}
+                        <br><br>{{ message.textaftermarkup }}</p>
                 </div>
             </div>
         {% elseif alertType == 'infoLink' %}
@@ -218,7 +222,8 @@
                 {{ _self.icon('information', 'opg-alert__icon') }}
                 <div class="behat-region-alert-message opg-alert__message">
                     <p class="govuk-body govuk-!-margin-bottom-0">
-                        {{ message.textbeforemarkup }}<a href="{{ message.link }}">{{ message.linktext }}</a>{{ message.textaftermarkup }}
+                        {{ message.textbeforemarkup }}<a
+                            href="{{ message.link }}">{{ message.linktext }}</a>{{ message.textaftermarkup }}
                     </p>
                 </div>
             </div>
@@ -286,7 +291,8 @@
                 {% if (section_link_params(report, section, +1)) %}
                     <li>
                         <a href="{{ section_link_params(report, section, +1).link }}" class="govuk-link">
-                            Next section: {{ ('prevNextLinks.sections.' ~ section_link_params(report, section, +1).section) | trans({}, 'report-common') }}
+                            Next
+                            section: {{ ('prevNextLinks.sections.' ~ section_link_params(report, section, +1).section) | trans({}, 'report-common') }}
                         </a>
                     </li>
                 {% endif %}
@@ -325,27 +331,31 @@
 
 {% macro icon(type, svgClass) %}
     {% if type == 'success' %}
-        <svg class="{{ svgClass }}" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
-            <path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z" />
+        <svg class="{{ svgClass }}" fill="currentColor" role="presentation" focusable="false"
+             xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+            <path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z"/>
         </svg>
     {% endif %}
 
     {% if type == 'warning' %}
-        <svg class="{{ svgClass }}" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
-            <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z" />
+        <svg class="{{ svgClass }}" fill="currentColor" role="presentation" focusable="false"
+             xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+            <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z"/>
         </svg>
     {% endif %}
 
     {% if type == 'startButton' %}
-        <svg class="{{ svgClass }}" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
-            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+        <svg class="{{ svgClass }}" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40"
+             role="presentation" focusable="false">
+            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
         </svg>
     {% endif %}
 
     {% if type == 'information' %}
-        <svg class="{{ svgClass }}" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+        <svg class="{{ svgClass }}" fill="currentColor" role="presentation" focusable="false"
+             xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
             <path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8
-C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z" />
+C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z"/>
         </svg>
     {% endif %}
 {% endmacro %}
@@ -364,15 +374,17 @@ C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.
 {% endmacro %}
 
 {% macro startSectionButton(path, text) %}
-    <a href={{ path }} role="button" draggable="false" class="govuk-button govuk-button--start behat-link-start" data-module="govuk-button">
+    <a href={{ path }} role="button" draggable="false" class="govuk-button govuk-button--start behat-link-start"
+       data-module="govuk-button">
         {{ text }}
-        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19"
+             viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
         </svg>
     </a>
 {% endmacro %}
 
-{#transDomain and successHeading are optional arguments to support passing in a pre-translated string#}
+{# transDomain and successHeading are optional arguments to support passing in a pre-translated string #}
 {% macro successBanner(successText, transDomain, successHeading) %}
     <div class="moj-banner moj-banner--success">
         {{ _self.icon('success', 'moj-banner__icon') }}
@@ -380,7 +392,7 @@ C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.
             {% if successHeading is not null %}
                 <h2 class="govuk-heading-m">
                     {% if transDomain is not null %}
-                        {{ successHeading | trans({}, transDomain)  }}
+                        {{ successHeading | trans({}, transDomain) }}
                     {% else %}
                         {{ successHeading }}
                     {% endif %}
@@ -388,15 +400,15 @@ C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.
             {% endif %}
             <span class="moj-banner__assistive">Success</span>
             {% if transDomain is not null %}
-                {{ successText | trans({}, transDomain) | nl2br  }}
+                {{ successText | trans({}, transDomain) | nl2br }}
             {% else %}
-                {{ successText | nl2br  }}
+                {{ successText | nl2br }}
             {% endif %}
         </div>
     </div>
 {% endmacro %}
 
-{#transDomain and warningHeading are optional arguments to support passing in a pre-translated string#}
+{# transDomain and warningHeading are optional arguments to support passing in a pre-translated string #}
 {% macro warningBanner(warningText, transDomain, warningHeading) %}
     <div class="moj-banner moj-banner--warning">
         {{ _self.icon('warning', 'moj-banner__icon') }}
@@ -404,7 +416,7 @@ C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.
             {% if warningHeading is not null %}
                 <h2 class="govuk-heading-m">
                     {% if transDomain is not null %}
-                        {{ warningHeading | trans({}, transDomain)  }}
+                        {{ warningHeading | trans({}, transDomain) }}
                     {% else %}
                         {{ warningHeading }}
                     {% endif %}
@@ -412,23 +424,23 @@ C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.
             {% endif %}
             <span class="moj-banner__assistive">Warning</span>
             {% if transDomain is not null %}
-                {{ warningText | trans({}, transDomain) | nl2br  }}
+                {{ warningText | trans({}, transDomain) | nl2br }}
             {% else %}
-                {{ warningText | nl2br  }}
+                {{ warningText | nl2br }}
             {% endif %}
         </div>
     </div>
 {% endmacro %}
 
-{#transDomain and infoHeading are optional arguments to support passing in a pre-translated string#}
+{# transDomain and infoHeading are optional arguments to support passing in a pre-translated string #}
 {% macro informationBanner(infoText, transDomain, infoHeading) %}
     <div class="moj-banner">
         {{ _self.icon('information', 'moj-banner__icon') }}
         <div class="moj-banner__message">
-            {% if infoHeading is not null  %}
+            {% if infoHeading is not null %}
                 <h2 class="govuk-heading-m">
                     {% if transDomain is not null %}
-                        {{ infoHeading | trans({}, transDomain)  }}
+                        {{ infoHeading | trans({}, transDomain) }}
                     {% else %}
                         {{ infoHeading }}
                     {% endif %}
@@ -436,9 +448,9 @@ C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.
             {% endif %}
             <span class="moj-banner__assistive">information</span>
             {% if transDomain is not null %}
-                {{ infoText | trans({}, transDomain) | nl2br  }}
+                {{ infoText | trans({}, transDomain) | nl2br }}
             {% else %}
-                {{ infoText | nl2br  }}
+                {{ infoText | nl2br }}
             {% endif %}
         </div>
     </div>
@@ -480,79 +492,83 @@ C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.
     <fieldset class="govuk-fieldset">
 
         {% if formObject.address is defined %}
-        <div class="govuk-form-group">
-            {% set formAddressLabel = translationPrefix ~ 'address.label' %}
-            {% set formAddressContext = translationPrefix ~ 'address.context' %}
-            {{ formAddressLabel | trans({}, transDomain) }}<span class="govuk-visually-hidden">{{ formAddressContext | trans({}, transDomain) }}</span>
-            {{ form_input(formObject.address, '') }}
-        </div>
+            <div class="govuk-form-group">
+                {% set formAddressLabel = translationPrefix ~ 'address.label' %}
+                {% set formAddressContext = translationPrefix ~ 'address.context' %}
+                {{ formAddressLabel | trans({}, transDomain) }}<span
+                    class="govuk-visually-hidden">{{ formAddressContext | trans({}, transDomain) }}</span>
+                {{ form_input(formObject.address, '') }}
+            </div>
         {% endif %}
 
         {% if formObject.address1 is defined %}
-        <div class="govuk-form-group">
-            {% set formAddress1Label = translationPrefix ~ 'address1.label' %}
-            {% set formAddress1Context = translationPrefix ~ 'address1.context' %}
-            {{ formAddress1Label | trans({}, transDomain) }}<span class="govuk-visually-hidden">{{ formAddress1Context | trans({}, transDomain) }}</span>
-            {{ form_input(formObject.address1, '') }}
-        </div>
+            <div class="govuk-form-group">
+                {% set formAddress1Label = translationPrefix ~ 'address1.label' %}
+                {% set formAddress1Context = translationPrefix ~ 'address1.context' %}
+                {{ formAddress1Label | trans({}, transDomain) }}<span
+                    class="govuk-visually-hidden">{{ formAddress1Context | trans({}, transDomain) }}</span>
+                {{ form_input(formObject.address1, '') }}
+            </div>
         {% endif %}
 
         {% if formObject.address2 is defined %}
-        <div class="govuk-form-group">
-            {% set formAddress2Label = translationPrefix ~ 'address2.label' %}
-            {% set formAddress2Context = translationPrefix ~ 'address2.context' %}
-            {{ formAddress2Label | trans({}, transDomain) }}<span class="govuk-visually-hidden">{{ formAddress2Context | trans({}, transDomain) }}</span>
-            {{ form_input(formObject.address2, '') }}
-        </div>
+            <div class="govuk-form-group">
+                {% set formAddress2Label = translationPrefix ~ 'address2.label' %}
+                {% set formAddress2Context = translationPrefix ~ 'address2.context' %}
+                {{ formAddress2Label | trans({}, transDomain) }}<span
+                    class="govuk-visually-hidden">{{ formAddress2Context | trans({}, transDomain) }}</span>
+                {{ form_input(formObject.address2, '') }}
+            </div>
         {% endif %}
 
         {% if formObject.county is defined %}
-        <div class="govuk-form-group">
-            {% set formCountyLabel = translationPrefix ~ 'county.label' %}
-            {{ formCountyLabel | trans({}, transDomain) }}
-            {{ form_input(formObject.county, '') }}
-        </div>
+            <div class="govuk-form-group">
+                {% set formCountyLabel = translationPrefix ~ 'county.label' %}
+                {{ formCountyLabel | trans({}, transDomain) }}
+                {{ form_input(formObject.county, '') }}
+            </div>
         {% endif %}
 
         {% if formObject.address3 is defined %}
-        <div class="govuk-form-group">
-            {% set formAddress3Label = translationPrefix ~ 'address3.label' %}
-            {% set formAddress3Context = translationPrefix ~ 'address3.context' %}
-            {{ formAddress3Label | trans({}, transDomain) }}<span class="govuk-visually-hidden">{{ formAddress3Context | trans({}, transDomain) }}</span>
-            {{ form_input(formObject.address3, '') }}
-        </div>
+            <div class="govuk-form-group">
+                {% set formAddress3Label = translationPrefix ~ 'address3.label' %}
+                {% set formAddress3Context = translationPrefix ~ 'address3.context' %}
+                {{ formAddress3Label | trans({}, transDomain) }}<span
+                    class="govuk-visually-hidden">{{ formAddress3Context | trans({}, transDomain) }}</span>
+                {{ form_input(formObject.address3, '') }}
+            </div>
         {% endif %}
 
         {% if formObject.postcode is defined %}
-        <div class="govuk-form-group">
-            {% set formPostcodeLabel = translationPrefix ~ 'postcode.label' %}
-            {{ formPostcodeLabel | trans({}, transDomain) }}
-            {{ form_input(formObject.postcode, '') }}
-        </div>
+            <div class="govuk-form-group">
+                {% set formPostcodeLabel = translationPrefix ~ 'postcode.label' %}
+                {{ formPostcodeLabel | trans({}, transDomain) }}
+                {{ form_input(formObject.postcode, '') }}
+            </div>
         {% endif %}
 
         {% if formObject.addressPostcode is defined %}
-        <div class="govuk-form-group">
-            {% set formaddressPostcodeLabel = translationPrefix ~ 'addressPostcode.label' %}
-            {{ formaddressPostcodeLabel | trans({}, transDomain) }}
-            {{ form_input(formObject.addressPostcode, '') }}
-        </div>
+            <div class="govuk-form-group">
+                {% set formaddressPostcodeLabel = translationPrefix ~ 'addressPostcode.label' %}
+                {{ formaddressPostcodeLabel | trans({}, transDomain) }}
+                {{ form_input(formObject.addressPostcode, '') }}
+            </div>
         {% endif %}
 
         {% if formObject.country is defined %}
-        <div class="govuk-form-group">
-            {% set formCountryLabel = translationPrefix ~ 'country.label' %}
-            {{ formCountryLabel | trans({}, transDomain) }}
-            {{ form_input(formObject.country, '') }}
-        </div>
+            <div class="govuk-form-group">
+                {% set formCountryLabel = translationPrefix ~ 'country.label' %}
+                {{ formCountryLabel | trans({}, transDomain) }}
+                {{ form_input(formObject.country, '') }}
+            </div>
         {% endif %}
 
         {% if formObject.addressCountry is defined %}
-        <div class="govuk-form-group">
-            {% set formaddressCountryLabel = translationPrefix ~ 'addressCountry.label' %}
-            {{ formaddressCountryLabel | trans({}, transDomain) }}
-            {{ form_input(formObject.addressCountry, '') }}
-        </div>
+            <div class="govuk-form-group">
+                {% set formaddressCountryLabel = translationPrefix ~ 'addressCountry.label' %}
+                {{ formaddressCountryLabel | trans({}, transDomain) }}
+                {{ form_input(formObject.addressCountry, '') }}
+            </div>
         {% endif %}
 
     </fieldset>

--- a/client/templates/Ndr/Ndr/_header.html.twig
+++ b/client/templates/Ndr/Ndr/_header.html.twig
@@ -11,8 +11,9 @@
     </div>
 
     <div class="govuk-panel__body">
-        <a class="govuk-button govuk-!-margin-0 push-half--top behat-link-ndr-submit" href="{{ path('ndr_review', {'ndrId': ndr.id}) }}" role="button" data-module="govuk-button">
-            {{ 'continue' | trans({}, 'common') }}
+        <a class="govuk-button govuk-!-margin-0 push-half--top behat-link-ndr-submit"
+           href="{{ path('ndr_review', {'ndrId': ndr.id}) }}" role="button" data-module="govuk-button">
+            {{ 'previewSubmitButton' | trans({}, 'ndr-overview') }}
         </a>
     </div>
 {% endif %}

--- a/client/templates/Ndr/Ndr/_pdf_download_link.html.twig
+++ b/client/templates/Ndr/Ndr/_pdf_download_link.html.twig
@@ -1,0 +1,6 @@
+{% set translationDomain = "report-display" %}
+{% trans_default_domain translationDomain %}
+
+<a class="govuk-link button-link js-trackDownloadLink" href="{{ path('ndr_pdf', {'ndrId': ndr.id}) }}">
+    <i class="icon icon-pdf"></i>{{ 'downloadAsPdf' | trans() }}
+</a>

--- a/client/templates/Ndr/Ndr/_review_buttons.html.twig
+++ b/client/templates/Ndr/Ndr/_review_buttons.html.twig
@@ -1,0 +1,25 @@
+{% set translationDomain = "report-display" %}
+{% trans_default_domain translationDomain %}
+
+{% if ndr.submitted == false %}
+<div class="govuk-button-group">
+    {% if preview %}
+        <a class="govuk-button" href="{{ path("ndr_overview" , {'ndrId': ndr.id }) }}">
+            {{ 'incomplete.backToEditingReport' | trans() }}
+        </a>
+    {% else %}
+        <a class="govuk-button govuk-button--secondary" data-module="govuk-button"
+           href="{{ path("ndr_overview" , {'ndrId': ndr.id }) }}">
+            {{ 'incomplete.backToEditingReport' | trans() }}
+        </a>
+
+        <a class="govuk-button" data-module="govuk-button"
+           href="{{ path("ndr_declaration" , {'ndrId': ndr.id }) }}">
+            {{ 'review.continueToDeclarationButton' | trans({}) }}
+        </a>
+    {% endif %}
+    {% else %}
+        <a class="govuk-button"
+           href="{{ path('homepage') }}">{{ 'backToYourReports' | trans({}, 'common') }}</a>
+    {% endif %}
+</div>

--- a/client/templates/Ndr/Ndr/_review_buttons.html.twig
+++ b/client/templates/Ndr/Ndr/_review_buttons.html.twig
@@ -2,7 +2,7 @@
 {% trans_default_domain translationDomain %}
 
 {% if ndr.submitted == false %}
-<div class="govuk-button-group">
+    <div class="govuk-button-group">
     {% if preview %}
         <a class="govuk-button" href="{{ path("ndr_overview" , {'ndrId': ndr.id }) }}">
             {{ 'incomplete.backToEditingReport' | trans() }}
@@ -18,8 +18,8 @@
             {{ 'review.continueToDeclarationButton' | trans({}) }}
         </a>
     {% endif %}
-    {% else %}
-        <a class="govuk-button"
-           href="{{ path('homepage') }}">{{ 'backToYourReports' | trans({}, 'common') }}</a>
-    {% endif %}
-</div>
+{% else %}
+    <a class="govuk-button"
+       href="{{ path('homepage') }}">{{ 'backToYourReports' | trans({}, 'common') }}</a>
+    </div>
+{% endif %}

--- a/client/templates/Ndr/Ndr/declaration.html.twig
+++ b/client/templates/Ndr/Ndr/declaration.html.twig
@@ -12,7 +12,7 @@
     <div class="breadcrumbs hard--bottom">
         <ol class="group">
             <li>
-                <a href="{{ path('homepage') }}">{{ 'yourReports' | trans({}, 'common' ) }}</a>
+                <a href="{{ path('homepage') }}">{{ 'yourReports' | trans({'deputyFirstname': app.user.firstname, 'deputyLastname': app.user.lastname}, 'common' ) }}</a>
             </li>
             <li>
                 <a href="{{ path('ndr_overview', {'ndrId': ndr.id}) }}"
@@ -43,7 +43,8 @@
 
     {{ form_checkbox(form.agree, 'agree', { 'labelClass': 'required' }) }}
 
-    <div class="govuk-form-group push-half--bottom {% if not form.agreedBehalfDeputy.vars.valid %}govuk-form-group--error{% endif %}">
+    <div
+        class="govuk-form-group push-half--bottom {% if not form.agreedBehalfDeputy.vars.valid %}govuk-form-group--error{% endif %}">
         {{ form_checkbox_group(form.agreedBehalfDeputy, 'agreedBehalfDeputy', {
             'useFormGroup': false,
             'fieldSetClass' : 'radio-agreed-behalf-deputy',

--- a/client/templates/Ndr/Ndr/overview.html.twig
+++ b/client/templates/Ndr/Ndr/overview.html.twig
@@ -21,13 +21,15 @@
                         <strong>{{ ndr.submitDate | date("j F Y") }}</strong>
 
                         <p class="flush--bottom">
-                            <a href="{{ path('ndr_pdf', {'ndrId': ndr.id}) }}" class="push-half--right">{{ 'status.downloadACopy' | trans({}, 'ndr-submitted') }}</a>
+                            <a href="{{ path('ndr_pdf', {'ndrId': ndr.id}) }}"
+                               class="push-half--right">{{ 'status.downloadACopy' | trans({}, 'ndr-submitted') }}</a>
                             <a href="{{ path('ndr_review', {'ndrId': ndr.id}) }}">{{ 'status.viewReportOnline' | trans({}, 'ndr-submitted') }}</a>
                         </p>
                     </li>
                 {% elseif not ndrStatus.isReadyToSubmit %}
                     <li>
-                        <p class="govuk-body">Report status: <strong>{{ ('status.' ~ ndrStatus.status) | trans() }}</strong></p>
+                        <p class="govuk-body">Report status:
+                            <strong>{{ ('status.' ~ ndrStatus.status) | trans() }}</strong></p>
                     </li>
                 {% endif %}
             </ul>
@@ -59,7 +61,8 @@
 
 
         <li>
-            <h2 class="govuk-heading-m opg-overview-section__divider">{{ client.firstname }}'s property and finances</h2>
+            <h2 class="govuk-heading-m opg-overview-section__divider">{{ client.firstname }}'s property and
+                finances</h2>
             {% include '@App/Ndr/Ndr/_subsection.html.twig' with {
                 transDomain: translationDomain,
                 subSection: 'deputy_expenses',
@@ -145,11 +148,13 @@
         <div class="push--top">
             {{ macros.notification('info', 'previewNotice' | trans()) }}
         </div>
-        <a id="edit-report-preview" class="govuk-button" href="{{ path('ndr_review', {'ndrId': ndr.id}) }}" data-module="govuk-button">{{ 'options.previewReport' | trans() }}</a>
+        <a id="edit-report-preview" class="govuk-button" href="{{ path('ndr_review', {'ndrId': ndr.id}) }}"
+           data-module="govuk-button">{{ 'options.previewReport' | trans() }}</a>
 
     {% else %}
 
-        <a id="edit-report-review" class="govuk-button push--top" href="{{ path('ndr_review', {'ndrId': ndr.id}) }}" data-module="govuk-button">{{ 'continue' | trans({}, 'common') }}</a>
+        <a id="edit-report-review" class="govuk-button push--top" href="{{ path('ndr_review', {'ndrId': ndr.id}) }}"
+           data-module="govuk-button">{{ 'previewSubmitButton' | trans({}, 'ndr-overview') }}</a>
 
     {% endif %}
 

--- a/client/templates/Ndr/Ndr/review.html.twig
+++ b/client/templates/Ndr/Ndr/review.html.twig
@@ -39,55 +39,35 @@
 
 {% block pageContent %}
 
+
     <div class="push--bottom">
         {% if ndr.submitted == false %}
             <p class="govuk-body">{{ (page ~ '.para1') | trans() }}</p>
             <p class="govuk-body">{{ (page ~ '.para2') | trans() }}</p>
-            {% if preview %}
-                <a class="button" href="{{ path("ndr_overview" , {'ndrId': ndr.id }) }}">
-                    {{ 'incomplete.backToEditingReport' | trans() }}
-                </a>
-                <a class="govuk-link button-link js-trackDownloadLink" href="{{ path('ndr_pdf', {'ndrId': ndr.id}) }}">
-                    <i class="icon icon-pdf"></i>{{ 'downloadAsPdf' | trans() }}
-                </a>
-            {% endif %}
-        {% else %}
-            <p class="govuk-body">{{ (page ~ '.introPara') | trans() }} {{ ndr.submitDate | date("j F Y") }}.</p>
-            <a class="govuk-button button"
-               href="{{ path('homepage') }}">{{ 'backToYourReports' | trans({}, 'common') }}</a>
-            <a class="govuk-link button-link js-trackDownloadLink" href="{{ path('ndr_pdf', {'ndrId': ndr.id}) }}">
-                <i class="icon icon-pdf"></i>{{ 'downloadAsPdf' | trans() }}
-            </a>
         {% endif %}
+
+        {% include '@App/Ndr/Ndr/_review_buttons.html.twig' %}
+
     </div>
+
+    <div>
+        <span class="opg-text--secondary">{{ 'pdfDraftSentence' | trans() }}</span>
+        {% include '@App/Ndr/Ndr/_pdf_download_link.html.twig' %}
+    </div>
+
 
     <div class="push--bottom">
-        {% include '@App/Ndr/Formatted/formatted_body.html.twig' %}
+        <div class="opg-border--secondary">
+            {% include '@App/Ndr/Formatted/formatted_body.html.twig' %}
+        </div>
     </div>
 
-    {% if ndr.submitted == false %}
-        <div class="govuk-button-group">
-        {% if preview %}
-            <a class="govuk-button" href="{{ path("ndr_overview" , {'ndrId': ndr.id }) }}">
-                {{ 'incomplete.backToEditingReport' | trans() }}
-            </a>
-        {% else %}
-            <a class="govuk-button govuk-button--secondary" data-module="govuk-button"
-               href="{{ path("ndr_overview" , {'ndrId': ndr.id }) }}">
-                {{ 'incomplete.backToEditingReport' | trans() }}
-            </a>
-
-            <a class="govuk-button" data-module="govuk-button"
-               href="{{ path("ndr_declaration" , {'ndrId': ndr.id }) }}">
-                {{ 'review.continueToDeclarationButton' | trans({}, 'report-display') }}
-            </a>
-        {% endif %}
-    {% else %}
-        <a class="govuk-button" href="{{ path('homepage') }}">{{ 'backToYourReports' | trans({}, 'common') }}</a>
-    {% endif %}
+    <div class="govuk-!-padding-bottom-5">
+        {% include '@App/Ndr/Ndr/_pdf_download_link.html.twig' %}
     </div>
 
-    <a class="govuk-link button-link js-trackDownloadLink" href="{{ path('ndr_pdf', {'ndrId': ndr.id}) }}">
-        <i class="icon icon-pdf"></i>{{ 'downloadAsPdf' | trans() }}
-    </a>
+
+    {% include '@App/Ndr/Ndr/_review_buttons.html.twig' %}
+
+
 {% endblock %}

--- a/client/templates/Ndr/Ndr/review.html.twig
+++ b/client/templates/Ndr/Ndr/review.html.twig
@@ -25,12 +25,13 @@
 
 {% block head %}
     {{ parent() }}
-    <link href="{{ 'stylesheets/formatted-report.css' | assetUrl }}"  rel="stylesheet" type="text/css">
+    <link href="{{ 'stylesheets/formatted-report.css' | assetUrl }}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block breadcrumbs %}
     {% if ndr.submitted == true %}
-        <a id="overview-button" href="{{ path('homepage') }}" class="link-back">{{ 'yourReports' | trans({}, 'common' ) }}</a>
+        <a id="overview-button" href="{{ path('homepage') }}"
+           class="link-back">{{ 'yourReports' | trans({}, 'common' ) }}</a>
     {% else %}
         {{ macros.breadcrumbs(ndr) }}
     {% endif %}
@@ -40,7 +41,8 @@
 
     <div class="push--bottom">
         {% if ndr.submitted == false %}
-            <p class="govuk-body">{{ (page ~ '.introPara') | trans() }}</p>
+            <p class="govuk-body">{{ (page ~ '.para1') | trans() }}</p>
+            <p class="govuk-body">{{ (page ~ '.para2') | trans() }}</p>
             {% if preview %}
                 <a class="button" href="{{ path("ndr_overview" , {'ndrId': ndr.id }) }}">
                     {{ 'incomplete.backToEditingReport' | trans() }}
@@ -51,7 +53,8 @@
             {% endif %}
         {% else %}
             <p class="govuk-body">{{ (page ~ '.introPara') | trans() }} {{ ndr.submitDate | date("j F Y") }}.</p>
-            <a class="govuk-button button" href="{{ path('homepage') }}">{{ 'backToYourReports' | trans({}, 'common') }}</a>
+            <a class="govuk-button button"
+               href="{{ path('homepage') }}">{{ 'backToYourReports' | trans({}, 'common') }}</a>
             <a class="govuk-link button-link js-trackDownloadLink" href="{{ path('ndr_pdf', {'ndrId': ndr.id}) }}">
                 <i class="icon icon-pdf"></i>{{ 'downloadAsPdf' | trans() }}
             </a>
@@ -63,19 +66,26 @@
     </div>
 
     {% if ndr.submitted == false %}
+        <div class="govuk-button-group">
         {% if preview %}
             <a class="govuk-button" href="{{ path("ndr_overview" , {'ndrId': ndr.id }) }}">
                 {{ 'incomplete.backToEditingReport' | trans() }}
             </a>
         {% else %}
-            <a class="govuk-button behat-link-ndr-declaration-page" href="{{ path("ndr_declaration" , {'ndrId': ndr.id }) }}">{{ 'continue' | trans({}, 'common') }}</a>
-            <a class="govuk-link button-link" href="{{ path("ndr_overview" , {'ndrId': ndr.id }) }}">
+            <a class="govuk-button govuk-button--secondary" data-module="govuk-button"
+               href="{{ path("ndr_overview" , {'ndrId': ndr.id }) }}">
                 {{ 'incomplete.backToEditingReport' | trans() }}
+            </a>
+
+            <a class="govuk-button" data-module="govuk-button"
+               href="{{ path("ndr_declaration" , {'ndrId': ndr.id }) }}">
+                {{ 'review.continueToDeclarationButton' | trans({}, 'report-display') }}
             </a>
         {% endif %}
     {% else %}
         <a class="govuk-button" href="{{ path('homepage') }}">{{ 'backToYourReports' | trans({}, 'common') }}</a>
     {% endif %}
+    </div>
 
     <a class="govuk-link button-link js-trackDownloadLink" href="{{ path('ndr_pdf', {'ndrId': ndr.id}) }}">
         <i class="icon icon-pdf"></i>{{ 'downloadAsPdf' | trans() }}

--- a/client/templates/Report/Report/_pdf_download_link.html.twig
+++ b/client/templates/Report/Report/_pdf_download_link.html.twig
@@ -1,0 +1,7 @@
+{% set translationDomain = "report-display" %}
+{% trans_default_domain translationDomain %}
+
+<a class="govuk-link button-link behat-link-download-pdf js-trackDownloadLink"
+   href="{{ path('report_pdf', {'reportId': report.id}) }}">
+    <i class="icon icon-pdf"></i>{{ 'downloadAsPdf' | trans() }}
+</a>

--- a/client/templates/Report/Report/_review_buttons.html.twig
+++ b/client/templates/Report/Report/_review_buttons.html.twig
@@ -1,0 +1,32 @@
+{% set translationDomain = "report-display" %}
+{% trans_default_domain translationDomain %}
+
+{% if report.submitted == false %}
+
+    <div class="govuk-button-group">
+    {% if preview %}
+        <a class="govuk-button" data-module="govuk-button"
+           href="{{ path("report_overview" , {'reportId': report.id }) }}">
+            {{ 'incomplete.backToEditingReport' | trans() }}
+        </a>
+    {% else %}
+        <a class="govuk-button govuk-button--secondary" data-module="govuk-button"
+           href="{{ path("report_overview" , {'reportId': report.id }) }}">
+            {{ 'incomplete.backToEditingReport' | trans() }}
+        </a>
+
+        <a class="govuk-button" data-module="govuk-button"
+           href="{{ path("report_declaration" , {'reportId': report.id }) }}">
+            {{ 'review.continueToDeclarationButton' | trans({}, 'report-display') }}
+        </a>
+    {% endif %}
+{% else %}
+    <a class="button" href="{{ backLink }}">
+        {% if isLayDeputy %}
+            {{ 'backToYourReports' | trans({}, 'common') }}
+        {% else %}
+            {{ 'backToClientProfile' | trans({}, 'common') }}
+        {% endif %}
+    </a>
+    </div>
+{% endif %}

--- a/client/templates/Report/Report/declaration.html.twig
+++ b/client/templates/Report/Report/declaration.html.twig
@@ -15,7 +15,7 @@
                 {% if app.user.isDeputyOrg() %}
                     <a href="{{ path('org_dashboard') }}">{{ 'dashboard' | trans({}, 'common' ) }}</a>
                 {% else %}
-                    <a href="{{ path('homepage') }}">{{ 'yourReports' | trans({}, 'common' ) }}</a>
+                    <a href="{{ path('homepage') }}">{{ 'yourReports' | trans({'deputyFirstname': app.user.firstname, 'deputyLastname': app.user.lastname}, 'common' ) }}</a>
                 {% endif %}
             </li>
             <li>
@@ -24,12 +24,13 @@
                     {% if app.user.isDeputyOrg() %}
                         {{ 'clientProfile' | trans({}, 'common' ) }}
                     {% else %}
-                        {{ 'deputyReportOverview' | trans({}, 'common' ) }}
+                        {{ 'deputyReportOverview' | trans({'startYear': report.startDate | date('Y'),'endYear': report.endDate | date('Y')}, 'common' ) }}
                     {% endif %}
                 </a>
             </li>
             <li>
-                <a href="{{ path('report_review', {'reportId': report.id}) }}" class="behat-link-breadcrumbs-report-review">
+                <a href="{{ path('report_review', {'reportId': report.id}) }}"
+                   class="behat-link-breadcrumbs-report-review">
                     {{ 'reviewReport' | trans({}, 'common' ) }}
                 </a>
             </li>
@@ -66,10 +67,11 @@
         {{ form_checkbox(form.agree, 'agree', { 'labelClass': 'required' }) }}
 
         {% set conditional_details %}
-            {{ form_input(form.agreedBehalfDeputyExplanation, 'agreedBehalfDeputyExplanation' )}}
+            {{ form_input(form.agreedBehalfDeputyExplanation, 'agreedBehalfDeputyExplanation' ) }}
         {% endset %}
 
-        <div class="govuk-form-group push-half--bottom {% if not form.agreedBehalfDeputy.vars.valid %}govuk-form-group--error{% endif %}">
+        <div
+            class="govuk-form-group push-half--bottom {% if not form.agreedBehalfDeputy.vars.valid %}govuk-form-group--error{% endif %}">
             {{ form_checkbox_group(form.agreedBehalfDeputy, 'agreedBehalfDeputy', {
                 'useFormGroup': false,
                 'fieldSetClass' : 'radio-agreed-behalf-deputy',

--- a/client/templates/Report/Report/review.html.twig
+++ b/client/templates/Report/Report/review.html.twig
@@ -21,19 +21,22 @@
 {% endif %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
-{% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
+{% block supportTitleTop %}{{ ('supportTitleTop') | trans({'startYear': report.startDate | date('Y'),'endYear': report.endDate | date('Y') }) }}{% endblock %}
+ {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 
 {% block head %}
     {{ parent() }}
-    <link href="{{ 'stylesheets/formatted-report.css' | assetUrl }}"  rel="stylesheet" type="text/css">
+    <link href="{{ 'stylesheets/formatted-report.css' | assetUrl }}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% block breadcrumbs %}
     {% if report.submitted == true %}
         {% if isLayDeputy %}
-            <a id="back-to-reports" href="{{ backLink }}" class="govuk-link link-back behat-link-back-to-reports">{{ 'back' | trans({}, 'common' ) }}</a>
+            <a id="back-to-reports" href="{{ backLink }}"
+               class="govuk-link link-back behat-link-back-to-reports">{{ 'back' | trans({}, 'common' ) }}</a>
         {% else %}
-            <a id="back-to-client" href="{{ backLink }}" class="govuk-link link-back behat-link-return-to-client-profile">{{ 'page.returnToClientProfile' | trans({}, 'report-submitted') }}</a>
+            <a id="back-to-client" href="{{ backLink }}"
+               class="govuk-link link-back behat-link-return-to-client-profile">{{ 'page.returnToClientProfile' | trans({}, 'report-submitted') }}</a>
         {% endif %}
     {% else %}
         {{ macros.breadcrumbs(report) }}
@@ -44,47 +47,76 @@
 
     <div class="push--bottom">
         {% if report.submitted == false %}
-            <p class="govuk-body">{{ (page ~ '.introPara') | trans() }}</p>
+        <p class="govuk-body">{{ (page ~ '.para1') | trans() }}</p>
+        <p class="govuk-body">{{ (page ~ '.para2') | trans() }}</p>
+        <div class="govuk-button-group">
+            {% if preview %}
+                <a class="govuk-button" data-module="govuk-button"
+                   href="{{ path("report_overview" , {'reportId': report.id }) }}">
+                    {{ 'incomplete.backToEditingReport' | trans() }}
+                </a>
+            {% else %}
+                <a class="govuk-button govuk-button--secondary" data-module="govuk-button"
+                   href="{{ path("report_overview" , {'reportId': report.id }) }}">
+                    {{ 'incomplete.backToEditingReport' | trans() }}
+                </a>
+
+                <a class="govuk-button" data-module="govuk-button"
+                   href="{{ path("report_declaration" , {'reportId': report.id }) }}">
+                    {{ 'review.continueToDeclarationButton' | trans({}, 'report-display') }}
+                </a>
+            {% endif %}
+            {% else %}
+                <a class="button" href="{{ backLink }}">
+                    {% if isLayDeputy %}
+                        {{ 'backToYourReports' | trans({}, 'common') }}
+                    {% else %}
+                        {{ 'backToClientProfile' | trans({}, 'common') }}
+                    {% endif %}
+                </a>
+            {% endif %}
+        </div>
+        <div>
+            <span class="opg-text--secondary">{{ 'pdfDraftSentence' | trans() }}</span>
+            <a class="govuk-link button-link behat-link-download-pdf js-trackDownloadLink"
+               href="{{ path('report_pdf', {'reportId': report.id}) }}">
+                <i class="icon icon-pdf"></i>{{ 'downloadAsPdf' | trans() }}
+            </a>
+        </div>
+
+    </div>
+
+    <div class="push--bottom">
+        <div class="opg-border--secondary">
+            {% include '@App/Report/Formatted/formatted_body.html.twig' %}
+        </div>
+    </div>
+
+    <div class="govuk-!-padding-bottom-4">
+        <a class="govuk-link button-link behat-link-download-pdf js-trackDownloadLink"
+           href="{{ path('report_pdf', {'reportId': report.id}) }}">
+            <i class="icon icon-pdf"></i>{{ 'downloadAsPdf' | trans() }}
+        </a>
+    </div>
+
+    {% if report.submitted == false %}
+        <div class="govuk-button-group">
             {% if preview %}
                 <a class="govuk-button" href="{{ path("report_overview" , {'reportId': report.id }) }}">
                     {{ 'incomplete.backToEditingReport' | trans() }}
                 </a>
-                <a class="govuk-link button-link js-trackDownloadLink" href="{{ path('report_pdf', {'reportId': report.id}) }}">
-                    <i class="icon icon-pdf"></i>{{ 'downloadAsPdf' | trans() }}
+            {% else %}
+                <a class="govuk-button govuk-button--secondary" data-module="govuk-button"
+                   href="{{ path("report_overview" , {'reportId': report.id }) }}">
+                    {{ 'incomplete.backToEditingReport' | trans() }}
+                </a>
+
+                <a class="govuk-button" data-module="govuk-button"
+                   href="{{ path("report_declaration" , {'reportId': report.id }) }}">
+                    {{ 'review.continueToDeclarationButton' | trans({}, 'report-display') }}
                 </a>
             {% endif %}
-        {% else %}
-            <p class="govuk-body">{{ (page ~ '.introPara') | trans() }} {{ report.submitDate | date("j F Y") }}.</p>
-            <a class="govuk-button" href="{{ backLink }}">
-                {% if isLayDeputy %}
-                    {{ 'backToYourReports' | trans({}, 'common') }}
-                {% else %}
-                    {{ 'backToClientProfile' | trans({}, 'common') }}
-                {% endif %}
-            </a>
-            <a class="govuk-link button-link js-trackDownloadLink" href="{{ path('report_pdf', {'reportId': report.id}) }}">
-                <i class="icon icon-pdf"></i>{{ 'downloadAsPdf' | trans() }}
-            </a>
-        {% endif %}
-    </div>
-
-    <div class="push--bottom">
-        {% include '@App/Report/Formatted/formatted_body.html.twig' %}
-    </div>
-
-    {% if report.submitted == false %}
-        {% if preview %}
-            <a class="govuk-button" href="{{ path("report_overview" , {'reportId': report.id }) }}">
-                {{ 'incomplete.backToEditingReport' | trans() }}
-            </a>
-        {% else %}
-            <a class="govuk-button left behat-link-declaration-page" href="{{ path("report_declaration" , {'reportId': report.id }) }}">
-                {{ 'continue' | trans({}, 'common') }}
-            </a>
-            <a class="govuk-link button-link" href="{{ path("report_overview" , {'reportId': report.id }) }}">
-                {{ 'incomplete.backToEditingReport' | trans() }}
-            </a>
-        {% endif %}
+        </div>
     {% else %}
         <a class="button" href="{{ backLink }}">
             {% if isLayDeputy %}
@@ -95,7 +127,5 @@
         </a>
     {% endif %}
 
-    <a class="govuk-link button-link behat-link-download-pdf js-trackDownloadLink" href="{{ path('report_pdf', {'reportId': report.id}) }}">
-        <i class="icon icon-pdf"></i>{{ 'downloadAsPdf' | trans() }}
-    </a>
+
 {% endblock %}

--- a/client/templates/Report/Report/review.html.twig
+++ b/client/templates/Report/Report/review.html.twig
@@ -47,44 +47,18 @@
 
     <div class="push--bottom">
         {% if report.submitted == false %}
-        <p class="govuk-body">{{ (page ~ '.para1') | trans() }}</p>
-        <p class="govuk-body">{{ (page ~ '.para2') | trans() }}</p>
-        <div class="govuk-button-group">
-            {% if preview %}
-                <a class="govuk-button" data-module="govuk-button"
-                   href="{{ path("report_overview" , {'reportId': report.id }) }}">
-                    {{ 'incomplete.backToEditingReport' | trans() }}
-                </a>
-            {% else %}
-                <a class="govuk-button govuk-button--secondary" data-module="govuk-button"
-                   href="{{ path("report_overview" , {'reportId': report.id }) }}">
-                    {{ 'incomplete.backToEditingReport' | trans() }}
-                </a>
+            <p class="govuk-body">{{ (page ~ '.para1') | trans() }}</p>
+            <p class="govuk-body">{{ (page ~ '.para2') | trans() }}</p>
+        {% endif %}
 
-                <a class="govuk-button" data-module="govuk-button"
-                   href="{{ path("report_declaration" , {'reportId': report.id }) }}">
-                    {{ 'review.continueToDeclarationButton' | trans({}, 'report-display') }}
-                </a>
-            {% endif %}
-            {% else %}
-                <a class="button" href="{{ backLink }}">
-                    {% if isLayDeputy %}
-                        {{ 'backToYourReports' | trans({}, 'common') }}
-                    {% else %}
-                        {{ 'backToClientProfile' | trans({}, 'common') }}
-                    {% endif %}
-                </a>
-            {% endif %}
-        </div>
-        <div>
-            <span class="opg-text--secondary">{{ 'pdfDraftSentence' | trans() }}</span>
-            <a class="govuk-link button-link behat-link-download-pdf js-trackDownloadLink"
-               href="{{ path('report_pdf', {'reportId': report.id}) }}">
-                <i class="icon icon-pdf"></i>{{ 'downloadAsPdf' | trans() }}
-            </a>
-        </div>
+        {% include '@App/Report/Report/_review_buttons.html.twig' %}
 
     </div>
+    <div>
+        <span class="opg-text--secondary">{{ 'pdfDraftSentence' | trans() }}</span>
+        {% include '@App/Report/Report/_pdf_download_link.html.twig' %}
+    </div>
+
 
     <div class="push--bottom">
         <div class="opg-border--secondary">
@@ -93,39 +67,10 @@
     </div>
 
     <div class="govuk-!-padding-bottom-4">
-        <a class="govuk-link button-link behat-link-download-pdf js-trackDownloadLink"
-           href="{{ path('report_pdf', {'reportId': report.id}) }}">
-            <i class="icon icon-pdf"></i>{{ 'downloadAsPdf' | trans() }}
-        </a>
+        {% include '@App/Report/Report/_pdf_download_link.html.twig' %}
     </div>
 
-    {% if report.submitted == false %}
-        <div class="govuk-button-group">
-            {% if preview %}
-                <a class="govuk-button" href="{{ path("report_overview" , {'reportId': report.id }) }}">
-                    {{ 'incomplete.backToEditingReport' | trans() }}
-                </a>
-            {% else %}
-                <a class="govuk-button govuk-button--secondary" data-module="govuk-button"
-                   href="{{ path("report_overview" , {'reportId': report.id }) }}">
-                    {{ 'incomplete.backToEditingReport' | trans() }}
-                </a>
-
-                <a class="govuk-button" data-module="govuk-button"
-                   href="{{ path("report_declaration" , {'reportId': report.id }) }}">
-                    {{ 'review.continueToDeclarationButton' | trans({}, 'report-display') }}
-                </a>
-            {% endif %}
-        </div>
-    {% else %}
-        <a class="button" href="{{ backLink }}">
-            {% if isLayDeputy %}
-                {{ 'backToYourReports' | trans({}, 'common') }}
-            {% else %}
-                {{ 'backToClientProfile' | trans({}, 'common') }}
-            {% endif %}
-        </a>
-    {% endif %}
+    {% include '@App/Report/Report/_review_buttons.html.twig' %}
 
 
 {% endblock %}

--- a/client/translations/common.en.yml
+++ b/client/translations/common.en.yml
@@ -18,10 +18,10 @@ start: Start
 startNow: Start now
 download: Download
 status:
-  notCreated: Create report
-  notStarted: Start now
-  notFinished: Continue
-  readyToSubmit: Continue
+    notCreated: Create report
+    notStarted: Start now
+    notFinished: Continue
+    readyToSubmit: Continue
 next: Next
 previous: Previous
 first: First
@@ -110,8 +110,8 @@ notSavedYet: Not saved yet
 changesNeeded: Changes needed
 
 # Breadcrumbs
-yourReports: Your reports
-deputyReportOverview: Deputy report overview
+yourReports: 'Your reports - deputyFirstname deputyLastname'
+deputyReportOverview: 'startYear to endYear report overview'
 newDeputyReportOverview: New deputy report overview
 reviewReport: Review report
 dashboard: Dashboard
@@ -154,10 +154,10 @@ summaryHeading: There are some problems on this page
 pleaseAnswer: Please answer this question
 
 lastLoggedIn:
-  lessThenAMinuteAgo:  less than a minute ago
-  minutesAgo: "{1} one minute ago | ]1,Inf] %count% minutes ago"
-  hoursAgo: "{1} about one hour ago | ]1,Inf] about %count% hours ago"
-  exactDate: "%date%"
+    lessThenAMinuteAgo: less than a minute ago
+    minutesAgo: "{1} one minute ago | ]1,Inf] %count% minutes ago"
+    hoursAgo: "{1} about one hour ago | ]1,Inf] about %count% hours ago"
+    exactDate: "%date%"
 
 back.label: Back to deputy report
 
@@ -177,14 +177,14 @@ registrationProgressBar:
 weHaveListed: We've listed your saved answers below.
 checkCorrect: Check they're correct and edit them where necessary.
 remindComplete: |
-  Do not worry if you've had to skip some questions. We'll remind you to complete them next time
-  you log in.
+    Do not worry if you've had to skip some questions. We'll remind you to complete them next time
+    you log in.
 canYouAnswer: |
-  Can you answer the missing questions? You won't be able to submit your annual deputy report
-  until it's complete.
+    Can you answer the missing questions? You won't be able to submit your annual deputy report
+    until it's complete.
 canYouAnswerNDR: |
-  Can you answer the missing questions? You won't be able to submit your new deputy report until
-  it's complete.
+    Can you answer the missing questions? You won't be able to submit your new deputy report until
+    it's complete.
 returnToReport: Return to report overview
 returnToClientProfile: Return to client profile
 

--- a/client/translations/ndr-overview.en.yml
+++ b/client/translations/ndr-overview.en.yml
@@ -2,12 +2,13 @@ page.htmlTitle: "New deputy report - Complete the deputy report | GOV.UK"
 report: "New deputy report"
 pageTitle: "New deputy report"
 pageSectionDescription: "Your new deputy report:"
+previewSubmitButton: "Preview and check report"
 heading:
-  title: "New deputy report"
-  planningTitle: ""
-  careAndWelfare: ""
-  finances: ""
-  finishYourReport: ""
+    title: "New deputy report"
+    planningTitle: ""
+    careAndWelfare: ""
+    finances: ""
+    finishYourReport: ""
 
 cantSubmitUntilComplete: You cannot submit your report until it's complete
 
@@ -20,85 +21,85 @@ sectionsRemaining: "sections remaining"
 overview: New deputy report
 
 status:
-  notStarted: "Not started"
-  notFinished: "Not finished"
-  readyToSubmit: "Ready to submit"
+    notStarted: "Not started"
+    notFinished: "Not finished"
+    readyToSubmit: "Ready to submit"
 
 options:
-  previewReport: "Preview report"
+    previewReport: "Preview report"
 
 guidanceNotice: |
-  You do not have to fill in all the sections in one go.
-  You can complete the report in any order you want, save it and return to it.
+    You do not have to fill in all the sections in one go.
+    You can complete the report in any order you want, save it and return to it.
 
 previewNotice: |
-  You may preview your report at anytime. When all sections are complete you will be able to submit the report to us.
+    You may preview your report at anytime. When all sections are complete you will be able to submit the report to us.
 
 completeNotice: |
-  All sections are now complete. Please review then submit your report.
+    All sections are now complete. Please review then submit your report.
 
 labels:
-  not-started: "Not started"
-  incomplete: "Not finished"
-  done: "Finished"
-  previewReport: "Preview report"
+    not-started: "Not started"
+    incomplete: "Not finished"
+    done: "Finished"
+    previewReport: "Preview report"
 
 visits_care:
-  subSectionTitle: "Visits and care"
-  subSectionDescription: "Give us an overview of who is looking after %client%"
-  edit: "Edit"
-  start: "Start"
-  label:
-    done: "Finished"
+    subSectionTitle: "Visits and care"
+    subSectionDescription: "Give us an overview of who is looking after %client%"
+    edit: "Edit"
+    start: "Start"
+    label:
+        done: "Finished"
 deputy_expenses:
-  subSectionTitle: "Deputy expenses"
-  subSectionDescription: "Claim for things you paid for on %client%'s behalf before your court order "
-  edit: "Edit"
-  start: "Start"
-  label:
-    done: "{0} no expenses | {1} 1 expense | ]1,Inf[ %count% expenses"
+    subSectionTitle: "Deputy expenses"
+    subSectionDescription: "Claim for things you paid for on %client%'s behalf before your court order "
+    edit: "Edit"
+    start: "Start"
+    label:
+        done: "{0} no expenses | {1} 1 expense | ]1,Inf[ %count% expenses"
 income_benefits:
-  subSectionTitle: "Income and benefits"
-  subSectionDescription: "Give us details of %client%'s income and any state benefits"
-  edit: "Edit"
-  start: "Start"
-  label:
-    done: "Finished"
+    subSectionTitle: "Income and benefits"
+    subSectionDescription: "Give us details of %client%'s income and any state benefits"
+    edit: "Edit"
+    start: "Start"
+    label:
+        done: "Finished"
 bank_accounts:
-  subSectionTitle: "Accounts"
-  subSectionDescription: "Add %client%'s bank, building society and savings accounts"
-  edit: "Edit"
-  start: "Start"
-  label:
-    done: "{0} no accounts | {1} 1 account | ]1,Inf[ %count% accounts"
+    subSectionTitle: "Accounts"
+    subSectionDescription: "Add %client%'s bank, building society and savings accounts"
+    edit: "Edit"
+    start: "Start"
+    label:
+        done: "{0} no accounts | {1} 1 account | ]1,Inf[ %count% accounts"
 assets:
-  subSectionTitle: "Assets"
-  subSectionDescription: "Enter details of %client%'s property, investments and other valuables"
-  edit: "Edit"
-  start: "Start"
-  label:
-    done: "{0} no assets | {1} 1 asset | ]1,Inf[ %count% assets"
+    subSectionTitle: "Assets"
+    subSectionDescription: "Enter details of %client%'s property, investments and other valuables"
+    edit: "Edit"
+    start: "Start"
+    label:
+        done: "{0} no assets | {1} 1 asset | ]1,Inf[ %count% assets"
 debts:
-  subSectionTitle: "Debts"
-  subSectionDescription: "Let us know about any debts %client% owes"
-  edit: "Edit"
-  start: "Start"
-  label:
-    done: "Finished"
+    subSectionTitle: "Debts"
+    subSectionDescription: "Let us know about any debts %client% owes"
+    edit: "Edit"
+    start: "Start"
+    label:
+        done: "Finished"
 actions:
-  subSectionTitle: "Actions you plan to take"
-  subSectionDescription: "What major financial decisions will you need to take for %client% in the next year?"
-  edit: "Edit"
-  start: "Start"
-  label:
-    done: "Finished"
+    subSectionTitle: "Actions you plan to take"
+    subSectionDescription: "What major financial decisions will you need to take for %client% in the next year?"
+    edit: "Edit"
+    start: "Start"
+    label:
+        done: "Finished"
 other_info:
-  subSectionTitle: "Any other information"
-  subSectionDescription: "Is there anything else you want to tell us about the deputyship?"
-  edit: "Edit"
-  start: "Start"
-  label:
-    done: "Finished"
+    subSectionTitle: "Any other information"
+    subSectionDescription: "Is there anything else you want to tell us about the deputyship?"
+    edit: "Edit"
+    start: "Start"
+    label:
+        done: "Finished"
 client_benefits_check:
     subSectionTitle: "Benefits check and income other people receive"
     subSectionDescription: "Tell us when you last checked what benefits %client% is entitled to, and about any income other people receive directly on %client%’s behalf."
@@ -108,21 +109,21 @@ client_benefits_check:
         done: "Finished"
 
 ndr_submit:
-  subSectionTitle: "Submit report"
-  edit: "Submit report"
-  start: "Submit report"
-  label:
-    done: "Ready to submit"
+    subSectionTitle: "Submit report"
+    edit: "Submit report"
+    start: "Submit report"
+    label:
+        done: "Ready to submit"
 
 additionalInformation:
-  subSectionTitle: More information
+    subSectionTitle: More information
 
 ndrSubmit:
-  checkbox:
-    label: I have reviewed and checked this new deputy report.
+    checkbox:
+        label: I have reviewed and checked this new deputy report.
 
 decisionsMadeAsDeputy: Decisions made as deputy
 
 announcement: |
-  We've made some changes to the layout of this page.<br/>
-  Use the links on this page to view and edit the different sections of your new deputy report.
+    We've made some changes to the layout of this page.<br/>
+    Use the links on this page to view and edit the different sections of your new deputy report.

--- a/client/translations/report-display.en.yml
+++ b/client/translations/report-display.en.yml
@@ -1,39 +1,46 @@
 downloadAsPdf: Download as PDF
+pdfDraftSentence: This is a PDF draft of your report. It has not been submitted to the OPG.
+supportTitleTop: "startYear to endYear report"
+
 incomplete:
-  backToEditingReport: Back to editing report
+    backToEditingReport: Go back and edit the report
 
 submitReport: Submit report
 
 preview:
-  htmlTitle: Preview report - Complete the deputy report | GOV.UK
-  pageTitle: Preview report
-  introPara: |
-    Use this section to check the details of the report are correct. When all sections are
-    completed you will be able to continue the report submission process.
+    htmlTitle: Preview report - Complete the deputy report | GOV.UK
+    pageTitle: Preview report
+    para1: Use this section to check the details of the report are correct.
+    para2: When all sections are completed you will be able to continue the report submission process.
 
 review:
-  htmlTitle: Review report - Complete the deputy report | GOV.UK
-  pageTitle: Review report
-  introPara: Please review all sections of this report before continuing to the deputy declaration.
+    htmlTitle: Review report - Complete the deputy report | GOV.UK
+    pageTitle: Check your report
+    para1: Once you’ve submitted the report, you won’t be able to make any changes.
+    para2: Before submitting please review all sections of the report in the PDF preview below. If you need to make changes you can go back and edit the report.
+    continueToDeclarationButton: Continue to declaration and submission
+
+
 
 submitted:
-  htmlTitle: Submitted report - Complete the deputy report | GOV.UK
-  pageTitle: Submitted report
-  introPara: This report was submitted to OPG on
+    htmlTitle: Submitted report - Complete the deputy report | GOV.UK
+    pageTitle: Submitted report
+    introPara: This report was submitted to OPG on
 
 ndr-preview:
-  htmlTitle: Preview report - Complete the deputy report | GOV.UK
-  pageTitle: Preview report
-  introPara: |
-    Use this section to check the details of the report are correct. When all sections are
-    completed you will be able to continue the report submission process.
+    htmlTitle: Preview report - Complete the deputy report | GOV.UK
+    pageTitle: Preview report
+    introPara: |
+        Use this section to check the details of the report are correct. When all sections are
+        completed you will be able to continue the report submission process.
 
 ndr-review:
-  htmlTitle: Review report - Complete the deputy report | GOV.UK
-  pageTitle: Review report
-  introPara: Please review all sections of this report before continuing to the deputy declaration.
+    htmlTitle: Review report - Complete the deputy report | GOV.UK
+    pageTitle: Check your report
+    para1: Once you’ve submitted the report, you won’t be able to make any changes.
+    para2: Before submitting please review all sections of the report in the PDF preview below. If you need to make changes you can go back and edit the report.
 
 ndr-submitted:
-  htmlTitle: Submitted report - Complete the deputy report | GOV.UK
-  pageTitle: Submitted report
-  introPara: This report was submitted to OPG on
+    htmlTitle: Submitted report - Complete the deputy report | GOV.UK
+    pageTitle: Submitted report
+    introPara: This report was submitted to OPG on

--- a/client/translations/report-display.en.yml
+++ b/client/translations/report-display.en.yml
@@ -1,4 +1,4 @@
-downloadAsPdf: Download as PDF
+downloadAsPdf: Download report as PDF
 pdfDraftSentence: This is a PDF draft of your report. It has not been submitted to the OPG.
 supportTitleTop: "startYear to endYear report"
 


### PR DESCRIPTION
## Purpose

A pattern has emerged that shows deputies are having trouble submitting their annual reports and NDRs. 

They either: 

mistakenly believe they have submitted their report when they haven't and the report ends up late (and OPG has to chase them)

make unnecessary contact with OPG to ask for help submitting the report 

Fixes DDPB-3832

## Approach
- Followed report prototype - https://www.figma.com/proto/SGISRCgqfPNJnxwlh98Y6Q/Digideps-LAY-DEPUTY?node-id=203%3A1384&scaling=min-zoom&page-id=0%3A1 
- Applied the above to both ndr and reports
- Created a 'submitting a report' feature test 

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [x] Translations are used and the profiler doesn't identify any missing
- [x] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
