### PR TITLE
DDPB 4186 - Report for admin accounts (Joiners, Movers, Leavers) 

### DIFF
--- a/api/src/Controller/StatsController.php
+++ b/api/src/Controller/StatsController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Repository\UserRepository;
+use App\Service\Formatter\RestFormatter;
 use App\Service\Stats\QueryFactory;
 use App\Service\Stats\StatsQueryParameters;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
@@ -43,5 +44,38 @@ class StatsController extends RestController
     public function getActiveLays()
     {
         return $this->userRepository->findActiveLaysInLastYear();
+    }
+
+    /**
+     * @Route("stats/admins/report_data", methods={"GET"})
+     * @Security("is_granted('ROLE_SUPER_ADMIN')")
+     */
+    public function getAdminUserAccountReportData(Request $request, RestFormatter $formatter)
+    {
+        $serialisedGroups = (array) $request->query->get('groups');
+        $formatter->setJmsSerialiserGroups($serialisedGroups);
+
+        $adminAccounts = $this->userRepository->getAllAdminAccounts();
+        $countOfAdminAccounts = count($adminAccounts);
+
+        $inactiveAdminAccounts = $this->userRepository->getAllAdminAccountsCreatedButNotActivatedWithin('-60 days');
+        $countOfInactiveAdminAccounts = count($inactiveAdminAccounts);
+
+        $activatedAdminAccounts = $this->userRepository->getAllActivatedAdminAccounts();
+        $countOfActivatedAdminAccounts = count($activatedAdminAccounts);
+
+        $activatedAdminAccountsNotUsedWithin90Days = $this->userRepository->getAllAdminAccountsNotUsedWithin('-90 days');
+        $countOfActivatedAdminAccountsNotUsedWithin90Days = count($activatedAdminAccountsNotUsedWithin90Days);
+
+        $activatedAdminAccountsUsedWithin90Days = $this->userRepository->getAllAdminAccountsUsedWithin('-90 days');
+        $countOfActivatedAdminAccountsUsedWithin90Days = count($activatedAdminAccountsUsedWithin90Days);
+
+        return [
+            'TotalAdminAccounts' => $countOfAdminAccounts,
+            'InactiveAdminAccounts' => $countOfInactiveAdminAccounts,
+            'ActivatedAdminAccounts' => $countOfActivatedAdminAccounts,
+            'ActivatedAdminAccountsNotUsedWithin90Days' => $countOfActivatedAdminAccountsNotUsedWithin90Days,
+            'ActivatedAdminAccountsUsedWithin90Days' => $countOfActivatedAdminAccountsUsedWithin90Days,
+        ];
     }
 }

--- a/api/src/Controller/StatsController.php
+++ b/api/src/Controller/StatsController.php
@@ -50,7 +50,7 @@ class StatsController extends RestController
      * @Route("stats/admins/report_data", methods={"GET"})
      * @Security("is_granted('ROLE_SUPER_ADMIN')")
      */
-    public function getAdminUserAccountReportData(Request $request, RestFormatter $formatter)
+    public function getAdminUserAccountReportData(Request $request, RestFormatter $formatter): array
     {
         $serialisedGroups = (array) $request->query->get('groups');
         $formatter->setJmsSerialiserGroups($serialisedGroups);

--- a/api/src/Repository/UserRepository.php
+++ b/api/src/Repository/UserRepository.php
@@ -235,15 +235,16 @@ SQL;
 
     public function getAllAdminAccountsCreatedButNotActivatedWithin(string $timeframe)
     {
-        $date = (new DateTime())->modify($timeframe)->format('Y-m-d H:i:s');
+        $date = (new DateTime())->modify($timeframe);
 
         $dql = "SELECT u FROM App\Entity\User u WHERE u.roleName IN('ROLE_ADMIN', 'ROLE_SUPER_ADMIN', 'ROLE_ADMIN_MANAGER')
                 AND u.lastLoggedIn IS NULL
-                AND u.registrationDate < '{$date}' ";
+                AND u.registrationDate < :date ";
 
         $query = $this
             ->getEntityManager()
-            ->createQuery($dql);
+            ->createQuery($dql)
+            ->setParameter('date', $date);
 
         return $query->getResult();
     }
@@ -262,28 +263,30 @@ SQL;
 
     public function getAllAdminAccountsNotUsedWithin(string $timeframe)
     {
-        $date = (new DateTime())->modify($timeframe)->format('Y-m-d H:i:s');
+        $date = (new DateTime())->modify($timeframe);
 
         $dql = "SELECT u FROM App\Entity\User u WHERE u.roleName IN('ROLE_ADMIN', 'ROLE_SUPER_ADMIN', 'ROLE_ADMIN_MANAGER')
-                AND u.lastLoggedIn < '{$date}'  ";
+                AND u.lastLoggedIn < :date ";
 
         $query = $this
             ->getEntityManager()
-            ->createQuery($dql);
+            ->createQuery($dql)
+            ->setParameter('date', $date);
 
         return $query->getResult();
     }
 
     public function getAllAdminAccountsUsedWithin(string $timeframe)
     {
-        $date = (new DateTime())->modify($timeframe)->format('Y-m-d H:i:s');
+        $date = (new DateTime())->modify($timeframe);
 
         $dql = "SELECT u FROM App\Entity\User u WHERE u.roleName IN('ROLE_ADMIN', 'ROLE_SUPER_ADMIN', 'ROLE_ADMIN_MANAGER')
-                AND u.lastLoggedIn > '{$date}'  ";
+                AND u.lastLoggedIn > :date ";
 
         $query = $this
             ->getEntityManager()
-            ->createQuery($dql);
+            ->createQuery($dql)
+            ->setParameter('date', $date);
 
         return $query->getResult();
     }

--- a/api/src/Repository/UserRepository.php
+++ b/api/src/Repository/UserRepository.php
@@ -259,4 +259,32 @@ SQL;
 
         return $query->getResult();
     }
+
+    public function getAllAdminAccountsNotUsedWithin(string $timeframe)
+    {
+        $date = (new DateTime())->modify($timeframe)->format('Y-m-d H:i:s');
+
+        $dql = "SELECT u FROM App\Entity\User u WHERE u.roleName IN('ROLE_ADMIN', 'ROLE_SUPER_ADMIN', 'ROLE_ADMIN_MANAGER')
+                AND u.lastLoggedIn < '{$date}'  ";
+
+        $query = $this
+            ->getEntityManager()
+            ->createQuery($dql);
+
+        return $query->getResult();
+    }
+
+    public function getAllAdminAccountsUsedWithin(string $timeframe)
+    {
+        $date = (new DateTime())->modify($timeframe)->format('Y-m-d H:i:s');
+
+        $dql = "SELECT u FROM App\Entity\User u WHERE u.roleName IN('ROLE_ADMIN', 'ROLE_SUPER_ADMIN', 'ROLE_ADMIN_MANAGER')
+                AND u.lastLoggedIn > '{$date}'  ";
+
+        $query = $this
+            ->getEntityManager()
+            ->createQuery($dql);
+
+        return $query->getResult();
+    }
 }

--- a/api/src/Repository/UserRepository.php
+++ b/api/src/Repository/UserRepository.php
@@ -224,8 +224,12 @@ SQL;
 
     public function getAllAdminAccounts()
     {
-        $user = ['Admin Role'];
+        $dql = "SELECT u FROM App\Entity\User u WHERE u.roleName IN('ROLE_ADMIN', 'ROLE_SUPER_ADMIN', 'ROLE_ADMIN_MANAGER')";
 
-        return $user;
+        $query = $this
+            ->getEntityManager()
+            ->createQuery($dql);
+
+        return $query->getResult();
     }
 }

--- a/api/src/Repository/UserRepository.php
+++ b/api/src/Repository/UserRepository.php
@@ -221,4 +221,11 @@ SQL;
 
         return $result->fetchAllAssociative();
     }
+
+    public function getAllAdminAccounts()
+    {
+        $user = ['Admin Role'];
+
+        return $user;
+    }
 }

--- a/api/src/Repository/UserRepository.php
+++ b/api/src/Repository/UserRepository.php
@@ -232,4 +232,20 @@ SQL;
 
         return $query->getResult();
     }
+
+    public function getAllAdminAccountsCreatedButNotActivatedWithin(string $timeframe)
+    {
+//        SELECT COUNT(*) AS inactive_account FROM dd_user WHERE active = FALSE AND registration_date > now() - interval '60 day';
+        $date = (new DateTime())->modify($timeframe)->format('Y-m-d H:i:s');
+
+        $dql = "SELECT u FROM App\Entity\User u WHERE u.roleName IN('ROLE_ADMIN', 'ROLE_SUPER_ADMIN', 'ROLE_ADMIN_MANAGER')
+                AND u.active = FALSE
+                AND u.registrationDate < '{$date}' ";
+
+        $query = $this
+            ->getEntityManager()
+            ->createQuery($dql);
+
+        return $query->getResult();
+    }
 }

--- a/api/src/Repository/UserRepository.php
+++ b/api/src/Repository/UserRepository.php
@@ -235,12 +235,23 @@ SQL;
 
     public function getAllAdminAccountsCreatedButNotActivatedWithin(string $timeframe)
     {
-//        SELECT COUNT(*) AS inactive_account FROM dd_user WHERE active = FALSE AND registration_date > now() - interval '60 day';
         $date = (new DateTime())->modify($timeframe)->format('Y-m-d H:i:s');
 
         $dql = "SELECT u FROM App\Entity\User u WHERE u.roleName IN('ROLE_ADMIN', 'ROLE_SUPER_ADMIN', 'ROLE_ADMIN_MANAGER')
-                AND u.active = FALSE
+                AND u.lastLoggedIn IS NULL
                 AND u.registrationDate < '{$date}' ";
+
+        $query = $this
+            ->getEntityManager()
+            ->createQuery($dql);
+
+        return $query->getResult();
+    }
+
+    public function getAllActivatedAdminAccounts()
+    {
+        $dql = "SELECT u FROM App\Entity\User u WHERE u.roleName IN('ROLE_ADMIN', 'ROLE_SUPER_ADMIN', 'ROLE_ADMIN_MANAGER')
+                AND u.lastLoggedIn IS NOT NULL";
 
         $query = $this
             ->getEntityManager()

--- a/api/tests/Behat/bootstrap/v2/ACL/ACLTrait.php
+++ b/api/tests/Behat/bootstrap/v2/ACL/ACLTrait.php
@@ -13,8 +13,6 @@ trait ACLTrait
      */
     public function iShouldBeAbleToAccessAnalyticsPage(string $page)
     {
-        $this->iVisitAdminAnalyticsPage();
-
         $linkText = 'Download %s';
         $this->assertLinkWithTextIsOnPage(sprintf($linkText, $page));
 
@@ -73,9 +71,11 @@ trait ACLTrait
             case 'user research report':
                 $this->iVisitAdminUserResearchReportPage();
                 break;
+            case 'view reports':
+                $this->iVisitAdminStatsReportsPage();
+                break;
             default:
                 throw new BehatException(sprintf('Analytics page "%s" unrecognised', $lowercasePageName));
-                break;
         }
     }
 

--- a/api/tests/Behat/bootstrap/v2/Analytics/AnalyticsTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Analytics/AnalyticsTrait.php
@@ -152,9 +152,7 @@ trait AnalyticsTrait
     {
         $linkTextItems = [
             'Download DAT file',
-            'Download satisfaction report',
-            'Download user research report',
-            'Download active lays report',
+            'View reports',
         ];
         foreach ($linkTextItems as $linkText) {
             $xpath = sprintf('//a[contains(.,"%s")]', $linkText);
@@ -202,7 +200,7 @@ trait AnalyticsTrait
      */
     public function iTryDownloadSatisfactionReport()
     {
-        $this->iVisitAdminAnalyticsPage();
+        $this->iVisitAdminStatsReportsPage();
         $this->currentLinkText = 'Download satisfaction report';
 
         $xpath = sprintf('//a[contains(.,"%s")]', $this->currentLinkText);
@@ -212,8 +210,6 @@ trait AnalyticsTrait
         }
         $downloadLink->click();
         $this->iAmOnAdminStatsSatisfactionPage();
-
-        $this->fillInAnalyticsStartEndDates();
     }
 
     /**
@@ -221,7 +217,7 @@ trait AnalyticsTrait
      */
     public function iTryDownloadUserResearchReport()
     {
-        $this->iVisitAdminAnalyticsPage();
+        $this->iVisitAdminStatsReportsPage();
         $this->currentLinkText = 'Download user research report';
 
         $xpath = sprintf('//a[contains(.,"%s")]', $this->currentLinkText);
@@ -231,8 +227,6 @@ trait AnalyticsTrait
         }
         $downloadLink->click();
         $this->iAmOnAdminStatsUserResearchPage();
-
-        $this->fillInAnalyticsStartEndDates();
     }
 
     /**
@@ -240,7 +234,7 @@ trait AnalyticsTrait
      */
     public function iTryDownloadActiveLaysReport()
     {
-        $this->iVisitAdminAnalyticsPage();
+        $this->iVisitAdminStatsReportsPage();
         $this->currentLinkText = 'Download active lays report';
 
         $xpath = sprintf('//a[contains(.,"%s")]', $this->currentLinkText);
@@ -271,7 +265,25 @@ trait AnalyticsTrait
     }
 
     /**
-     * @When I should have no issues downloading the file
+     * @When I try to view the reports page
+     */
+    public function iTryViewTheReportsPage()
+    {
+        $this->iVisitAdminAnalyticsPage();
+        $this->currentLinkText = 'View reports';
+
+        $xpath = sprintf('//a[contains(.,"%s")]', $this->currentLinkText);
+        $link = $this->getSession()->getPage()->find('xpath', $xpath);
+        if (is_null($link)) {
+            throw new BehatException(sprintf('Missing the following text: %s', $this->currentLinkText));
+        }
+        $link->click();
+        $this->iAmOnAdminStatsReportsPage();
+    }
+
+    /**
+     * @Then I should have no issues downloading the file
+     * @Then I should have no issues viewing the page
      */
     public function shouldHaveNoIssuesDownloadingFile()
     {

--- a/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnAdminTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnAdminTrait.php
@@ -193,4 +193,12 @@ trait IShouldBeOnAdminTrait
     {
         return $this->iAmOnPage('/admin\/settings\/service-notification$/');
     }
+
+    /**
+     * @Then I should be on the admin stats reports page
+     */
+    public function iAmOnAdminStatsReportsPage()
+    {
+        return $this->iAmOnPage('/admin\/stats\/reports$/');
+    }
 }

--- a/api/tests/Behat/bootstrap/v2/Common/IVisitAdminTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/IVisitAdminTrait.php
@@ -156,6 +156,14 @@ trait IVisitAdminTrait
     }
 
     /**
+     * @When I visit the admin stats reports page
+     */
+    public function iVisitAdminStatsReportsPage()
+    {
+        $this->visitAdminPath($this->getAdminStatsReportsUrl());
+    }
+
+    /**
      * @When I visit the admin login page
      */
     public function iVisitAdminLoginPage()

--- a/api/tests/Behat/bootstrap/v2/Common/PageUrlsTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/PageUrlsTrait.php
@@ -53,6 +53,7 @@ trait PageUrlsTrait
     private string $adminActiveLaysReportUrl = '/admin/stats/downloadActiveLaysCsv';
     private string $adminAddUserUrl = '/admin/user-add';
     private string $adminAnalyticsUrl = '/admin/stats/metrics';
+    private string $adminStatsReportsUrl = '/admin/stats/reports';
     private string $adminClientSearchUrl = '/admin/client/search';
     private string $adminClientDetailsUrl = '/admin/client/%s/details';
     private string $adminDATReportUrl = '/admin/stats';
@@ -220,6 +221,11 @@ trait PageUrlsTrait
     public function getAdminAnalyticsUrl(): string
     {
         return $this->adminAnalyticsUrl;
+    }
+
+    public function getAdminStatsReportsUrl(): string
+    {
+        return $this->adminStatsReportsUrl;
     }
 
     public function getDebtsSectionUrl(int $reportId): string

--- a/api/tests/Behat/features-v2/acl/admin/super-admin-only.feature
+++ b/api/tests/Behat/features-v2/acl/admin/super-admin-only.feature
@@ -1,4 +1,4 @@
-@v2 @v2_admin @acl @acs
+@v2 @v2_admin @acl
 Feature: Limiting access to sections of the app to super admins
     As a super admin user
     In order to prevent other types of users from accessing sensitive or confusing data

--- a/api/tests/Behat/features-v2/acl/admin/super-admin-only.feature
+++ b/api/tests/Behat/features-v2/acl/admin/super-admin-only.feature
@@ -1,35 +1,37 @@
-@v2 @v2_admin @acl
+@v2 @v2_admin @acl @acs
 Feature: Limiting access to sections of the app to super admins
-  As a super admin user
-  In order to prevent other types of users from accessing sensitive or confusing data
-  I need to limit access to certain areas of the app to Super Admins
+    As a super admin user
+    In order to prevent other types of users from accessing sensitive or confusing data
+    I need to limit access to certain areas of the app to Super Admins
 
-  @super-admin
-  Scenario: A super admin attempts to access analytics, reports and fixtures
-    Given a super admin user accesses the admin app
-    When I navigate to the admin analytics page
-    Then I should be able to access the "DAT file"
-    Then I should be able to access the "satisfaction report"
-    Then I should be able to access the "active lays report"
-    Then I should be able to access the "user research report"
-    Then I should be able to access the fixtures page
+    @super-admin
+    Scenario: A super admin attempts to access analytics, reports and fixtures
+        Given a super admin user accesses the admin app
+        When I navigate to the admin analytics page
+        Then I should be able to access the "DAT file"
+        When I visit the admin stats reports page
+        Then I should be able to access the "satisfaction report"
+        When I visit the admin stats reports page
+        Then I should be able to access the "active lays report"
+        When I visit the admin stats reports page
+        Then I should be able to access the "user research report"
+        When I visit the admin stats reports page
+        Then I should be able to access the fixtures page
 
-  @admin-manager
-  Scenario: An admin manager attempts to access analytics and reports
-    Given an admin manager user accesses the admin app
-    When I navigate to the admin analytics page
-    Then I should be able to access the "DAT file"
-    Then I should not be able to access the "satisfaction report"
-    Then I should not be able to access the "active lays report"
-    Then I should not be able to access the "user research report"
-    Then I should not be able to access the fixtures page
+    @admin-manager
+    Scenario: An admin manager attempts to access analytics and reports
+        Given an admin manager user accesses the admin app
+        When I navigate to the admin analytics page
+        Then I should be able to access the "DAT file"
+        When I navigate to the admin analytics page
+        Then I should not be able to access the "view reports"
+        Then I should not be able to access the fixtures page
 
-  @admin
-  Scenario: An admin attempts to access analytics and reports
-    Given an admin user accesses the admin app
-    When I navigate to the admin analytics page
-    Then I should be able to access the "DAT file"
-    Then I should not be able to access the "satisfaction report"
-    Then I should not be able to access the "active lays report"
-    Then I should not be able to access the "user research report"
-    Then I should not be able to access the fixtures page
+    @admin
+    Scenario: An admin attempts to access analytics and reports
+        Given an admin user accesses the admin app
+        When I navigate to the admin analytics page
+        Then I should be able to access the "DAT file"
+        When I navigate to the admin analytics page
+        Then I should not be able to access the "view reports"
+        Then I should not be able to access the fixtures page

--- a/api/tests/Behat/features-v2/analytics/analytics.feature
+++ b/api/tests/Behat/features-v2/analytics/analytics.feature
@@ -1,4 +1,4 @@
-@v2 @v2_admin @analytics @acs
+@v2 @v2_admin @analytics
 Feature: Analytics - view and download analytics
 
 #    Covering all user types here due to data creating in parallel runs breaking tests

--- a/api/tests/Behat/features-v2/analytics/analytics.feature
+++ b/api/tests/Behat/features-v2/analytics/analytics.feature
@@ -1,4 +1,4 @@
-@v2 @v2_admin @analytics
+@v2 @v2_admin @analytics @acs
 Feature: Analytics - view and download analytics
 
 #    Covering all user types here due to data creating in parallel runs breaking tests
@@ -30,6 +30,8 @@ Feature: Analytics - view and download analytics
         Then I should see the correct options in the actions dropdown
         When I try to download the DAT file
         Then I should have no issues downloading the file
+        When I try to view the reports page
+        Then I should have no issues viewing the page
         When I try to download user research report
         Then I should have no issues downloading the file
         When I try to download satisfaction report

--- a/api/tests/Unit/Entity/Repository/UserRepositoryTest.php
+++ b/api/tests/Unit/Entity/Repository/UserRepositoryTest.php
@@ -162,10 +162,21 @@ class UserRepositoryTest extends WebTestCase
         $userHelper = new UserTestHelper();
         $usersToAdd = [];
         $usersToAdd[] = $adminUserMoreThan60Days = $userHelper->createUser(null, User::ROLE_ADMIN);
+        $usersToAdd[] = $superAdminUserMoreThan60Days = $userHelper->createUser(null, User::ROLE_SUPER_ADMIN);
+        $usersToAdd[] = $adminManagerUserMoreThan60Days = $userHelper->createUser(null, User::ROLE_ADMIN_MANAGER);
         $usersToAdd[] = $adminUserLessThan60Days = $userHelper->createUser(null, User::ROLE_ADMIN);
+        $usersToAdd[] = $nonAdminUserLessThan60Days = $userHelper->createUser(null, User::ROLE_LAY_DEPUTY);
 
         $adminUserMoreThan60Days->setRegistrationDate(new DateTime('-61 days'));
+        $adminUserMoreThan60Days->setActive(false);
+        $superAdminUserMoreThan60Days->setRegistrationDate(new DateTime('-61 days'));
+        $superAdminUserMoreThan60Days->setActive(false);
+        $adminManagerUserMoreThan60Days->setRegistrationDate(new DateTime('-61 days'));
+        $adminManagerUserMoreThan60Days->setActive(false);
         $adminUserLessThan60Days->setRegistrationDate(new DateTime('-5 days'));
+        $adminUserLessThan60Days->setActive(true);
+        $nonAdminUserLessThan60Days->setRegistrationDate(new DateTime('-61 days'));
+        $adminUserLessThan60Days->setActive(false);
 
         foreach ($usersToAdd as $user) {
             $this->em->persist($user);
@@ -173,16 +184,16 @@ class UserRepositoryTest extends WebTestCase
 
         $this->em->flush();
 
-        $expectedAdminUsersReturned = [$adminUserMoreThan60Days];
-        $expectedAdminUsersNotReturned = [$adminUserLessThan60Days];
+        $expectedAdminUsersReturned = [$adminUserMoreThan60Days, $superAdminUserMoreThan60Days, $adminManagerUserMoreThan60Days];
+        $expectedAdminUsersNotReturned = [$adminUserLessThan60Days, $nonAdminUserLessThan60Days];
 
         $actualAdminUsers = $this->sut->getAllAdminAccountsCreatedButNotActivatedWithin('-60 days');
 
-        self::assertEquals(1, count($actualAdminUsers));
+        self::assertEquals(3, count($actualAdminUsers));
         self::assertEquals($expectedAdminUsersReturned, $actualAdminUsers);
 
-        foreach ($expectedAdminUsersNotReturned as $deputyUser) {
-            self::assertNotContains($deputyUser, $actualAdminUsers);
+        foreach ($expectedAdminUsersNotReturned as $user) {
+            self::assertNotContains($user, $actualAdminUsers);
         }
     }
 

--- a/api/tests/Unit/Entity/Repository/UserRepositoryTest.php
+++ b/api/tests/Unit/Entity/Repository/UserRepositoryTest.php
@@ -126,6 +126,19 @@ class UserRepositoryTest extends WebTestCase
         self::assertNotContains($inactiveUserTwo->getId(), $resultsUserIds);
     }
 
+    /** @test */
+    public function getAllAdminAccounts()
+    {
+        $userHelper = new UserTestHelper();
+        $user = $userHelper->createUser(null, User::ROLE_ADMIN);
+
+        $this->em->persist($user);
+        $this->em->flush();
+        $adminUsers = $this->sut->getAllAdminAccounts();
+        self::assertEquals(1, count($adminUsers));
+        self::assertContains($user, $adminUsers);
+    }
+
     protected function tearDown(): void
     {
         parent::tearDown();

--- a/api/tests/Unit/Entity/Repository/UserRepositoryTest.php
+++ b/api/tests/Unit/Entity/Repository/UserRepositoryTest.php
@@ -76,8 +76,7 @@ class UserRepositoryTest extends WebTestCase
         self::assertCount(2, $inactiveUsers);
     }
 
-    /** @test */
-    public function findActiveLaysInLastYear()
+    public function testFindActiveLaysInLastYear()
     {
         $userHelper = new UserTestHelper();
         $reportHelper = new ReportTestHelper();
@@ -126,8 +125,7 @@ class UserRepositoryTest extends WebTestCase
         self::assertNotContains($inactiveUserTwo->getId(), $resultsUserIds);
     }
 
-    /** @test */
-    public function getAllAdminAccounts()
+    public function testGetAllAdminAccounts()
     {
         $userHelper = new UserTestHelper();
         $usersToAdd = [];
@@ -155,8 +153,7 @@ class UserRepositoryTest extends WebTestCase
         }
     }
 
-    /** @test */
-    public function getAllAdminAccountsCreatedButNotActivatedWithin()
+    public function testGetAllAdminAccountsCreatedButNotActivatedWithin()
     {
         $userHelper = new UserTestHelper();
         $usersToAdd = [];
@@ -195,8 +192,7 @@ class UserRepositoryTest extends WebTestCase
         }
     }
 
-    /** @test */
-    public function getAllActivatedAdminAccounts()
+    public function testGetAllActivatedAdminAccounts()
     {
         $userHelper = new UserTestHelper();
         $usersToAdd = [];
@@ -230,8 +226,7 @@ class UserRepositoryTest extends WebTestCase
         }
     }
 
-    /** @test */
-    public function getAllAdminAccountsNotUsedWithin()
+    public function testGetAllAdminAccountsNotUsedWithin()
     {
         $userHelper = new UserTestHelper();
         $usersToAdd = [];
@@ -265,8 +260,7 @@ class UserRepositoryTest extends WebTestCase
         }
     }
 
-    /** @test */
-    public function getAllAdminAccountsUsedWithin()
+    public function testGetAllAdminAccountsUsedWithin()
     {
         $userHelper = new UserTestHelper();
         $usersToAdd = [];

--- a/client/src/Controller/Admin/StatsController.php
+++ b/client/src/Controller/Admin/StatsController.php
@@ -217,7 +217,7 @@ class StatsController extends AbstractController
      *
      * @return array|Response
      */
-    public function reports(Request $request)
+    public function reports()
     {
     }
 
@@ -228,7 +228,7 @@ class StatsController extends AbstractController
      *
      * @return array|Response
      */
-    public function userAccountReports(Request $request)
+    public function userAccountReports()
     {
         return $this->statsApi->getAdminUserAccountReportData();
     }

--- a/client/src/Controller/Admin/StatsController.php
+++ b/client/src/Controller/Admin/StatsController.php
@@ -211,6 +211,29 @@ class StatsController extends AbstractController
     }
 
     /**
+     * @Route("/reports", name="admin_reports")
+     * @Security("is_granted('ROLE_SUPER_ADMIN')")
+     * @Template("@App/Admin/Stats/reports.html.twig")
+     *
+     * @return array|Response
+     */
+    public function reports(Request $request)
+    {
+    }
+
+    /**
+     * @Route("/reports/user_accounts", name="admin_user_account_reports")
+     * @Security("is_granted('ROLE_SUPER_ADMIN')")
+     * @Template("@App/Admin/Stats/userAccountReports.html.twig")
+     *
+     * @return array|Response
+     */
+    public function userAccountReports(Request $request)
+    {
+        return $this->statsApi->getAdminUserAccountReportData();
+    }
+
+    /**
      * Map an array of metric responses to be addressible by deputyType.
      */
     private function mapToDeputyType(array $result): array

--- a/client/src/Service/Client/Internal/StatsApi.php
+++ b/client/src/Service/Client/Internal/StatsApi.php
@@ -9,6 +9,7 @@ use App\Service\Client\RestClientInterface;
 class StatsApi
 {
     protected const GET_ACTIVE_LAY_REPORT_DATA_ENDPOINT = 'stats/deputies/lay/active';
+    protected const GET_ADMIN_USER_ACCOUNT_REPORT_DATA = 'stats/admins/report_data';
 
     private RestClientInterface $restClient;
 
@@ -26,6 +27,18 @@ class StatsApi
             self::GET_ACTIVE_LAY_REPORT_DATA_ENDPOINT,
             'array',
             ['active-users']
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function getAdminUserAccountReportData()
+    {
+        return $this->restClient->get(
+            self::GET_ADMIN_USER_ACCOUNT_REPORT_DATA,
+            'array',
+            ['admin-account-reports']
         );
     }
 }

--- a/client/src/Service/Client/Internal/StatsApi.php
+++ b/client/src/Service/Client/Internal/StatsApi.php
@@ -18,10 +18,7 @@ class StatsApi
         $this->restClient = $restClient;
     }
 
-    /**
-     * @return array
-     */
-    public function getActiveLayReportData()
+    public function getActiveLayReportData(): array
     {
         return $this->restClient->get(
             self::GET_ACTIVE_LAY_REPORT_DATA_ENDPOINT,
@@ -30,10 +27,7 @@ class StatsApi
         );
     }
 
-    /**
-     * @return array
-     */
-    public function getAdminUserAccountReportData()
+    public function getAdminUserAccountReportData(): array
     {
         return $this->restClient->get(
             self::GET_ADMIN_USER_ACCOUNT_REPORT_DATA,

--- a/client/templates/Admin/Stats/metrics.html.twig
+++ b/client/templates/Admin/Stats/metrics.html.twig
@@ -71,44 +71,44 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full text--center">
-      <span class="govuk-caption-l govuk-!-margin-top-2" id="metric-satisfaction-total-label">
-        {{ 'metrics.satisfaction.totalLabel' | trans }}
-      </span>
+            <span class="govuk-caption-l govuk-!-margin-top-2" id="metric-satisfaction-total-label">
+            {{ 'metrics.satisfaction.totalLabel' | trans }}
+            </span>
             <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-80"
                   aria-labelledby="metric-satisfaction-total-label">
-        {{ stats.satisfaction.all | default('-') }}%
-      </span>
+                {{ stats.satisfaction.all | default('-') }}%
+            </span>
         </div>
     </div>
 
     <div class="govuk-grid-row govuk-!-margin-bottom-9">
         <div class="govuk-grid-column-one-third text--center">
-      <span class="govuk-caption-l govuk-!-margin-top-2" id="metric-reportsSubmitted-total-label">
-        {{ 'metrics.reportsSubmitted.totalLabel' | trans }}
-      </span>
+            <span class="govuk-caption-l govuk-!-margin-top-2" id="metric-reportsSubmitted-total-label">
+            {{ 'metrics.reportsSubmitted.totalLabel' | trans }}
+            </span>
             <span class="govuk-heading-xl govuk-!-margin-bottom-4"
                   aria-labelledby="metric-reportsSubmitted-total-label">
-        {{ stats.reportsSubmitted.all | default('-') }}
-      </span>
+                    {{ stats.reportsSubmitted.all | default('-') }}
+            </span>
         </div>
 
         <div class="govuk-grid-column-one-third text--center">
-      <span class="govuk-caption-l govuk-!-margin-top-2" id="metric-registeredDeputies-total-label">
-        {{ 'metrics.registeredDeputies.totalLabel' | trans }}
-      </span>
+            <span class="govuk-caption-l govuk-!-margin-top-2" id="metric-registeredDeputies-total-label">
+            {{ 'metrics.registeredDeputies.totalLabel' | trans }}
+            </span>
             <span class="govuk-heading-xl govuk-!-margin-bottom-4"
                   aria-labelledby="metric-registeredDeputies-total-label">
-        {{ stats.registeredDeputies.all | default('-') }}
-      </span>
+                 {{ stats.registeredDeputies.all | default('-') }}
+            </span>
         </div>
 
         <div class="govuk-grid-column-one-third text--center">
-      <span class="govuk-caption-l govuk-!-margin-top-2" id="metric-clients-total-label">
-        {{ 'metrics.clients.totalLabel' | trans }}
-      </span>
+          <span class="govuk-caption-l govuk-!-margin-top-2" id="metric-clients-total-label">
+            {{ 'metrics.clients.totalLabel' | trans }}
+          </span>
             <span class="govuk-heading-xl govuk-!-margin-bottom-4" aria-labelledby="metric-clients-total-label">
-        {{ stats.clients.all | default('-') }}
-      </span>
+            {{ stats.clients.all | default('-') }}
+          </span>
         </div>
     </div>
 
@@ -120,8 +120,8 @@
             {% for metric in metrics %}
                 <span class="govuk-caption-m govuk-!-margin-top-5"
                       id="metric-{{ metric }}-{{ dimension }}-{{ value }}-label">
-          {{ ('metrics.' ~ metric  ~ '.label') | trans }}
-        </span>
+                     {{ ('metrics.' ~ metric  ~ '.label') | trans }}
+                </span>
                 <span class="govuk-heading-l govuk-!-margin-bottom-4"
                       aria-labelledby="metric-{{ metric }}-{{ dimension }}-{{ value }}-label">
         {% set val = stats[metric][value] | default('-') %}
@@ -130,7 +130,7 @@
                     {% else %}
                         {{ ('metrics.' ~ metric  ~ '.format') | trans({ '%value%': val }) }}
                     {% endif %}
-        </span>
+                </span>
             {% endfor %}
         </div>
     {% endmacro %}

--- a/client/templates/Admin/Stats/metrics.html.twig
+++ b/client/templates/Admin/Stats/metrics.html.twig
@@ -9,140 +9,135 @@
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 
 {% block actions %}
+
+    <a href="{{ path('admin_stats') }}" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+        {{ (page ~ '.downloadDAT') | trans }}
+    </a>
     {% if is_granted('ROLE_SUPER_ADMIN') %}
-        <a href="{{ path('admin_stats') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
-            {{ (page ~ '.downloadDAT') | trans }}
-        </a>
-
-        <a href="{{ path('admin_satisfaction') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
-            {{ (page ~ '.downloadSatisfaction') | trans }}
-        </a>
-
-        <a href="{{ path('admin_user_research') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
-            {{ (page ~ '.downloadUserResearch') | trans }}
-        </a>
-
-        <a href="{{ path('admin_active_lays_csv') }}" role="button" draggable="false" class="govuk-button moj-button-menu__item govuk-button--secondary " data-module="govuk-button">
-            {{ (page ~ '.downloadActiveLays') | trans }}
-        </a>
-    {% else %}
-        <a href="{{ path('admin_stats') }}" class="govuk-button govuk-button--secondary" data-module="govuk-button">
-            {{ (page ~ '.downloadDAT') | trans }}
+        <a href="{{ path('admin_reports') }}" class="govuk-button govuk-button--secondary govuk-!-margin-left-3"
+           data-module="govuk-button">
+            {{ (page ~ '.reports') | trans }}
         </a>
     {% endif %}
 {% endblock %}
 
 {% block pageContent %}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-1">
-        {{ ('form.period.options.' ~ form.period.vars.value) | trans }}
-      </h2>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-1">
+                {{ ('form.period.options.' ~ form.period.vars.value) | trans }}
+            </h2>
 
-      <details class="govuk-details govuk-!-margin-bottom-4" data-module="govuk-details" role="group">
-        <summary class="govuk-details__summary" role="button" aria-controls="details-content-16e5bdaa-a396-45cd-97cf-035235053ee4" aria-expanded="false">
+            <details class="govuk-details govuk-!-margin-bottom-4" data-module="govuk-details" role="group">
+                <summary class="govuk-details__summary" role="button"
+                         aria-controls="details-content-16e5bdaa-a396-45cd-97cf-035235053ee4" aria-expanded="false">
         <span class="govuk-details__summary-text">
             {{ 'form.title' | trans }}
         </span>
-        </summary>
-        <div class="govuk-details__text">
-        {{ form_start(form) }}
+                </summary>
+                <div class="govuk-details__text">
+                    {{ form_start(form) }}
 
-        {% set customDateRange %}
-            <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-half">
-                {{ form_known_date(form.startDate, 'form.startDate') }}
-            </div>
-            <div class="govuk-grid-column-one-half">
-                {{ form_known_date(form.endDate, 'form.endDate') }}
-            </div>
-            </div>
-        {% endset %}
+                    {% set customDateRange %}
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-one-half">
+                                {{ form_known_date(form.startDate, 'form.startDate') }}
+                            </div>
+                            <div class="govuk-grid-column-one-half">
+                                {{ form_known_date(form.endDate, 'form.endDate') }}
+                            </div>
+                        </div>
+                    {% endset %}
 
-        {{ form_checkbox_group(form.period, 'form.period', {
-            classes: 'govuk-radios--small',
-            legendClass: 'govuk-visually-hidden',
-            items: [
-            {},
-            {},
-            {},
-            { conditional: customDateRange }
-            ]
-        }) }}
+                    {{ form_checkbox_group(form.period, 'form.period', {
+                        classes: 'govuk-radios--small',
+                        legendClass: 'govuk-visually-hidden',
+                        items: [
+                            {},
+                            {},
+                            {},
+                            { conditional: customDateRange }
+                        ]
+                    }) }}
 
-        {{ form_submit(form.update, 'form.update', { buttonClass: 'govuk-!-margin-bottom-0' }) }}
+                    {{ form_submit(form.update, 'form.update', { buttonClass: 'govuk-!-margin-bottom-0' }) }}
 
-        {{ form_end(form) }}
+                    {{ form_end(form) }}
+                </div>
+            </details>
         </div>
-      </details>
     </div>
-  </div>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full text--center">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full text--center">
       <span class="govuk-caption-l govuk-!-margin-top-2" id="metric-satisfaction-total-label">
         {{ 'metrics.satisfaction.totalLabel' | trans }}
       </span>
-      <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-80" aria-labelledby="metric-satisfaction-total-label">
+            <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-80"
+                  aria-labelledby="metric-satisfaction-total-label">
         {{ stats.satisfaction.all | default('-') }}%
       </span>
+        </div>
     </div>
-  </div>
 
-  <div class="govuk-grid-row govuk-!-margin-bottom-9">
-    <div class="govuk-grid-column-one-third text--center">
+    <div class="govuk-grid-row govuk-!-margin-bottom-9">
+        <div class="govuk-grid-column-one-third text--center">
       <span class="govuk-caption-l govuk-!-margin-top-2" id="metric-reportsSubmitted-total-label">
         {{ 'metrics.reportsSubmitted.totalLabel' | trans }}
       </span>
-      <span class="govuk-heading-xl govuk-!-margin-bottom-4" aria-labelledby="metric-reportsSubmitted-total-label">
+            <span class="govuk-heading-xl govuk-!-margin-bottom-4"
+                  aria-labelledby="metric-reportsSubmitted-total-label">
         {{ stats.reportsSubmitted.all | default('-') }}
       </span>
-    </div>
+        </div>
 
-    <div class="govuk-grid-column-one-third text--center">
+        <div class="govuk-grid-column-one-third text--center">
       <span class="govuk-caption-l govuk-!-margin-top-2" id="metric-registeredDeputies-total-label">
         {{ 'metrics.registeredDeputies.totalLabel' | trans }}
       </span>
-      <span class="govuk-heading-xl govuk-!-margin-bottom-4" aria-labelledby="metric-registeredDeputies-total-label">
+            <span class="govuk-heading-xl govuk-!-margin-bottom-4"
+                  aria-labelledby="metric-registeredDeputies-total-label">
         {{ stats.registeredDeputies.all | default('-') }}
       </span>
-    </div>
+        </div>
 
-    <div class="govuk-grid-column-one-third text--center">
+        <div class="govuk-grid-column-one-third text--center">
       <span class="govuk-caption-l govuk-!-margin-top-2" id="metric-clients-total-label">
         {{ 'metrics.clients.totalLabel' | trans }}
       </span>
-      <span class="govuk-heading-xl govuk-!-margin-bottom-4" aria-labelledby="metric-clients-total-label">
+            <span class="govuk-heading-xl govuk-!-margin-bottom-4" aria-labelledby="metric-clients-total-label">
         {{ stats.clients.all | default('-') }}
       </span>
+        </div>
     </div>
-  </div>
 
-  <hr />
+    <hr/>
 
-  {% macro dimensionBox(dimension, value, metrics, stats) %}
-    <div class="govuk-grid-column-one-third">
-      <h3 class="govuk-heading-m govuk-!-padding-top-3 govuk-!-padding-bottom-4">{{ ('dimensions.' ~ dimension ~ '.' ~ value) | trans }}</h3>
-      {% for metric in metrics %}
-        <span class="govuk-caption-m govuk-!-margin-top-5" id="metric-{{metric}}-{{dimension}}-{{value}}-label">
+    {% macro dimensionBox(dimension, value, metrics, stats) %}
+        <div class="govuk-grid-column-one-third">
+            <h3 class="govuk-heading-m govuk-!-padding-top-3 govuk-!-padding-bottom-4">{{ ('dimensions.' ~ dimension ~ '.' ~ value) | trans }}</h3>
+            {% for metric in metrics %}
+                <span class="govuk-caption-m govuk-!-margin-top-5"
+                      id="metric-{{ metric }}-{{ dimension }}-{{ value }}-label">
           {{ ('metrics.' ~ metric  ~ '.label') | trans }}
         </span>
-        <span class="govuk-heading-l govuk-!-margin-bottom-4" aria-labelledby="metric-{{metric}}-{{dimension}}-{{value}}-label">
+                <span class="govuk-heading-l govuk-!-margin-bottom-4"
+                      aria-labelledby="metric-{{ metric }}-{{ dimension }}-{{ value }}-label">
         {% set val = stats[metric][value] | default('-') %}
-          {% if (val == '-') %}
-            -
-          {% else %}
-            {{ ('metrics.' ~ metric  ~ '.format') | trans({ '%value%': val }) }}
-          {% endif %}
+                    {% if (val == '-') %}
+                        -
+                    {% else %}
+                        {{ ('metrics.' ~ metric  ~ '.format') | trans({ '%value%': val }) }}
+                    {% endif %}
         </span>
-      {% endfor %}
-    </div>
-  {% endmacro %}
+            {% endfor %}
+        </div>
+    {% endmacro %}
 
-  <div class="govuk-grid-row">
-    {{ _self.dimensionBox('deputyType', 'lay', [ 'satisfaction', 'reportsSubmitted', 'registeredDeputies', 'clients' ], stats) }}
-    {{ _self.dimensionBox('deputyType', 'prof', [ 'satisfaction', 'reportsSubmitted', 'registeredDeputies', 'clients' ], stats) }}
-    {{ _self.dimensionBox('deputyType', 'pa', [ 'satisfaction', 'reportsSubmitted', 'registeredDeputies', 'clients' ], stats) }}
-  </div>
+    <div class="govuk-grid-row">
+        {{ _self.dimensionBox('deputyType', 'lay', [ 'satisfaction', 'reportsSubmitted', 'registeredDeputies', 'clients' ], stats) }}
+        {{ _self.dimensionBox('deputyType', 'prof', [ 'satisfaction', 'reportsSubmitted', 'registeredDeputies', 'clients' ], stats) }}
+        {{ _self.dimensionBox('deputyType', 'pa', [ 'satisfaction', 'reportsSubmitted', 'registeredDeputies', 'clients' ], stats) }}
+    </div>
 {% endblock %}

--- a/client/templates/Admin/Stats/reports.html.twig
+++ b/client/templates/Admin/Stats/reports.html.twig
@@ -1,0 +1,35 @@
+{% extends '@App/Layouts/application.html.twig' %}
+
+{% trans_default_domain "admin-metrics" %}
+{% set page = 'reports' %}
+
+{% set navSection = 'reports' %}
+
+{% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
+{% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
+
+{% block pageContent %}
+    <p>
+        <a href="{{ path('admin_active_lays_csv') }}" class="govuk-link">
+            {{ (page ~ '.downloadActiveLays') | trans }}
+        </a>
+    </p>
+
+    <p>
+        <a href="{{ path('admin_satisfaction') }}" class="govuk-link">
+            {{ (page ~ '.downloadSatisfaction') | trans }}
+        </a>
+    </p>
+    <p>
+        <a href="{{ path('admin_user_research') }}" class="govuk-link">
+            {{ (page ~ '.downloadUserResearch') | trans }}
+        </a>
+    </p>
+
+    <p>
+        <a href="{{ path('admin_user_account_reports') }}" class="govuk-link">
+            {{ (page ~ '.userAccountReports') | trans }}
+        </a>
+    </p>
+
+{% endblock %}

--- a/client/templates/Admin/Stats/userAccountReports.html.twig
+++ b/client/templates/Admin/Stats/userAccountReports.html.twig
@@ -1,0 +1,78 @@
+{% extends '@App/Layouts/application.html.twig' %}
+
+{% trans_default_domain "admin-metrics" %}
+{% set page = 'adminAccounts' %}
+
+{% set navSection = 'reports' %}
+
+{% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
+{% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
+
+{% block pageContent %}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full text--center">
+            <span class="govuk-caption-l govuk-!-margin-top-2 ">
+                Total
+            </span>
+        <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40">
+                 {{ TotalAdminAccounts }}
+            </span>
+    </div>
+</div>
+
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half text--center">
+             <span class="govuk-caption-l govuk-!-margin-top-2">
+                    Inactive
+             </span>
+        <p class="govuk-caption-l govuk-!-margin-top-2">
+            (created but not activated in the last 60 days)
+        </p>
+        <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40 ">
+                    {{ InactiveAdminAccounts }}
+             </span>
+    </div>
+
+
+    <div class="govuk-grid-column-one-half text--center">
+             <span class="govuk-caption-l govuk-!-margin-top-2">
+                    Activated
+             </span>
+        <p class="govuk-caption-l govuk-!-margin-top-2">
+            (a user has enabled their account through registration)
+        </p>
+        <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40">
+                {{ ActivatedAdminAccounts }}
+             </span>
+    </div>
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half text--center">
+            <span class="govuk-caption-l govuk-!-margin-top-2">
+                Activated
+            </span>
+            <p class="govuk-caption-l govuk-!-margin-top-2">
+                (not used within the last 90 days)
+            </p>
+            <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40">
+                {{ ActivatedAdminAccountsNotUsedWithin90Days }}
+            </span>
+        </div>
+
+
+        <div class="govuk-grid-column-one-half text--center">
+             <span class="govuk-caption-l govuk-!-margin-top-2">
+                  Activated
+             </span>
+            <p class="govuk-caption-l govuk-!-margin-top-2">
+                (used within the last 90 days)
+            </p>
+            <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40">
+                {{ ActivatedAdminAccountsUsedWithin90Days }}
+            </span>
+        </div>
+    </div>
+
+    {% endblock %}

--- a/client/templates/Admin/Stats/userAccountReports.html.twig
+++ b/client/templates/Admin/Stats/userAccountReports.html.twig
@@ -12,66 +12,40 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full text--center">
-            <span class="govuk-caption-l govuk-!-margin-top-2 ">
-                Total
-            </span>
-        <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40">
-                 {{ TotalAdminAccounts }}
-            </span>
+        <span class="govuk-caption-l govuk-!-margin-top-2 ">Total</span>
+        <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40">{{ TotalAdminAccounts }}</span>
     </div>
 </div>
 
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half text--center">
-             <span class="govuk-caption-l govuk-!-margin-top-2">
-                    Inactive
-             </span>
-        <p class="govuk-caption-l govuk-!-margin-top-2">
-            (created but not activated in the last 60 days)
-        </p>
-        <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40 ">
-                    {{ InactiveAdminAccounts }}
-             </span>
+        <span class="govuk-caption-l govuk-!-margin-top-2">Inactive</span>
+        <p class="govuk-caption-l govuk-!-margin-top-2">(created but not activated in the last 60 days)</p>
+        <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40 ">{{ InactiveAdminAccounts }}</span>
     </div>
 
 
     <div class="govuk-grid-column-one-half text--center">
-             <span class="govuk-caption-l govuk-!-margin-top-2">
-                    Activated
-             </span>
-        <p class="govuk-caption-l govuk-!-margin-top-2">
-            (a user has enabled their account through registration)
-        </p>
-        <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40">
-                {{ ActivatedAdminAccounts }}
-             </span>
+        <span class="govuk-caption-l govuk-!-margin-top-2">Activated</span>
+        <p class="govuk-caption-l govuk-!-margin-top-2">(a user has enabled their account through registration)</p>
+        <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40">{{ ActivatedAdminAccounts }}</span>
     </div>
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half text--center">
-            <span class="govuk-caption-l govuk-!-margin-top-2">
-                Activated
-            </span>
-            <p class="govuk-caption-l govuk-!-margin-top-2">
-                (not used within the last 90 days)
-            </p>
-            <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40">
-                {{ ActivatedAdminAccountsNotUsedWithin90Days }}
-            </span>
+            <span class="govuk-caption-l govuk-!-margin-top-2">Activated</span>
+            <p class="govuk-caption-l govuk-!-margin-top-2">(not used within the last 90 days)</p>
+            <span
+                class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40">{{ ActivatedAdminAccountsNotUsedWithin90Days }}</span>
         </div>
 
 
         <div class="govuk-grid-column-one-half text--center">
-             <span class="govuk-caption-l govuk-!-margin-top-2">
-                  Activated
-             </span>
-            <p class="govuk-caption-l govuk-!-margin-top-2">
-                (used within the last 90 days)
-            </p>
-            <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40">
-                {{ ActivatedAdminAccountsUsedWithin90Days }}
-            </span>
+            <span class="govuk-caption-l govuk-!-margin-top-2">Activated</span>
+            <p class="govuk-caption-l govuk-!-margin-top-2">(used within the last 90 days)</p>
+            <span
+                class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40">{{ ActivatedAdminAccountsUsedWithin90Days }}</span>
         </div>
     </div>
 

--- a/client/translations/admin-metrics.en.yml
+++ b/client/translations/admin-metrics.en.yml
@@ -2,9 +2,17 @@ indexPage:
     htmlTitle: Administration - Analytics
     pageTitle: Analytics
     downloadDAT: Download DAT file
+    reports: View reports
+
+adminAccounts:
+    pageTitle: Admin Accounts
+
+reports:
+    pageTitle: Reports
     downloadSatisfaction: Download satisfaction report
     downloadUserResearch: Download user research report
     downloadActiveLays: Download active lays report
+    userAccountReports: View admin account metrics
 
 form:
     title: Change reporting period


### PR DESCRIPTION
## Purpose
The JML team need retention data on Digideps user accounts, so that we can help form a security process for leavers and movers. 

Fixes DDPB-4186

## Approach
- Created a new reports page (only accessible for super admins) that enable admins to view a summary of the current admin account metrics based on the requested search criteria. 
- Also moved the existing links from the button menu to the reports page to avoid overloading the existing dropdown menu.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [x] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
