### PR TITLE
Add more hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,4 +47,3 @@ repos:
     rev: v2.5.1
     hooks:
       - id: prettier
-        files: \.(js|ts|jsx|tsx|css|less|html|twig|json|markdown|md|yaml|yml)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,9 @@ repos:
     hooks:
       - id: prettier
         files: \.(js|ts|jsx|tsx|css|less|html|json|markdown|md|yaml|yml)$
+
+  - repo: git://github.com/Bahjat/pre-commit-golang
+    rev: master
+    hooks:
+      - id: go-unit-tests
+      - id: go-static-check # install https://staticcheck.io/docs/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,4 +47,4 @@ repos:
     rev: v2.5.1
     hooks:
       - id: prettier
-        files: \.(js|ts|jsx|tsx|css|less|html|html.twig|json|markdown|md|yaml|yml)$
+        files: \.(js|ts|jsx|tsx|css|less|html|twig|json|markdown|md|yaml|yml)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,4 +47,4 @@ repos:
     rev: v2.5.1
     hooks:
       - id: prettier
-        files: \.(js|ts|jsx|tsx|css|less|html|json|markdown|md|yaml|yml)$
+        files: \.(js|ts|jsx|tsx|css|less|html|html.twig|json|markdown|md|yaml|yml)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,9 +48,3 @@ repos:
     hooks:
       - id: prettier
         files: \.(js|ts|jsx|tsx|css|less|html|json|markdown|md|yaml|yml)$
-
-  - repo: git://github.com/Bahjat/pre-commit-golang
-    rev: master
-    hooks:
-      - id: go-unit-tests
-      - id: go-static-check # install https://staticcheck.io/docs/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,3 +47,7 @@ repos:
     rev: v2.5.1
     hooks:
       - id: prettier
+        args: ["--write"]
+        additional_dependencies:
+          - prettier@2.5.1
+          - "prettier-plugin-twig-melody"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,30 +2,49 @@
 # See https://pre-commit.com/hooks.html for more hooks
 
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
--   repo: https://github.com/antonbabenko/pre-commit-terraform
+      - id: check-added-large-files # prevents giant files from being committed.
+        args: ["--maxkb=20480"]
+      - id: check-case-conflict # checks for files that would conflict in case-insensitive filesystems.
+      - id: check-merge-conflict # checks for files that contain merge conflict strings.
+      - id: check-yaml # checks yaml files for parseable syntax.
+      - id: detect-private-key # detects the presence of private keys.
+      - id: end-of-file-fixer # ensures that a file is either empty, or ends with one newline.
+      - id: mixed-line-ending # replaces or checks mixed line ending.
+        args: ["--fix=auto"]
+      - id: requirements-txt-fixer # sorts entries in requirements.txt.
+      - id: trailing-whitespace # trims trailing whitespace.
+
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.56.0
     hooks:
-    -   id: terraform_fmt
-    -   id: terraform_validate
--   repo: https://github.com/awslabs/git-secrets
+      - id: terraform_fmt
+      - id: terraform_validate
+
+  - repo: https://github.com/awslabs/git-secrets
     rev: master
     hooks:
-    -   id: git-secrets
--   repo: https://github.com/digitalpulp/pre-commit-php.git
+      - id: git-secrets
+
+  - repo: https://github.com/digitalpulp/pre-commit-php.git
     rev: 1.4.0
     hooks:
-    - id: php-cs-fixer
-      files: \.(php)$
-      args: ["--rules=@PSR12,@Symfony"]
-    - id: php-stan
-      files: \.(php)$
--   repo: https://github.com/ministryofjustice/opg-pre-commit-hooks.git
+      - id: php-cs-fixer
+        files: \.(php)$
+        args: ["--rules=@PSR12,@Symfony"]
+      - id: php-stan
+        files: \.(php)$
+
+  - repo: https://github.com/ministryofjustice/opg-pre-commit-hooks.git
     rev: v0.1.0
     hooks:
       - id: check-for-raw-in-templates
-        args: ['-d', 'client/templates', '-c', '1']
+        args: ["-d", "client/templates", "-c", "1"]
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.5.1
+    hooks:
+      - id: prettier
+        files: \.(js|ts|jsx|tsx|css|less|html|json|markdown|md|yaml|yml)$

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "twigPrintWidth": 140
+}

--- a/client/templates/Report/Formatted/_action.html.twig
+++ b/client/templates/Report/Formatted/_action.html.twig
@@ -3,20 +3,25 @@
 {% set append104 = report.get104TransSuffix %}
 
 <div class="section" id="action-section">
-                        <h2 class="section-heading">Actions you plan to take</h2>
+    <h2 class="section-heading">
+        Actions you plan to take
+    </h2>
 
-    {{ macros.answerYesNo({
-        question: ('form.doYouExpectFinancialDecisions.label' ~ append104) | trans(transOptions, 'report-actions'),
-        answer: report.action.doYouExpectFinancialDecisions,
-        moreDetails: report.action.doYouExpectFinancialDecisionsDetails,
-        showMoreDetailsWith: 'yes'
-    }) }}
+    {{
+        macros.answerYesNo({
+            question: ('form.doYouExpectFinancialDecisions.label' ~ append104)|trans(transOptions, 'report-actions'),
+            answer: report.action.doYouExpectFinancialDecisions,
+            moreDetails: report.action.doYouExpectFinancialDecisionsDetails,
+            showMoreDetailsWith: 'yes'
+        })
+    }}
 
-    {{ macros.answerYesNo({
-        question: 'form.doYouHaveConcerns.label' | trans({}, 'report-actions'),
-        answer: report.action.doYouHaveConcerns,
-        moreDetails: report.action.doYouHaveConcernsDetails,
-        showMoreDetailsWith: 'yes'
-    }) }}
-
+    {{
+        macros.answerYesNo({
+            question: 'form.doYouHaveConcerns.label'|trans({}, 'report-actions'),
+            answer: report.action.doYouHaveConcerns,
+            moreDetails: report.action.doYouHaveConcernsDetails,
+            showMoreDetailsWith: 'yes'
+        })
+    }}
 </div>

--- a/client/templates/Report/Formatted/_action.html.twig
+++ b/client/templates/Report/Formatted/_action.html.twig
@@ -3,7 +3,7 @@
 {% set append104 = report.get104TransSuffix %}
 
 <div class="section" id="action-section">
-                    <h2 class="section-heading">Actions you plan to take</h2>
+                        <h2 class="section-heading">Actions you plan to take</h2>
 
     {{ macros.answerYesNo({
         question: ('form.doYouExpectFinancialDecisions.label' ~ append104) | trans(transOptions, 'report-actions'),

--- a/client/templates/Report/Formatted/_action.html.twig
+++ b/client/templates/Report/Formatted/_action.html.twig
@@ -3,7 +3,7 @@
 {% set append104 = report.get104TransSuffix %}
 
 <div class="section" id="action-section">
-    <h2 class="section-heading">Actions you plan to take</h2>
+                <h2 class="section-heading">Actions you plan to take</h2>
 
     {{ macros.answerYesNo({
         question: ('form.doYouExpectFinancialDecisions.label' ~ append104) | trans(transOptions, 'report-actions'),

--- a/client/templates/Report/Formatted/_action.html.twig
+++ b/client/templates/Report/Formatted/_action.html.twig
@@ -3,7 +3,7 @@
 {% set append104 = report.get104TransSuffix %}
 
 <div class="section" id="action-section">
-                <h2 class="section-heading">Actions you plan to take</h2>
+                    <h2 class="section-heading">Actions you plan to take</h2>
 
     {{ macros.answerYesNo({
         question: ('form.doYouExpectFinancialDecisions.label' ~ append104) | trans(transOptions, 'report-actions'),


### PR DESCRIPTION
## Purpose
Following the PR comments in #766 I've bulked our pre-commit hooks up dramatically to try to minimise as many formatting discussions as possible. I considered adding one for PHP return types but decided against it as we have some old code that would need re-writing due to some inconsistencies with how function return values are used.

I've included a twig file here showing some of the formatting changes. Made the decision to use a large line width for heavily nested twig files to maintain readability.
