### PR TITLE
Fix document tests and ensure all tests run in CI

### DIFF
--- a/api/tests/Behat/features-v2/contact-details/contact-details.feature
+++ b/api/tests/Behat/features-v2/contact-details/contact-details.feature
@@ -1,4 +1,4 @@
-@contact-details @v2
+@contact-details @v2_admin @v2
 Feature: Contact details
     Scenario: Home screen should show lay deputy email address
         When I visit the client login page

--- a/api/tests/Behat/features-v2/report-submission/document-synchronisation.feature
+++ b/api/tests/Behat/features-v2/report-submission/document-synchronisation.feature
@@ -1,4 +1,4 @@
-@report-submissions @document-sync @v2
+@report-submissions @document-sync @v2_admin @v2
 Feature: Synchronising Documents with Sirius
 
     @super-admin @lay-pfa-high-completed
@@ -13,7 +13,7 @@ Feature: Synchronising Documents with Sirius
         And I view the pending submissions
         Then I should see the case number of the user I'm interacting with
         And the report PDF document should be queued
-        And the document "test-image.png" should be queued
+        And the document "testimage.png" should be queued
 
     @super-admin @ndr-completed
     Scenario: Submitting an NDR sets the synchronisation status of the report PDF to queued
@@ -33,7 +33,7 @@ Feature: Synchronising Documents with Sirius
         And I visit the admin submissions page
         And I view the pending submissions
         Then I should see the case number of the user I'm interacting with
-        And the document "test-image.png" should be queued
+        And the document "testimage.png" should be queued
 
     @super-admin @prof-admin-health-welfare-submitted
     Scenario: Running the document-sync command syncs queued documents with Sirius
@@ -46,8 +46,8 @@ Feature: Synchronising Documents with Sirius
         Then I should see the case number of the user I'm interacting with
         And the report PDF document should be synced
 #       Supporting documents can only sync after report PDF has synced
-        And the document "test-image.png" should be queued
+        And the document "testimage.png" should be queued
         And I run the document-sync command
         And I visit the admin submissions page
         And I view the pending submissions
-        And the document "test-image.png" should be synced
+        And the document "testimage.png" should be synced

--- a/api/tests/Behat/features-v2/report-submission/report-submission.feature
+++ b/api/tests/Behat/features-v2/report-submission/report-submission.feature
@@ -1,4 +1,4 @@
-@report-submissions @v2
+@report-submissions @v2_admin @v2
 Feature: Report submissions dashboard
 
     @super-admin

--- a/api/tests/Behat/features-v2/reporting/sections/gifts/gifts.feature
+++ b/api/tests/Behat/features-v2/reporting/sections/gifts/gifts.feature
@@ -1,4 +1,4 @@
-@gifts
+@gifts @v2 @v2_reporting_1
 Feature: Gifts
 
 @lay-pfa-high-not-started


### PR DESCRIPTION
## Purpose
After working on the filename sanitisation ticket (#751) the behat tests for documents were failing locally. After investigation, it turned out we had 4 feature files we didn't have tagged properly to run in CI. This ticket adds missing tags and fixes the document sync tickets.

## Learning
For behat feature tests to run in CI the `Feature` step needs to be tagged with `v2` and one of `v2_admin`, `v2_reporting_1` or `v2_reporting_2`. We should probably come up with a way to enforce this or come up with a more elegant solution to chunking up the tests into groups.