### PR TITLE
DDPB-4175: Return JSON for report rather than whole objects, fix CSV download

### DIFF
--- a/api/src/Controller/UserResearchController.php
+++ b/api/src/Controller/UserResearchController.php
@@ -11,6 +11,7 @@ use App\Service\Formatter\RestFormatter;
 use DateTime;
 use RuntimeException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -74,10 +75,10 @@ class UserResearchController extends RestController
             $toDate = empty($toDateString) ?
                 (new DateTime())->setTime(23, 59, 59) : (new DateTime($toDateString))->setTime(23, 59, 59);
 
-            $groups = $request->get('groups') ? $request->get('groups') : ['satisfaction', 'user-research', 'user'];
+            $groups = ['satisfaction', 'user-research', 'user-email', 'user-phone-main'];
             $this->formatter->setJmsSerialiserGroups($groups);
 
-            return $this->userResearchResponseRepository->getAllFilteredByDate($fromDate, $toDate);
+            return new JsonResponse(['data' => $this->userResearchResponseRepository->getAllFilteredByDate($fromDate, $toDate), 'success' => true]);
         } catch (Throwable $e) {
             throw new RuntimeException(sprintf('There was a problem getting user research responses: %s', $e->getMessage()), Response::HTTP_BAD_REQUEST);
         }

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -5,8 +5,10 @@ namespace App\Entity;
 use App\Entity\Report\Report;
 use App\Entity\Traits\AddressTrait;
 use App\Entity\UserResearch\UserResearchResponse;
+use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Exception;
 use JMS\Serializer\Annotation as JMS;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -150,7 +152,7 @@ class User implements UserInterface
     private $salt;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
      * @JMS\Groups({"user"})
      *
@@ -167,7 +169,7 @@ class User implements UserInterface
     private $registrationToken;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
      * @JMS\Groups({"user"})
      *
@@ -200,7 +202,7 @@ class User implements UserInterface
      * @var string
      *
      * @JMS\Type("string")
-     * @JMS\Groups({"user", "report-submitted-by", "user-list"})
+     * @JMS\Groups({"user", "report-submitted-by", "user-list", "user-phone-main"})
      * @ORM\Column(name="phone_main", type="string", length=20, nullable=true)
      */
     private $phoneMain;
@@ -215,7 +217,7 @@ class User implements UserInterface
     private $phoneAlternative;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
      * @JMS\Groups({"user"})
      *
@@ -269,7 +271,7 @@ class User implements UserInterface
     private $agreeTermsUse;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      * @JMS\Type("DateTime<'Y-m-d'>")
      * @JMS\Groups({"user"})
      *
@@ -419,7 +421,7 @@ class User implements UserInterface
     /**
      * Set registrationDate.
      *
-     * @param \DateTime $registrationDate
+     * @param DateTime $registrationDate
      *
      * @return User
      */
@@ -433,7 +435,7 @@ class User implements UserInterface
     /**
      * Get registrationDate.
      *
-     * @return \DateTime
+     * @return DateTime
      */
     public function getRegistrationDate()
     {
@@ -445,12 +447,12 @@ class User implements UserInterface
      *
      * @return User
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function recreateRegistrationToken()
     {
         $this->setRegistrationToken(bin2hex(random_bytes(16)));
-        $this->setTokenDate(new \DateTime());
+        $this->setTokenDate(new DateTime());
 
         return $this;
     }
@@ -506,7 +508,7 @@ class User implements UserInterface
     /**
      * Set tokenDate.
      *
-     * @param \DateTime $tokenDate
+     * @param DateTime $tokenDate
      *
      * @return User
      */
@@ -520,7 +522,7 @@ class User implements UserInterface
     /**
      * Get tokenDate.
      *
-     * @return \DateTime
+     * @return DateTime
      */
     public function getTokenDate()
     {
@@ -763,7 +765,7 @@ class User implements UserInterface
     }
 
     /**
-     * @return \DateTime
+     * @return DateTime
      */
     public function getLastLoggedIn()
     {
@@ -771,9 +773,9 @@ class User implements UserInterface
     }
 
     /**
-     * @param \DateTime $lastLoggedIn
+     * @param DateTime $lastLoggedIn
      */
-    public function setLastLoggedIn(\DateTime $lastLoggedIn = null)
+    public function setLastLoggedIn(DateTime $lastLoggedIn = null)
     {
         $this->lastLoggedIn = $lastLoggedIn;
 
@@ -960,14 +962,14 @@ class User implements UserInterface
         $this->agreeTermsUse = $agreeTermsUse;
 
         if ($agreeTermsUse) {
-            $this->agreeTermsUseDate = new \DateTime('now');
+            $this->agreeTermsUseDate = new DateTime('now');
         }
 
         return $this;
     }
 
     /**
-     * @return \DateTime
+     * @return DateTime
      */
     public function getAgreeTermsUseDate()
     {
@@ -1248,6 +1250,6 @@ class User implements UserInterface
      */
     public function regBeforeToday(User $user): bool
     {
-        return $user->getRegistrationDate() < (new \DateTime())->setTime(00, 00, 00);
+        return $user->getRegistrationDate() < (new DateTime())->setTime(00, 00, 00);
     }
 }

--- a/api/src/Repository/UserResearchResponseRepository.php
+++ b/api/src/Repository/UserResearchResponseRepository.php
@@ -8,6 +8,8 @@ use App\Entity\User;
 use App\Entity\UserResearch\UserResearchResponse;
 use DateTime;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\OptimisticLockException;
+use Doctrine\ORM\ORMException;
 use Doctrine\Persistence\ManagerRegistry;
 
 class UserResearchResponseRepository extends ServiceEntityRepository
@@ -18,8 +20,8 @@ class UserResearchResponseRepository extends ServiceEntityRepository
     }
 
     /**
-     * @throws \Doctrine\ORM\ORMException
-     * @throws \Doctrine\ORM\OptimisticLockException
+     * @throws ORMException
+     * @throws OptimisticLockException
      */
     public function create(UserResearchResponse $userResearchResponse, User $user): void
     {
@@ -38,10 +40,13 @@ class UserResearchResponseRepository extends ServiceEntityRepository
     {
         $qb = $this
             ->createQueryBuilder('urr')
+            ->select('urr', 'u', 's', 'rt')
             ->leftJoin('urr.satisfaction', 's')
+            ->leftJoin('urr.user', 'u')
+            ->leftJoin('urr.researchType', 'rt')
             ->where('urr.created > :from')->setParameter('from', $from)
             ->andWhere('urr.created < :to')->setParameter('to', $to);
 
-        return $qb->getQuery()->getResult();
+        return $qb->getQuery()->getArrayResult();
     }
 }

--- a/api/tests/Unit/Entity/Repository/UserResearchResponseRepositoryTest.php
+++ b/api/tests/Unit/Entity/Repository/UserResearchResponseRepositoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity\Repository;
+
+use App\Entity\UserResearch\UserResearchResponse;
+use App\Repository\UserResearchResponseRepository;
+use App\Tests\Unit\Fixtures;
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class UserResearchResponseRepositoryTest extends KernelTestCase
+{
+    private EntityManagerInterface $em;
+    private Fixtures $fixtures;
+    private UserResearchResponseRepository $sut;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->em = $kernel->getContainer()->get('doctrine')->getManager();
+        $this->fixtures = new Fixtures($this->em);
+
+        $this->sut = $this->em->getRepository(UserResearchResponse::class);
+    }
+
+    // Not to be run in test suites as it takes forever - run this to generate large amounts of userResearchResponses
+    // for manual testing
+    public function canHandleLargeAmountsOfData()
+    {
+        $this->fixtures->createUserResearchResponse(2000);
+        $urs = $this->sut->getAllFilteredByDate(new DateTime('-1 day'), new DateTime());
+    }
+}

--- a/client/src/Controller/Admin/StatsController.php
+++ b/client/src/Controller/Admin/StatsController.php
@@ -24,6 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\Routing\Annotation\Route;
+use Throwable;
 
 /**
  * @Route("/admin/stats")
@@ -68,7 +69,7 @@ class StatsController extends AbstractController
                 $downloadableData = $transformer->transform($reportSubmissionSummaries);
 
                 return $this->buildResponse($downloadableData);
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 throw new DisplayableException($e);
             }
         }
@@ -106,7 +107,7 @@ class StatsController extends AbstractController
                 $response->headers->set('Content-Disposition', $disposition);
 
                 return $response;
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 throw new DisplayableException($e);
             }
         }
@@ -131,7 +132,8 @@ class StatsController extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             try {
                 $userResearchResponses = $mapper->getBy($form->getData());
-                $csv = $this->userResearchResponseCsvGenerator->generateUserResearchResponsesCsv($userResearchResponses);
+                $userResearchResponsesArray = json_decode($userResearchResponses, true)['data'];
+                $csv = $this->userResearchResponseCsvGenerator->generateUserResearchResponsesCsv($userResearchResponsesArray);
 
                 $response = new Response($csv);
 
@@ -144,7 +146,7 @@ class StatsController extends AbstractController
                 $response->headers->set('Content-Disposition', $disposition);
 
                 return $response;
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 throw new DisplayableException($e);
             }
         }

--- a/client/src/Service/Client/Internal/UserResearchApi.php
+++ b/client/src/Service/Client/Internal/UserResearchApi.php
@@ -40,7 +40,6 @@ class UserResearchApi
                 'order' => $query->getSortOrder(),
                 'fromDate' => $fromDate,
                 'toDate' => $toDate,
-                'groups' => ['satisfaction', 'user', 'user-research'],
             ];
 
             $url = sprintf(
@@ -50,6 +49,6 @@ class UserResearchApi
             );
         }
 
-        return $this->restClient->get($url, 'App\Entity\UserResearch\UserResearchResponse[]');
+        return $this->restClient->get($url, 'raw');
     }
 }

--- a/client/tests/phpunit/Service/Csv/UserResearchResponseCsvGeneratorTest.php
+++ b/client/tests/phpunit/Service/Csv/UserResearchResponseCsvGeneratorTest.php
@@ -1,15 +1,9 @@
-<?php declare(strict_types=1);
+<?php
 
+declare(strict_types=1);
 
 namespace App\Service\Csv;
 
-use App\Entity\Report\Satisfaction;
-use App\Entity\User;
-use App\Entity\UserResearch\ResearchType;
-use App\Entity\UserResearch\UserResearchResponse;
-use App\TestHelpers\UserHelpers;
-use App\TestHelpers\UserResearchResponseHelpers;
-use DateTime;
 use PHPUnit\Framework\TestCase;
 
 class UserResearchResponseCsvGeneratorTest extends TestCase
@@ -17,63 +11,83 @@ class UserResearchResponseCsvGeneratorTest extends TestCase
     /** @test */
     public function generateUserResearchResponseCsv()
     {
-        $user1 = (new User())
-            ->setEmail('test1@non.com')
-            ->setPhoneMain('01211234567');
-
-        $user2 = (new User())
-            ->setEmail('test2@non.com')
-            ->setPhoneMain('01217654321');
-
-        $satisfaction1 = (new Satisfaction())
-            ->setComments('Amazing service')
-            ->setCreated(new DateTime('01-01-2020'))
-            ->setDeputyrole('ROLE_LAY_DEPUTY')
-            ->setReporttype('102')
-            ->setScore(5);
-
-        $satisfaction2 = (new Satisfaction())
-            ->setComments('Not impressed')
-            ->setCreated(new DateTime('12-12-2020'))
-            ->setDeputyrole('ROLE_PROF_ADMIN')
-            ->setReporttype('103')
-            ->setScore(2);
-
-        $urResponses = [
-            (new UserResearchResponse())
-                ->setSatisfaction($satisfaction1)
-                ->setDeputyshipLength('underOne')
-                ->setResearchType(
-                    (new ResearchType())
-                        ->setPhone(true)
-                        ->setInPerson(true)
-                )
-                ->setUser($user1)
-                ->setHasAccessToVideoCallDevice(true)
-                ->setCreated(new DateTime('01-01-2020')),
-            (new UserResearchResponse())
-                ->setSatisfaction($satisfaction2)
-                ->setDeputyshipLength('sixToTen')
-                ->setResearchType(
-                    (new ResearchType())
-                        ->setSurveys(true)
-                        ->setVideoCall(true)
-                        ->setInPerson(true)
-                        ->setPhone(true)
-                )
-                ->setUser($user2)
-                ->setHasAccessToVideoCallDevice(false)
-                ->setCreated(new DateTime('12-12-2020')),
+        $urArray = [
+            '0' => [
+                'id' => 'f0c69ca2-883b-44ed-a182-87939b9d443d',
+                'deputyshipLength' => 'underOne',
+                'hasAccessToVideoCallDevice' => 1,
+                'created' => [
+                    'date' => '2022-02-17 14:41:52.000000',
+                    'timezone_type' => 3,
+                    'timezone' => 'Europe/London',
+                ],
+                'satisfaction' => [
+                    'id' => '10012',
+                    'score' => 5,
+                    'comments' => 'Amazing service',
+                    'deputyrole' => 'ROLE_LAY_DEPUTY',
+                    'reporttype' => '102',
+                    'created' => [
+                        'date' => '2020-01-01 14:41:52.000000',
+                        'timezone_type' => 3,
+                        'timezone' => 'Europe/London',
+                    ],
+                ],
+                'user' => [
+                    'email' => 'test1@example.org',
+                    'phoneMain' => '01211234567',
+                 ],
+                'researchType' => [
+                    'id' => '317abaf1-33bb-44d7-abef-23fa0249ea4c',
+                    'surveys' => null,
+                    'videoCall' => null,
+                    'phone' => 1,
+                    'inPerson' => 1,
+                ],
+            ],
+            '1' => [
+                'id' => 'f0c69ca2-883b-44ed-a182-87939b9d443e',
+                'deputyshipLength' => 'sixToTen',
+                'hasAccessToVideoCallDevice' => 0,
+                'created' => [
+                    'date' => '2022-02-17 14:41:52.000000',
+                    'timezone_type' => 3,
+                    'timezone' => 'Europe/London',
+                ],
+                'satisfaction' => [
+                    'id' => '10012',
+                    'score' => 2,
+                    'comments' => 'Not impressed',
+                    'deputyrole' => 'ROLE_PROF_ADMIN',
+                    'reporttype' => '103',
+                    'created' => [
+                        'date' => '2020-12-12 14:41:52.000000',
+                        'timezone_type' => 3,
+                        'timezone' => 'Europe/London',
+                    ],
+                ],
+                'user' => [
+                    'email' => 'test2@example.org',
+                    'phoneMain' => '01217654321',
+                ],
+                'researchType' => [
+                    'id' => '317abaf1-33bb-44d7-abef-23fa0249ea4c',
+                    'surveys' => 1,
+                    'videoCall' => 1,
+                    'phone' => 1,
+                    'inPerson' => 1,
+                ],
+            ],
         ];
 
         $expectedCsv = <<<CSV
 "Satisfaction Score",Comments,"Deputy Role","Report Type","Date Provided","Deputyship Length Years","Agreed Research Types","Has Videocall Access",Email,"Phone Number"
-5,"Amazing service",ROLE_LAY_DEPUTY,102,2020-01-01,"Less than 1","phone,inPerson",Yes,test1@non.com,01211234567
-2,"Not impressed",ROLE_PROF_ADMIN,103,2020-12-12,"6 - 10","surveys,videoCall,phone,inPerson",No,test2@non.com,01217654321
+5,"Amazing service",ROLE_LAY_DEPUTY,102,2020-01-01,"Less than 1","phone,inPerson",Yes,test1@example.org,01211234567
+2,"Not impressed",ROLE_PROF_ADMIN,103,2020-12-12,"6 - 10","surveys,videoCall,phone,inPerson",No,test2@example.org,01217654321
 
 CSV;
 
         $sut = new UserResearchResponseCsvGenerator(new CsvBuilder());
-        self::assertEquals($expectedCsv, $sut->generateUserResearchResponsesCsv($urResponses));
+        self::assertEquals($expectedCsv, $sut->generateUserResearchResponsesCsv($urArray));
     }
 }

--- a/client/translations/admin-metrics.en.yml
+++ b/client/translations/admin-metrics.en.yml
@@ -8,6 +8,7 @@ adminAccounts:
     pageTitle: Admin Accounts
 
 reports:
+    htmlTitle: Administration - Reports
     pageTitle: Reports
     downloadSatisfaction: Download satisfaction report
     downloadUserResearch: Download user research report
@@ -34,19 +35,19 @@ metrics:
     clients:
         label: Clients
         totalLabel: Total clients
-        format: '%value%'
+        format: "%value%"
     registeredDeputies:
         label: Registered deputies
         totalLabel: Total registered deputies
-        format: '%value%'
+        format: "%value%"
     reportsSubmitted:
         label: Reports submitted
         totalLabel: Total reports submitted
-        format: '%value%'
+        format: "%value%"
     satisfaction:
         label: Satisfaction
         totalLabel: Overall satisfaction
-        format: '%value%%'
+        format: "%value%%"
 
 dimensions:
     deputyType:


### PR DESCRIPTION
## Purpose
As we were working with hydrating full models and returning them from the API to the frontend, our API was timing out whenever more than a day or two of reports was selected. This change returns an array of raw data in JSON that we manually parse into the CSV on the frontend.

Fixes DDPB-4175

## Approach
From some manual testing it looked like the slowdown was in Doctrine hydrating the objects fully to then turn back into JSON. We now skip this step and just return the raw data. I tested this locally with 10000 user research responses and it was returning the CSV is around 3 seconds. Our timeout for the API is 20 seconds so we should be able to go comfortably above this without timing out.

Unfortunately, I wasn't able to come up with a way for testing this without having a very slow running test. To create the required data in the DB (User, Client, Report, Report Submission, Satisfaction and User Research Response) it was taking around 45 seconds to create 2000 records. We may want to look in the future into having some raw SQL persisted somewhere that can create these records but as this is a super-admin-only feature I didn't want to sink too much time into it.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes