### PR TITLE
DDPB-2740: Autocomplete disabled for repeated password fields

### DIFF
--- a/client/src/Form/ChangePasswordType.php
+++ b/client/src/Form/ChangePasswordType.php
@@ -11,24 +11,26 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class ChangePasswordType extends AbstractType
 {
-    const VALIDATION_GROUP = 'user_change_password';
+    public const VALIDATION_GROUP = 'user_change_password';
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->add('current_password', FormTypes\PasswordType::class, [
-                    'mapped' => false,
-                    'constraints' => [
-                        new Assert\NotBlank(['message' => 'user.password.existing.notBlank', 'groups' => [self::VALIDATION_GROUP]]),
-                        new DUserPassword(['message' => 'user.password.existing.notCorrect', 'groups' => [self::VALIDATION_GROUP]]),
-                    ],
-                ])
-                ->add('password', FormTypes\RepeatedType::class, [
-                    'mapped' => true,
-                    'type' => FormTypes\PasswordType::class,
-                    'invalid_message' => 'user.password.new.doesntMatch',
-                ])
-                ->add('id', FormTypes\HiddenType::class)
-                ->add('save', FormTypes\SubmitType::class);
+            'mapped' => false,
+            'constraints' => [
+                new Assert\NotBlank(['message' => 'user.password.existing.notBlank', 'groups' => [self::VALIDATION_GROUP]]),
+                new DUserPassword(['message' => 'user.password.existing.notCorrect', 'groups' => [self::VALIDATION_GROUP]]),
+            ],
+        ])
+            ->add('password', FormTypes\RepeatedType::class, [
+                'mapped' => true,
+                'type' => FormTypes\PasswordType::class,
+                'invalid_message' => 'user.password.new.doesntMatch',
+                'first_options' => ['attr' => ['autocomplete' => 'off']],
+                'second_options' => ['attr' => ['autocomplete' => 'off']],
+            ])
+            ->add('id', FormTypes\HiddenType::class)
+            ->add('save', FormTypes\SubmitType::class);
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/client/src/Form/ResetPasswordType.php
+++ b/client/src/Form/ResetPasswordType.php
@@ -9,16 +9,18 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ResetPasswordType extends AbstractType
 {
-    const VALIDATION_GROUP = 'user_set_password';
+    public const VALIDATION_GROUP = 'user_set_password';
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-                ->add('password', FormTypes\RepeatedType::class, [
-                    'type' => FormTypes\PasswordType::class,
-                    'invalid_message' => $options['passwordMismatchMessage'],
-                ])
-                ->add('save', FormTypes\SubmitType::class);
+            ->add('password', FormTypes\RepeatedType::class, [
+                'type' => FormTypes\PasswordType::class,
+                'invalid_message' => $options['passwordMismatchMessage'],
+                'first_options' => ['attr' => ['autocomplete' => 'off']],
+                'second_options' => ['attr' => ['autocomplete' => 'off']],
+            ])
+            ->add('save', FormTypes\SubmitType::class);
     }
 
     public function configureOptions(OptionsResolver $resolver)
@@ -27,7 +29,7 @@ class ResetPasswordType extends AbstractType
             'translation_domain' => 'password-reset',
             'validation_groups' => [self::VALIDATION_GROUP],
         ])
-        ->setRequired(['passwordMismatchMessage']);
+            ->setRequired(['passwordMismatchMessage']);
     }
 
     public function getBlockPrefix()

--- a/client/src/Form/SetPasswordType.php
+++ b/client/src/Form/SetPasswordType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Validator\Constraints as Constraints;
 
 class SetPasswordType extends AbstractType
 {
-    const VALIDATION_GROUP = 'user_set_password';
+    public const VALIDATION_GROUP = 'user_set_password';
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -20,6 +20,8 @@ class SetPasswordType extends AbstractType
             [
                 'type' => FormTypes\PasswordType::class,
                 'invalid_message' => $options['passwordMismatchMessage'],
+                'first_options' => ['attr' => ['autocomplete' => 'off']],
+                'second_options' => ['attr' => ['autocomplete' => 'off']],
             ]
         );
         if (!empty($options['showTermsAndConditions'])) {
@@ -34,11 +36,11 @@ class SetPasswordType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-              'translation_domain' => 'user-activate',
-              'validation_groups' => [self::VALIDATION_GROUP],
-              'showTermsAndConditions' => false,
+            'translation_domain' => 'user-activate',
+            'validation_groups' => [self::VALIDATION_GROUP],
+            'showTermsAndConditions' => false,
         ])
-        ->setRequired(['passwordMismatchMessage']);
+            ->setRequired(['passwordMismatchMessage']);
     }
 
     public function getBlockPrefix()


### PR DESCRIPTION
## Purpose
ITHC identified that certain forms containing sensitive fields did not have autocomplete disabled which could create a security risk.

Fixes DDPB-2740

## Approach
- Confirmed that password fields were the only fields containing sensitive information.
- Identified where autocomplete had not been disabled for sensitive form fields, this seemed to only be the case for the repeated password fields.
- Disabled autocomplete for the necessary sensitive form fields by adding an attribute.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

