### PR TITLE
DDPB-4245 - add breakglass read/write to cloud9 instances

### DIFF
--- a/environment/versions.tf
+++ b/environment/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "3.61.0"
+      version = "3.72.0"
     }
     local = {
       source = "hashicorp/local"

--- a/shared/cloud9.tf
+++ b/shared/cloud9.tf
@@ -7,3 +7,9 @@ resource "aws_cloud9_environment_ec2" "shared" {
   owner_arn                   = "arn:aws:iam::${var.accounts[terraform.workspace].account_id}:assumed-role/operator/alex.saunders"
   tags                        = local.default_tags
 }
+
+resource "aws_cloud9_environment_membership" "shared" {
+  environment_id = aws_cloud9_environment_ec2.shared.id
+  permissions    = "read-write"
+  user_arn       = "arn:aws:iam::${var.accounts[terraform.workspace].account_id}:assumed-role/breakglass"
+}

--- a/shared/versions.tf
+++ b/shared/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "3.61.0"
+      version = "3.72.0"
     }
     local = {
       source = "hashicorp/local"


### PR DESCRIPTION
- DDPB-4245 - upgrade aws provider
- DDPB-4245 - give breakglass read/write for cloud9

## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes DDPB-####

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
