### PR TITLE
DDPB-4245 - Cloud9 memberships

### DIFF
--- a/shared/cloud9.tf
+++ b/shared/cloud9.tf
@@ -4,12 +4,14 @@ resource "aws_cloud9_environment_ec2" "shared" {
   automatic_stop_time_minutes = 20
   description                 = "Shared Cloud9 instance to be used by all devs"
   subnet_id                   = aws_subnet.public[0].id
-  owner_arn                   = "arn:aws:iam::${var.accounts[terraform.workspace].account_id}:assumed-role/operator/alex.saunders"
+  owner_arn                   = "arn:aws:iam::${var.accounts[terraform.workspace].account_id}:assumed-role/operator/tom.gulliver"
   tags                        = local.default_tags
 }
 
 resource "aws_cloud9_environment_membership" "shared" {
+  for_each = toset(local.cloud9_users)
+
   environment_id = aws_cloud9_environment_ec2.shared.id
   permissions    = "read-write"
-  user_arn       = "arn:aws:iam::${var.accounts[terraform.workspace].account_id}:assumed-role/breakglass/tom.gulliver"
+  user_arn       = "arn:aws:iam::${var.accounts[terraform.workspace].account_id}:assumed-role/operator/${each.value}"
 }

--- a/shared/variables.tf
+++ b/shared/variables.tf
@@ -28,4 +28,10 @@ locals {
   }
 
   s3_bucket = local.account.name == "production" ? "${local.account.name}02" : local.account.name
+
+  cloud9_users = [
+    "alex.saunders",
+    "gugandeep.chani",
+    "stephen.hinett",
+  ]
 }

--- a/shared/variables.tf
+++ b/shared/variables.tf
@@ -32,6 +32,7 @@ locals {
   cloud9_users = [
     "alex.saunders",
     "gugandeep.chani",
-    "stephen.hinett",
+    "mia.gordon",
+    "stephen.hinett"
   ]
 }


### PR DESCRIPTION
## Purpose
Handle Cloud9 access programatically

Fixes DDPB-4245

## Approach
The "cloud9_users" list in `shared/variables.tf` is iterated through in the `aws_cloud9_environment_membership` block in `shared/cloud9.tf`, assigning read/write c9 access to each listed user. User name has to be the same as AWS

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
