### PR TITLE
DDPB-4280: Upgrade circleCI images to next gen versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1111,7 +1111,7 @@ jobs:
 
   api-unit-tests:
     docker:
-      - image: cimg/php
+      - image: cimg/php:8.0.14
         auth:
           username: $DOCKER_USER
           password: $DOCKER_ACCESS_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -582,7 +582,7 @@ orbs:
     executors:
       terraform:
         docker:
-          - image: circleci/golang:1.16
+          - image: cimg/go:1.16
             auth:
               username: $DOCKER_USER
               password: $DOCKER_ACCESS_TOKEN
@@ -1111,7 +1111,7 @@ jobs:
 
   api-unit-tests:
     docker:
-      - image: circleci/php
+      - image: cimg/php
         auth:
           username: $DOCKER_USER
           password: $DOCKER_ACCESS_TOKEN


### PR DESCRIPTION
## Purpose
The images we're using in CI for PHP and Golang are about to be out of support. This bumps to the newer maintained versions for both.

Fixes DDPB-4280