### PR TITLE
DDPB-4281: Update from classic image to ubuntu image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1151,7 +1151,7 @@ jobs:
 
   cross-browser-test:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-2004:202111-02
     steps:
       - dockerhub_helper/dockerhub_login
       - aws-cli/install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1212,7 +1212,7 @@ jobs:
 
   pa11y-ci:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-2004:202111-02
     steps:
       - dockerhub_helper/dockerhub_login
       - checkout


### PR DESCRIPTION
## Purpose
Due to some [deprecations](https://discuss.circleci.com/t/github-ssh-deprecation-information-resolutions/42887) in CircleCI the use of RSA SSH will stop working with certain images. From investigation, it appears this could only impact us on our pa11y and cross-browser tests. This change updates the machine images to use to the newest ubuntu images that have the required tools.

Fixes DDPB-4281.