### PR TITLE
DDPB-4286: Allow null values for whoReceivedMoney to support migrations

### DIFF
--- a/api/src/Entity/Ndr/MoneyReceivedOnClientsBehalf.php
+++ b/api/src/Entity/Ndr/MoneyReceivedOnClientsBehalf.php
@@ -71,7 +71,7 @@ class MoneyReceivedOnClientsBehalf implements MoneyReceivedOnClientsBehalfInterf
     private ?float $amount;
 
     /**
-     * @ORM\Column(name="who_received_money", type="string", nullable=false)
+     * @ORM\Column(name="who_received_money", type="string", nullable=true)
      *
      * @JMS\Groups({"client-benefits-check"})
      * @JMS\Type("string")

--- a/api/src/Entity/Report/MoneyReceivedOnClientsBehalf.php
+++ b/api/src/Entity/Report/MoneyReceivedOnClientsBehalf.php
@@ -71,7 +71,7 @@ class MoneyReceivedOnClientsBehalf implements MoneyReceivedOnClientsBehalfInterf
     private ?float $amount;
 
     /**
-     * @ORM\Column(name="who_received_money", type="string", nullable=false)
+     * @ORM\Column(name="who_received_money", type="string", nullable=true)
      *
      * @JMS\Groups({"client-benefits-check"})
      * @JMS\Type("string")

--- a/api/src/Migrations/Version262.php
+++ b/api/src/Migrations/Version262.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version262 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Remove not null constraint from who_received_money to allow for migrations on existing DBs';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE income_received_on_clients_behalf ALTER who_received_money DROP NOT NULL');
+        $this->addSql('ALTER TABLE odr_income_received_on_clients_behalf ALTER who_received_money DROP NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE income_received_on_clients_behalf ALTER who_received_money SET NOT NULL');
+        $this->addSql('ALTER TABLE odr_income_received_on_clients_behalf ALTER who_received_money SET NOT NULL');
+    }
+}


### PR DESCRIPTION
## Purpose
As part of expanding the new benefits section we added a field to record where money was received from. The migration to create the new column ran fine locally and in envs where the DB was dropped and created but in preproduction we have some existing rows in the DB that would have NULL values in this column post migration. This change removes the DB constraint and relies on code constraints instead to allow the migration to run.

Fixes DDPB-4286

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes