### PR TITLE
DDPB-4285: Add report to metrics page for total liquid and non-liquid assets

### DIFF
--- a/api/src/Controller/StatsController.php
+++ b/api/src/Controller/StatsController.php
@@ -4,25 +4,25 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Repository\NdrRepository;
+use App\Repository\ReportRepository;
 use App\Repository\UserRepository;
 use App\Service\Formatter\RestFormatter;
 use App\Service\Stats\QueryFactory;
 use App\Service\Stats\StatsQueryParameters;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
 class StatsController extends RestController
 {
-    private QueryFactory $QueryFactory;
-    private UserRepository $userRepository;
-
     public function __construct(
-        QueryFactory $QueryFactory,
-        UserRepository $userRepository
+        private QueryFactory $QueryFactory,
+        private UserRepository $userRepository,
+        private ReportRepository $reportRepository,
+        private NdrRepository $ndrRepository,
     ) {
-        $this->QueryFactory = $QueryFactory;
-        $this->userRepository = $userRepository;
     }
 
     /**
@@ -77,5 +77,69 @@ class StatsController extends RestController
             'ActivatedAdminAccountsNotUsedWithin90Days' => $countOfActivatedAdminAccountsNotUsedWithin90Days,
             'ActivatedAdminAccountsUsedWithin90Days' => $countOfActivatedAdminAccountsUsedWithin90Days,
         ];
+    }
+
+    /**
+     * @Route("stats/assets/total_values", methods={"GET"})
+     * @Security("is_granted('ROLE_SUPER_ADMIN')")
+     */
+    public function getAssetsTotalValueData()
+    {
+        $ret = [
+            'lays' => ['liquid' => 0, 'non-liquid' => 0],
+            'profs' => ['liquid' => 0, 'non-liquid' => 0],
+            'pas' => ['liquid' => 0, 'non-liquid' => 0],
+            'grandTotal' => 0,
+        ];
+
+        $lays = $this->reportRepository->getAllSubmittedReportsWithin12Months('LAY');
+        $profs = $this->reportRepository->getAllSubmittedReportsWithin12Months('PROF');
+        $pas = $this->reportRepository->getAllSubmittedReportsWithin12Months('PA');
+        $ndrs = $this->ndrRepository->getAllSubmittedNdrsWithin12Months();
+
+        $layClientIds = [];
+
+        foreach ($lays as $layReport) {
+            $layClientIds[] = $layReport->getClientId();
+            $ret['lays']['non-liquid'] += $layReport->getAssetsTotalValue();
+            foreach ($layReport->getBankAccounts() as $bankAccount) {
+                $ret['lays']['liquid'] += $bankAccount->getClosingBalance();
+            }
+        }
+
+        foreach ($profs as $profReport) {
+            $ret['profs']['non-liquid'] += $profReport->getAssetsTotalValue();
+            foreach ($profReport->getBankAccounts() as $bankAccount) {
+                $ret['profs']['liquid'] += $bankAccount->getClosingBalance();
+            }
+        }
+
+        foreach ($pas as $paReport) {
+            $ret['pas']['non-liquid'] += $paReport->getAssetsTotalValue();
+            foreach ($paReport->getBankAccounts() as $bankAccount) {
+                $ret['pas']['liquid'] += $bankAccount->getClosingBalance();
+            }
+        }
+
+        foreach ($ndrs as $ndr) {
+            if (in_array($ndr->getClient()->getId(), $layClientIds)) {
+                continue;
+            }
+
+            $ret['lays']['non-liquid'] += $ndr->getAssetsTotalValue();
+            foreach ($ndr->getBankAccounts() as $bankAccount) {
+                $ret['lays']['liquid'] += $bankAccount->getClosingBalance();
+            }
+        }
+
+        $ret['grandTotal'] =
+            $ret['lays']['non-liquid'] +
+            $ret['lays']['liquid'] +
+            $ret['profs']['non-liquid'] +
+            $ret['profs']['liquid'] +
+            $ret['pas']['non-liquid'] +
+            $ret['pas']['liquid'];
+
+        return new JsonResponse($ret);
     }
 }

--- a/api/src/Entity/CasRec.php
+++ b/api/src/Entity/CasRec.php
@@ -58,8 +58,8 @@ class CasRec
         // @deprecated (DDPB-2044)
         [true, self::REALM_PROF, ['l3', 'l3g', 'a3'], 'opg102', Report::PROF_PFA_HIGH_ASSETS_TYPE],
         [true, self::REALM_PROF, ['hw'], '', Report::PROF_HW_TYPE],
-        [true, self::REALM_PROF, ['hw'], 'opg103', Report::PROF_COMBINED_LOW_ASSETS],
-        [true, self::REALM_PROF, ['hw'], 'opg102', Report::PROF_COMBINED_HIGH_ASSETS],
+        [true, self::REALM_PROF, ['hw'], 'opg103', Report::PROF_COMBINED_LOW_ASSETS_TYPE],
+        [true, self::REALM_PROF, ['hw'], 'opg102', Report::PROF_COMBINED_HIGH_ASSETS_TYPE],
     ];
     /**
      * Filled from cron.

--- a/api/src/Entity/Ndr/AssetProperty.php
+++ b/api/src/Entity/Ndr/AssetProperty.php
@@ -395,10 +395,7 @@ class AssetProperty extends Asset implements AssetInterface
             $asset->getPostcode() === $this->getPostcode();
     }
 
-    /**
-     * @return float|null
-     */
-    public function getValueTotal()
+    public function getValueTotal(): float | int | null
     {
         if (self::OWNED_PARTLY == $this->getOwned()) {
             return $this->getValue() * $this->getOwnedPercentage() / 100;

--- a/api/src/Entity/Ndr/AssetProperty.php
+++ b/api/src/Entity/Ndr/AssetProperty.php
@@ -4,7 +4,9 @@ namespace App\Entity\Ndr;
 
 use App\Entity\AssetInterface;
 use App\Entity\Report\AssetProperty as ReportAssetProperty;
+use DateTime;
 use Doctrine\ORM\Mapping as ORM;
+use InvalidArgumentException;
 use JMS\Serializer\Annotation as JMS;
 
 /**
@@ -121,7 +123,7 @@ class AssetProperty extends Asset implements AssetInterface
     private $isRentedOut;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      * @JMS\Groups({"ndr-asset"})
      * @JMS\Type("DateTime<'Y-m-d'>")
      * @ORM\Column(name="rent_agreement_end_date", type="datetime", nullable=true)
@@ -280,7 +282,7 @@ class AssetProperty extends Asset implements AssetInterface
     public function setOwned($owned)
     {
         if (!in_array($owned, [self::OWNED_FULLY, self::OWNED_PARTLY])) {
-            throw new \InvalidArgumentException(__METHOD__ . "Invalid owned type [$owned]");
+            throw new InvalidArgumentException(__METHOD__."Invalid owned type [$owned]");
         }
 
         $this->owned = $owned;
@@ -350,16 +352,16 @@ class AssetProperty extends Asset implements AssetInterface
      */
     public function deleteUnusedData()
     {
-        if ($this->getIsRentedOut() === 'no') {
+        if ('no' === $this->getIsRentedOut()) {
             $this->setRentAgreementEndDate(null);
             $this->setRentIncomeMonth(null);
         }
 
-        if ($this->getHasMortgage() ===  'no') {
+        if ('no' === $this->getHasMortgage()) {
             $this->setMortgageOutstandingAmount(null);
         }
 
-        if ($this->getOwned() === self::OWNED_FULLY) {
+        if (self::OWNED_FULLY === $this->getOwned()) {
             $this->setOwnedPercentage(null);
         }
     }
@@ -380,7 +382,6 @@ class AssetProperty extends Asset implements AssetInterface
     }
 
     /**
-     * @param AssetInterface $asset
      * @return bool
      */
     public function isEqual(AssetInterface $asset)
@@ -392,5 +393,17 @@ class AssetProperty extends Asset implements AssetInterface
         return $asset->getAddress() === $this->getAddress() &&
             $asset->getAddress2() === $this->getAddress2() &&
             $asset->getPostcode() === $this->getPostcode();
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getValueTotal()
+    {
+        if (self::OWNED_PARTLY == $this->getOwned()) {
+            return $this->getValue() * $this->getOwnedPercentage() / 100;
+        }
+
+        return parent::getValueTotal();
     }
 }

--- a/api/src/Entity/Ndr/Ndr.php
+++ b/api/src/Entity/Ndr/Ndr.php
@@ -10,6 +10,7 @@ use App\Entity\Satisfaction;
 use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use InvalidArgumentException;
 use JMS\Serializer\Annotation as JMS;
 
 /**
@@ -511,7 +512,7 @@ class Ndr implements ReportInterface
     {
         $acceptedValues = ['only_deputy', 'more_deputies_behalf', 'more_deputies_not_behalf'];
         if ($agreedBehalfDeputy && !in_array($agreedBehalfDeputy, $acceptedValues)) {
-            throw new \InvalidArgumentException(__METHOD__." {$agreedBehalfDeputy} given. Expected value: ".implode(' or ', $acceptedValues));
+            throw new InvalidArgumentException(__METHOD__." {$agreedBehalfDeputy} given. Expected value: ".implode(' or ', $acceptedValues));
         }
 
         $this->agreedBehalfDeputy = $agreedBehalfDeputy;
@@ -669,5 +670,15 @@ class Ndr implements ReportInterface
         $this->clientBenefitsCheck = $clientBenefitsCheck;
 
         return $this;
+    }
+
+    public function getAssetsTotalValue(): float | int
+    {
+        $ret = 0;
+        foreach ($this->getAssets() as $asset) {
+            $ret += $asset->getValueTotal();
+        }
+
+        return $ret;
     }
 }

--- a/api/src/Entity/Report/AssetProperty.php
+++ b/api/src/Entity/Report/AssetProperty.php
@@ -4,7 +4,9 @@ namespace App\Entity\Report;
 
 use App\Entity\AssetInterface;
 use App\Entity\Ndr\AssetProperty as NdrAssetProperty;
+use DateTime;
 use Doctrine\ORM\Mapping as ORM;
+use InvalidArgumentException;
 use JMS\Serializer\Annotation as JMS;
 
 /**
@@ -121,7 +123,7 @@ class AssetProperty extends Asset implements AssetInterface
     private $isRentedOut;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      * @JMS\Groups({"asset"})
      * @JMS\Type("DateTime<'Y-m-d'>")
      * @ORM\Column(name="rent_agreement_end_date", type="datetime", nullable=true)
@@ -280,7 +282,7 @@ class AssetProperty extends Asset implements AssetInterface
     public function setOwned($owned)
     {
         if (!in_array($owned, [self::OWNED_FULLY, self::OWNED_PARTLY])) {
-            throw new \InvalidArgumentException(__METHOD__ . "Invalid owned type [$owned]");
+            throw new InvalidArgumentException(__METHOD__."Invalid owned type [$owned]");
         }
 
         $this->owned = $owned;
@@ -344,12 +346,9 @@ class AssetProperty extends Asset implements AssetInterface
         return $this;
     }
 
-    /**
-     * @return float|null
-     */
-    public function getValueTotal()
+    public function getValueTotal(): float | int | null
     {
-        if ($this->getOwned() == self::OWNED_PARTLY) {
+        if (self::OWNED_PARTLY == $this->getOwned()) {
             return $this->getValue() * $this->getOwnedPercentage() / 100;
         }
 
@@ -362,16 +361,16 @@ class AssetProperty extends Asset implements AssetInterface
      */
     public function deleteUnusedData()
     {
-        if ($this->getIsRentedOut() === 'no') {
+        if ('no' === $this->getIsRentedOut()) {
             $this->setRentAgreementEndDate(null);
             $this->setRentIncomeMonth(null);
         }
 
-        if ($this->getHasMortgage() ===  'no') {
+        if ('no' === $this->getHasMortgage()) {
             $this->setMortgageOutstandingAmount(null);
         }
 
-        if ($this->getOwned() === self::OWNED_FULLY) {
+        if (self::OWNED_FULLY === $this->getOwned()) {
             $this->setOwnedPercentage(null);
         }
     }
@@ -392,7 +391,6 @@ class AssetProperty extends Asset implements AssetInterface
     }
 
     /**
-     * @param AssetInterface $asset
      * @return bool
      */
     public function isEqual(AssetInterface $asset)

--- a/api/src/Entity/Report/Report.php
+++ b/api/src/Entity/Report/Report.php
@@ -10,10 +10,14 @@ use App\Entity\Satisfaction;
 use App\Entity\User;
 use App\Service\ReportService;
 use App\Service\ReportStatusService;
+use DateInterval;
 use DateTime;
+use DateTimeZone;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use InvalidArgumentException;
 use JMS\Serializer\Annotation as JMS;
+use RuntimeException;
 
 /**
  * Reports.
@@ -77,8 +81,8 @@ class Report implements ReportInterface
     const PROF_PFA_LOW_ASSETS_TYPE = '103-5';
     const PROF_PFA_HIGH_ASSETS_TYPE = '102-5';
     const PROF_HW_TYPE = '104-5';
-    const PROF_COMBINED_LOW_ASSETS = '103-4-5';
-    const PROF_COMBINED_HIGH_ASSETS = '102-4-5';
+    const PROF_COMBINED_LOW_ASSETS_TYPE = '103-4-5';
+    const PROF_COMBINED_HIGH_ASSETS_TYPE = '102-4-5';
 
     const TYPE_HEALTH_WELFARE = '104';
     const TYPE_PROPERTY_AND_AFFAIRS_HIGH_ASSETS = '102';
@@ -162,6 +166,39 @@ class Report implements ReportInterface
             // add when ready
             self::SECTION_PROF_DEPUTY_COSTS_ESTIMATE => self::allProfReportTypes(),
             self::SECTION_DOCUMENTS => self::allRolesAllReportTypes(),
+        ];
+    }
+
+    public static function getAllLayTypes(): array
+    {
+        return [
+            self::LAY_PFA_LOW_ASSETS_TYPE,
+            self::LAY_PFA_HIGH_ASSETS_TYPE,
+            self::LAY_HW_TYPE,
+            self::LAY_COMBINED_LOW_ASSETS_TYPE,
+            self::LAY_COMBINED_HIGH_ASSETS_TYPE,
+        ];
+    }
+
+    public static function getAllProfTypes(): array
+    {
+        return [
+            self::PROF_PFA_LOW_ASSETS_TYPE,
+            self::PROF_PFA_HIGH_ASSETS_TYPE,
+            self::PROF_HW_TYPE,
+            self::PROF_COMBINED_LOW_ASSETS_TYPE,
+            self::PROF_COMBINED_HIGH_ASSETS_TYPE,
+        ];
+    }
+
+    public static function getAllPaTypes(): array
+    {
+        return [
+            self::PA_PFA_LOW_ASSETS_TYPE,
+            self::PA_PFA_HIGH_ASSETS_TYPE,
+            self::PA_HW_TYPE,
+            self::PA_COMBINED_LOW_ASSETS_TYPE,
+            self::PA_COMBINED_HIGH_ASSETS_TYPE,
         ];
     }
 
@@ -443,16 +480,16 @@ class Report implements ReportInterface
     public function __construct(Client $client, $type, DateTime $startDate, DateTime $endDate, $dateChecks = true)
     {
         if (!in_array($type, self::allRolesAllReportTypes())) {
-            throw new \InvalidArgumentException("$type not a valid report type");
+            throw new InvalidArgumentException("$type not a valid report type");
         }
         $this->type = $type;
         $this->client = $client;
-        $this->startDate = new DateTime($startDate->format('Y-m-d'), new \DateTimeZone('Europe/London'));
-        $this->endDate = new DateTime($endDate->format('Y-m-d'), new \DateTimeZone('Europe/London'));
+        $this->startDate = new DateTime($startDate->format('Y-m-d'), new DateTimeZone('Europe/London'));
+        $this->endDate = new DateTime($endDate->format('Y-m-d'), new DateTimeZone('Europe/London'));
         $this->updateDueDateBasedOnEndDate();
 
         if ($dateChecks && count($client->getUnsubmittedReports()) > 0) {
-            throw new \RuntimeException('Client '.$client->getId().' already has an unsubmitted report. Cannot create another one');
+            throw new RuntimeException('Client '.$client->getId().' already has an unsubmitted report. Cannot create another one');
         }
 
         // check date interval overlapping other reports
@@ -466,7 +503,7 @@ class Report implements ReportInterface
             $expectedStartDate->modify('+1 day');
             $daysDiff = (int) $expectedStartDate->diff($this->startDate)->format('%a');
             if (0 !== $daysDiff) {
-                throw new \RuntimeException(sprintf('Incorrect start date. Last submitted report was on %s, '.'therefore the new report is expected to start on %s, not on %s', $endDateLastReport->format('d/m/Y'), $expectedStartDate->format('d/m/Y'), $this->startDate->format('d/m/Y')));
+                throw new RuntimeException(sprintf('Incorrect start date. Last submitted report was on %s, '.'therefore the new report is expected to start on %s, not on %s', $endDateLastReport->format('d/m/Y'), $expectedStartDate->format('d/m/Y'), $this->startDate->format('d/m/Y')));
             }
         }
 
@@ -533,9 +570,9 @@ class Report implements ReportInterface
         // 13/11/19. Then it is 21 days (DDPB-2996)
         $this->dueDate = clone $this->endDate;
         if ($this->isLayReport() && $this->getEndDate()->format('Ymd') >= '20191113') {
-            $this->dueDate->add(new \DateInterval('P21D'));
+            $this->dueDate->add(new DateInterval('P21D'));
         } else {
-            $this->dueDate->add(new \DateInterval('P56D'));
+            $this->dueDate->add(new DateInterval('P56D'));
         }
     }
 
@@ -827,9 +864,7 @@ class Report implements ReportInterface
     }
 
     /**
-     * @param \App\Entity\Report\Action $action
-     *
-     * @return \App\Entity\Report\Report
+     * @return Report
      */
     public function setAction(Action $action)
     {
@@ -895,7 +930,7 @@ class Report implements ReportInterface
         $acceptedValues = ['not_deputy', 'only_deputy', 'more_deputies_behalf', 'more_deputies_not_behalf'];
 
         if ($agreeBehalfDeputy && !in_array($agreeBehalfDeputy, $acceptedValues)) {
-            throw new \InvalidArgumentException(__METHOD__." {$agreeBehalfDeputy} given. Expected value: ".implode(' or ', $acceptedValues));
+            throw new InvalidArgumentException(__METHOD__." {$agreeBehalfDeputy} given. Expected value: ".implode(' or ', $acceptedValues));
         }
 
         $this->agreedBehalfDeputy = $agreeBehalfDeputy;
@@ -1310,8 +1345,8 @@ class Report implements ReportInterface
             self::PROF_PFA_LOW_ASSETS_TYPE => 'propertyAffairsMinimal',
             self::PROF_PFA_HIGH_ASSETS_TYPE => 'propertyAffairsGeneral',
             self::PROF_HW_TYPE => 'healthWelfare',
-            self::PROF_COMBINED_LOW_ASSETS => 'propertyAffairsMinimalHealthWelfare',
-            self::PROF_COMBINED_HIGH_ASSETS => 'propertyAffairsGeneralHealthWelfare',
+            self::PROF_COMBINED_LOW_ASSETS_TYPE => 'propertyAffairsMinimalHealthWelfare',
+            self::PROF_COMBINED_HIGH_ASSETS_TYPE => 'propertyAffairsGeneralHealthWelfare',
         ];
 
         return $titleTranslationKeys[$this->getType()];
@@ -1332,7 +1367,7 @@ class Report implements ReportInterface
 
     public function isProfReport()
     {
-        return in_array($this->getType(), [self::PROF_PFA_HIGH_ASSETS_TYPE, self::PROF_PFA_LOW_ASSETS_TYPE, self::PROF_HW_TYPE, self::PROF_COMBINED_HIGH_ASSETS, self::PROF_COMBINED_LOW_ASSETS]);
+        return in_array($this->getType(), [self::PROF_PFA_HIGH_ASSETS_TYPE, self::PROF_PFA_LOW_ASSETS_TYPE, self::PROF_HW_TYPE, self::PROF_COMBINED_HIGH_ASSETS_TYPE, self::PROF_COMBINED_LOW_ASSETS_TYPE]);
     }
 
     public function getSatisfaction(): Satisfaction
@@ -1409,7 +1444,7 @@ class Report implements ReportInterface
         return [
             self::LAY_PFA_LOW_ASSETS_TYPE, self::LAY_PFA_HIGH_ASSETS_TYPE, self::LAY_HW_TYPE, self::LAY_COMBINED_LOW_ASSETS_TYPE, self::LAY_COMBINED_HIGH_ASSETS_TYPE,
             self::PA_PFA_LOW_ASSETS_TYPE, self::PA_PFA_HIGH_ASSETS_TYPE, self::PA_HW_TYPE, self::PA_COMBINED_LOW_ASSETS_TYPE, self::PA_COMBINED_HIGH_ASSETS_TYPE,
-            self::PROF_PFA_LOW_ASSETS_TYPE, self::PROF_PFA_HIGH_ASSETS_TYPE, self::PROF_HW_TYPE, self::PROF_COMBINED_LOW_ASSETS, self::PROF_COMBINED_HIGH_ASSETS,
+            self::PROF_PFA_LOW_ASSETS_TYPE, self::PROF_PFA_HIGH_ASSETS_TYPE, self::PROF_HW_TYPE, self::PROF_COMBINED_LOW_ASSETS_TYPE, self::PROF_COMBINED_HIGH_ASSETS_TYPE,
         ];
     }
 
@@ -1418,7 +1453,7 @@ class Report implements ReportInterface
         return [
             self::LAY_HW_TYPE, self::LAY_COMBINED_LOW_ASSETS_TYPE, self::LAY_COMBINED_HIGH_ASSETS_TYPE,
             self::PA_HW_TYPE, self::PA_COMBINED_LOW_ASSETS_TYPE, self::PA_COMBINED_HIGH_ASSETS_TYPE,
-            self::PROF_HW_TYPE, self::PROF_COMBINED_LOW_ASSETS, self::PROF_COMBINED_HIGH_ASSETS,
+            self::PROF_HW_TYPE, self::PROF_COMBINED_LOW_ASSETS_TYPE, self::PROF_COMBINED_HIGH_ASSETS_TYPE,
         ];
     }
 
@@ -1427,14 +1462,14 @@ class Report implements ReportInterface
         return [
             self::LAY_PFA_LOW_ASSETS_TYPE, self::LAY_PFA_HIGH_ASSETS_TYPE, self::LAY_COMBINED_LOW_ASSETS_TYPE, self::LAY_COMBINED_HIGH_ASSETS_TYPE,
             self::PA_PFA_LOW_ASSETS_TYPE, self::PA_PFA_HIGH_ASSETS_TYPE, self::PA_COMBINED_LOW_ASSETS_TYPE, self::PA_COMBINED_HIGH_ASSETS_TYPE,
-            self::PROF_PFA_LOW_ASSETS_TYPE, self::PROF_PFA_HIGH_ASSETS_TYPE, self::PROF_COMBINED_LOW_ASSETS, self::PROF_COMBINED_HIGH_ASSETS,
+            self::PROF_PFA_LOW_ASSETS_TYPE, self::PROF_PFA_HIGH_ASSETS_TYPE, self::PROF_COMBINED_LOW_ASSETS_TYPE, self::PROF_COMBINED_HIGH_ASSETS_TYPE,
         ];
     }
 
     public static function allProfReportTypes(): array
     {
         return [
-            self::PROF_PFA_LOW_ASSETS_TYPE, self::PROF_PFA_HIGH_ASSETS_TYPE, self::PROF_HW_TYPE, self::PROF_COMBINED_LOW_ASSETS, self::PROF_COMBINED_HIGH_ASSETS,
+            self::PROF_PFA_LOW_ASSETS_TYPE, self::PROF_PFA_HIGH_ASSETS_TYPE, self::PROF_HW_TYPE, self::PROF_COMBINED_LOW_ASSETS_TYPE, self::PROF_COMBINED_HIGH_ASSETS_TYPE,
         ];
     }
 
@@ -1443,7 +1478,7 @@ class Report implements ReportInterface
         return [
             self::LAY_PFA_HIGH_ASSETS_TYPE, self::LAY_COMBINED_HIGH_ASSETS_TYPE,
             self::PA_PFA_HIGH_ASSETS_TYPE, self::PA_COMBINED_HIGH_ASSETS_TYPE,
-            self::PROF_PFA_HIGH_ASSETS_TYPE, self::PROF_COMBINED_HIGH_ASSETS,
+            self::PROF_PFA_HIGH_ASSETS_TYPE, self::PROF_COMBINED_HIGH_ASSETS_TYPE,
         ];
     }
 
@@ -1452,7 +1487,7 @@ class Report implements ReportInterface
         return [
             self::LAY_PFA_LOW_ASSETS_TYPE, self::LAY_COMBINED_LOW_ASSETS_TYPE,
             self::PA_PFA_LOW_ASSETS_TYPE, self::PA_COMBINED_LOW_ASSETS_TYPE,
-            self::PROF_PFA_LOW_ASSETS_TYPE, self::PROF_COMBINED_LOW_ASSETS,
+            self::PROF_PFA_LOW_ASSETS_TYPE, self::PROF_COMBINED_LOW_ASSETS_TYPE,
         ];
     }
 
@@ -1473,7 +1508,7 @@ class Report implements ReportInterface
     public static function profPfaAndCombinedReportTypes(): array
     {
         return [
-            self::PROF_PFA_LOW_ASSETS_TYPE, self::PROF_PFA_HIGH_ASSETS_TYPE, self::PROF_COMBINED_LOW_ASSETS, self::PROF_COMBINED_HIGH_ASSETS,
+            self::PROF_PFA_LOW_ASSETS_TYPE, self::PROF_PFA_HIGH_ASSETS_TYPE, self::PROF_COMBINED_LOW_ASSETS_TYPE, self::PROF_COMBINED_HIGH_ASSETS_TYPE,
         ];
     }
 }

--- a/api/src/Repository/ReportRepository.php
+++ b/api/src/Repository/ReportRepository.php
@@ -10,8 +10,12 @@ use App\Entity\Report\MoneyShortCategory as ReportMoneyShortCategory;
 use App\Entity\Report\Report;
 use App\Entity\SynchronisableInterface;
 use App\Service\Search\ClientSearchFilter;
+use DateTime;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\ORMException;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
@@ -56,7 +60,7 @@ class ReportRepository extends ServiceEntityRepository
     /**
      * @return int|null
      *
-     * @throws \Doctrine\ORM\ORMException
+     * @throws ORMException
      */
     public function addFeesToReportIfMissing(Report $report)
     {
@@ -128,7 +132,7 @@ class ReportRepository extends ServiceEntityRepository
      *
      * @return array|mixed|null
      *
-     * @throws \Doctrine\ORM\NonUniqueResultException
+     * @throws NonUniqueResultException
      */
     public function getAllByDeterminant($orgIdsOrUserId, $determinant, ParameterBag $query, $select, $status)
     {
@@ -155,7 +159,7 @@ class ReportRepository extends ServiceEntityRepository
             $this->filter->handleSearchTermFilter($searchTerm, $qb, 'c');
         }
 
-        $endOfToday = new \DateTime('today midnight');
+        $endOfToday = new DateTime('today midnight');
 
         if (Report::STATUS_READY_TO_SUBMIT === $status) {
             $qb->andWhere('r.reportStatusCached = :status AND r.endDate < :endOfToday')
@@ -187,7 +191,7 @@ class ReportRepository extends ServiceEntityRepository
     }
 
     /**
-     * @throws \Doctrine\DBAL\DBALException
+     * @throws DBALException
      */
     public function getReportsIdsWithQueuedChecklistsAndSetChecklistsToInProgress(int $limit): array
     {
@@ -229,5 +233,42 @@ DQL;
             ->getEntityManager()
             ->createQuery('SELECT COUNT(r.id) FROM App\Entity\Report\Report r')
             ->getSingleScalarResult();
+    }
+
+    /**
+     * @return Report[]
+     */
+    public function getAllSubmittedReportsWithin12Months(string $deputyType)
+    {
+        $oneYearAgo = new DateTime('-1 year');
+
+        switch ($deputyType) {
+            case 'LAY':
+                $types = Report::getAllLayTypes();
+                break;
+            case 'PROF':
+                $types = Report::getAllProfTypes();
+                break;
+            case 'PA':
+                $types = Report::getAllPaTypes();
+                break;
+            default:
+                $types = [];
+                break;
+        }
+
+        $dql = <<<DQL
+SELECT r FROM App\Entity\Report\Report r
+WHERE r.submitDate > :oneYearAgo
+AND r.type IN (:types)
+DQL;
+
+        $query = $this
+            ->getEntityManager()
+            ->createQuery($dql)
+            ->setParameter('oneYearAgo', $oneYearAgo)
+            ->setParameter('types', $types);
+
+        return $query->getResult();
     }
 }

--- a/api/src/Repository/ReportRepository.php
+++ b/api/src/Repository/ReportRepository.php
@@ -242,20 +242,12 @@ DQL;
     {
         $oneYearAgo = new DateTime('-1 year');
 
-        switch ($deputyType) {
-            case 'LAY':
-                $types = Report::getAllLayTypes();
-                break;
-            case 'PROF':
-                $types = Report::getAllProfTypes();
-                break;
-            case 'PA':
-                $types = Report::getAllPaTypes();
-                break;
-            default:
-                $types = [];
-                break;
-        }
+        $types = match ($deputyType) {
+            'LAY' => Report::getAllLayTypes(),
+            'PROF' => Report::getAllProfTypes(),
+            'PA' => Report::getAllPaTypes(),
+            default => [],
+        };
 
         $dql = <<<DQL
 SELECT r FROM App\Entity\Report\Report r

--- a/api/tests/Behat/bootstrap/v2/Helpers/FixtureHelper.php
+++ b/api/tests/Behat/bootstrap/v2/Helpers/FixtureHelper.php
@@ -661,7 +661,7 @@ class FixtureHelper
             $testRunId,
             User::ROLE_PROF_ADMIN,
             'prof-admin-combined-high-not-started',
-            Report::PROF_COMBINED_HIGH_ASSETS,
+            Report::PROF_COMBINED_HIGH_ASSETS_TYPE,
             false,
             false
         );
@@ -675,7 +675,7 @@ class FixtureHelper
             $testRunId,
             User::ROLE_PROF_ADMIN,
             'prof-admin-combined-high-completed',
-            Report::PROF_COMBINED_HIGH_ASSETS,
+            Report::PROF_COMBINED_HIGH_ASSETS_TYPE,
             true,
             false
         );
@@ -689,7 +689,7 @@ class FixtureHelper
             $testRunId,
             User::ROLE_PROF_ADMIN,
             'prof-admin-combined-high-submitted',
-            Report::PROF_COMBINED_HIGH_ASSETS,
+            Report::PROF_COMBINED_HIGH_ASSETS_TYPE,
             true,
             true
         );
@@ -966,7 +966,7 @@ class FixtureHelper
 
     public function createDataForAnalytics(string $testRunId, $timeAgo, $satisfactionScore)
     {
-        $startDate = new \DateTime($timeAgo);
+        $startDate = new DateTime($timeAgo);
         $deputies = [];
 
         $deputies[] = $this->createOrgUserClientNamedDeputyAndReport(

--- a/api/tests/Behat/bootstrap/v2/ReportManagement/ReportManagementTrait.php
+++ b/api/tests/Behat/bootstrap/v2/ReportManagement/ReportManagementTrait.php
@@ -77,8 +77,8 @@ trait ReportManagementTrait
             'Health and welfare' => [User::TYPE_PA => Report::PA_HW_TYPE, User::TYPE_PROF => Report::PROF_HW_TYPE, User::TYPE_LAY => Report::LAY_HW_TYPE],
             'PFA high assets' => [User::TYPE_PA => Report::PA_PFA_HIGH_ASSETS_TYPE, User::TYPE_PROF => Report::PROF_PFA_HIGH_ASSETS_TYPE, User::TYPE_LAY => Report::LAY_PFA_HIGH_ASSETS_TYPE],
             'PFA low assets' => [User::TYPE_PA => Report::PA_PFA_LOW_ASSETS_TYPE, User::TYPE_PROF => Report::PROF_PFA_LOW_ASSETS_TYPE, User::TYPE_LAY => Report::LAY_PFA_LOW_ASSETS_TYPE],
-            'Combined high assets' => [User::TYPE_PA => Report::PA_COMBINED_HIGH_ASSETS_TYPE, User::TYPE_PROF => Report::PROF_COMBINED_HIGH_ASSETS, User::TYPE_LAY => Report::LAY_COMBINED_HIGH_ASSETS_TYPE],
-            'Combined low assets' => [User::TYPE_PA => Report::PA_COMBINED_LOW_ASSETS_TYPE, User::TYPE_PROF => Report::PROF_COMBINED_LOW_ASSETS, User::TYPE_LAY => Report::LAY_COMBINED_LOW_ASSETS_TYPE],
+            'Combined high assets' => [User::TYPE_PA => Report::PA_COMBINED_HIGH_ASSETS_TYPE, User::TYPE_PROF => Report::PROF_COMBINED_HIGH_ASSETS_TYPE, User::TYPE_LAY => Report::LAY_COMBINED_HIGH_ASSETS_TYPE],
+            'Combined low assets' => [User::TYPE_PA => Report::PA_COMBINED_LOW_ASSETS_TYPE, User::TYPE_PROF => Report::PROF_COMBINED_LOW_ASSETS_TYPE, User::TYPE_LAY => Report::LAY_COMBINED_LOW_ASSETS_TYPE],
         ];
 
         switch ($reportType) {

--- a/api/tests/Unit/Entity/CasRecTest.php
+++ b/api/tests/Unit/Entity/CasRecTest.php
@@ -114,10 +114,10 @@ class CasRecTest extends TestCase
             // 104-5
             ['hw', '', CasRec::REALM_PROF, Report::PROF_HW_TYPE],
             // 103-4-5
-            ['hw', 'opg103', CasRec::REALM_PROF, Report::PROF_COMBINED_LOW_ASSETS],
+            ['hw', 'opg103', CasRec::REALM_PROF, Report::PROF_COMBINED_LOW_ASSETS_TYPE],
             // 102-4-5
-            ['hw', 'opg102', CasRec::REALM_PROF, Report::PROF_COMBINED_HIGH_ASSETS],
-            ['hw', 'opg102', CasRec::REALM_PROF, Report::PROF_COMBINED_HIGH_ASSETS],
+            ['hw', 'opg102', CasRec::REALM_PROF, Report::PROF_COMBINED_HIGH_ASSETS_TYPE],
+            ['hw', 'opg102', CasRec::REALM_PROF, Report::PROF_COMBINED_HIGH_ASSETS_TYPE],
         ];
     }
 

--- a/client/src/Entity/CasRec.php
+++ b/client/src/Entity/CasRec.php
@@ -3,6 +3,8 @@
 namespace App\Entity;
 
 use App\Entity\Report\Report;
+use DateTime;
+use InvalidArgumentException;
 use JMS\Serializer\Annotation as JMS;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -50,8 +52,8 @@ class CasRec
         // @deprecated (DDPB-2044)
         [true, self::REALM_PROF, ['l3', 'l3g', 'a3'], 'opg102', Report::PROF_PFA_HIGH_ASSETS_TYPE],
         [true, self::REALM_PROF, ['hw'], '', Report::PROF_HW_TYPE],
-        [true, self::REALM_PROF, ['hw'], 'opg103', Report::PROF_COMBINED_LOW_ASSETS],
-        [true, self::REALM_PROF, ['hw'], 'opg102', Report::PROF_COMBINED_HIGH_ASSETS],
+        [true, self::REALM_PROF, ['hw'], 'opg103', Report::PROF_COMBINED_LOW_ASSETS_TYPE],
+        [true, self::REALM_PROF, ['hw'], 'opg102', Report::PROF_COMBINED_HIGH_ASSETS_TYPE],
     ];
 
     /**
@@ -126,14 +128,14 @@ class CasRec
     private $otherColumns;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      *
      * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
      */
     private $createdAt;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      *
      * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
      */
@@ -145,7 +147,7 @@ class CasRec
     private $source;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      */
     private $orderDate;
 
@@ -205,7 +207,7 @@ class CasRec
         return isset($row[$key]) ? $row[$key] : null;
     }
 
-    public function setUpdatedAt(\DateTime $updatedAt): CasRec
+    public function setUpdatedAt(DateTime $updatedAt): CasRec
     {
         $this->updatedAt = $updatedAt;
 
@@ -213,9 +215,9 @@ class CasRec
     }
 
     /**
-     * @return \DateTime|null
+     * @return DateTime|null
      */
-    public function getUpdatedAt(): \DateTime
+    public function getUpdatedAt(): DateTime
     {
         return $this->updatedAt;
     }
@@ -229,7 +231,7 @@ class CasRec
     {
         $source = strtolower($source);
         if (!in_array($source, self::validSources())) {
-            throw new \InvalidArgumentException(sprintf('Attempting to set invalid source: %s given', $source));
+            throw new InvalidArgumentException(sprintf('Attempting to set invalid source: %s given', $source));
         }
 
         $this->source = $source;
@@ -245,12 +247,12 @@ class CasRec
         ];
     }
 
-    public function getOrderDate(): \DateTime
+    public function getOrderDate(): DateTime
     {
         return $this->orderDate;
     }
 
-    public function setOrderDate(\DateTime $orderDate): CasRec
+    public function setOrderDate(DateTime $orderDate): CasRec
     {
         $this->orderDate = $orderDate;
 

--- a/client/src/Entity/Report/Report.php
+++ b/client/src/Entity/Report/Report.php
@@ -10,6 +10,7 @@ use App\Validator\Constraints as AppAssert;
 use App\Validator\Constraints\StartEndDateComparableInterface;
 use DateTime;
 use JMS\Serializer\Annotation as JMS;
+use RuntimeException;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -1090,7 +1091,7 @@ class Report implements ReportInterface, StartEndDateComparableInterface
         $submitDate = $this->getSubmitDate();
 
         if (is_null($endDate)) {
-            throw new \RuntimeException('Cannot create an attachment for a report with no end date');
+            throw new RuntimeException('Cannot create an attachment for a report with no end date');
         }
 
         $attachmentName = sprintf(
@@ -1255,7 +1256,7 @@ class Report implements ReportInterface, StartEndDateComparableInterface
                 Report::LAY_PFA_HIGH_ASSETS_TYPE,
                 Report::LAY_COMBINED_HIGH_ASSETS_TYPE,
                 Report::PROF_PFA_HIGH_ASSETS_TYPE,
-                Report::PROF_COMBINED_HIGH_ASSETS,
+                Report::PROF_COMBINED_HIGH_ASSETS_TYPE,
                 Report::PA_PFA_HIGH_ASSETS_TYPE,
                 Report::PA_COMBINED_HIGH_ASSETS_TYPE,
             ]
@@ -1274,7 +1275,7 @@ class Report implements ReportInterface, StartEndDateComparableInterface
 
     public function isProfReport(): bool
     {
-        return in_array($this->getType(), [self::PROF_PFA_HIGH_ASSETS_TYPE, self::PROF_PFA_LOW_ASSETS_TYPE, self::PROF_HW_TYPE, self::PROF_COMBINED_HIGH_ASSETS, self::PROF_COMBINED_LOW_ASSETS]);
+        return in_array($this->getType(), [self::PROF_PFA_HIGH_ASSETS_TYPE, self::PROF_PFA_LOW_ASSETS_TYPE, self::PROF_HW_TYPE, self::PROF_COMBINED_HIGH_ASSETS_TYPE, self::PROF_COMBINED_LOW_ASSETS_TYPE]);
     }
 
     /**

--- a/client/src/Entity/ReportInterface.php
+++ b/client/src/Entity/ReportInterface.php
@@ -25,8 +25,8 @@ interface ReportInterface
     const PROF_PFA_LOW_ASSETS_TYPE = '103-5';
     const PROF_PFA_HIGH_ASSETS_TYPE = '102-5';
     const PROF_HW_TYPE = '104-5';
-    const PROF_COMBINED_LOW_ASSETS = '103-4-5';
-    const PROF_COMBINED_HIGH_ASSETS = '102-4-5';
+    const PROF_COMBINED_LOW_ASSETS_TYPE = '103-4-5';
+    const PROF_COMBINED_HIGH_ASSETS_TYPE = '102-4-5';
 
     public function getId();
 

--- a/client/src/Service/Client/Internal/StatsApi.php
+++ b/client/src/Service/Client/Internal/StatsApi.php
@@ -10,6 +10,7 @@ class StatsApi
 {
     protected const GET_ACTIVE_LAY_REPORT_DATA_ENDPOINT = 'stats/deputies/lay/active';
     protected const GET_ADMIN_USER_ACCOUNT_REPORT_DATA = 'stats/admins/report_data';
+    protected const GET_ASSETS_TOTAL_VALUES = 'stats/assets/total_values';
 
     private RestClientInterface $restClient;
 
@@ -34,5 +35,16 @@ class StatsApi
             'array',
             ['admin-account-reports']
         );
+    }
+
+    public function getAssetsTotalValuesWithin12Months(): string
+    {
+        $response = $this->restClient->get(
+            self::GET_ASSETS_TOTAL_VALUES,
+            'raw',
+            ['admin-account-reports']
+        );
+
+        return (string) $response;
     }
 }

--- a/client/src/Service/Csv/AssetsTotalsCSVGenerator.php
+++ b/client/src/Service/Csv/AssetsTotalsCSVGenerator.php
@@ -13,10 +13,7 @@ class AssetsTotalsCSVGenerator
         $this->csvBuilder = $csvBuilder;
     }
 
-    /**
-     * @return string
-     */
-    public function generateAssetsTotalValuesCSV(array $assetsTotals)
+    public function generateAssetsTotalValuesCSV(array $assetsTotals): string
     {
         $headers = [
             'Lay - Liquid',

--- a/client/src/Service/Csv/AssetsTotalsCSVGenerator.php
+++ b/client/src/Service/Csv/AssetsTotalsCSVGenerator.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Csv;
+
+class AssetsTotalsCSVGenerator
+{
+    private CsvBuilder $csvBuilder;
+
+    public function __construct(CsvBuilder $csvBuilder)
+    {
+        $this->csvBuilder = $csvBuilder;
+    }
+
+    /**
+     * @return string
+     */
+    public function generateAssetsTotalValuesCSV(array $assetsTotals)
+    {
+        $headers = [
+            'Lay - Liquid',
+            'Lay - Non-Liquid',
+            'Prof - Liquid',
+            'Prof - Non-Liquid',
+            'PA - Liquid',
+            'PA - Non-Liquid',
+            'Grand Total',
+        ];
+
+        $rows = [
+            [
+                $assetsTotals['lays']['liquid'],
+                $assetsTotals['lays']['non-liquid'],
+                $assetsTotals['profs']['liquid'],
+                $assetsTotals['profs']['non-liquid'],
+                $assetsTotals['pas']['liquid'],
+                $assetsTotals['pas']['non-liquid'],
+                $assetsTotals['grandTotal'],
+            ],
+        ];
+
+        return $this->csvBuilder->buildCsv($headers, $rows);
+    }
+}

--- a/client/templates/Admin/Stats/reports.html.twig
+++ b/client/templates/Admin/Stats/reports.html.twig
@@ -32,4 +32,10 @@
         </a>
     </p>
 
+    <p>
+        <a href="{{ path('admin_total_assets_values') }}" class="govuk-link">
+            {{ (page ~ '.downloadAssetsTotalValues') | trans }}
+        </a>
+    </p>
+
 {% endblock %}

--- a/client/translations/admin-metrics.en.yml
+++ b/client/translations/admin-metrics.en.yml
@@ -10,9 +10,10 @@ adminAccounts:
 reports:
     htmlTitle: Administration - Reports
     pageTitle: Reports
+    downloadActiveLays: Download active lays report
+    downloadAssetsTotalValues: Download total value of assets on submitted reports in last 12 months report
     downloadSatisfaction: Download satisfaction report
     downloadUserResearch: Download user research report
-    downloadActiveLays: Download active lays report
     userAccountReports: View admin account metrics
 
 form:


### PR DESCRIPTION
## Purpose
OPG require a report showing the total value of liquid and non-liquid assets managed in digideps broken down by type. This change adds a CSV download link to the metrics admin page showing the values.

Fixes DDPB-4285

## Approach
I started to just write an SQL query for this report but it was getting complex once I started to try to exclude NDRs that had already been submitted so I pivoted to creating a downloaded report via code.

Given the tight deadlines I've not TDDed this or written tests but have carried out some manual checks to ensure we're getting back the expected figures. We should play a follow-up ticket to add tests to this once we have the time next week.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes