### PR TITLE
Match on any number of digits

### DIFF
--- a/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnAdminTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnAdminTrait.php
@@ -209,6 +209,6 @@ trait IShouldBeOnAdminTrait
 
     public function iAmOnAdminClientArchivedPage()
     {
-        return $this->iAmOnPage('/admin\/client\/[0-9]{1,4}\/archived.*$/');
+        return $this->iAmOnPage('/admin\/client\/[0-9]+\/archived.*$/');
     }
 }


### PR DESCRIPTION
## Purpose
Removes length limit of client id check to ensure we can pass tests when a client ID is more than 4 digits long.
