### PR TITLE
DDPB-4291: Fix assets report

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,1 @@
-{
-  "twigPrintWidth": 140
-}
+{}

--- a/api/config/services.yml
+++ b/api/config/services.yml
@@ -1,6 +1,6 @@
 parameters:
     fixtures:
-        account_password: '%env(FIXTURES_ACCOUNTPASSWORD)%'
+        account_password: "%env(FIXTURES_ACCOUNTPASSWORD)%"
 
     # set this param to a higher value than session_expire_seconds on the client
     user_provider_timeout_seconds: 3901
@@ -9,28 +9,28 @@ parameters:
         frontend: [ROLE_DEPUTY]
 
     shared_email_domains:
-        - 'aol.com'
-        - 'aol.co.uk'
-        - 'btconnect.com'
-        - 'btinternet.com'
-        - 'gmail.com'
-        - 'googlemail.com'
-        - 'hotmail.com'
-        - 'hotmail.co.uk'
-        - 'icloud.com'
-        - 'live.co.uk'
-        - 'live.com'
-        - 'mac.com'
-        - 'me.com'
-        - 'msn.com'
-        - 'nhs.net'
-        - 'ntlworld.com'
-        - 'outlook.com'
-        - 'sky.com'
-        - 'talktalk.net'
-        - 'yahoo.com'
-        - 'yahoo.co.uk'
-        - 'example.com'
+        - "aol.com"
+        - "aol.co.uk"
+        - "btconnect.com"
+        - "btinternet.com"
+        - "gmail.com"
+        - "googlemail.com"
+        - "hotmail.com"
+        - "hotmail.co.uk"
+        - "icloud.com"
+        - "live.co.uk"
+        - "live.com"
+        - "mac.com"
+        - "me.com"
+        - "msn.com"
+        - "nhs.net"
+        - "ntlworld.com"
+        - "outlook.com"
+        - "sky.com"
+        - "talktalk.net"
+        - "yahoo.com"
+        - "yahoo.co.uk"
+        - "example.com"
 
 services:
     em:
@@ -38,42 +38,45 @@ services:
 
     # default configuration for services in *this* file
     _defaults:
-        autowire: true      # Automatically injects dependencies in your services.
+        autowire: true # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
         bind:
             $fixturesEnabled: "%env(bool:FIXTURES_ENABLED)%"
             $yamlFixtureLocation: "%kernel.root_dir%/src/DataFixtures/"
-            $fixtureParams: '%fixtures%'
+            $fixtureParams: "%fixtures%"
             $symfonyEnvironment: "%kernel.environment%"
             $rootDir: "%kernel.root_dir%"
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name
     App\:
-        resource: '../src/*'
-        exclude: '../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}'
+        resource: "../src/*"
+        exclude: "../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}"
 
     App\Controller\:
-        resource: '../src/Controller/'
+        resource: "../src/Controller/"
         tags: [controller.service_arguments]
 
     App\v2\Controller\:
-        resource: '../src/v2/Controller'
+        resource: "../src/v2/Controller"
         tags: [controller.service_arguments]
 
     App\v2\Registration\Controller\:
-        resource: '../src/v2/Registration/Controller'
+        resource: "../src/v2/Registration/Controller"
         tags: [controller.service_arguments]
 
     Doctrine\Migrations\Version\DbalMigrationFactory: ~
     App\Migrations\Factory\MigrationFactoryDecorator:
         decorates: Doctrine\Migrations\Version\DbalMigrationFactory
-        arguments: ['@App\Migrations\Factory\MigrationFactoryDecorator.inner', '@service_container']
-
+        arguments:
+            [
+                '@App\Migrations\Factory\MigrationFactoryDecorator.inner',
+                "@service_container",
+            ]
 
     monolog.processor.add_request_id:
         class: App\Service\RequestIdLoggerProcessor
-        arguments:  [ "@service_container" ]
+        arguments: ["@service_container"]
         tags:
             - { name: monolog.processor, method: processRecord }
 
@@ -82,73 +85,110 @@ services:
         tags:
             - { name: doctrine.event_subscriber, connection: default }
         calls:
-            - [ setAnnotationReader, [ "@annotation_reader" ] ]
+            - [setAnnotationReader, ["@annotation_reader"]]
 
     gedmo.listener.timestampable:
         class: Gedmo\Timestampable\TimestampableListener
         tags:
             - { name: doctrine.event_subscriber, connection: default }
         calls:
-            - [ setAnnotationReader, [ "@annotation_reader" ] ]
+            - [setAnnotationReader, ["@annotation_reader"]]
 
     App\DataFixtures\:
-        resource: '../src/DataFixtures'
-        tags: ['doctrine.fixture.orm']
+        resource: "../src/DataFixtures"
+        tags: ["doctrine.fixture.orm"]
         autowire: true
 
     App\Controller\Report\ReportController:
         class: App\Controller\Report\ReportController
         arguments:
-            $updateHandlers: [
-                '@rest_handler.report.deputy_costs_estimate_report_update_handler',
-                '@rest_handler.report.deputy_costs_report_update_handler',
-                '@rest_handler.report.pa_fees_expenses_report_update_handler'
-            ]
+            $updateHandlers:
+                [
+                    "@rest_handler.report.deputy_costs_estimate_report_update_handler",
+                    "@rest_handler.report.deputy_costs_report_update_handler",
+                    "@rest_handler.report.pa_fees_expenses_report_update_handler",
+                ]
 
     App\EventListener\RestInputOuputFormatter:
-        arguments: [ "@jms_serializer", "@logger", ["json"], "json", "%kernel.debug%" ]
+        arguments:
+            ["@jms_serializer", "@logger", ["json"], "json", "%kernel.debug%"]
         tags:
-            - { name: kernel.event_listener, event: kernel.view, method: onKernelView }
-            - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }
-            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
+            - {
+                  name: kernel.event_listener,
+                  event: kernel.view,
+                  method: onKernelView,
+              }
+            - {
+                  name: kernel.event_listener,
+                  event: kernel.exception,
+                  method: onKernelException,
+              }
+            - {
+                  name: kernel.event_listener,
+                  event: kernel.request,
+                  method: onKernelRequest,
+              }
 
     App\EventListener\DoctrineListener:
         tags:
-            - { name: doctrine.event_listener, event: prePersist, method: prePersist }
-            - { name: doctrine.event_listener, event: preUpdate, method: preUpdate }
-            - { name: doctrine.event_listener, event: preRemove, method: preRemove }
+            - {
+                  name: doctrine.event_listener,
+                  event: prePersist,
+                  method: prePersist,
+              }
+            - {
+                  name: doctrine.event_listener,
+                  event: preUpdate,
+                  method: preUpdate,
+              }
+            - {
+                  name: doctrine.event_listener,
+                  event: preRemove,
+                  method: preRemove,
+              }
 
     App\EventListener\FixDefaultSchemaListener:
         class: App\EventListener\FixDefaultSchemaListener
         tags:
-            - { name: doctrine.event_listener, event: postGenerateSchema, method: postGenerateSchema }
+            - {
+                  name: doctrine.event_listener,
+                  event: postGenerateSchema,
+                  method: postGenerateSchema,
+              }
 
     App\Factory\OrganisationFactory:
         class: App\Factory\OrganisationFactory
-        arguments: ['%shared_email_domains%']
+        arguments: ["%shared_email_domains%"]
 
     App\Service\RestHandler\OrganisationRestHandler:
         class: App\Service\RestHandler\OrganisationRestHandler
         arguments:
-            - '@em'
-            - '@validator'
+            - "@em"
+            - "@validator"
             - '@App\Repository\OrganisationRepository'
             - '@App\Repository\UserRepository'
             - '@App\Factory\OrganisationFactory'
-            - '%shared_email_domains%'
+            - "%shared_email_domains%"
 
     App\Service\Auth\UserProvider:
-        arguments: [ '@em', "@snc_redis.default", "@logger", { "timeout_seconds": "%user_provider_timeout_seconds%" }, '@App\Repository\UserRepository' ]
+        arguments:
+            [
+                "@em",
+                "@snc_redis.default",
+                "@logger",
+                { "timeout_seconds": "%user_provider_timeout_seconds%" },
+                '@App\Repository\UserRepository',
+            ]
 
     App\Security\OrganisationVoter:
         class: App\Security\OrganisationVoter
-        arguments: [ "@security.helper" ]
+        arguments: ["@security.helper"]
         tags:
             - { name: security.voter }
 
     App\Security\ClientVoter:
         class: App\Security\ClientVoter
-        arguments: [ "@security.helper" ]
+        arguments: ["@security.helper"]
         tags:
             - { name: security.voter }
 
@@ -161,108 +201,112 @@ services:
     App\Service\ReportStatusService: ~
     App\Service\Stats\StatsQueryParameters: ~
 
-    Symfony\Component\Security\Core\Role\RoleHierarchyInterface: '@security.role_hierarchy'
+    Symfony\Component\Security\Core\Role\RoleHierarchyInterface: "@security.role_hierarchy"
 
     App\Repository\CasRecRepository:
         class: App\Repository\CasRecRepository
-        tags: ['doctrine.repository_service']
+        tags: ["doctrine.repository_service"]
 
     App\Repository\ClientContactRepository:
         class: App\Repository\ClientContactRepository
-        tags: [ 'doctrine.repository_service' ]
+        tags: ["doctrine.repository_service"]
 
     App\Repository\ClientRepository:
         class: App\Repository\ClientRepository
-        tags: [ 'doctrine.repository_service' ]
+        tags: ["doctrine.repository_service"]
 
     App\Repository\DocumentRepository:
         class: App\Repository\DocumentRepository
-        tags: [ 'doctrine.repository_service' ]
+        tags: ["doctrine.repository_service"]
 
     App\Repository\NamedDeputyRepository:
         class: App\Repository\NamedDeputyRepository
-        tags: [ 'doctrine.repository_service' ]
+        tags: ["doctrine.repository_service"]
 
     App\Repository\NdrRepository:
         class: App\Repository\NdrRepository
-        tags: [ 'doctrine.repository_service' ]
+        tags: ["doctrine.repository_service"]
 
     App\Repository\NoteRepository:
         class: App\Repository\NoteRepository
-        tags: [ 'doctrine.repository_service' ]
+        tags: ["doctrine.repository_service"]
 
     App\Repository\OrganisationRepository:
         class: App\Repository\OrganisationRepository
-        tags: [ 'doctrine.repository_service' ]
+        tags: ["doctrine.repository_service"]
 
     App\Repository\ReportRepository:
         class: App\Repository\ReportRepository
-        tags: [ 'doctrine.repository_service' ]
+        tags: ["doctrine.repository_service"]
 
     App\Repository\ReportSubmissionRepository:
         class: App\Repository\ReportSubmissionRepository
-        tags: [ 'doctrine.repository_service' ]
+        tags: ["doctrine.repository_service"]
 
     App\Repository\SatisfactionRepository:
         class: App\Repository\SatisfactionRepository
-        tags: [ 'doctrine.repository_service' ]
+        tags: ["doctrine.repository_service"]
 
     App\Repository\UserRepository:
         class: App\Repository\UserRepository
-        tags: ['doctrine.repository_service']
+        tags: ["doctrine.repository_service"]
 
     App\Repository\UserResearchResponseRepository:
         class: App\Repository\UserResearchResponseRepository
-        tags: ['doctrine.repository_service']
+        tags: ["doctrine.repository_service"]
+
+    App\Repository\AssetRepository:
+        class: App\Repository\AssetRepository
+        tags: ["doctrine.repository_service"]
 
     App\Service\Auth\AuthService:
         arguments:
-            $encoderFactory: '@security.encoder_factory'
-            $logger: '@logger'
+            $encoderFactory: "@security.encoder_factory"
+            $logger: "@logger"
             $userRepository: '@App\Repository\UserRepository'
-            $roleHierarchy: '@security.role_hierarchy'
-            $clientPermissions: '%client_permissions%'
+            $roleHierarchy: "@security.role_hierarchy"
+            $clientPermissions: "%client_permissions%"
 
     App\Service\BruteForce\AttemptsInTimeChecker:
-        arguments: [ "@snc_redis.default" ]
+        arguments: ["@snc_redis.default"]
         calls:
-            - [ setRedisPrefix, ["ac_ret_code"] ]
+            - [setRedisPrefix, ["ac_ret_code"]]
             # after 5 attempts in the last 10 minutes, return a different return code (activate captcha)
-            - [ addTrigger, [  5, 600 ] ]
+            - [addTrigger, [5, 600]]
 
     App\Service\BruteForce\AttemptsIncrementalWaitingChecker:
-        arguments: [ "@snc_redis.default" ]
+        arguments: ["@snc_redis.default"]
         calls:
-            - [ setRedisPrefix, ["ac_exception"] ]
+            - [setRedisPrefix, ["ac_exception"]]
             # after 10 attempts, freeze for 30 minutes
-            - [ addFreezingRule, [  10, 1800 ] ]
+            - [addFreezingRule, [10, 1800]]
             # after further 10 attempts. freeze for 1h
-            - [ addFreezingRule, [  20, 3600 ] ]
+            - [addFreezingRule, [20, 3600]]
             # after further 10 attempts. freeze for 2h
-            - [ addFreezingRule, [  30, 7200 ] ]
+            - [addFreezingRule, [30, 7200]]
 
     logstash_formatter:
         class: Monolog\Formatter\LogstashFormatter
         arguments:
-        - application.api
-        - null
-        - null
-        - ""
-        - 1
+            - application.api
+            - null
+            - null
+            - ""
+            - 1
     line_formatter:
         class: Monolog\Formatter\LineFormatter
 
     rest_handler.report.deputy_costs_estimate_report_update_handler:
         class: App\Service\RestHandler\Report\DeputyCostsEstimateReportUpdateHandler
-        arguments: [ '@em' ]
+        arguments: ["@em"]
 
     rest_handler.report.deputy_costs_report_update_handler:
         class: App\Service\RestHandler\Report\DeputyCostsReportUpdateHandler
-        arguments: [ '@em' ]
+        arguments: ["@em"]
 
     rest_handler.report.pa_fees_expenses_report_update_handler:
         class: App\Service\RestHandler\Report\PaFeesExpensesReportUpdateHandler
-        arguments: [ '@em' ]
+        arguments: ["@em"]
 
     PlainDeputyAssembler:
         class: App\v2\Assembler\DeputyAssembler
@@ -287,7 +331,12 @@ services:
             - { name: serializer.denormalizer }
 
     Aws\Ssm\SsmClient:
-        arguments: [ "%ssm_client_params%" ]
+        arguments: ["%ssm_client_params%"]
 
     App\Service\ParameterStoreService:
-        arguments: [ '@Aws\Ssm\SsmClient', '%env(PARAMETER_PREFIX)%', '%env(FEATURE_FLAG_PREFIX)%' ]
+        arguments:
+            [
+                '@Aws\Ssm\SsmClient',
+                "%env(PARAMETER_PREFIX)%",
+                "%env(FEATURE_FLAG_PREFIX)%",
+            ]

--- a/api/config/services.yml
+++ b/api/config/services.yml
@@ -263,6 +263,14 @@ services:
         class: App\Repository\BankAccountRepository
         tags: ["doctrine.repository_service"]
 
+    App\Repository\NdrAssetRepository:
+        class: App\Repository\NdrAssetRepository
+        tags: ["doctrine.repository_service"]
+
+    App\Repository\NdrBankAccountRepository:
+        class: App\Repository\NdrBankAccountRepository
+        tags: ["doctrine.repository_service"]
+
     App\Service\Auth\AuthService:
         arguments:
             $encoderFactory: "@security.encoder_factory"

--- a/api/config/services.yml
+++ b/api/config/services.yml
@@ -259,6 +259,10 @@ services:
         class: App\Repository\AssetRepository
         tags: ["doctrine.repository_service"]
 
+    App\Repository\BankAccountRepository:
+        class: App\Repository\BankAccountRepository
+        tags: ["doctrine.repository_service"]
+
     App\Service\Auth\AuthService:
         arguments:
             $encoderFactory: "@security.encoder_factory"

--- a/api/src/Controller/StatsController.php
+++ b/api/src/Controller/StatsController.php
@@ -95,7 +95,6 @@ class StatsController extends RestController
         $lays = $this->reportRepository->getAllSubmittedReportsWithin12Months('LAY');
         $profs = $this->reportRepository->getAllSubmittedReportsWithin12Months('PROF');
         $pas = $this->reportRepository->getAllSubmittedReportsWithin12Months('PA');
-        $ndrs = $this->ndrRepository->getAllSubmittedNdrsWithin12Months();
 
         $layClientIds = [];
 
@@ -121,11 +120,9 @@ class StatsController extends RestController
             }
         }
 
-        foreach ($ndrs as $ndr) {
-            if (in_array($ndr->getClient()->getId(), $layClientIds)) {
-                continue;
-            }
+        $ndrs = $this->ndrRepository->getAllSubmittedNdrsWithin12Months($layClientIds);
 
+        foreach ($ndrs as $ndr) {
             $ret['lays']['non-liquid'] += $ndr->getAssetsTotalValue();
             foreach ($ndr->getBankAccounts() as $bankAccount) {
                 $ret['lays']['liquid'] += $bankAccount->getClosingBalance();

--- a/api/src/Controller/StatsController.php
+++ b/api/src/Controller/StatsController.php
@@ -7,6 +7,7 @@ namespace App\Controller;
 use App\Entity\Report\AssetOther;
 use App\Entity\Report\AssetProperty;
 use App\Repository\AssetRepository;
+use App\Repository\BankAccountRepository;
 use App\Repository\NdrRepository;
 use App\Repository\ReportRepository;
 use App\Repository\UserRepository;
@@ -26,7 +27,8 @@ class StatsController extends RestController
         private UserRepository $userRepository,
         private ReportRepository $reportRepository,
         private NdrRepository $ndrRepository,
-        private AssetRepository $assetRepository
+        private AssetRepository $assetRepository,
+        private BankAccountRepository $bankAccountRepository,
     ) {
     }
 
@@ -100,35 +102,16 @@ class StatsController extends RestController
         $oneYearAgo = new DateTime('-1 year');
 
         $ret['lays']['non-liquid'] += $this->assetRepository->getSumOfAssets(AssetOther::class, 'LAY', $oneYearAgo);
+        $ret['profs']['non-liquid'] += $this->assetRepository->getSumOfAssets(AssetOther::class, 'PROF', $oneYearAgo);
+        $ret['pas']['non-liquid'] += $this->assetRepository->getSumOfAssets(AssetOther::class, 'PA', $oneYearAgo);
+
         $ret['lays']['non-liquid'] += $this->assetRepository->getSumOfAssets(AssetProperty::class, 'LAY', $oneYearAgo);
+        $ret['profs']['non-liquid'] += $this->assetRepository->getSumOfAssets(AssetProperty::class, 'PROF', $oneYearAgo);
+        $ret['pas']['non-liquid'] += $this->assetRepository->getSumOfAssets(AssetProperty::class, 'PA', $oneYearAgo);
 
-//        $lays = $this->reportRepository->getAllSubmittedReportsWithin12Months('LAY');
-//        $profs = $this->reportRepository->getAllSubmittedReportsWithin12Months('PROF');
-//        $pas = $this->reportRepository->getAllSubmittedReportsWithin12Months('PA');
-
-        $layClientIds = [];
-
-//        foreach ($lays as $layReport) {
-//            $layClientIds[] = $layReport->getClientId();
-//            $ret['lays']['non-liquid'] += $layReport->getAssetsTotalValue();
-//            foreach ($layReport->getBankAccounts() as $bankAccount) {
-//                $ret['lays']['liquid'] += $bankAccount->getClosingBalance();
-//            }
-//        }
-//
-//        foreach ($profs as $profReport) {
-//            $ret['profs']['non-liquid'] += $profReport->getAssetsTotalValue();
-//            foreach ($profReport->getBankAccounts() as $bankAccount) {
-//                $ret['profs']['liquid'] += $bankAccount->getClosingBalance();
-//            }
-//        }
-//
-//        foreach ($pas as $paReport) {
-//            $ret['pas']['non-liquid'] += $paReport->getAssetsTotalValue();
-//            foreach ($paReport->getBankAccounts() as $bankAccount) {
-//                $ret['pas']['liquid'] += $bankAccount->getClosingBalance();
-//            }
-//        }
+        $ret['lays']['liquid'] += $this->bankAccountRepository->getSumOfAccounts('LAY', $oneYearAgo);
+        $ret['profs']['liquid'] += $this->bankAccountRepository->getSumOfAccounts('PROF', $oneYearAgo);
+        $ret['pas']['liquid'] += $this->bankAccountRepository->getSumOfAccounts('PA', $oneYearAgo);
 //
 //        $ndrs = $this->ndrRepository->getAllSubmittedNdrsWithin12Months($layClientIds);
 //

--- a/api/src/Entity/Ndr/Asset.php
+++ b/api/src/Entity/Ndr/Asset.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity\Ndr;
 
+use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as JMS;
 
@@ -9,7 +10,7 @@ use JMS\Serializer\Annotation as JMS;
  * Asset.
  *
  * @ORM\Table(name="odr_asset")
- * @ORM\Entity()
+ * @ORM\Entity(repositoryClass="App\Repository\NdrAssetRepository")
  * @ORM\InheritanceType("SINGLE_TABLE")
  * @ORM\DiscriminatorColumn(name="type", type="string")
  * @ORM\DiscriminatorMap({
@@ -43,7 +44,7 @@ abstract class Asset
     private $value;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      * @JMS\Groups({"ndr-asset"})
      * @JMS\Type("DateTime")
      * @ORM\Column(name="last_edit", type="datetime", nullable=true)
@@ -121,7 +122,7 @@ abstract class Asset
     /**
      * Set lastedit.
      *
-     * @param \DateTime $lastEdit
+     * @param DateTime $lastEdit
      *
      * @return Asset
      */
@@ -135,7 +136,7 @@ abstract class Asset
     /**
      * Get lastedit.
      *
-     * @return \DateTime
+     * @return DateTime
      */
     public function getLastEdit()
     {
@@ -190,6 +191,6 @@ abstract class Asset
      */
     public function updateLastEdit()
     {
-        $this->setLastEdit(new \DateTime());
+        $this->setLastEdit(new DateTime());
     }
 }

--- a/api/src/Entity/Ndr/BankAccount.php
+++ b/api/src/Entity/Ndr/BankAccount.php
@@ -3,6 +3,7 @@
 namespace App\Entity\Ndr;
 
 use App\Entity\BankAccountInterface;
+use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as JMS;
 
@@ -10,7 +11,7 @@ use JMS\Serializer\Annotation as JMS;
  * Account.
  *
  * @ORM\Table(name="odr_account")
- * @ORM\Entity()
+ * @ORM\Entity(repositoryClass="App\Repository\NdrBankAccountRepository")
  */
 class BankAccount implements BankAccountInterface
 {
@@ -37,7 +38,7 @@ class BankAccount implements BankAccountInterface
     private static $typesNotRequiringSortCode = [
         'postoffice',
         'cfo',
-        'other_no_sortcode'
+        'other_no_sortcode',
     ];
 
     /**
@@ -47,7 +48,7 @@ class BankAccount implements BankAccountInterface
      */
     private static $typesNotRequiringBankName = [
         'postoffice',
-        'cfo'
+        'cfo',
     ];
 
     /**
@@ -92,7 +93,7 @@ class BankAccount implements BankAccountInterface
     private $accountNumber;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      * @JMS\Groups({"ndr-account"})
      *
      * @ORM\Column(name="created_at", type="datetime", nullable=true)
@@ -133,7 +134,7 @@ class BankAccount implements BankAccountInterface
     public function __construct()
     {
         $this->lastEdit = null;
-        $this->createdAt = new \DateTime();
+        $this->createdAt = new DateTime();
     }
 
     /**
@@ -288,7 +289,7 @@ class BankAccount implements BankAccountInterface
     }
 
     /**
-     * @return \DateTime
+     * @return DateTime
      */
     public function getCreatedAt()
     {
@@ -296,7 +297,7 @@ class BankAccount implements BankAccountInterface
     }
 
     /**
-     * @param \DateTime $createdAt
+     * @param DateTime $createdAt
      *
      * @return BankAccount
      */
@@ -393,7 +394,7 @@ class BankAccount implements BankAccountInterface
      * <bank> - <type> (****<last 4 digits>)
      * e.g.
      * barclays - Current account (****1234)
-     * Natwest - ISA (****4444)
+     * Natwest - ISA (****4444).
      *
      * @JMS\VirtualProperty
      * @JMS\SerializedName("name_one_line")
@@ -403,8 +404,8 @@ class BankAccount implements BankAccountInterface
      */
     public function getNameOneLine()
     {
-        return (!empty($this->getBank()) ? $this->getBank() . ' - '  : '')
-            . $this->getAccountTypeText()
-            . ' (****' . $this->getAccountNumber() . ')';
+        return (!empty($this->getBank()) ? $this->getBank().' - ' : '')
+            .$this->getAccountTypeText()
+            .' (****'.$this->getAccountNumber().')';
     }
 }

--- a/api/src/Entity/Report/Asset.php
+++ b/api/src/Entity/Report/Asset.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity\Report;
 
+use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as JMS;
 
@@ -9,7 +10,7 @@ use JMS\Serializer\Annotation as JMS;
  * Asset.
  *
  * @ORM\Table(name="asset")
- * @ORM\Entity()
+ * @ORM\Entity(repositoryClass="App\Repository\AssetRepository")
  * @ORM\InheritanceType("SINGLE_TABLE")
  * @ORM\DiscriminatorColumn(name="type", type="string")
  * @ORM\DiscriminatorMap({
@@ -43,7 +44,7 @@ abstract class Asset
     private $value;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      * @JMS\Groups({"asset"})
      * @JMS\Type("DateTime")
      * @ORM\Column(name="last_edit", type="datetime", nullable=true)
@@ -59,7 +60,7 @@ abstract class Asset
     private $report;
 
     /**
-     * Discriminator field
+     * Discriminator field.
      *
      * @var string
      * @JMS\Exclude
@@ -136,7 +137,7 @@ abstract class Asset
     /**
      * Set lastedit.
      *
-     * @param \DateTime $lastedit
+     * @param DateTime $lastedit
      *
      * @return Asset
      */
@@ -150,7 +151,7 @@ abstract class Asset
     /**
      * Get lastedit.
      *
-     * @return \DateTime
+     * @return DateTime
      */
     public function getLastedit()
     {
@@ -202,6 +203,6 @@ abstract class Asset
      */
     public function updateLastEdit()
     {
-        $this->setLastedit(new \DateTime());
+        $this->setLastedit(new DateTime());
     }
 }

--- a/api/src/Repository/AssetRepository.php
+++ b/api/src/Repository/AssetRepository.php
@@ -28,13 +28,6 @@ class AssetRepository extends ServiceEntityRepository
 
         $selectQuery = AssetOther::class === $assetType ? 'SUM(a.value)' : 'SUM(a.value * a.ownedPercentage)';
 
-        $types = match (strtoupper($deputyType)) {
-            'LAY' => Report::getAllLayTypes(),
-            'PROF' => Report::getAllProfTypes(),
-            'PA' => Report::getAllPaTypes(),
-            default => [],
-        };
-
         $query = $this
             ->getEntityManager()
             ->createQueryBuilder()
@@ -49,6 +42,13 @@ class AssetRepository extends ServiceEntityRepository
         }
 
         if ($deputyType) {
+            $types = match (strtoupper($deputyType)) {
+                'LAY' => Report::getAllLayTypes(),
+                'PROF' => Report::getAllProfTypes(),
+                'PA' => Report::getAllPaTypes(),
+                default => [],
+            };
+
             $query
                 ->andWhere('r.type IN (:types)')
                 ->setParameter('types', $types);

--- a/api/src/Repository/AssetRepository.php
+++ b/api/src/Repository/AssetRepository.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Report\Asset;
+use App\Entity\Report\AssetOther;
+use App\Entity\Report\AssetProperty;
+use App\Entity\Report\Report;
+use DateTime;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use InvalidArgumentException;
+
+class AssetRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Asset::class);
+    }
+
+    public function getSumOfAssets(string $assetType = AssetOther::class, ?string $deputyType = null, ?DateTime $after = null): int
+    {
+        if (!in_array($assetType, [AssetProperty::class, AssetOther::class])) {
+            throw new InvalidArgumentException('Only "AssetProperty" or "AssetOther" assets are supported');
+        }
+
+        $selectQuery = AssetOther::class === $assetType ? 'SUM(a.value)' : 'SUM(a.value * a.ownedPercentage)';
+
+        $types = match (strtoupper($deputyType)) {
+            'LAY' => Report::getAllLayTypes(),
+            'PROF' => Report::getAllProfTypes(),
+            'PA' => Report::getAllPaTypes(),
+            default => [],
+        };
+
+        $query = $this
+            ->getEntityManager()
+            ->createQueryBuilder()
+            ->select($selectQuery)
+            ->from($assetType, 'a');
+
+        if ($after) {
+            $query
+                ->andWhere('r.submitDate > :after')
+                ->setParameter('after', $after);
+        }
+
+        if ($deputyType) {
+            $query
+                ->leftJoin('a.report', 'r')
+                ->andWhere('r.type IN (:types)')
+                ->setParameter('types', $types);
+        }
+
+        return intval($query->getQuery()->getSingleScalarResult());
+    }
+}

--- a/api/src/Repository/BankAccountRepository.php
+++ b/api/src/Repository/BankAccountRepository.php
@@ -4,30 +4,21 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
-use App\Entity\Report\Asset;
-use App\Entity\Report\AssetOther;
-use App\Entity\Report\AssetProperty;
+use App\Entity\Report\BankAccount;
 use App\Entity\Report\Report;
 use DateTime;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
-use InvalidArgumentException;
 
-class AssetRepository extends ServiceEntityRepository
+class BankAccountRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)
     {
-        parent::__construct($registry, Asset::class);
+        parent::__construct($registry, BankAccount::class);
     }
 
-    public function getSumOfAssets(string $assetType = AssetOther::class, ?string $deputyType = null, ?DateTime $after = null): int
+    public function getSumOfAccounts(string $deputyType = '', ?DateTime $after = null): int
     {
-        if (!in_array($assetType, [AssetProperty::class, AssetOther::class])) {
-            throw new InvalidArgumentException('Only "AssetProperty" or "AssetOther" assets are supported');
-        }
-
-        $selectQuery = AssetOther::class === $assetType ? 'SUM(a.value)' : 'SUM(a.value * a.ownedPercentage)';
-
         $types = match (strtoupper($deputyType)) {
             'LAY' => Report::getAllLayTypes(),
             'PROF' => Report::getAllProfTypes(),
@@ -38,8 +29,8 @@ class AssetRepository extends ServiceEntityRepository
         $query = $this
             ->getEntityManager()
             ->createQueryBuilder()
-            ->select($selectQuery)
-            ->from($assetType, 'a')
+            ->select('SUM(a.closingBalance)')
+            ->from('App\Entity\Report\BankAccount', 'a')
             ->leftJoin('a.report', 'r');
 
         if ($after) {

--- a/api/src/Repository/BankAccountRepository.php
+++ b/api/src/Repository/BankAccountRepository.php
@@ -17,15 +17,8 @@ class BankAccountRepository extends ServiceEntityRepository
         parent::__construct($registry, BankAccount::class);
     }
 
-    public function getSumOfAccounts(string $deputyType = '', ?DateTime $after = null): int
+    public function getSumOfAccounts(?string $deputyType = null, ?DateTime $after = null): int
     {
-        $types = match (strtoupper($deputyType)) {
-            'LAY' => Report::getAllLayTypes(),
-            'PROF' => Report::getAllProfTypes(),
-            'PA' => Report::getAllPaTypes(),
-            default => [],
-        };
-
         $query = $this
             ->getEntityManager()
             ->createQueryBuilder()
@@ -40,6 +33,13 @@ class BankAccountRepository extends ServiceEntityRepository
         }
 
         if ($deputyType) {
+            $types = match (strtoupper($deputyType)) {
+                'LAY' => Report::getAllLayTypes(),
+                'PROF' => Report::getAllProfTypes(),
+                'PA' => Report::getAllPaTypes(),
+                default => [],
+            };
+
             $query
                 ->andWhere('r.type IN (:types)')
                 ->setParameter('types', $types);

--- a/api/src/Repository/NdrAssetRepository.php
+++ b/api/src/Repository/NdrAssetRepository.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Ndr\Asset;
+use App\Entity\Ndr\AssetOther;
+use App\Entity\Ndr\AssetProperty;
+use DateTime;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class NdrAssetRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Asset::class);
+    }
+
+    public function getSumOfAssets(string $assetType = AssetOther::class, ?DateTime $after = null, array $excludeByClientId = []): int
+    {
+        if (!in_array($assetType, [AssetProperty::class, AssetOther::class])) {
+            throw new InvalidArgumentException('Only "AssetProperty" or "AssetOther" assets are supported');
+        }
+
+        $selectQuery = AssetOther::class === $assetType ? 'SUM(a.value)' : 'SUM(a.value * a.ownedPercentage)';
+
+        $query = $this
+            ->getEntityManager()
+            ->createQueryBuilder()
+            ->select($selectQuery)
+            ->from($assetType, 'a')
+            ->leftJoin('a.ndr', 'ndr');
+
+        if ($after) {
+            $query
+                ->andWhere('ndr.submitDate > :after')
+                ->setParameter('after', $after);
+        }
+
+        if (!empty($excludeByClientId)) {
+            $query
+                ->leftJoin('ndr.client', 'c')
+                ->andWhere('c.id NOT IN (:clientIds)')
+                ->setParameter('clientIds', $excludeByClientId);
+        }
+
+        return intval($query->getQuery()->getSingleScalarResult());
+    }
+}

--- a/api/src/Repository/NdrBankAccountRepository.php
+++ b/api/src/Repository/NdrBankAccountRepository.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\Ndr\BankAccount;
+use DateTime;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class NdrBankAccountRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, BankAccount::class);
+    }
+
+    public function getSumOfAccounts(?DateTime $after = null, array $excludeByClientId = []): int
+    {
+        $query = $this
+            ->getEntityManager()
+            ->createQueryBuilder()
+            ->select('SUM(a.balanceOnCourtOrderDate)')
+            ->from('App\Entity\Ndr\BankAccount', 'a')
+            ->leftJoin('a.ndr', 'ndr');
+
+        if ($after) {
+            $query
+                ->andWhere('ndr.submitDate > :after')
+                ->setParameter('after', $after);
+        }
+
+        if (!empty($excludeByClientId)) {
+            $query
+                ->leftJoin('ndr.client', 'c')
+                ->andWhere('c.id NOT IN (:clientIds)')
+                ->setParameter('clientIds', $excludeByClientId);
+        }
+
+        return intval($query->getQuery()->getSingleScalarResult());
+    }
+}

--- a/api/src/Repository/NdrRepository.php
+++ b/api/src/Repository/NdrRepository.php
@@ -6,7 +6,6 @@ use App\Entity\Ndr\Debt;
 use App\Entity\Ndr\Ndr;
 use App\Entity\Ndr\OneOff;
 use App\Entity\Ndr\StateBenefit;
-use DateTime;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -69,27 +68,5 @@ class NdrRepository extends ServiceEntityRepository
         }
 
         return $ret;
-    }
-
-    /**
-     * @return Ndr[]
-     */
-    public function getAllSubmittedNdrsWithin12Months(array $clientIds): array
-    {
-        $oneYearAgo = new DateTime('-1 year');
-
-        $dql = <<<DQL
-SELECT n FROM App\Entity\Ndr\Ndr n
-WHERE n.submitDate > :oneYearAgo
-AND n.client NOT IN (:clientIds)
-DQL;
-
-        $query = $this
-            ->getEntityManager()
-            ->createQuery($dql)
-            ->setParameter('oneYearAgo', $oneYearAgo)
-            ->setParameter('clientIds', $clientIds);
-
-        return $query->getResult();
     }
 }

--- a/api/src/Repository/NdrRepository.php
+++ b/api/src/Repository/NdrRepository.php
@@ -74,19 +74,21 @@ class NdrRepository extends ServiceEntityRepository
     /**
      * @return Ndr[]
      */
-    public function getAllSubmittedNdrsWithin12Months(): array
+    public function getAllSubmittedNdrsWithin12Months(array $clientIds): array
     {
         $oneYearAgo = new DateTime('-1 year');
 
         $dql = <<<DQL
 SELECT n FROM App\Entity\Ndr\Ndr n
 WHERE n.submitDate > :oneYearAgo
+AND n.client NOT IN (:clientIds)
 DQL;
 
         $query = $this
             ->getEntityManager()
             ->createQuery($dql)
-            ->setParameter('oneYearAgo', $oneYearAgo);
+            ->setParameter('oneYearAgo', $oneYearAgo)
+            ->setParameter('clientIds', $clientIds);
 
         return $query->getResult();
     }

--- a/api/src/Repository/ReportRepository.php
+++ b/api/src/Repository/ReportRepository.php
@@ -236,30 +236,6 @@ DQL;
             ->getSingleScalarResult();
     }
 
-//     Assets
-
-//    Get SUM of lays, profs and pros for 'other' asset types
-
-//    select SUM(asset.asset_value) as total from asset
-//    LEFT JOIN report ON asset.report_id = report.id
-//    where report.submit_date > '2022-02-12'
-//    and asset.type = 'other'
-
-//    Get SUM of lays, profs and pros for 'property' asset types (using percentage owned)
-
-//    select SUM(asset.asset_value * asset.owned_percentage) as total from asset
-//    LEFT JOIN report ON asset.report_id = report.id
-//    where report.submit_date > '2022-02-12'
-//    and asset.type = 'property'
-
-//    Bank Accounts
-
-//    Get SUM of lays, profs and pros account closing balances
-
-//    select SUM(account.closing_balance) as total from account
-//    LEFT JOIN report ON account.report_id = report.id
-//    where report.submit_date > '2022-02-12'
-
     /**
      * @return string[]
      */

--- a/api/tests/Unit/Entity/Repository/UserResearchResponseRepositoryTest.php
+++ b/api/tests/Unit/Entity/Repository/UserResearchResponseRepositoryTest.php
@@ -28,6 +28,10 @@ class UserResearchResponseRepositoryTest extends KernelTestCase
 
     // Not to be run in test suites as it takes forever - run this to generate large amounts of userResearchResponses
     // for manual testing
+
+    /**
+     * @test
+     */
     public function canHandleLargeAmountsOfData()
     {
         $this->fixtures->createUserResearchResponse(2000);

--- a/api/tests/Unit/Entity/Repository/UserResearchResponseRepositoryTest.php
+++ b/api/tests/Unit/Entity/Repository/UserResearchResponseRepositoryTest.php
@@ -28,10 +28,6 @@ class UserResearchResponseRepositoryTest extends KernelTestCase
 
     // Not to be run in test suites as it takes forever - run this to generate large amounts of userResearchResponses
     // for manual testing
-
-    /**
-     * @test
-     */
     public function canHandleLargeAmountsOfData()
     {
         $this->fixtures->createUserResearchResponse(2000);

--- a/api/tests/Unit/Fixtures.php
+++ b/api/tests/Unit/Fixtures.php
@@ -147,12 +147,35 @@ class Fixtures
         }
 
         if (is_null($report)) {
-            $report = $this->createReport($this->createClient($user));
+            $client = $this->createClient($user);
+
+            $report = $this->createReport($client);
+
+            $other = (new EntityDir\Report\AssetOther())
+                ->setValue(rand(1, 10000))
+                ->setReport($report);
+
+            $property = (new EntityDir\Report\AssetProperty())
+                ->setValue(rand(1, 10000))
+                ->setOwnedPercentage(rand(1, 100) / 100)
+                ->setReport($report);
+
+            $bankAccount = (new EntityDir\Report\BankAccount())
+                ->setClosingBalance(floatval(rand(10, 1000000) / 10))
+                ->setReport($report);
+
+            $report->addAsset($other);
+            $report->addAsset($property);
+            $report->addAccount($bankAccount);
+
+            $ndr = $this->createNdr($client);
         }
 
         $submission = new ReportSubmission($report, $user);
+        $report->setSubmitDate(new DateTime('-2 days'));
 
         $this->em->persist($submission);
+        $this->em->persist($report);
 
         return $submission;
     }


### PR DESCRIPTION
## Purpose
The original code to generate a report of asset values relied on iterating over PHP entities and summing values. This worked fine locally with a dataset of 10 reports and NDRs but took too long to response once run on prod. This change pushes the summing logic down into DQL to make sure we can actually run the report on prod.

Fixes DDPB-4291.

## Learning
Having relied on ORMs so heavily in the past whenever I get a data ticket I tend to avoid trying to come up with a DQL/SQL solution as its out of my comfort zone. This (along with previous time out bugs) should serve as a reminder that its not scary and SO is my friend 😂 . Interstingly this solution took around the same amount of time to come up with compared to the original.

Also, test against large datasets!

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
