### PR TITLE
DDPB-4278: Set client benefits section section release date to 16 March 2022

### DIFF
--- a/api/src/Entity/Report/Report.php
+++ b/api/src/Entity/Report/Report.php
@@ -1426,7 +1426,7 @@ class Report implements ReportInterface
 
     public function getBenefitsSectionReleaseDate(): ?DateTime
     {
-        return $this->benefitsSectionReleaseDate ?: new DateTime('31-12-2030 00:00:00');
+        return $this->benefitsSectionReleaseDate ?: new DateTime('16-03-2022 00:00:00');
     }
 
     /**


### PR DESCRIPTION
## Purpose
We've had the new benefits check section toggled off while developing for full reports. This change enables the section for all reports (plus 60 days from the date set here). It's already live for NDRs.

Fixes DDPB-4278.
