### PR TITLE
DDPB-4288: Allow checklists linked to a discharged client to be synced with Sirius

### DIFF
--- a/api/src/Controller/Report/ReportController.php
+++ b/api/src/Controller/Report/ReportController.php
@@ -931,6 +931,7 @@ class ReportController extends RestController
             $filter->disableForEntity(Client::class);
 
             $reports[] = $this->findEntityBy(Report::class, $reportId);
+            $filter->enableForEntity(Client::class);
         }
 
         $this->formatter->setJmsSerialiserGroups($this->checklistGroups);

--- a/api/src/Controller/Report/ReportController.php
+++ b/api/src/Controller/Report/ReportController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Report;
 
 use App\Controller\RestController;
 use App\Entity as EntityDir;
+use App\Entity\Client;
 use App\Entity\Report\Report;
 use App\Entity\User;
 use App\Exception\UnauthorisedException;
@@ -926,6 +927,9 @@ class ReportController extends RestController
 
         $reports = [];
         foreach ($queuedReportIds as $reportId) {
+            $filter = $this->em->getFilters()->getFilter('softdeleteable');
+            $filter->disableForEntity(Client::class);
+
             $reports[] = $this->findEntityBy(Report::class, $reportId);
         }
 

--- a/api/src/Entity/SynchronisableTrait.php
+++ b/api/src/Entity/SynchronisableTrait.php
@@ -1,11 +1,11 @@
 <?php
 
 declare(strict_types=1);
-declare(strict_types=1);
 
 namespace App\Entity;
 
 use DateTime;
+use InvalidArgumentException;
 
 trait SynchronisableTrait
 {
@@ -63,7 +63,7 @@ trait SynchronisableTrait
             self::SYNC_STATUS_PERMANENT_ERROR,
             ])
         ) {
-            throw new \InvalidArgumentException('Invalid synchronisation status');
+            throw new InvalidArgumentException('Invalid synchronisation status');
         }
 
         $this->synchronisationStatus = $status;

--- a/api/src/Repository/ReportRepository.php
+++ b/api/src/Repository/ReportRepository.php
@@ -221,11 +221,9 @@ DQL;
 UPDATE App\Entity\Report\Checklist c SET c.synchronisationStatus = 'IN_PROGRESS' WHERE c.id IN (:idsString)
 DQL;
 
-            $idsString = implode(',', $ids);
-
             $em
                 ->createQuery($dql)
-                ->setParameter('idsString', $idsString)
+                ->setParameter('idsString', $ids)
                 ->getResult();
         }
 

--- a/api/tests/Behat/bootstrap/v2/ClientManagement/ClientManagementTrait.php
+++ b/api/tests/Behat/bootstrap/v2/ClientManagement/ClientManagementTrait.php
@@ -8,6 +8,7 @@ use App\Entity\Client;
 use App\Tests\Behat\BehatException;
 use App\Tests\Behat\v2\Common\UserDetails;
 use DateTime;
+use Throwable;
 
 trait ClientManagementTrait
 {
@@ -306,7 +307,7 @@ MESSAGE;
             $this->clickLink('Discharge deputy');
             $this->iAmOnAdminClientDischargePage();
             $this->clickLink('Discharge deputy');
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             // This step is used as part of testing the discharge button isnt here so swallow errors and assert on following step
         }
     }
@@ -381,7 +382,7 @@ MESSAGE;
             $this->clickLink('Un-archive client');
             $this->iAmOnAdminClientUnarchivePage();
             $this->clickLink('Return to client dashboard');
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             // This step is used as part of testing the unarchive button isnt here so swallow errors and assert on following step
         }
     }
@@ -408,7 +409,6 @@ MESSAGE;
      */
     public function theClientShouldBeUnarchived()
     {
-        $this->assertInteractingWithUserIsSet();
         $this->iAmOnAdminClientDetailsPage();
     }
 
@@ -417,11 +417,23 @@ MESSAGE;
      */
     public function theClientShouldNotBeUnarchived()
     {
-        $this->assertInteractingWithUserIsSet();
-
         $this->iVisitAdminClientDetailsPageForDeputyInteractingWith();
 
         // Expecting to be redirected to the client archived page
         $this->iAmOnAdminClientArchivedPage();
+    }
+
+    /**
+     * @Given /^the deputy I am interacting with has been discharged$/
+     */
+    public function theDeputyHasBeenDischarged()
+    {
+        $this->assertInteractingWithUserIsSet();
+
+        $client = $this->em->find(Client::class, $this->interactingWithUserDetails->getClientId());
+        $client->setDeletedAt(new DateTime());
+
+        $this->em->persist($client);
+        $this->em->flush();
     }
 }

--- a/api/tests/Behat/bootstrap/v2/Common/IVisitAdminTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/IVisitAdminTrait.php
@@ -223,4 +223,16 @@ trait IVisitAdminTrait
     {
         $this->visitAdminPath($this->getAdminNotificationUrl());
     }
+
+    /**
+     * @When I visit the checklist page for the previously submitted report for the user I am interacting with
+     */
+    public function iVisitTheChecklistPageForSubmittedReport()
+    {
+        $this->assertInteractingWithUserIsSet();
+
+        $this->visitAdminPath(
+            $this->getAdminChecklistPage($this->interactingWithUserDetails->getPreviousReportId())
+        );
+    }
 }

--- a/api/tests/Behat/bootstrap/v2/Common/PageUrlsTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/PageUrlsTrait.php
@@ -50,28 +50,29 @@ trait PageUrlsTrait
     private string $visitsAndCareSectionUrl = '/%s/%s/visits-care';
 
     // Admin
+    private string $adminUserSearchUrl = '/admin';
+    private string $adminUploadLayUsersUrl = '/admin/casrec-upload';
+    private string $adminClientArchivedUrl = '/admin/client/%s/archived';
+    private string $adminClientDetailsUrl = '/admin/client/%s/details';
+    private string $adminClientSearchUrl = '/admin/client/search';
+    private string $adminSubmissionsPage = '/admin/documents/list';
+    private string $adminEditUserUrl = '/admin/edit-user?filter=%s';
+    private string $adminUploadOrgUsersUrl = '/admin/org-csv-upload';
+    private string $adminChecklistPage = '/admin/report/%s/checklist';
+    private string $adminNotificationUrl = '/admin/settings/service-notification';
+    private string $adminDATReportUrl = '/admin/stats';
     private string $adminActiveLaysReportUrl = '/admin/stats/downloadActiveLaysCsv';
-    private string $adminAddUserUrl = '/admin/user-add';
     private string $adminAnalyticsUrl = '/admin/stats/metrics';
     private string $adminStatsReportsUrl = '/admin/stats/reports';
-    private string $adminClientSearchUrl = '/admin/client/search';
-    private string $adminClientDetailsUrl = '/admin/client/%s/details';
-    private string $adminClientArchivedUrl = '/admin/client/%s/archived';
-    private string $adminDATReportUrl = '/admin/stats';
-    private string $adminEditUserUrl = '/admin/edit-user?filter=%s';
-    private string $adminFixturesUrl = '/admin/fixtures';
-    private string $adminMyUserProfileUrl = '/deputyship-details/your-details';
-    private string $adminNotificationUrl = '/admin/settings/service-notification';
     private string $adminSatisfactionReportUrl = '/admin/stats/satisfaction';
-    private string $adminSubmissionsPage = '/admin/documents/list';
     private string $adminUserResearchReportUrl = '/admin/stats/user-research';
-    private string $adminUserSearchUrl = '/admin';
+    private string $adminAddUserUrl = '/admin/user-add';
     private string $adminViewUserUrl = '/admin/user/%s';
     private string $adminUploadUsersUrl = '/admin/upload';
-    private string $adminUploadOrgUsersUrl = '/admin/org-csv-upload';
-    private string $adminUploadLayUsersUrl = '/admin/casrec-upload';
+    private string $adminMyUserProfileUrl = '/deputyship-details/your-details';
 
     // Fixtures
+    private string $adminFixturesUrl = '/admin/fixtures';
     private string $courtOrdersFixtureUrl = '/admin/fixtures/court-orders?%s';
 
     public function getReportSubmittedUrl(int $reportId): string
@@ -382,5 +383,10 @@ trait PageUrlsTrait
     public function getClientBenefitsCheckSummaryUrl(int $reportId): string
     {
         return sprintf($this->clientBenefitCheckSummaryPageUrl, $this->reportUrlPrefix, $reportId);
+    }
+
+    public function getAdminChecklistPage(string $reportId): string
+    {
+        return sprintf($this->adminChecklistPage, $reportId);
     }
 }

--- a/api/tests/Behat/bootstrap/v2/Reporting/Admin/ReportingAdminFeatureContext.php
+++ b/api/tests/Behat/bootstrap/v2/Reporting/Admin/ReportingAdminFeatureContext.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace App\Tests\Behat\v2\Reporting\Admin;
 
 use App\Tests\Behat\SearchTrait;
+use App\Tests\Behat\v2\ClientManagement\ClientManagementTrait;
 use App\Tests\Behat\v2\Common\BaseFeatureContext;
 use App\Tests\Behat\v2\Reporting\Sections\ClientBenefitsCheckSectionTrait;
 
 class ReportingAdminFeatureContext extends BaseFeatureContext
 {
     use ClientBenefitsCheckSectionTrait;
+    use ClientManagementTrait;
     use ReportingChecklistTrait;
     use SearchTrait;
 }

--- a/api/tests/Behat/bootstrap/v2/Reporting/Admin/ReportingChecklistTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Reporting/Admin/ReportingChecklistTrait.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Behat\v2\Reporting\Admin;
 
 use App\Entity\Report\Report;
+use App\Tests\Behat\BehatException;
 
 trait ReportingChecklistTrait
 {
@@ -202,5 +203,39 @@ trait ReportingChecklistTrait
                 }
             }
         }
+    }
+
+    /**
+     * @Then /^the checklist status should be \'([^\']*)\'$/
+     */
+    public function theChecklistStatusShouldBe(string $status)
+    {
+        $this->iAmOnAdminReportChecklistPage();
+
+        $expectedStatus = match (strtolower($status)) {
+            'queued' => 'Pending',
+            'synced' => 'Sent to Sirius',
+        };
+
+        $xpath = sprintf('//p[contains(.,"%s")]', $expectedStatus);
+        $sideMenu = $this->getSession()->getPage()->find('xpath', $xpath);
+
+        if (is_null($sideMenu)) {
+            throw new BehatException('The checklist sync status was not visible on the page');
+        }
+    }
+
+    /**
+     * @Given /^I run the checklist-sync command$/
+     */
+    public function iRunTheChecklistSyncCommand()
+    {
+        $this->visitAdminPath('/admin/behat/run-checklist-sync-command');
+
+        if ($this->getSession()->getStatusCode() > 299) {
+            throw new BehatException('There was an non successful response when running the checklist-sync command');
+        }
+
+        sleep(2);
     }
 }

--- a/api/tests/Behat/features-v2/report-checklist/checklist-synchronisation.feature
+++ b/api/tests/Behat/features-v2/report-checklist/checklist-synchronisation.feature
@@ -1,0 +1,28 @@
+@report-checklist @checklist-sync @v2_sequential @v2
+Feature: Synchronising Checklists with Sirius
+
+    @super-admin @lay-health-welfare-submitted
+    Scenario: Completing a report checklist sets the status of the checklist to queued and running the sync command syncs the checklist
+        Given a Lay Deputy has submitted a health and welfare report
+        And a super admin user accesses the admin app
+        When I visit the admin client details page associated with the deputy I'm interacting with
+        And I navigate to the clients report checklist page
+        And I submit the checklist with the form filled in
+        When I visit the checklist page for the previously submitted report for the user I am interacting with
+        Then the checklist status should be 'queued'
+        When I run the checklist-sync command
+        And I visit the checklist page for the previously submitted report for the user I am interacting with
+        Then the checklist status should be 'synced'
+
+    @super-admin @lay-health-welfare-submitted @acs
+    Scenario: Reports associated with a discharged deputy (deleted client) successfully syncs with Sirius
+        Given a Lay Deputy has submitted a health and welfare report
+        And the deputy I am interacting with has been discharged
+        And a super admin user accesses the admin app
+        When I visit the admin client details page associated with the deputy I'm interacting with
+        And I navigate to the clients report checklist page
+        And I submit the checklist with the form filled in
+        And I visit the checklist page for the previously submitted report for the user I am interacting with
+        And I run the checklist-sync command
+        And I visit the checklist page for the previously submitted report for the user I am interacting with
+        Then the checklist status should be 'synced'

--- a/client/src/Controller/Admin/BehatController.php
+++ b/client/src/Controller/Admin/BehatController.php
@@ -6,6 +6,7 @@ namespace App\Controller\Admin;
 
 use App\Controller\AbstractController;
 use App\Service\Client\RestClient;
+use Exception;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
@@ -27,13 +28,13 @@ class BehatController extends AbstractController
     }
 
     /**
-     * @Route("/admin/behat/run-document-sync-command", name="behat_admin_run_sync_command", methods={"GET"})
+     * @Route("/admin/behat/run-document-sync-command", name="behat_admin_run_document_sync_command", methods={"GET"})
      *
      * @param KernelInterface $kernel
      *
      * @return Response
      *
-     * @throws \Exception
+     * @throws Exception
      */
     public function runDocumentSyncCommand()
     {
@@ -45,6 +46,32 @@ class BehatController extends AbstractController
         $application->setAutoExit(false);
 
         $input = new ArrayInput(['command' => 'digideps:document-sync']);
+        $output = new NullOutput();
+
+        $application->run($input, $output);
+
+        return new Response('');
+    }
+
+    /**
+     * @Route("/admin/behat/run-checklist-sync-command", name="behat_admin_run_checklist_sync_command", methods={"GET"})
+     *
+     * @param KernelInterface $kernel
+     *
+     * @return Response
+     *
+     * @throws Exception
+     */
+    public function runChecklistSyncCommand()
+    {
+        if ('prod' === $this->symfonyEnvironment) {
+            throw $this->createNotFoundException();
+        }
+
+        $application = new Application($this->kernel);
+        $application->setAutoExit(false);
+
+        $input = new ArrayInput(['command' => 'digideps:checklist-sync']);
         $output = new NullOutput();
 
         $application->run($input, $output);

--- a/client/templates/Admin/Client/Report/checklist.html.twig
+++ b/client/templates/Admin/Client/Report/checklist.html.twig
@@ -171,13 +171,13 @@
         </div>
         {% if checklist.submittedOn and checklist.finalDecision == 'for-review' %}
             <div class="govuk-grid-column-one-third opg-sticky-menu">
-                {% include '@App/Admin/Client/Report/sidebar/_statuses.html.twig' with {checklistDomain: 'lodging'} %}
+                {% include '@App/Admin/Client/Report/sidebar/_statuses.html.twig' with {checklistDomain: 'lodging', syncStatus: syncStatus} %}
                 {% include '@App/Admin/Client/Report/sidebar/_fullReview.html.twig' %}
                 {% include '@App/Admin/Client/Report/sidebar/_backToTopLinks.html.twig' with {checklistDomain: 'lodging'} %}
             </div>
         {% else %}
             <div class="govuk-grid-column-one-third opg-sticky-menu">
-                {% include '@App/Admin/Client/Report/sidebar/_statuses.html.twig' with {checklistDomain: 'lodging'} %}
+                {% include '@App/Admin/Client/Report/sidebar/_statuses.html.twig' with {checklistDomain: 'lodging', syncStatus: syncStatus} %}
                 {% include '@App/Admin/Client/Report/sidebar/_lodging.html.twig' %}
                 {% include '@App/Admin/Client/Report/sidebar/_backToTopLinks.html.twig' with {checklistDomain: 'lodging'} %}
             </div>

--- a/client/templates/Admin/Client/Report/sidebar/_statuses.html.twig
+++ b/client/templates/Admin/Client/Report/sidebar/_statuses.html.twig
@@ -21,6 +21,10 @@
         <br>
         {{ checklist.submittedBy.fullName}}, {{ checklist.submittedBy.roleFullName }}
     </p>
-{% endif %}
 
-{#<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">#}
+    {% if (syncStatus) %}
+        <p class="govuk-body-s">
+            {{ 'synchronisedStatus' | trans({}, 'common') }}: {{ syncStatus }}
+        </p>
+    {% endif %}
+{% endif %}

--- a/client/translations/common.en.yml
+++ b/client/translations/common.en.yml
@@ -85,6 +85,7 @@ savedBy: Saved by
 date: Date
 lastSaved: Last saved
 lastSubmitted: Last submitted
+synchronisedStatus: Synchronised status
 dischargedOn: Discharged on
 archivedOn: Archived on
 namedDeputy: Named deputy
@@ -111,8 +112,8 @@ notSavedYet: Not saved yet
 changesNeeded: Changes needed
 
 # Breadcrumbs
-yourReports: 'Your reports - deputyFirstname deputyLastname'
-deputyReportOverview: 'startYear to endYear report overview'
+yourReports: "Your reports - deputyFirstname deputyLastname"
+deputyReportOverview: "startYear to endYear report overview"
 newDeputyReportOverview: New deputy report overview
 reviewReport: Review report
 dashboard: Dashboard


### PR DESCRIPTION
## Purpose
Following some reports from case managers on checklists failing to sync we investigated and noticed that checklists linked to a report belonging to a discharged deputy (e.g. client soft deleted) were throwing errors during the sync process. This change allows checklists with discharged deputies to be synced, adds a sync status to the checklist and covers the feature in behat tests.

Fixes DDPB-4288.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes
