### PR TITLE
DDPB-4296: Drop enabling softdeleteable filter in loop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1150,7 +1150,7 @@ jobs:
 
   cross-browser-test:
     machine:
-      image: ubuntu-2004:202111-02
+      image: ubuntu-2004:202201-02
     steps:
       - dockerhub_helper/dockerhub_login
       - aws-cli/install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,6 @@ workflows:
             ]
           filters: { branches: { ignore: [main] } }
           task_name: integration_test_v2
-          tf_workspace: integration
           override: "sh,./tests/Behat/run-tests.sh,--tags,@v2_sequential,--profile,v2-tests-goutte"
           timeout: 1200
 

--- a/api/src/Controller/Report/ReportController.php
+++ b/api/src/Controller/Report/ReportController.php
@@ -931,7 +931,6 @@ class ReportController extends RestController
             $filter->disableForEntity(Client::class);
 
             $reports[] = $this->findEntityBy(Report::class, $reportId);
-            $filter->enableForEntity(Client::class);
         }
 
         $this->formatter->setJmsSerialiserGroups($this->checklistGroups);

--- a/api/tests/Behat/bootstrap/v2/Reporting/Admin/ReportingChecklistTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Reporting/Admin/ReportingChecklistTrait.php
@@ -235,7 +235,5 @@ trait ReportingChecklistTrait
         if ($this->getSession()->getStatusCode() > 299) {
             throw new BehatException('There was an non successful response when running the checklist-sync command');
         }
-
-        sleep(2);
     }
 }

--- a/client/src/Command/ChecklistSyncCommand.php
+++ b/client/src/Command/ChecklistSyncCommand.php
@@ -21,6 +21,7 @@ class ChecklistSyncCommand extends Command
 {
     /** @var string */
     const FALLBACK_ROW_LIMITS = '30';
+    const COMPLETED_MESSAGE = 'Sync command completed';
 
     /** @var string */
     public static $defaultName = 'digideps:checklist-sync';
@@ -96,6 +97,8 @@ class ChecklistSyncCommand extends Command
             $output->writeln(sprintf('%d checklists failed to sync', $this->notSyncedCount));
             $this->notSyncedCount = 0;
         }
+
+        $output->writeln(self::COMPLETED_MESSAGE);
 
         return 0;
     }

--- a/client/src/Command/ChecklistSyncCommand.php
+++ b/client/src/Command/ChecklistSyncCommand.php
@@ -6,7 +6,6 @@ namespace App\Command;
 
 use App\Service\ChecklistSyncService;
 use App\Service\Client\Internal\ReportApi;
-use App\Service\Client\RestClient;
 use App\Service\ParameterStoreService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -26,7 +25,6 @@ class ChecklistSyncCommand extends Command
      */
     public function __construct(
         private ChecklistSyncService $syncService,
-        private RestClient $restClient,
         private ParameterStoreService $parameterStore,
         private ReportApi $reportApi,
         $name = null

--- a/client/src/Command/ChecklistSyncCommand.php
+++ b/client/src/Command/ChecklistSyncCommand.php
@@ -4,13 +4,8 @@ declare(strict_types=1);
 
 namespace App\Command;
 
-use App\Entity\Report\Checklist;
-use App\Entity\Report\Report;
-use App\Exception\PdfGenerationFailedException;
-use App\Exception\SiriusDocumentSyncFailedException;
-use App\Model\Sirius\QueuedChecklistData;
-use App\Service\ChecklistPdfGenerator;
 use App\Service\ChecklistSyncService;
+use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\Service\ParameterStoreService;
 use Symfony\Component\Console\Command\Command;
@@ -26,36 +21,16 @@ class ChecklistSyncCommand extends Command
     /** @var string */
     public static $defaultName = 'digideps:checklist-sync';
 
-    /** @var ChecklistPdfGenerator */
-    private $pdfGenerator;
-
-    /** @var ChecklistSyncService */
-    private $syncService;
-
-    /** @var RestClient */
-    private $restClient;
-
-    /** @var ParameterStoreService */
-    private $parameterStore;
-
-    /** @var int */
-    private $notSyncedCount = 0;
-
     /**
      * @param null $name
      */
     public function __construct(
-        ChecklistPdfGenerator $pdfGenerator,
-        ChecklistSyncService $syncService,
-        RestClient $restClient,
-        ParameterStoreService $parameterStore,
+        private ChecklistSyncService $syncService,
+        private RestClient $restClient,
+        private ParameterStoreService $parameterStore,
+        private ReportApi $reportApi,
         $name = null
     ) {
-        $this->pdfGenerator = $pdfGenerator;
-        $this->syncService = $syncService;
-        $this->restClient = $restClient;
-        $this->parameterStore = $parameterStore;
-
         parent::__construct($name);
     }
 
@@ -69,33 +44,16 @@ class ChecklistSyncCommand extends Command
             return 0;
         }
 
+        $rowLimit = $this->getSyncRowLimit();
+
         /** @var array $reports */
-        $reports = $this->getReportsWithQueuedChecklists();
+        $reports = $this->reportApi->getReportsWithQueuedChecklists($rowLimit);
         $output->writeln(sprintf('%d checklists to upload', count($reports)));
 
-        /** @var Report $report */
-        foreach ($reports as $report) {
-            try {
-                $content = $this->pdfGenerator->generate($report);
-            } catch (PdfGenerationFailedException $e) {
-                $this->updateChecklistWithError($report, $e);
-                ++$this->notSyncedCount;
-                continue;
-            }
+        $notSyncedCount = $this->syncService->processChecklistsInCommand($reports);
 
-            try {
-                $queuedChecklistData = $this->buildChecklistData($report, $content);
-                $uuid = $this->syncService->sync($queuedChecklistData);
-                $this->updateChecklistWithSuccess($report, $uuid);
-            } catch (SiriusDocumentSyncFailedException $e) {
-                $this->updateChecklistWithError($report, $e);
-                ++$this->notSyncedCount;
-            }
-        }
-
-        if ($this->notSyncedCount > 0) {
-            $output->writeln(sprintf('%d checklists failed to sync', $this->notSyncedCount));
-            $this->notSyncedCount = 0;
+        if ($notSyncedCount > 0) {
+            $output->writeln(sprintf('%d checklists failed to sync', $notSyncedCount));
         }
 
         $output->writeln(self::COMPLETED_MESSAGE);
@@ -109,45 +67,6 @@ class ChecklistSyncCommand extends Command
     }
 
     /**
-     * @return QueuedChecklistData[]
-     */
-    private function getReportsWithQueuedChecklists(): array
-    {
-        return $this->restClient->apiCall(
-            'get',
-            'report/all-with-queued-checklists',
-            ['row_limit' => $this->getSyncRowLimit()],
-            'Report\Report[]',
-            [],
-            false
-        );
-    }
-
-    private function getSyncRowLimit(): string
-    {
-        $limit = $this->parameterStore->getParameter(ParameterStoreService::PARAMETER_CHECKLIST_SYNC_ROW_LIMIT);
-
-        return $limit ? $limit : self::FALLBACK_ROW_LIMITS;
-    }
-
-    /**
-     * @param $content
-     */
-    protected function buildChecklistData(Report $report, $content): QueuedChecklistData
-    {
-        return (new QueuedChecklistData())
-            ->setChecklistId($report->getChecklist()->getId())
-            ->setChecklistUuid($report->getChecklist()->getUuid())
-            ->setCaseNumber($report->getClient()->getCaseNumber())
-            ->setChecklistFileContents($content)
-            ->setReportStartDate($report->getStartDate())
-            ->setReportEndDate($report->getEndDate())
-            ->setReportSubmissions($report->getReportSubmissions())
-            ->setSubmitterEmail($report->getChecklist()->getSubmittedBy()->getEmail())
-            ->setReportType($report->determineReportType());
-    }
-
-    /**
      * {@inheritDoc}
      */
     protected function configure(): void
@@ -155,42 +74,10 @@ class ChecklistSyncCommand extends Command
         $this->setDescription('Uploads queued checklists to Sirius and reports back the success');
     }
 
-    /**
-     * @param $e
-     */
-    protected function updateChecklistWithError(Report $report, $e): void
+    private function getSyncRowLimit(): string
     {
-        $this->updateChecklist($report->getChecklist()->getId(), Checklist::SYNC_STATUS_PERMANENT_ERROR, $e->getMessage());
-    }
+        $limit = $this->parameterStore->getParameter(ParameterStoreService::PARAMETER_CHECKLIST_SYNC_ROW_LIMIT);
 
-    /**
-     * @param $uuid
-     */
-    protected function updateChecklistWithSuccess(Report $report, $uuid): void
-    {
-        $this->updateChecklist($report->getChecklist()->getId(), Checklist::SYNC_STATUS_SUCCESS, null, $uuid);
-    }
-
-    private function updateChecklist(int $id, string $status, string $message = null, string $uuid = null): void
-    {
-        $data = ['syncStatus' => $status];
-
-        if (null !== $message) {
-            $errorMessage = json_decode($message, true) ? json_decode($message, true) : $message;
-            $data['syncError'] = $errorMessage;
-        }
-
-        if (null !== $uuid) {
-            $data['uuid'] = $uuid;
-        }
-
-        $this->restClient->apiCall(
-            'put',
-            sprintf('checklist/%s', $id),
-            json_encode($data),
-            'raw',
-            [],
-            false
-        );
+        return $limit ?: self::FALLBACK_ROW_LIMITS;
     }
 }

--- a/client/src/Command/ChecklistSyncCommand.php
+++ b/client/src/Command/ChecklistSyncCommand.php
@@ -48,7 +48,7 @@ class ChecklistSyncCommand extends Command
         $reports = $this->reportApi->getReportsWithQueuedChecklists($rowLimit);
         $output->writeln(sprintf('%d checklists to upload', count($reports)));
 
-        $notSyncedCount = $this->syncService->processChecklistsInCommand($reports);
+        $notSyncedCount = $this->syncService->syncChecklistsByReports($reports);
 
         if ($notSyncedCount > 0) {
             $output->writeln(sprintf('%d checklists failed to sync', $notSyncedCount));

--- a/client/src/Command/DocumentSyncCommand.php
+++ b/client/src/Command/DocumentSyncCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 class DocumentSyncCommand extends DaemonableCommand
 {
     const FALLBACK_ROW_LIMITS = '100';
+    const COMPLETED_MESSAGE = 'Sync command completed';
 
     public static $defaultName = 'digideps:document-sync';
 
@@ -79,6 +80,8 @@ class DocumentSyncCommand extends DaemonableCommand
             $output->writeln(sprintf('%d documents failed to sync', $this->documentSyncService->getDocsNotSyncedCount()));
             $this->documentSyncService->setDocsNotSyncedCount(0);
         }
+
+        $output->writeln(self::COMPLETED_MESSAGE);
 
         return 0;
     }

--- a/client/src/Service/ChecklistSyncService.php
+++ b/client/src/Service/ChecklistSyncService.php
@@ -175,7 +175,7 @@ class ChecklistSyncService
             isset($e->getResponse()->getBody()['errors']);
     }
 
-    public function processChecklistsInCommand(array $reports): int
+    public function syncChecklistsByReports(array $reports): int
     {
         $notSyncedCount = 0;
 

--- a/client/src/Service/Client/Internal/ReportApi.php
+++ b/client/src/Service/Client/Internal/ReportApi.php
@@ -15,6 +15,7 @@ use App\Exception\DisplayableException;
 use App\Exception\ReportSubmittedException;
 use App\Exception\RestClientException;
 use App\Service\Client\RestClient;
+use DateTime;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ReportApi
@@ -23,6 +24,7 @@ class ReportApi
     private const REPORT_SUBMIT_ENDPOINT = 'report/%s/submit';
     private const REPORT_UNSUBMIT_ENDPOINT = 'report/%s/unsubmit';
     private const REPORT_REFRESH_CACHE_ENDPOINT = 'report/%s/refresh-cache';
+    private const REPORT_GET_ALL_WITH_QUEUED_CHECKLISTS_ENDPOINT = 'report/all-with-queued-checklists';
 
     private const NDR_ENDPOINT_BY_ID = 'ndr/%s';
 
@@ -152,7 +154,7 @@ class ReportApi
 
     public function unsubmit(Report $report, User $user, string $trigger): void
     {
-        $report->setUnSubmitDate(new \DateTime());
+        $report->setUnSubmitDate(new DateTime());
         $uri = sprintf(self::REPORT_UNSUBMIT_ENDPOINT, $report->getId());
 
         $this->restClient->put($uri, $report, [
@@ -180,6 +182,21 @@ class ReportApi
             $jmsGroups,
             'Report\\Report',
             ['query' => ['groups' => $jmsGroups]]
+        );
+    }
+
+    /**
+     * @return Report[]
+     */
+    public function getReportsWithQueuedChecklists(string $rowLimit): array
+    {
+        return $this->restClient->apiCall(
+            'get',
+            self::REPORT_GET_ALL_WITH_QUEUED_CHECKLISTS_ENDPOINT,
+            ['row_limit' => $rowLimit],
+            'Report\Report[]',
+            [],
+            false
         );
     }
 }

--- a/client/src/TestHelpers/ChecklistTestHelper.php
+++ b/client/src/TestHelpers/ChecklistTestHelper.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TestHelpers;
+
+use App\Entity\Client;
+use App\Entity\Report\Checklist;
+use App\Entity\Report\Report;
+use App\Entity\User;
+use DateTime;
+
+class ChecklistTestHelper
+{
+    public static function buildPfaHighReport(int $id, string $email, string $caseNumber): Report
+    {
+        $user = (new User())->setEmail($email);
+
+        $report = (new Report())
+            ->setStartDate(new DateTime('2020-02-01'))
+            ->setEndDate(new DateTime('2021-02-01'))
+            ->setReportSubmissions([])
+            ->setType(Report::TYPE_PROPERTY_AND_AFFAIRS_HIGH_ASSETS);
+
+        $checklist = (new Checklist($report))->setSubmittedBy($user);
+        $checklist->setId($id);
+
+        $report->setChecklist($checklist);
+
+        $client = new Client();
+        $client->setCaseNumber($caseNumber);
+
+        $report->setClient($client);
+
+        return $report;
+    }
+}

--- a/client/tests/phpunit/Command/ChecklistSyncCommandTest.php
+++ b/client/tests/phpunit/Command/ChecklistSyncCommandTest.php
@@ -3,24 +3,15 @@
 namespace App\Tests\Command;
 
 use App\Command\ChecklistSyncCommand;
-use App\Entity\Client;
-use App\Entity\Report\Checklist;
-use App\Entity\Report\Report;
-use App\Entity\User;
-use App\Exception\PdfGenerationFailedException;
-use App\Exception\SiriusDocumentSyncFailedException;
-use App\Model\Sirius\QueuedChecklistData;
-use App\Service\ChecklistPdfGenerator;
 use App\Service\ChecklistSyncService;
-use App\Service\Client\RestClient;
+use App\Service\Client\Internal\ReportApi;
 use App\Service\ParameterStoreService;
-use DateTime;
+use App\TestHelpers\ChecklistTestHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
-use Throwable;
 
 class ChecklistSyncCommandTest extends KernelTestCase
 {
@@ -29,11 +20,13 @@ class ChecklistSyncCommandTest extends KernelTestCase
     /** @var MockObject */
     private $syncService;
     private $parameterStore;
-    private $restClient;
+    private $reportApi;
     private $pdfGenerator;
 
     /** @var CommandTester */
     private $commandTester;
+
+    private ?string $output = null;
 
     public function setUp(): void
     {
@@ -42,10 +35,9 @@ class ChecklistSyncCommandTest extends KernelTestCase
 
         $this->syncService = $this->createMock(ChecklistSyncService::class);
         $this->parameterStore = $this->getMockBuilder(ParameterStoreService::class)->disableOriginalConstructor()->getMock();
-        $this->restClient = $this->getMockBuilder(RestClient::class)->disableOriginalConstructor()->getMock();
-        $this->pdfGenerator = $this->getMockBuilder(ChecklistPdfGenerator::class)->disableOriginalConstructor()->getMock();
+        $this->reportApi = $this->getMockBuilder(ReportApi::class)->disableOriginalConstructor()->getMock();
 
-        $app->add(new ChecklistSyncCommand($this->pdfGenerator, $this->syncService, $this->restClient, $this->parameterStore));
+        $app->add(new ChecklistSyncCommand($this->syncService, $this->parameterStore, $this->reportApi));
 
         $command = $app->find(ChecklistSyncCommand::$defaultName);
         $this->commandTester = new CommandTester($command);
@@ -62,16 +54,39 @@ class ChecklistSyncCommandTest extends KernelTestCase
             ->invokeTest();
     }
 
-    private function invokeTest(): void
+    private function invokeTest(): self
     {
         $this->commandTester->execute([]);
+
+        $this->output = $this->commandTester->getDisplay();
+
+        return $this;
+    }
+
+    /**
+     * @test
+     */
+    public function outputContainsExpectedText()
+    {
+        $this
+            ->ensureFeatureIsEnabled()
+            ->ensureThereAreNChecklistsToSync(3)
+            ->ensureNChecklistsFailedToSync(2)
+            ->invokeTest()
+            ->assertCommandOutputContains('3 checklists to upload')
+            ->assertCommandOutputContains('2 checklists failed to sync')
+            ->assertCommandOutputContains('Sync command completed');
     }
 
     private function assertSyncServiceIsNotInvoked(): ChecklistSyncCommandTest
     {
+        $this->reportApi
+            ->expects($this->never())
+            ->method('getReportsWithQueuedChecklists');
+
         $this->syncService
             ->expects($this->never())
-            ->method('sync');
+            ->method('syncChecklistsByReports');
 
         return $this;
     }
@@ -85,84 +100,29 @@ class ChecklistSyncCommandTest extends KernelTestCase
         return $this;
     }
 
-    /**
-     * @test
-     */
-    public function updatesSyncStatusOnFailedPdfGenerations()
+    private function ensureThereAreNChecklistsToSync(int $numberOfChecklists): self
     {
-        $apiCallArguments = [
-            [
-                'get',
-                'report/all-with-queued-checklists',
-                ['row_limit' => '30'],
-                'Report\Report[]',
-                [],
-                false,
-            ],
-            [
-                'put',
-                'checklist/3923',
-                json_encode([
-                    'syncStatus' => Checklist::SYNC_STATUS_PERMANENT_ERROR,
-                    'syncError' => 'Failed to generate PDF',
-                ]),
-                'raw',
-                [],
-                false,
-            ],
-        ];
+        $reports = [];
 
-        $returnValues = [
-            [$this->buildReport(3923)],
-            [],
-        ];
+        foreach (range(1, $numberOfChecklists) as $index) {
+            $reports[] = ChecklistTestHelper::buildPfaHighReport($index, 'test@test.com', 'case-number');
+        }
 
-        $this
-            ->ensureFeatureIsEnabled()
-            ->assertApiCallsAreMade($apiCallArguments, $returnValues)
-            ->ensurePdfGenerationWillFailWith(new PdfGenerationFailedException('Failed to generate PDF'))
-            ->invokeTest();
-    }
-
-    private function buildReport(int $id)
-    {
-        $user = (new User())->setEmail('test@test.com');
-
-        $report = (new Report())
-            ->setStartDate(new DateTime())
-            ->setEndDate(new DateTime())
-            ->setReportSubmissions([])
-            ->setType(Report::TYPE_PROPERTY_AND_AFFAIRS_HIGH_ASSETS);
-
-        $checklist = (new Checklist($report))->setSubmittedBy($user);
-        $checklist->setId($id);
-
-        $report->setChecklist($checklist);
-
-        $client = new Client();
-        $client->setCaseNumber('case-number');
-
-        $report->setClient($client);
-
-        return $report;
-    }
-
-    private function ensurePdfGenerationWillFailWith(Throwable $e): ChecklistSyncCommandTest
-    {
-        $this->pdfGenerator
-            ->method('generate')
-            ->willThrowException($e);
+        $this->reportApi->method('getReportsWithQueuedChecklists')->willReturn($reports);
 
         return $this;
     }
 
-    private function assertApiCallsAreMade(array $argumentArrays, array $returnValueArrays): ChecklistSyncCommandTest
+    private function ensureNChecklistsFailedToSync(int $numberOfChecklists): self
     {
-        $this->restClient
-            ->expects($this->exactly(count($argumentArrays)))
-            ->method('apiCall')
-            ->withConsecutive(...$argumentArrays)
-            ->willReturnOnConsecutiveCalls(...$returnValueArrays);
+        $this->syncService->method('syncChecklistsByReports')->willReturn($numberOfChecklists);
+
+        return $this;
+    }
+
+    private function assertCommandOutputContains(string $outputContent): self
+    {
+        self::assertStringContainsString($outputContent, $this->output);
 
         return $this;
     }
@@ -172,295 +132,6 @@ class ChecklistSyncCommandTest extends KernelTestCase
         $this->parameterStore
             ->method('getFeatureFlag')
             ->willReturn('1');
-
-        return $this;
-    }
-
-    /**
-     * @test
-     */
-    public function doesNotAttemptToSyncFailedPdfGenerations()
-    {
-        $apiCallArguments = [
-            [
-                'get',
-                'report/all-with-queued-checklists',
-                ['row_limit' => '30'],
-                'Report\Report[]',
-                [],
-                false,
-            ],
-            [
-                'put',
-                'checklist/3923',
-                json_encode([
-                    'syncStatus' => Checklist::SYNC_STATUS_PERMANENT_ERROR,
-                    'syncError' => 'Failed to generate PDF',
-                ]),
-                'raw',
-                [],
-                false,
-            ],
-        ];
-
-        $returnValues = [
-            [$this->buildReport(3923)],
-            [],
-        ];
-
-        $this
-            ->ensureFeatureIsEnabled()
-            ->assertApiCallsAreMade($apiCallArguments, $returnValues)
-            ->ensurePdfGenerationWillFailWith(new PdfGenerationFailedException('Failed to generate PDF'))
-            ->assertSyncServiceIsNotInvoked()
-            ->invokeTest();
-    }
-
-    /**
-     * @test
-     */
-    public function fetchesAndSendsQueuedChecklistsToSyncService()
-    {
-        $apiCallArguments = [
-            [
-                'get',
-                'report/all-with-queued-checklists',
-                ['row_limit' => '30'],
-                'Report\Report[]',
-                [],
-                false,
-            ],
-            [
-                'put',
-                'checklist/3923',
-                json_encode([
-                    'syncStatus' => Checklist::SYNC_STATUS_SUCCESS,
-                    'uuid' => 'uuid-1',
-                ]),
-                'raw',
-                [],
-                false,
-            ],
-            [
-                'put',
-                'checklist/3924',
-                json_encode([
-                    'syncStatus' => Checklist::SYNC_STATUS_SUCCESS,
-                    'uuid' => 'uuid-2',
-                ]),
-                'raw',
-                [],
-                false,
-            ],
-        ];
-
-        $returnValues = [
-            [
-                $this->buildReport(3923),
-                $this->buildReport(3924),
-            ],
-            [],
-        ];
-
-        $this
-            ->ensureFeatureIsEnabled()
-            ->assertApiCallsAreMade($apiCallArguments, $returnValues)
-            ->ensurePdfGenerationWillSucceed()
-            ->assertEachRowWillBeTransformedAndSentToSyncService()
-            ->invokeTest();
-    }
-
-    private function assertEachRowWillBeTransformedAndSentToSyncService(): ChecklistSyncCommandTest
-    {
-        $this->syncService
-            ->expects($this->exactly(2))
-            ->method('sync')
-            ->withConsecutive(
-                [$this->isInstanceOf(QueuedChecklistData::class)],
-                [$this->isInstanceOf(QueuedChecklistData::class)]
-            )
-            ->willReturnOnConsecutiveCalls('uuid-1', 'uuid-2');
-
-        return $this;
-    }
-
-    private function ensurePdfGenerationWillSucceed(): ChecklistSyncCommandTest
-    {
-        $this->pdfGenerator
-            ->method('generate')
-            ->willReturn('file-contents');
-
-        return $this;
-    }
-
-    /**
-     * @test
-     */
-    public function fetchesAConfigurableLimitOfChecklists()
-    {
-        $rowLimit = '45';
-
-        $apiCallArguments = [
-            [
-                'get',
-                'report/all-with-queued-checklists',
-                ['row_limit' => $rowLimit],
-                'Report\Report[]',
-                [],
-                false,
-            ],
-        ];
-
-        $returnValues = [
-            [],
-            [],
-        ];
-
-        $this
-            ->ensureFeatureIsEnabled()
-            ->ensureConfigurableRowLimitIsSetTo($rowLimit)
-            ->assertApiCallsAreMade($apiCallArguments, $returnValues)
-            ->ensurePdfGenerationWillSucceed()
-            ->invokeTest();
-    }
-
-    private function ensureConfigurableRowLimitIsSetTo(string $limit): ChecklistSyncCommandTest
-    {
-        $this->parameterStore
-            ->method('getParameter')
-            ->with(ParameterStoreService::PARAMETER_CHECKLIST_SYNC_ROW_LIMIT)
-            ->willReturn($limit);
-
-        return $this;
-    }
-
-    /**
-     * @test
-     */
-    public function fetchesDefaultLimitOfChecklistsOfConfigurableValueNotSet()
-    {
-        $apiCallArguments = [
-            [
-                'get',
-                'report/all-with-queued-checklists',
-                ['row_limit' => ChecklistSyncCommand::FALLBACK_ROW_LIMITS],
-                'Report\Report[]',
-                [],
-                false,
-            ],
-            [
-                'put',
-                'checklist/3923',
-                json_encode([
-                    'syncStatus' => Checklist::SYNC_STATUS_SUCCESS,
-                    'uuid' => 'uuid-1',
-                ]),
-                'raw',
-                [],
-                false,
-            ],
-            [
-                'put',
-                'checklist/3924',
-                json_encode([
-                    'syncStatus' => Checklist::SYNC_STATUS_SUCCESS,
-                    'uuid' => 'uuid-2',
-                ]),
-                'raw',
-                [],
-                false,
-            ],
-        ];
-
-        $returnValues = [
-            [$this->buildReport(3923), $this->buildReport(3924)],
-            [],
-        ];
-
-        $this
-            ->ensureFeatureIsEnabled()
-            ->ensureConfigurableRowLimitIsNotSet()
-            ->ensurePdfGenerationWillSucceed()
-            ->assertApiCallsAreMade($apiCallArguments, $returnValues)
-            ->assertEachRowWillBeTransformedAndSentToSyncService()
-            ->invokeTest();
-    }
-
-    private function ensureConfigurableRowLimitIsNotSet(): ChecklistSyncCommandTest
-    {
-        $this->parameterStore
-            ->method('getParameter')
-            ->with(ParameterStoreService::PARAMETER_CHECKLIST_SYNC_ROW_LIMIT)
-            ->willReturn(null);
-
-        return $this;
-    }
-
-    /**
-     * @test
-     */
-    public function updatesSyncStatusOnFailedDocumentSyncs()
-    {
-        $apiCallArguments = [
-            [
-                'get',
-                'report/all-with-queued-checklists',
-                ['row_limit' => ChecklistSyncCommand::FALLBACK_ROW_LIMITS],
-                'Report\Report[]',
-                [],
-                false,
-            ],
-            [
-                'put',
-                'checklist/3923',
-                json_encode([
-                    'syncStatus' => Checklist::SYNC_STATUS_PERMANENT_ERROR,
-                    'syncError' => 'Failed to sync document',
-                ]),
-                'raw',
-                [],
-                false,
-            ],
-            [
-                'put',
-                'checklist/3924',
-                json_encode([
-                    'syncStatus' => Checklist::SYNC_STATUS_PERMANENT_ERROR,
-                    'syncError' => 'Failed to sync document',
-                ]),
-                'raw',
-                [],
-                false,
-            ],
-        ];
-
-        $returnValues = [
-            [
-                $this->buildReport(3923),
-                $this->buildReport(3924),
-            ],
-            [],
-        ];
-
-        $this
-            ->ensureFeatureIsEnabled()
-            ->ensureConfigurableRowLimitIsNotSet()
-            ->ensurePdfGenerationWillSucceed()
-            ->assertApiCallsAreMade($apiCallArguments, $returnValues)
-            ->ensureSyncWillFailWith(new SiriusDocumentSyncFailedException('Failed to sync document'))
-            ->invokeTest();
-    }
-
-    private function ensureSyncWillFailWith(Throwable $e): ChecklistSyncCommandTest
-    {
-        $this->syncService
-            ->expects($this->exactly(2))
-            ->method('sync')
-            ->withConsecutive(
-                [$this->isInstanceOf(QueuedChecklistData::class)],
-                [$this->isInstanceOf(QueuedChecklistData::class)]
-            )
-            ->willThrowException($e);
 
         return $this;
     }

--- a/client/tests/phpunit/Service/ChecklistSyncServiceTest.php
+++ b/client/tests/phpunit/Service/ChecklistSyncServiceTest.php
@@ -1,11 +1,11 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Service;
 
-use App\Entity\Report\Checklist;
 use App\Entity\Report\ReportSubmission;
 use App\Entity\User;
-use App\Exception\PdfGenerationFailedException;
 use App\Exception\SiriusDocumentSyncFailedException;
 use App\Model\Sirius\QueuedChecklistData;
 use App\Model\Sirius\SiriusChecklistPdfDocumentMetadata;
@@ -13,12 +13,17 @@ use App\Model\Sirius\SiriusDocumentFile;
 use App\Model\Sirius\SiriusDocumentUpload;
 use App\Service\Client\RestClient;
 use App\Service\Client\Sirius\SiriusApiGatewayClient;
+use App\TestHelpers\ChecklistTestHelper;
+use DateTime;
+use Exception;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject;
 
 class ChecklistSyncServiceTest extends TestCase
 {
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    /** @var PHPUnit_Framework_MockObject_MockObject */
     private $restClient;
     private $siriusApiGatewayClient;
     private $errorTranslator;
@@ -29,16 +34,23 @@ class ChecklistSyncServiceTest extends TestCase
     /** @var QueuedChecklistData */
     private $dataInput;
 
+    /** @var QueuedChecklistData[] */
+    private $dataInputs;
+
     /** @var string */
     private $returnValue;
+
+    /** @var ChecklistPdfGenerator|mixed|MockObject */
+    private mixed $pdfGenerator;
 
     public function setUp(): void
     {
         $this->restClient = $this->getMockBuilder(RestClient::class)->disableOriginalConstructor()->getMock();
         $this->siriusApiGatewayClient = $this->getMockBuilder(SiriusApiGatewayClient::class)->disableOriginalConstructor()->getMock();
         $this->errorTranslator = $this->getMockBuilder(SiriusApiErrorTranslator::class)->disableOriginalConstructor()->getMock();
+        $this->pdfGenerator = $this->getMockBuilder(ChecklistPdfGenerator::class)->disableOriginalConstructor()->getMock();
 
-        $this->sut = new ChecklistSyncService($this->restClient, $this->siriusApiGatewayClient, $this->errorTranslator);
+        $this->sut = new ChecklistSyncService($this->restClient, $this->siriusApiGatewayClient, $this->errorTranslator, $this->pdfGenerator);
     }
 
     /**
@@ -66,7 +78,7 @@ class ChecklistSyncServiceTest extends TestCase
     /**
      * @test
      */
-    public function postsActualReportUuidForReportsWithAsubmission()
+    public function postsActualReportUuidForReportsWithASubmission()
     {
         $this
             ->buildChecklistDataInput()->withChecklistUuid()->withReportSubmission()
@@ -77,7 +89,7 @@ class ChecklistSyncServiceTest extends TestCase
     /**
      * @test
      */
-    public function sendsDummyReportUuidForReportsWithoutAsubmission()
+    public function sendsDummyReportUuidForReportsWithoutASubmission()
     {
         $this
             ->buildChecklistDataInput()->withoutChecklistUuid()->withoutReportSubmission()
@@ -118,8 +130,8 @@ class ChecklistSyncServiceTest extends TestCase
             ->setCaseNumber('12395438')
             ->setChecklistId(231)
             ->setChecklistFileContents('file-contents')
-            ->setReportStartDate(new \DateTime('2020-02-01'))
-            ->setreportEndDate(new \DateTime('2021-02-01'))
+            ->setReportStartDate(new DateTime('2020-02-01'))
+            ->setreportEndDate(new DateTime('2021-02-01'))
             ->setReportType('PF')
             ->setSubmitterEmail('a@b.com');
 
@@ -129,12 +141,14 @@ class ChecklistSyncServiceTest extends TestCase
     private function withChecklistUuid(): ChecklistSyncServiceTest
     {
         $this->dataInput->setChecklistUuid('cl-uuid');
+
         return $this;
     }
 
     private function withoutChecklistUuid(): ChecklistSyncServiceTest
     {
         $this->dataInput->setChecklistUuid(null);
+
         return $this;
     }
 
@@ -146,12 +160,14 @@ class ChecklistSyncServiceTest extends TestCase
             ->setUuid('rs-uuid');
 
         $this->dataInput->setReportSubmissions([$submission]);
+
         return $this;
     }
 
     private function withoutReportSubmission(): ChecklistSyncServiceTest
     {
         $this->dataInput->setReportSubmissions(null);
+
         return $this;
     }
 
@@ -254,7 +270,7 @@ class ChecklistSyncServiceTest extends TestCase
             ->siriusApiGatewayClient
             ->expects($this->once())
             ->method('postChecklistPdf')
-            ->willThrowException(new \Exception('Failed to Sync document'));
+            ->willThrowException(new Exception('Failed to Sync document'));
 
         return $this;
     }
@@ -265,24 +281,23 @@ class ChecklistSyncServiceTest extends TestCase
             ->siriusApiGatewayClient
             ->expects($this->once())
             ->method('putChecklistPdf')
-            ->willThrowException(new \Exception('Failed to Sync document'));
+            ->willThrowException(new Exception('Failed to Sync document'));
 
         return $this;
     }
 
-    /**
-     * @return SiriusDocumentUpload
-     */
-    private function buildExpectedUploadObject(): SiriusDocumentUpload
+    private function buildExpectedUploadObject(?string $source = null): SiriusDocumentUpload
     {
+        $encodedSource = $source ? base64_encode($source) : base64_encode($this->dataInput->getChecklistFileContents());
+
         $file = (new SiriusDocumentFile())
             ->setName('checklist-12395438-2020-2021.pdf')
             ->setMimetype('application/pdf')
-            ->setSource(base64_encode($this->dataInput->getChecklistFileContents()));
+            ->setSource($encodedSource);
 
         $attributes = (new SiriusChecklistPdfDocumentMetadata())
-            ->setReportingPeriodFrom(new \DateTime('2020-02-01'))
-            ->setReportingPeriodTo(new \DateTime('2021-02-01'))
+            ->setReportingPeriodFrom(new DateTime('2020-02-01'))
+            ->setReportingPeriodTo(new DateTime('2021-02-01'))
             ->setSubmitterEmail('a@b.com')
             ->setType('PF')
             ->setYear(2021)
@@ -302,16 +317,60 @@ class ChecklistSyncServiceTest extends TestCase
     private function invokeTest(): ChecklistSyncServiceTest
     {
         $this->returnValue = $this->sut->sync($this->dataInput);
+
         return $this;
     }
 
-    /**
-     * @return Response
-     */
     private function getSuccessfulResponse(): Response
     {
         $successResponseBody = ['data' => ['id' => 'returned-checklist-uuid']];
         $successResponse = new Response('200', [], json_encode($successResponseBody));
+
         return $successResponse;
+    }
+
+    /**
+     * @test
+     */
+    public function syncChecklistsByReports()
+    {
+        $reports = [];
+
+        foreach (range(1, 2) as $index) {
+            $report = ChecklistTestHelper::buildPfaHighReport($index, 'a@b.com', '12395438');
+
+            $submission = (new ReportSubmission())
+                ->setId(1)
+                ->setCreatedBy((new User())->setEmail('a@b.com'))
+                ->setUuid('rs-uuid');
+            $report->setReportSubmissions([$submission]);
+
+            $reports[] = $report;
+        }
+
+        $this->pdfGenerator
+            ->expects($this->exactly(2))
+            ->method('generate')
+            ->willReturn('file-contents');
+
+        $this
+            ->siriusApiGatewayClient
+            ->expects($this->exactly(2))
+            ->method('postChecklistPdf')
+            ->withConsecutive(
+                [
+                    $this->isInstanceOf(SiriusDocumentUpload::class),
+                    'rs-uuid',
+                    '12395438',
+                ],
+                [
+                    $this->isInstanceOf(SiriusDocumentUpload::class),
+                    'rs-uuid',
+                    '12395438',
+                ],
+            )
+            ->willReturn($this->getSuccessfulResponse());
+
+        $this->sut->syncChecklistsByReports($reports);
     }
 }

--- a/client/tests/phpunit/Service/ChecklistSyncServiceTest.php
+++ b/client/tests/phpunit/Service/ChecklistSyncServiceTest.php
@@ -36,9 +36,6 @@ class ChecklistSyncServiceTest extends TestCase
     /** @var QueuedChecklistData */
     private $dataInput;
 
-    /** @var QueuedChecklistData[] */
-    private $dataInputs;
-
     /** @var string */
     private $returnValue;
 

--- a/environment/parameters.tf
+++ b/environment/parameters.tf
@@ -53,7 +53,7 @@ resource "aws_ssm_parameter" "checklist_sync_row_limit" {
 resource "aws_ssm_parameter" "flag_checklist_sync" {
   name  = "${local.feature_flag_prefix}checklist-sync"
   type  = "String"
-  value = "0"
+  value = "1"
 
   tags = local.default_tags
 


### PR DESCRIPTION
## Purpose
Turns out re-enabling the softdeleteable filter in a foreach loop stops records with a deleted client from being returned in time. I've dropped this line and tests are passing again (must have gamed the CI tests somehow).

Fixes DDPB-4296.
