### PR TITLE
DDPB-4299: Allow whoReceivedMoney to be null

### DIFF
--- a/api/src/Entity/Ndr/MoneyReceivedOnClientsBehalf.php
+++ b/api/src/Entity/Ndr/MoneyReceivedOnClientsBehalf.php
@@ -76,7 +76,7 @@ class MoneyReceivedOnClientsBehalf implements MoneyReceivedOnClientsBehalfInterf
      * @JMS\Groups({"client-benefits-check"})
      * @JMS\Type("string")
      */
-    private string $whoReceivedMoney;
+    private ?string $whoReceivedMoney;
 
     public function getClientBenefitsCheck(): ClientBenefitsCheck
     {
@@ -138,12 +138,12 @@ class MoneyReceivedOnClientsBehalf implements MoneyReceivedOnClientsBehalfInterf
         return $this;
     }
 
-    public function getWhoReceivedMoney(): string
+    public function getWhoReceivedMoney(): ?string
     {
         return $this->whoReceivedMoney;
     }
 
-    public function setWhoReceivedMoney(string $whoReceivedMoney): self
+    public function setWhoReceivedMoney(?string $whoReceivedMoney): self
     {
         $this->whoReceivedMoney = $whoReceivedMoney;
 

--- a/api/src/Entity/Report/MoneyReceivedOnClientsBehalf.php
+++ b/api/src/Entity/Report/MoneyReceivedOnClientsBehalf.php
@@ -76,7 +76,7 @@ class MoneyReceivedOnClientsBehalf implements MoneyReceivedOnClientsBehalfInterf
      * @JMS\Groups({"client-benefits-check"})
      * @JMS\Type("string")
      */
-    private string $whoReceivedMoney;
+    private ?string $whoReceivedMoney;
 
     public function getClientBenefitsCheck(): ClientBenefitsCheck
     {
@@ -138,12 +138,12 @@ class MoneyReceivedOnClientsBehalf implements MoneyReceivedOnClientsBehalfInterf
         return $this;
     }
 
-    public function getWhoReceivedMoney(): string
+    public function getWhoReceivedMoney(): ?string
     {
         return $this->whoReceivedMoney;
     }
 
-    public function setWhoReceivedMoney(string $whoReceivedMoney): MoneyReceivedOnClientsBehalf
+    public function setWhoReceivedMoney(?string $whoReceivedMoney): MoneyReceivedOnClientsBehalf
     {
         $this->whoReceivedMoney = $whoReceivedMoney;
 


### PR DESCRIPTION
## Purpose
An NDR user reported they were unable to submit their NDR and after some investigation, it was clear this was linked to the recent changes to the client benefits check section. This section was live for NDR Users in February but we added a field to the section in March which was nullable at DB level but not app level. This resulted in application errors being thrown when users logged in. 

Fixes DDPB-4299

## Approach
Allowing this value to be null fixes the issue.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
