### PR TITLE
Also scale admin in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -864,6 +864,7 @@ jobs:
           name: scale services
           command: |
             aws ecs update-service --service front-${TF_WORKSPACE} --cluster ${TF_WORKSPACE} --desired-count << parameters.replicas >> --profile << parameters.profile >>
+            aws ecs update-service --service admin-${TF_WORKSPACE} --cluster ${TF_WORKSPACE} --desired-count << parameters.replicas >> --profile << parameters.profile >>
             aws ecs update-service --service api-${TF_WORKSPACE} --cluster ${TF_WORKSPACE} --desired-count << parameters.replicas >> --profile << parameters.profile >>
 
   destroy-workspaces:


### PR DESCRIPTION
## Purpose
We scale our AWS ECS tasks for API and frontend services just before running our integration tests. We skip scaling admin though and given our very flaky test runs of late it looks like bumping admin has helped somewhat in branch env test runs.
