### PR TITLE
DDPB-4304: Limit app notifications page to super admin users

### DIFF
--- a/api/tests/Behat/bootstrap/v2/ACL/ACLTrait.php
+++ b/api/tests/Behat/bootstrap/v2/ACL/ACLTrait.php
@@ -80,22 +80,32 @@ trait ACLTrait
     }
 
     /**
-     * @Then I should be able to access the fixtures page
+     * @Then /^I should be able to access the \'([^\']*)\' page$/
      */
-    public function iShouldBeAbleToFixturesPage()
+    public function iShouldBeAbleToAccessThePage(string $page)
     {
-        $this->assertLinkWithTextIsOnPage('Fixtures');
-        $this->iVisitAdminFixturesPage();
+        $this->assertLinkWithTextIsOnPage($page);
+
+        match (strtolower($page)) {
+            'fixtures' => $this->iVisitAdminFixturesPage(),
+            'notifications' => $this->iVisitTheAdminNotificationPage()
+        };
+
         $this->canAccessSensitivePage();
     }
 
     /**
-     * @Then I should not be able to access the fixtures page
+     * @Then /^I should not be able to access the \'([^\']*)\' page$/
      */
-    public function iShouldNotBeAbleToFixturesPage()
+    public function iShouldNotBeAbleToAccessThePage(string $page)
     {
-        $this->assertLinkWithTextIsNotOnPage('Fixtures');
-        $this->iVisitAdminFixturesPage();
+        $this->assertLinkWithTextIsNotOnPage($page);
+
+        match (strtolower($page)) {
+            'fixtures' => $this->iVisitAdminFixturesPage(),
+            'notifications' => $this->iVisitTheAdminNotificationPage()
+        };
+
         $this->canNotAccessSensitivePage();
     }
 }

--- a/api/tests/Behat/bootstrap/v2/AppNotification/AppNotificationTrait.php
+++ b/api/tests/Behat/bootstrap/v2/AppNotification/AppNotificationTrait.php
@@ -70,7 +70,7 @@ trait AppNotificationTrait
      */
     public function iTurnOffTheServiceNotificationAndCanNoLongerSeeItOnTheClientLoginPage()
     {
-        $this->loginToAdminAs($this->adminDetails->getUserEmail());
+        $this->loginToAdminAs($this->loggedInUserDetails->getUserEmail());
 
         $this->iVisitTheAdminNotificationPage();
         $this->iAmOnAdminNotificationPage();

--- a/api/tests/Behat/features-v2/acl/admin/super-admin-only.feature
+++ b/api/tests/Behat/features-v2/acl/admin/super-admin-only.feature
@@ -5,7 +5,7 @@ Feature: Limiting access to sections of the app to super admins
     I need to limit access to certain areas of the app to Super Admins
 
     @super-admin
-    Scenario: A super admin attempts to access analytics, reports and fixtures
+    Scenario: A super admin attempts to access analytics, reports, fixtures and notifications
         Given a super admin user accesses the admin app
         When I navigate to the admin analytics page
         Then I should be able to access the "DAT file"
@@ -16,22 +16,25 @@ Feature: Limiting access to sections of the app to super admins
         When I visit the admin stats reports page
         Then I should be able to access the "user research report"
         When I visit the admin stats reports page
-        Then I should be able to access the fixtures page
+        Then I should be able to access the 'Fixtures' page
+        Then I should be able to access the 'Notifications' page
 
     @admin-manager
-    Scenario: An admin manager attempts to access analytics and reports
+    Scenario: An admin manager attempts to access analytics, reports, fixtures and notifications
         Given an admin manager user accesses the admin app
         When I navigate to the admin analytics page
         Then I should be able to access the "DAT file"
         When I navigate to the admin analytics page
         Then I should not be able to access the "view reports"
-        Then I should not be able to access the fixtures page
+        Then I should not be able to access the 'Fixtures' page
+        Then I should not be able to access the 'Notifications' page
 
     @admin
-    Scenario: An admin attempts to access analytics and reports
+    Scenario: An admin attempts to access analytics, reports, fixtures and notifications
         Given an admin user accesses the admin app
         When I navigate to the admin analytics page
         Then I should be able to access the "DAT file"
         When I navigate to the admin analytics page
         Then I should not be able to access the "view reports"
-        Then I should not be able to access the fixtures page
+        Then I should not be able to access the 'Fixtures' page
+        Then I should not be able to access the 'Notifications' page

--- a/api/tests/Behat/features-v2/app-notification/app-notification.feature
+++ b/api/tests/Behat/features-v2/app-notification/app-notification.feature
@@ -1,23 +1,23 @@
 @v2 @v2_admin @app-notification
 Feature: App Notification - An admin can add and remove app notification for deputies
 
-    @admin
+    @super-admin
     Scenario: An admin turns on an service notification with a message
-        Given an admin user accesses the admin app
+        Given a super admin user accesses the admin app
         When I visit the service notification page
         And I set a service notification
         Then I should see the service message on the client login page
 
-    @admin
+    @super-admin
     Scenario: An admin turns off an service notification after setting one
-        Given an admin user accesses the admin app
+        Given a super admin user accesses the admin app
         When I visit the service notification page
         And I set a service notification and see it on the login page
         Then I turn off the service notification and can no longer see it on the client login page
 
-    @admin
+    @super-admin
     Scenario: An admin trys to set a service notification without a message
-        Given an admin user accesses the admin app
+        Given a super admin user accesses the admin app
         When I visit the service notification page
         And I set a service notification without a message
         Then I should see a validation error

--- a/client/src/Controller/Admin/SettingController.php
+++ b/client/src/Controller/Admin/SettingController.php
@@ -28,7 +28,7 @@ class SettingController extends AbstractController
 
     /**
      * @Route("/service-notification", name="admin_setting_service_notifications")
-     * @Security("is_granted('ROLE_ADMIN')")
+     * @Security("is_granted('ROLE_SUPER_ADMIN')")
      * @Template("@App/Admin/Setting/serviceNotification.html.twig")
      */
     public function serviceNotificationAction(Request $request)

--- a/client/templates/Layouts/admin_moj_template.html.twig
+++ b/client/templates/Layouts/admin_moj_template.html.twig
@@ -98,14 +98,6 @@
                             ) }}
                         </li>
                         <li class="moj-primary-navigation__item">
-                            {{ _self.navLink(
-                                'admin_setting_service_notifications',
-                                'nav.serviceNotification',
-                                navSection == 'notifications',
-                                'behat-link-admin-settings'
-                            ) }}
-                        </li>
-                        <li class="moj-primary-navigation__item">
                             {{ _self.navLink('admin_metrics', 'nav.adminStats', navSection == 'metrics') }}
                         </li>
                     {% elseif is_granted('ROLE_AD') %}
@@ -117,6 +109,14 @@
                         </li>
                     {% endif %}
                     {% if is_granted('ROLE_SUPER_ADMIN') %}
+                        <li class="moj-primary-navigation__item">
+                            {{ _self.navLink(
+                                'admin_setting_service_notifications',
+                                'nav.serviceNotification',
+                                navSection == 'notifications',
+                                'behat-link-admin-settings'
+                            ) }}
+                        </li>
                         <li class="moj-primary-navigation__item">
                             {{ _self.navLink('admin_fixtures', 'nav.adminFixtures', navSection == 'fixtures') }}
                         </li>


### PR DESCRIPTION
## Purpose
The notifications section of the app is meant for super admins only but it looks like when we implemented super admins this link and endpoint was missed. This change limits the link visibility and endpoint to users with a super admin role.

Fixes DDPB-4304.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes