### PR TITLE
Reduce document sync schedule time to 2 minutes

### DIFF
--- a/environment/document_sync.tf
+++ b/environment/document_sync.tf
@@ -29,7 +29,7 @@ locals {
     }
   }
 
-  document_sync_interval = local.environment == "production02" ? "rate(5 minutes)" : "rate(24 hours)"
+  document_sync_interval = local.environment == "production02" ? "rate(2 minutes)" : "rate(24 hours)"
 
 }
 


### PR DESCRIPTION
## Purpose
Having tested this with a backlog of hundreds of documents recently we can reduce the scheduled time the document sync task runs to get through the queued documents in a shorter period of time.