### PR TITLE
[DDPB-4206] Track how often users are completing information in the new benefits section

### DIFF
--- a/api/src/Controller/StatsController.php
+++ b/api/src/Controller/StatsController.php
@@ -135,4 +135,28 @@ class StatsController extends RestController
 
         return new JsonResponse($ret);
     }
+
+    /**
+     * @Route("stats/report/benefits-report-metrics", name="benefits_reoprt_metrics")
+     * @Security("is_granted('ROLE_SUPER_ADMIN')")
+     *
+     * - track how often users select 'yes', 'no', and 'I don't know' to the 'Does anyone other than you receive income on Client's behalf?' question
+     * - track what the users list when selecting 'yes' and are given the 'Tell us about the income other people receive on Client's behalf' question
+     * - track the free input box when selectin ' I don't know' to the 'Does anyone other than you receive income on Client's behalf?' question
+     */
+    public function getBenefitsReportMetrics(): array
+    {
+        $yesResponses = $this->reportRepository->getBenefitsRepsonse('yes');
+        $yesResponsesCount = count($yesResponses);
+        $noResponses = $this->reportRepository->getBenefitsRepsonse('no');
+        $noResponsesCount = count($noResponses);
+        $dontKnowResponses = $this->reportRepository->getBenefitsRepsonse('dontKnow');
+        $dontKnowResponsesCount = count($dontKnowResponses);
+
+        return [
+            'YesResponsesCount' => $yesResponsesCount,
+            'NoResponsesCount' => $noResponsesCount,
+            'DontKnowResponsesCount' => $dontKnowResponsesCount,
+        ];
+    }
 }

--- a/api/src/Controller/StatsController.php
+++ b/api/src/Controller/StatsController.php
@@ -149,7 +149,6 @@ class StatsController extends RestController
         $startDate = $request->query->get('startDate');
         $endDate = $request->query->get('endDate');
 
-        $result = $this->reportRepository->getBenefitsResponseMetrics($startDate, $endDate, $deputyType);
-        return $result;
+        return $this->reportRepository->getBenefitsResponseMetrics($startDate, $endDate, $deputyType);
     }
 }

--- a/api/src/Controller/StatsController.php
+++ b/api/src/Controller/StatsController.php
@@ -9,6 +9,7 @@ use App\Entity\Ndr\AssetOther as NdrAssetOther;
 use App\Entity\Ndr\AssetProperty as NdrAssetProperty;
 use App\Entity\Report\AssetOther;
 use App\Entity\Report\AssetProperty;
+use App\Entity\Report\Report;
 use App\Entity\User;
 use App\Repository\AssetRepository;
 use App\Repository\BankAccountRepository;
@@ -141,10 +142,6 @@ class StatsController extends RestController
     /**
      * @Route("stats/report/benefits-report-metrics", methods={"GET", "POST"})
      * @Security("is_granted('ROLE_SUPER_ADMIN')")
-     *
-     * - track how often users select 'yes', 'no', and 'I don't know' to the 'Does anyone other than you receive income on Client's behalf?' question
-     * - track what the users list when selecting 'yes' and are given the 'Tell us about the income other people receive on Client's behalf' question
-     * - track the free input box when selectin ' I don't know' to the 'Does anyone other than you receive income on Client's behalf?' question
      */
     public function getBenefitsReportMetrics(Request $request): array
     {
@@ -152,32 +149,7 @@ class StatsController extends RestController
         $startDate = $request->query->get('startDate');
         $endDate = $request->query->get('endDate');
 
-        $results = $this->reportRepository->getBenefitsRepsonseMetrics();
-
-        $updatedResults = [];
-        foreach ($results as $key => $result) {
-            if ($startDate === null && $endDate === null) {
-                if ('all' === $deputyType) {
-                    array_push($updatedResults, $result);
-                } elseif ('prof' === $deputyType && User::$depTypeIdToRealm[$result['deputy_type']] === CasRec::REALM_PROF) {
-                    array_push($updatedResults, $result);
-                } elseif ('pa' === $deputyType && User::$depTypeIdToRealm[$result['deputy_type']] === CasRec::REALM_PA) {
-                    array_push($updatedResults, $result);
-                }
-            } else {
-                $createdAt = new DateTime($result['created_at']);
-                if ($createdAt->format('Y-m-d') > $startDate && $createdAt->format('Y-m-d') < $endDate) {
-                    if ('all' === $deputyType) {
-                        array_push($updatedResults, $result);
-                    } elseif ('prof' === $deputyType && User::$depTypeIdToRealm[$result['deputy_type']] === CasRec::REALM_PROF) {
-                        array_push($updatedResults, $result);
-                    } elseif ('pa' === $deputyType && User::$depTypeIdToRealm[$result['deputy_type']] === CasRec::REALM_PA) {
-                        array_push($updatedResults, $result);
-                    }
-                }
-            }
-        }
-
-        return $updatedResults;
+        $result = $this->reportRepository->getBenefitsResponseMetrics($startDate, $endDate, $deputyType);
+        return $result;
     }
 }

--- a/api/src/Entity/Report/ClientBenefitsCheck.php
+++ b/api/src/Entity/Report/ClientBenefitsCheck.php
@@ -50,7 +50,7 @@ class ClientBenefitsCheck implements ClientBenefitsCheckInterface
     private DateTime $created;
 
     /**
-     * @ORM\OneToOne (targetEntity="App\Entity\Report\Report", inversedBy="clientBenefitsCheck")
+     * @ORM\OneToOne(targetEntity="App\Entity\Report\Report", inversedBy="clientBenefitsCheck")
      * @ORM\JoinColumn(name="report_id", referencedColumnName="id", onDelete="CASCADE",nullable=true)
      *
      * @JMS\Groups({"client-benefits-check-report"})

--- a/api/src/Repository/ReportRepository.php
+++ b/api/src/Repository/ReportRepository.php
@@ -25,8 +25,8 @@ class ReportRepository extends ServiceEntityRepository
     /** @var ClientSearchFilter */
     private $filter;
 
-    const USER_DETERMINANT = 1;
-    const ORG_DETERMINANT = 2;
+    public const USER_DETERMINANT = 1;
+    public const ORG_DETERMINANT = 2;
 
     public function __construct(ManagerRegistry $registry, ClientSearchFilter $filter)
     {
@@ -37,10 +37,8 @@ class ReportRepository extends ServiceEntityRepository
     /**
      * add empty Debts to Report.
      * Called from doctrine listener.
-     *
-     * @return int changed records
      */
-    public function addDebtsToReportIfMissing(Report $report)
+    public function addDebtsToReportIfMissing(Report $report): int
     {
         $ret = 0;
 
@@ -59,11 +57,9 @@ class ReportRepository extends ServiceEntityRepository
     }
 
     /**
-     * @return int|null
-     *
      * @throws ORMException
      */
-    public function addFeesToReportIfMissing(Report $report)
+    public function addFeesToReportIfMissing(Report $report): ?int
     {
         if (!$report->isPAreport()) {
             return null;
@@ -109,11 +105,9 @@ class ReportRepository extends ServiceEntityRepository
     }
 
     /**
-     * @param string $role
-     *
      * @return mixed
      */
-    public function findAllActiveReportsByCaseNumbersAndRole(array $caseNumbers, $role)
+    public function findAllActiveReportsByCaseNumbersAndRole(array $caseNumbers, string $role)
     {
         $qb = $this->createQueryBuilder('r');
         $qb->leftJoin('r.client', 'c')
@@ -126,16 +120,11 @@ class ReportRepository extends ServiceEntityRepository
     }
 
     /**
-     * @param mixed       $orgIdsOrUserId
-     * @param int         $determinant
-     * @param string      $select
-     * @param string|null $status
-     *
      * @return array|mixed|null
      *
      * @throws NonUniqueResultException
      */
-    public function getAllByDeterminant($orgIdsOrUserId, $determinant, ParameterBag $query, $select, $status)
+    public function getAllByDeterminant(mixed $orgIdsOrUserId, int $determinant, ParameterBag $query, string $select, ?string $status)
     {
         $qb = $this->createQueryBuilder('r');
 
@@ -259,5 +248,17 @@ DQL;
             ->setParameter('types', $types);
 
         return $query->getQuery()->getResult(AbstractQuery::HYDRATE_SCALAR_COLUMN);
+    }
+
+    public function getBenefitsRepsonse(string $answer): mixed
+    {
+        $dql = "SELECT b FROM App\Entity\Report\ClientBenefitsCheck b WHERE b.doOthersReceiveIncomeOnClientsBehalf = :answer";
+
+        $query = $this
+            ->getEntityManager()
+            ->createQuery($dql)
+            ->setParameter('answer', $answer);
+
+        return $query->getResult();
     }
 }

--- a/api/src/Repository/ReportRepository.php
+++ b/api/src/Repository/ReportRepository.php
@@ -296,41 +296,4 @@ END deputy_type";
 
         return $query->getQuery()->getArrayResult();
     }
-
-    /**
-     * Replaces any parameter placeholders in a query with the value of that
-     * parameter. Useful for debugging. Assumes anonymous parameters from
-     * $params are are in the same order as specified in $query
-     *
-     * @param string $query The sql query with parameter placeholders
-     * @param array $params The array of substitution parameters
-     * @return string The interpolated query
-     */
-    public function interpolateQuery($query, $params)
-    {
-        $keys = array();
-        $values = $params;
-
-        # build a regular expression for each parameter
-        foreach ($params as $key => $value) {
-            if (is_string($key)) {
-                $keys[] = '/:' . $key . '/';
-            } else {
-                $keys[] = '/[?]/';
-            }
-
-            if (is_string($value))
-                $values[$key] = "" . $value . "";
-
-            if (is_array($value))
-                $values[$key] = "'" . implode("','", $value) . "'";
-
-            if (is_null($value))
-                $values[$key] = 'NULL';
-        }
-
-        $query = preg_replace($keys, $values, $query);
-
-        return $query;
-    }
 }

--- a/api/src/Repository/ReportRepository.php
+++ b/api/src/Repository/ReportRepository.php
@@ -250,15 +250,21 @@ DQL;
         return $query->getQuery()->getResult(AbstractQuery::HYDRATE_SCALAR_COLUMN);
     }
 
-    public function getBenefitsRepsonse(string $answer): mixed
+    public function getBenefitsRepsonseMetrics(): mixed
     {
-        $dql = "SELECT b FROM App\Entity\Report\ClientBenefitsCheck b WHERE b.doOthersReceiveMoneyOnClientsBehalf = :answer";
+        $conn = $this->getEntityManager()->getConnection();
 
-        $query = $this
-            ->getEntityManager()
-            ->createQuery($dql)
-            ->setParameter('answer', $answer);
+        $sql = <<<SQL
+SELECT b.*, nd.deputy_type
+FROM (((client_benefits_check b
+LEFT JOIN report r ON b.report_id = r.id)
+LEFT JOIN client c ON c.id = r.client_id)
+LEFT JOIN named_deputy nd ON nd.id = c.named_deputy_id)
+SQL;
 
-        return $query->getResult();
+        $stmt = $conn->prepare($sql);
+        $result = $stmt->executeQuery();
+
+        return $result->fetchAllAssociative();
     }
 }

--- a/api/src/Repository/ReportRepository.php
+++ b/api/src/Repository/ReportRepository.php
@@ -252,7 +252,7 @@ DQL;
 
     public function getBenefitsRepsonse(string $answer): mixed
     {
-        $dql = "SELECT b FROM App\Entity\Report\ClientBenefitsCheck b WHERE b.doOthersReceiveIncomeOnClientsBehalf = :answer";
+        $dql = "SELECT b FROM App\Entity\Report\ClientBenefitsCheck b WHERE b.doOthersReceiveMoneyOnClientsBehalf = :answer";
 
         $query = $this
             ->getEntityManager()

--- a/api/src/Repository/ReportRepository.php
+++ b/api/src/Repository/ReportRepository.php
@@ -252,8 +252,6 @@ DQL;
 
     public function getBenefitsResponseMetrics(?string $startDate = null, ?string $endDate = null, ?string $deputyType = null): array
     {
-        $conn = $this->getEntityManager()->getConnection();
-
         $caseStatement = "CASE
         WHEN r.type IN ('103', '102', '104', '103-4', '102-4') THEN 'Lay'
         WHEN r.type IN ('103-5','102-5','104-5','103-4-5','102-4-5') THEN 'Prof'

--- a/api/tests/Unit/Controller/StatsControllerTest.php
+++ b/api/tests/Unit/Controller/StatsControllerTest.php
@@ -52,4 +52,26 @@ class StatsControllerTest extends AbstractTestController
             );
         }
     }
+
+    /** @test */
+    public function benefitsReportMetricsOnlySuperAdminsCanAccess()
+    {
+        $unauthorisedUserTokens = [
+            $this->loginAsAdmin(),
+            $this->loginAsDeputy(),
+            $this->loginAsProf(),
+            $this->loginAsPa(),
+        ];
+
+        foreach ($unauthorisedUserTokens as $token) {
+            $this->assertJsonRequest(
+                'GET',
+                '/stats/report/benefits_metrics',
+                [
+                    'mustFail' => true,
+                    'AuthToken' => $token,
+                ]
+            );
+        }
+    }
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12992,9 +12992,9 @@
             }
         },
         "moment": {
-            "version": "2.29.2",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-            "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
+            "version": "2.29.3",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
+            "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
         },
         "ms": {
             "version": "2.0.0",

--- a/client/src/Controller/Admin/StatsController.php
+++ b/client/src/Controller/Admin/StatsController.php
@@ -4,6 +4,7 @@ namespace App\Controller\Admin;
 
 use App\Controller\AbstractController;
 use App\Exception\DisplayableException;
+use App\Form\Admin\BenefitsMetricsFilterType;
 use App\Form\Admin\ReportSubmissionDownloadFilterType;
 use App\Form\Admin\SatisfactionFilterType;
 use App\Form\Admin\StatPeriodType;
@@ -224,6 +225,24 @@ class StatsController extends AbstractController
     public function userAccountReports()
     {
         return $this->statsApi->getAdminUserAccountReportData();
+    }
+
+    /**
+     * @Route("/reports/benefits-report-metrics", name="benefits_reoprt_metrics")
+     * @Security("is_granted('ROLE_SUPER_ADMIN')")
+     * @Template("@App/Admin/Stats/benefitsReportMetrics.html.twig")
+     *
+     * @return array|Response
+     */
+    public function benefitsReportMetrics(Request $request)
+    {
+        $form = $this->createForm(BenefitsMetricsFilterType::class, new DateRangeQuery());
+        $form->handleRequest($request);
+
+        return [
+            'stats' => $this->statsApi->getBenefitsReportMetrics(),
+            'form' => $form->createView(),
+        ];
     }
 
     /**

--- a/client/src/Controller/Admin/StatsController.php
+++ b/client/src/Controller/Admin/StatsController.php
@@ -161,7 +161,7 @@ class StatsController extends AbstractController
         $response->headers->set('Content-Type', 'application/octet-stream');
 
         $attachmentName = sprintf('cwsdigidepsopg00001%s.dat', date('YmdHi'));
-        $response->headers->set('Content-Disposition', 'attachment; filename="'.$attachmentName.'"');
+        $response->headers->set('Content-Disposition', 'attachment; filename="' . $attachmentName . '"');
 
         $response->sendHeaders();
 
@@ -191,8 +191,8 @@ class StatsController extends AbstractController
         $metrics = ['satisfaction', 'reportsSubmitted', 'clients', 'registeredDeputies'];
 
         foreach ($metrics as $metric) {
-            $all = $this->restClient->get('stats?metric='.$metric.$append, 'array');
-            $byRole = $this->restClient->get('stats?metric='.$metric.'&dimension[]=deputyType'.$append, 'array');
+            $all = $this->restClient->get('stats?metric=' . $metric . $append, 'array');
+            $byRole = $this->restClient->get('stats?metric=' . $metric . '&dimension[]=deputyType' . $append, 'array');
 
             $stats[$metric] = array_merge(
                 ['all' => $all[0]['amount']],
@@ -240,8 +240,6 @@ class StatsController extends AbstractController
     {
         $form = $this->createForm(BenefitsMetricsFilterType::class, new DateRangeQuery());
         $form->handleRequest($request);
-
-        $append = '';
 
         if ($form->isSubmitted() && $form->isValid()) {
             try {

--- a/client/src/Controller/Admin/StatsController.php
+++ b/client/src/Controller/Admin/StatsController.php
@@ -239,8 +239,21 @@ class StatsController extends AbstractController
         $form = $this->createForm(BenefitsMetricsFilterType::class, new DateRangeQuery());
         $form->handleRequest($request);
 
+        $append = '';
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $deputyType = $form->get('deputyType')->getData();
+            $append = "?deputyType={$deputyType}";
+
+            $startDate = $form->get('startDate')->getData();
+            $endDate = $form->get('endDate')->getData();
+            if (null !== $startDate && null !== $endDate) {
+                $append .= "&startDate={$startDate->format('Y-m-d')}&endDate={$endDate->format('Y-m-d')}";
+            }
+        }
+
         return [
-            'stats' => $this->statsApi->getBenefitsReportMetrics(),
+            'stats' => $this->statsApi->getBenefitsReportMetrics($append),
             'form' => $form->createView(),
         ];
     }

--- a/client/src/Controller/Admin/StatsController.php
+++ b/client/src/Controller/Admin/StatsController.php
@@ -255,8 +255,8 @@ class StatsController extends AbstractController
                 }
 
                 $benefitMetricsSummaries = $this->statsApi->getBenefitsReportMetrics($append);
-                $csv = $this->clientBenefitMetricsCsvGenerator->generateClientBenefitsMetricCsv($benefitMetricsSummaries);
 
+                $csv = $this->clientBenefitMetricsCsvGenerator->generateClientBenefitsMetricCsv($benefitMetricsSummaries);
                 $response = new Response($csv);
 
                 $response->headers->set('Content-Type', 'text/csv; charset=utf-8');

--- a/client/src/Entity/User.php
+++ b/client/src/Entity/User.php
@@ -49,6 +49,21 @@ class User implements UserInterface, DeputyInterface
         self::ROLE_ADMIN_MANAGER,
     ];
 
+    public static $depTypeIdToRealm = [
+        //PA
+        23 => CasRec::REALM_PA,
+        //PROFESSIONAL
+        21 => CasRec::REALM_PROF,
+        26 => CasRec::REALM_PROF,
+        63 => CasRec::REALM_PROF,
+        22 => CasRec::REALM_PROF,
+        24 => CasRec::REALM_PROF,
+        25 => CasRec::REALM_PROF,
+        27 => CasRec::REALM_PROF,
+        29 => CasRec::REALM_PROF,
+        50 => CasRec::REALM_PROF,
+    ];
+
     /**
      * @JMS\Exclude
      */

--- a/client/src/Entity/User.php
+++ b/client/src/Entity/User.php
@@ -49,21 +49,6 @@ class User implements UserInterface, DeputyInterface
         self::ROLE_ADMIN_MANAGER,
     ];
 
-    public static $depTypeIdToRealm = [
-        //PA
-        23 => CasRec::REALM_PA,
-        //PROFESSIONAL
-        21 => CasRec::REALM_PROF,
-        26 => CasRec::REALM_PROF,
-        63 => CasRec::REALM_PROF,
-        22 => CasRec::REALM_PROF,
-        24 => CasRec::REALM_PROF,
-        25 => CasRec::REALM_PROF,
-        27 => CasRec::REALM_PROF,
-        29 => CasRec::REALM_PROF,
-        50 => CasRec::REALM_PROF,
-    ];
-
     /**
      * @JMS\Exclude
      */
@@ -848,10 +833,9 @@ class User implements UserInterface, DeputyInterface
     public function hasAddressDetails()
     {
         return !empty($this->getAddress1())
-              && !empty($this->getAddressCountry())
-              && !empty($this->getAddressPostcode())
-              && !empty($this->getPhoneMain())
-        ;
+            && !empty($this->getAddressCountry())
+            && !empty($this->getAddressPostcode())
+            && !empty($this->getPhoneMain());
     }
 
     /**

--- a/client/src/Form/Admin/BenefitsMetricsFilterType.php
+++ b/client/src/Form/Admin/BenefitsMetricsFilterType.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form\Admin;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type as FormTypes;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class BenefitsMetricsFilterType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add(
+                'startDate',
+                FormTypes\DateType::class,
+                [
+                    'widget' => 'text',
+                    'input' => 'datetime',
+                    'format' => 'dd-MM-yyyy',
+                    'invalid_message' => 'Enter a valid date',
+                ]
+            )
+            ->add(
+                'endDate',
+                FormTypes\DateType::class,
+                [
+                    'widget' => 'text',
+                    'input' => 'datetime',
+                    'format' => 'dd-MM-yyyy',
+                    'invalid_message' => 'Enter a valid date',
+                ]
+            )
+            ->add('submitAndDownload', FormTypes\SubmitType::class)
+            ->addEventListener(FormEvents::POST_SUBMIT, [$this, 'onPostSubmit']);
+    }
+
+    public function onPostSubmit(FormEvent $event)
+    {
+        $entity = $event->getData();
+
+        if ($entity->getEndDate() instanceof \DateTime) {
+            $endDate = $entity->getEndDate();
+            $entity->setEndDate($endDate->setTime(23, 59, 59));
+        }
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'translation_domain' => 'admin-metrics',
+        ]);
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'admin';
+    }
+}

--- a/client/src/Form/Admin/BenefitsMetricsFilterType.php
+++ b/client/src/Form/Admin/BenefitsMetricsFilterType.php
@@ -41,6 +41,7 @@ class BenefitsMetricsFilterType extends AbstractType
                 FormTypes\ChoiceType::class, [
                     'choices' => [
                         'All' => 'all',
+                        'Lay' => 'lay',
                         'Prof' => 'prof',
                         'Pa' => 'pa',
                     ],

--- a/client/src/Form/Admin/BenefitsMetricsFilterType.php
+++ b/client/src/Form/Admin/BenefitsMetricsFilterType.php
@@ -36,6 +36,18 @@ class BenefitsMetricsFilterType extends AbstractType
                     'invalid_message' => 'Enter a valid date',
                 ]
             )
+            ->add(
+                'deputyType',
+                FormTypes\ChoiceType::class, [
+                    'choices' => [
+                        'All' => 'all',
+                        'Prof' => 'prof',
+                        'Pa' => 'pa',
+                    ],
+                    'expanded' => false,
+                    'mapped' => false,
+                ]
+            )
             ->add('submitAndDownload', FormTypes\SubmitType::class)
             ->addEventListener(FormEvents::POST_SUBMIT, [$this, 'onPostSubmit']);
     }

--- a/client/src/Service/Client/Internal/StatsApi.php
+++ b/client/src/Service/Client/Internal/StatsApi.php
@@ -49,11 +49,11 @@ class StatsApi
         return (string) $response;
     }
 
-    public function getBenefitsReportMetrics(string $appened = null)
+    public function getBenefitsReportMetrics(?string $append = null)
     {
         $link = self::GET_BENEFITS_REPORT_METRICS;
-        if (null !== $appened) {
-            $link = self::GET_BENEFITS_REPORT_METRICS.$appened;
+        if (null !== $append) {
+            $link = self::GET_BENEFITS_REPORT_METRICS.$append;
         }
 
         return $this->restClient->get(

--- a/client/src/Service/Client/Internal/StatsApi.php
+++ b/client/src/Service/Client/Internal/StatsApi.php
@@ -11,6 +11,7 @@ class StatsApi
     protected const GET_ACTIVE_LAY_REPORT_DATA_ENDPOINT = 'stats/deputies/lay/active';
     protected const GET_ADMIN_USER_ACCOUNT_REPORT_DATA = 'stats/admins/report_data';
     protected const GET_ASSETS_TOTAL_VALUES = 'stats/assets/total_values';
+    protected const GET_BENEFITS_REPORT_METRICS = 'stats/report/benefits-report-metrics';
 
     private RestClientInterface $restClient;
 
@@ -46,5 +47,14 @@ class StatsApi
         );
 
         return (string) $response;
+    }
+
+    public function getBenefitsReportMetrics(): array
+    {
+        return $this->restClient->get(
+            self::GET_BENEFITS_REPORT_METRICS,
+            'array',
+            ['benefits-report-metrics']
+        );
     }
 }

--- a/client/src/Service/Client/Internal/StatsApi.php
+++ b/client/src/Service/Client/Internal/StatsApi.php
@@ -49,12 +49,17 @@ class StatsApi
         return (string) $response;
     }
 
-    public function getBenefitsReportMetrics(): array
+    public function getBenefitsReportMetrics(string $appened = null)
     {
+        $link = self::GET_BENEFITS_REPORT_METRICS;
+        if (null !== $appened) {
+            $link = self::GET_BENEFITS_REPORT_METRICS.$appened;
+        }
+
         return $this->restClient->get(
-            self::GET_BENEFITS_REPORT_METRICS,
+            $link,
             'array',
-            ['benefits-report-metrics']
+            ['admin-benefits-metrics']
         );
     }
 }

--- a/client/src/Service/Csv/ClientBenefitMetricsCsvGenerator.php
+++ b/client/src/Service/Csv/ClientBenefitMetricsCsvGenerator.php
@@ -18,8 +18,6 @@ class ClientBenefitMetricsCsvGenerator
     }
 
     /**
-     * @param []UserResearchResponse $userResearchResponses
-     *
      * @return string
      */
     public function generateClientBenefitsMetricCsv(array $clientBenefitResponses)

--- a/client/src/Service/Csv/ClientBenefitMetricsCsvGenerator.php
+++ b/client/src/Service/Csv/ClientBenefitMetricsCsvGenerator.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Csv;
+
+use App\Entity\CasRec;
+use App\Entity\User;
+use DateTime;
+
+class ClientBenefitMetricsCsvGenerator
+{
+    private CsvBuilder $csvBuilder;
+
+    public function __construct(CsvBuilder $csvBuilder)
+    {
+        $this->csvBuilder = $csvBuilder;
+    }
+
+    /**
+     * @param []UserResearchResponse $userResearchResponses
+     *
+     * @return string
+     */
+    public function generateClientBenefitsMetricCsv(array $clientBenefitResponses)
+    {
+        $headers = [
+            'Deputy Type',
+            'Last Check Entitlement',
+            'Do Others Receive Money on Clients Behalf',
+            'Date Last Checked',
+            'Never Checked Explanation',
+            'Don\'t Know Explanation',
+            'Created On',
+        ];
+
+        $rows = [];
+
+        foreach ($clientBenefitResponses as $response) {
+            $deputyType = CasRec::REALM_PA === User::$depTypeIdToRealm[$response['deputy_type']] ? 'pa' : 'prof';
+
+            if (null !== $response['date_last_checked_entitlement']) {
+                $dateLastCheckedFormatted = (new DateTime($response['date_last_checked_entitlement']))->format('Y-m-d');
+            }
+
+            $rows[] = [
+                $deputyType,
+                $response['when_last_checked_entitlement'],
+                $response['do_others_receive_money_on_clients_behalf'],
+                $dateLastCheckedFormatted,
+                $response['never_checked_explanation'],
+                $response['dont_know_money_explanation'],
+                $response['created_at'],
+            ];
+        }
+
+        return $this->csvBuilder->buildCsv($headers, $rows);
+    }
+}

--- a/client/src/Service/Csv/ClientBenefitMetricsCsvGenerator.php
+++ b/client/src/Service/Csv/ClientBenefitMetricsCsvGenerator.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace App\Service\Csv;
 
-use App\Entity\CasRec;
-use App\Entity\User;
 use DateTime;
+use Exception;
 
 class ClientBenefitMetricsCsvGenerator
 {
@@ -18,9 +17,9 @@ class ClientBenefitMetricsCsvGenerator
     }
 
     /**
-     * @return string
+     * @throws Exception
      */
-    public function generateClientBenefitsMetricCsv(array $clientBenefitResponses)
+    public function generateClientBenefitsMetricCsv(array $clientBenefitResponses): string
     {
         $headers = [
             'Deputy Type',
@@ -35,14 +34,12 @@ class ClientBenefitMetricsCsvGenerator
         $rows = [];
 
         foreach ($clientBenefitResponses as $response) {
-            $deputyType = CasRec::REALM_PA === User::$depTypeIdToRealm[$response['deputy_type']] ? 'pa' : 'prof';
-
             if (null !== $response['date_last_checked_entitlement']) {
                 $dateLastCheckedFormatted = (new DateTime($response['date_last_checked_entitlement']))->format('Y-m-d');
             }
 
             $rows[] = [
-                $deputyType,
+                $response['deputy_type'],
                 $response['when_last_checked_entitlement'],
                 $response['do_others_receive_money_on_clients_behalf'],
                 $dateLastCheckedFormatted,

--- a/client/src/Service/Csv/ClientBenefitMetricsCsvGenerator.php
+++ b/client/src/Service/Csv/ClientBenefitMetricsCsvGenerator.php
@@ -34,18 +34,18 @@ class ClientBenefitMetricsCsvGenerator
         $rows = [];
 
         foreach ($clientBenefitResponses as $response) {
-            if (null !== $response['date_last_checked_entitlement']) {
-                $dateLastCheckedFormatted = (new DateTime($response['date_last_checked_entitlement']))->format('Y-m-d');
+            if (null !== $response['dateLastCheckedEntitlement']) {
+                $dateLastCheckedFormatted = (new DateTime($response['dateLastCheckedEntitlement']))->format('Y-m-d');
             }
 
             $rows[] = [
                 $response['deputy_type'],
-                $response['when_last_checked_entitlement'],
-                $response['do_others_receive_money_on_clients_behalf'],
+                $response['whenLastCheckedEntitlement'],
+                $response['doOthersReceiveMoneyOnClientsBehalf'],
                 $dateLastCheckedFormatted,
-                $response['never_checked_explanation'],
-                $response['dont_know_money_explanation'],
-                $response['created_at'],
+                $response['neverCheckedExplanation'],
+                $response['dontKnowMoneyExplanation'],
+                $response['created'],
             ];
         }
 

--- a/client/src/Service/Csv/ClientBenefitMetricsCsvGenerator.php
+++ b/client/src/Service/Csv/ClientBenefitMetricsCsvGenerator.php
@@ -9,11 +9,8 @@ use Exception;
 
 class ClientBenefitMetricsCsvGenerator
 {
-    private CsvBuilder $csvBuilder;
-
-    public function __construct(CsvBuilder $csvBuilder)
+    public function __construct(private CsvBuilder $csvBuilder)
     {
-        $this->csvBuilder = $csvBuilder;
     }
 
     /**

--- a/client/templates/Admin/Stats/benefitsReportMetrics.html.twig
+++ b/client/templates/Admin/Stats/benefitsReportMetrics.html.twig
@@ -1,0 +1,47 @@
+{% extends '@App/Layouts/application.html.twig' %}
+
+{% set translationDomain = "admin-metrics" %}
+{% trans_default_domain translationDomain %}
+{% set page = 'benefitsReportMetrics' %}
+
+{% set navSection = 'reports' %}
+
+{% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
+{% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
+{% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}
+
+{% block pageContent %}
+
+    {{ form_start(form, {attr: {class: 'search', novalidate: 'novalidate' }}) }}
+        {{ form_known_date(form.startDate, 'benefitsReportMetrics.form.fromDate', {
+            'hintText': (page ~ '.form.fromDate.hint') | trans,
+        }) }}<span class="govuk-visually-hidden">of benefits report metrics responses search period</span>
+
+        {{ form_known_date(form.endDate, 'benefitsReportMetrics.form.toDate', {
+            'hintText': (page ~ '.form.toDate.hint') | trans,
+        }) }}<span class="govuk-visually-hidden">of benefits report metrics responses search period</span>
+
+        <div class="govuk-form-group">
+            {{ form_submit(form.submitAndDownload, 'benefitsReportMetrics.form.submitAndDownload', {
+                'buttonClass': 'behat-link-submit-and-download'
+            }) }}
+            <a href="{{ path('admin_stats') }}" class="govuk-link button-link">{{ 'benefitsReportMetrics.form.clear' | trans }}</a>
+        </div>
+    {{ form_end(form) }}
+
+    {# <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third text--center">
+            <span class="govuk-caption-l govuk-!-margin-top-2">Yes Responses</span>
+            <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40 ">{{ stats.YesResponsesCount }}</span>
+        </div>
+        <div class="govuk-grid-column-one-third text--center">
+            <span class="govuk-caption-l govuk-!-margin-top-2">No Responses</span>
+            <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40 ">{{ stats.NoResponsesCount }}</span>
+        </div>
+        <div class="govuk-grid-column-one-third text--center">
+            <span class="govuk-caption-l govuk-!-margin-top-2">Don't Know Responses</span>
+            <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40 ">{{ stats.DontKnowResponsesCount }}</span>
+        </div>
+    </div> #}
+
+{% endblock %}

--- a/client/templates/Admin/Stats/benefitsReportMetrics.html.twig
+++ b/client/templates/Admin/Stats/benefitsReportMetrics.html.twig
@@ -34,6 +34,4 @@
         </div>
     {{ form_end(form) }}
 
-    {{ dump(stats) }}
-
 {% endblock %}

--- a/client/templates/Admin/Stats/benefitsReportMetrics.html.twig
+++ b/client/templates/Admin/Stats/benefitsReportMetrics.html.twig
@@ -21,27 +21,19 @@
             'hintText': (page ~ '.form.toDate.hint') | trans,
         }) }}<span class="govuk-visually-hidden">of benefits report metrics responses search period</span>
 
+        {{ form_select(form.deputyType, 'benefitsReportMetrics.form.deputyType', {
+        'fieldSetClass' : 'inline',
+        'legendClass' : 'govuk-label--s'
+        }) }}
+
         <div class="govuk-form-group">
             {{ form_submit(form.submitAndDownload, 'benefitsReportMetrics.form.submitAndDownload', {
                 'buttonClass': 'behat-link-submit-and-download'
             }) }}
-            <a href="{{ path('admin_stats') }}" class="govuk-link button-link">{{ 'benefitsReportMetrics.form.clear' | trans }}</a>
+            <a href="{{ path('benefits_reoprt_metrics') }}" class="govuk-link button-link">{{ 'benefitsReportMetrics.form.clear' | trans }}</a>
         </div>
     {{ form_end(form) }}
 
-    {# <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-third text--center">
-            <span class="govuk-caption-l govuk-!-margin-top-2">Yes Responses</span>
-            <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40 ">{{ stats.YesResponsesCount }}</span>
-        </div>
-        <div class="govuk-grid-column-one-third text--center">
-            <span class="govuk-caption-l govuk-!-margin-top-2">No Responses</span>
-            <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40 ">{{ stats.NoResponsesCount }}</span>
-        </div>
-        <div class="govuk-grid-column-one-third text--center">
-            <span class="govuk-caption-l govuk-!-margin-top-2">Don't Know Responses</span>
-            <span class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-font-size-40 ">{{ stats.DontKnowResponsesCount }}</span>
-        </div>
-    </div> #}
+    {{ dump(stats) }}
 
 {% endblock %}

--- a/client/templates/Admin/Stats/reports.html.twig
+++ b/client/templates/Admin/Stats/reports.html.twig
@@ -1,37 +1,34 @@
 {% extends '@App/Layouts/application.html.twig' %}
 
-{% trans_default_domain "admin-metrics" %}
+{% trans_default_domain 'admin-metrics' %}
 {% set page = 'reports' %}
 
 {% set navSection = 'reports' %}
 
-{% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
-{% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
+{% block htmlTitle %}
+    {{ (page ~ '.htmlTitle')|trans }}
+{% endblock %}
+{% block pageTitle %}
+    {{ (page ~ '.pageTitle')|trans }}
+{% endblock %}
 
 {% block pageContent %}
     <p>
-        <a href="{{ path('admin_active_lays_csv') }}" class="govuk-link">
-            {{ (page ~ '.downloadActiveLays') | trans }}
-        </a>
+        <a href="{{ path('admin_active_lays_csv') }}" class="govuk-link">{{ (page ~ '.downloadActiveLays')|trans }}</a>
     </p>
 
     <p>
-        <a href="{{ path('admin_satisfaction') }}" class="govuk-link">
-            {{ (page ~ '.downloadSatisfaction') | trans }}
-        </a>
+        <a href="{{ path('admin_satisfaction') }}" class="govuk-link">{{ (page ~ '.downloadSatisfaction')|trans }}</a>
     </p>
     <p>
-        <a href="{{ path('admin_user_research') }}" class="govuk-link">
-            {{ (page ~ '.downloadUserResearch') | trans }}
-        </a>
+        <a href="{{ path('admin_user_research') }}" class="govuk-link">{{ (page ~ '.downloadUserResearch')|trans }}</a>
     </p>
-
     <p>
-        <a href="{{ path('admin_user_account_reports') }}" class="govuk-link">
-            {{ (page ~ '.userAccountReports') | trans }}
-        </a>
+        <a href="{{ path('admin_user_account_reports') }}" class="govuk-link">{{ (page ~ '.userAccountReports')|trans }}</a>
     </p>
-
+    <p>
+        <a href="{{ path('benefits_reoprt_metrics') }}" class="govuk-link">{{ (page ~ '.benefitsSectionMetrics')|trans }}</a>
+    </p>
     <p>
         <a href="{{ path('admin_total_assets_values') }}" class="govuk-link">
             {{ (page ~ '.downloadAssetsTotalValues') | trans }}

--- a/client/templates/Admin/Stats/satisfaction.html.twig
+++ b/client/templates/Admin/Stats/satisfaction.html.twig
@@ -1,6 +1,7 @@
 {% extends '@App/Layouts/application.html.twig' %}
 
-{% trans_default_domain "admin" %}
+{% set translationDomain = "admin" %}
+{% trans_default_domain translationDomain %}
 {% set page = 'satisfactionPage' %}
 
 {% set navSection = 'metrics' %}
@@ -19,11 +20,11 @@
         {{ form_start(form, {attr: {class: 'search', novalidate: 'novalidate' }}) }}
 
         {{ form_known_date(form.startDate, 'satisfactionPage.form.fromDate', {
-            'hintText': 'satisfactionPage.form.fromDate.hint'
+            'hintText': (page ~ '.form.fromDate.hint') | trans
         }) }}<span class="govuk-visually-hidden">of satisfaction search period</span>
 
         {{ form_known_date(form.endDate, 'satisfactionPage.form.toDate', {
-            'hintText': 'satisfactionPage.form.toDate.hint'
+            'hintText': (page ~ '.form.toDate.hint') | trans
         }) }}<span class="govuk-visually-hidden">of satisfaction search period</span>
 
         <div class="govuk-form-group">

--- a/client/templates/Admin/Stats/urResponses.html.twig
+++ b/client/templates/Admin/Stats/urResponses.html.twig
@@ -1,6 +1,7 @@
 {% extends '@App/Layouts/application.html.twig' %}
 
-{% trans_default_domain "admin" %}
+{% set translationDomain = "admin" %}
+{% trans_default_domain translationDomain %}
 {% set page = 'urResponses' %}
 
 {% set navSection = 'metrics' %}
@@ -16,21 +17,20 @@
         <p class="govuk-body">{{ (page ~ '.DescriptionPara') | trans }}</p>
 
         {{ form_start(form, {attr: {class: 'search', novalidate: 'novalidate' }}) }}
+            {{ form_known_date(form.startDate, 'urResponses.form.fromDate', {
+                'hintText': (page ~ '.form.fromDate.hint') | trans
+            }) }}<span class="govuk-visually-hidden">of user research responses search period</span>
 
-        {{ form_known_date(form.startDate, 'urResponses.form.fromDate', {
-            'hintText': 'urResponses.form.fromDate.hint'
-        }) }}<span class="govuk-visually-hidden">of user research responses search period</span>
+            {{ form_known_date(form.endDate, 'urResponses.form.toDate', {
+                'hintText': (page ~ '.form.toDate.hint') | trans
+            }) }}<span class="govuk-visually-hidden">of user research responses search period</span>
 
-        {{ form_known_date(form.endDate, 'urResponses.form.toDate', {
-            'hintText': 'urResponses.form.toDate.hint'
-        }) }}<span class="govuk-visually-hidden">of user research responses search period</span>
-
-        <div class="govuk-form-group">
-            {{ form_submit(form.submitAndDownload, (page ~ '.form.submitAndDownload'), {
-                'buttonClass': 'behat-link-submit-and-download'
-            }) }}
-            <a href="{{ path('admin_stats') }}" class="govuk-link button-link">{{ 'homeForm.clear' | trans }}</a>
-        </div>
+            <div class="govuk-form-group">
+                {{ form_submit(form.submitAndDownload, (page ~ '.form.submitAndDownload'), {
+                    'buttonClass': 'behat-link-submit-and-download'
+                }) }}
+                <a href="{{ path('admin_stats') }}" class="govuk-link button-link">{{ 'homeForm.clear' | trans }}</a>
+            </div>
         {{ form_end(form) }}
 
     </div>

--- a/client/templates/Admin/Stats/userAccountReports.html.twig
+++ b/client/templates/Admin/Stats/userAccountReports.html.twig
@@ -7,6 +7,7 @@
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
+{% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}
 
 {% block pageContent %}
 
@@ -49,4 +50,4 @@
         </div>
     </div>
 
-    {% endblock %}
+{% endblock %}

--- a/client/translations/admin-metrics.en.yml
+++ b/client/translations/admin-metrics.en.yml
@@ -5,7 +5,9 @@ indexPage:
     reports: View reports
 
 adminAccounts:
+    htmlTitle: Administration - Admin Accounts Analytics
     pageTitle: Admin Accounts
+    supportTitle: Analytics
 
 reports:
     htmlTitle: Administration - Reports
@@ -15,6 +17,26 @@ reports:
     downloadSatisfaction: Download satisfaction report
     downloadUserResearch: Download user research report
     userAccountReports: View admin account metrics
+    benefitsSectionMetrics: View benefits report metrics
+
+benefitsReportMetrics:
+    htmlTitle: Administration - Benefits Report Metrics
+    pageTitle: Benefits Report Metrics
+    supportTitle: Analytics
+    form:
+        startDate:
+            label: Start date
+        endDate:
+            label: End date
+        fromDate:
+            legend: Start date
+            hint: For example, 31 3 2015
+        toDate:
+            legend: End date
+            hint: For example, 31 3 2016
+        submitAndDownload:
+            label: Download
+        clear: Clear filter
 
 form:
     title: Change reporting period

--- a/client/translations/admin-metrics.en.yml
+++ b/client/translations/admin-metrics.en.yml
@@ -24,16 +24,14 @@ benefitsReportMetrics:
     pageTitle: Benefits Report Metrics
     supportTitle: Analytics
     form:
-        startDate:
-            label: Start date
-        endDate:
-            label: End date
         fromDate:
             legend: Start date
             hint: For example, 31 3 2015
         toDate:
             legend: End date
             hint: For example, 31 3 2016
+        deputyType:
+            label: Select a Deputy Type
         submitAndDownload:
             label: Download
         clear: Clear filter


### PR DESCRIPTION
## Purpose
We are implementing the first new section in a long time and it would be good to use this as an opportunity to get some stats on a new piece of work. 

It is difficult to find information about how users typically respond to this question because it is less commonly answered with supporting information and it is difficult to track the information across paper only reports. 

Fixes DDPB-4206

## Approach

Stuff I'm not too keen on in this PR but was unable to figure out a different way to do it:
- `api/src/Controller/StatsController::getBenefitsReportMetrics()` don't like the way I have to filter the results out based on the query parameters sent in the download request. Feel like the foreach is doing too much work and it's duplicating a whole section but was unsure how to filter the results when it came done to removing them based on the date filter
- `api/src/Repository/ReportRepository.php::getBenefitsReportMetrics()` this is a plain SQL query as using DQL wasn't allowing me to `LEFT JOIN` the tables the same and therefore was putting a whole report within the metric because the `report_id` inside `client_benefits_check` table is associated with a whole report. Although looking around I think SQL is the only way to go for this.


## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work (TODO added one test but this could probably do with more)
- [ ] The product team have approved these changes