### PR TITLE
DDPB-4239 - Skip rows with blank fields which are mandatory

### DIFF
--- a/api/src/v2/Registration/Assembler/SiriusToLayDeputyshipDtoAssembler.php
+++ b/api/src/v2/Registration/Assembler/SiriusToLayDeputyshipDtoAssembler.php
@@ -87,6 +87,10 @@ class SiriusToLayDeputyshipDtoAssembler implements LayDeputyshipDtoAssemblerInte
             default => false
         };
 
-        return $supported ? $reportType : '';
+        if ($supported) {
+            return $reportType;
+        } else {
+            throw new InvalidArgumentException();
+        }
     }
 }


### PR DESCRIPTION
## Purpose
Found an issue where when transforming rows from the CSV into the DTO, an error occurred resulting in the upload failing.

Discovered that the CSV sometimes contains rows with blank fields. This error in particular was caused by having a blank row for the `ReportType` field in the CSV.

Logic was unable to determine report type, and was not throwing any exceptions.

Fixes DDPB-4329

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
