### PR TITLE
DDPB-4331: Make case number search not case sensitive during org csv upload

### DIFF
--- a/api/src/Repository/ClientRepository.php
+++ b/api/src/Repository/ClientRepository.php
@@ -131,4 +131,13 @@ class ClientRepository extends ServiceEntityRepository
             ->createQuery('SELECT COUNT(c.id) FROM App\Entity\Client c')
             ->getSingleScalarResult();
     }
+
+    public function findByCaseNumber(string $caseNumber)
+    {
+        return $this
+            ->getEntityManager()
+            ->createQuery('SELECT c FROM App\Entity\Client c WHERE LOWER(c.caseNumber) = LOWER(:caseNumber)')
+            ->setParameter('caseNumber', $caseNumber)
+            ->getSingleResult();
+    }
 }

--- a/api/src/v2/Registration/Uploader/OrgDeputyshipUploader.php
+++ b/api/src/v2/Registration/Uploader/OrgDeputyshipUploader.php
@@ -64,7 +64,7 @@ class OrgDeputyshipUploader
             try {
                 $this->handleDtoErrors($deputyshipDto);
 
-                $this->client = ($this->em->getRepository(Client::class))->findOneBy(['caseNumber' => $deputyshipDto->getCaseNumber()]);
+                $this->client = ($this->em->getRepository(Client::class))->findByCaseNumber($deputyshipDto->getCaseNumber());
 
                 $this->skipArchivedClients();
                 $this->handleNamedDeputy($deputyshipDto);

--- a/api/tests/Unit/v2/Registration/Uploader/OrgDeputyshipUploaderTest.php
+++ b/api/tests/Unit/v2/Registration/Uploader/OrgDeputyshipUploaderTest.php
@@ -450,4 +450,32 @@ class OrgDeputyshipUploaderTest extends KernelTestCase
             $updatedClient->getNamedDeputy()->getAddress1()
         );
     }
+
+    /** @test */
+    public function uploadCaseNumberSearchIsNotCaseSensitive()
+    {
+        $deputyships = OrgDeputyshipDTOTestHelper::generateSiriusOrgDeputyshipDtos(1, 0);
+        $client = OrgDeputyshipDTOTestHelper::ensureClientInUploadExists($deputyships[0], $this->em);
+        $client->setCourtDate(null);
+        $client->setCaseNumber('1234567t');
+        $deputyships[0]->setCaseNumber('1234567T');
+
+        $this->em->persist($client);
+        $this->em->flush();
+
+        $uploadResults = $this->sut->upload($deputyships);
+
+        self::assertCount(
+            1,
+            $uploadResults['updated']['clients'],
+            sprintf('Expecting 1, got %d', count($uploadResults['updated']['clients']))
+        );
+
+        $updatedClient = $this->em->getRepository(Client::class)->find($client);
+
+        self::assertEquals(
+            $deputyships[0]->getCourtDate(),
+            $updatedClient->getCourtDate()
+        );
+    }
 }


### PR DESCRIPTION
## Purpose
Does what it says on the tin - ensures we don't duplicate clients during CSV upload.

Fixes DDPB-4331