### PR TITLE
DDPB-4327: Only check CSV uploaded on production

### DIFF
--- a/environment/check_csv_uploaded.tf
+++ b/environment/check_csv_uploaded.tf
@@ -67,6 +67,7 @@ resource "aws_cloudwatch_event_rule" "check_csv_uploaded_cron_rule" {
   description         = "Check daily which CSVs have been uploaded in ${terraform.workspace}"
   schedule_expression = local.check_csv_uploaded_interval
   tags                = local.default_tags
+  is_enabled          = local.environment == "production02" ? true : false
 }
 
 resource "aws_cloudwatch_event_target" "check_csv_uploaded_scheduled_task" {


### PR DESCRIPTION
## Purpose
Limits checking if Sirius CSVs have been uploaded to production.

Fixes DDPB-4327

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
