### PR TITLE
DDPB-4352 bump terraform version and provider versions (specifically AWS)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,8 +588,8 @@ orbs:
               password: $DOCKER_ACCESS_TOKEN
         resource_class: small
         environment:
-          TF_VERSION: 1.0.0
-          TF_SHA256SUM: 8be33cc3be8089019d95eb8f546f35d41926e7c1e5deff15792e969dde573eb5
+          TF_VERSION: 1.2.1
+          TF_SHA256SUM: 8cf8eb7ed2d95a4213fbfd0459ab303f890e79220196d1c4aae9ecf22547302e
           TF_CLI_ARGS_plan: -input=false -lock=false
           TF_CLI_ARGS_apply: -input=false -auto-approve
           TF_CLI_ARGS_destroy: -input=false -auto-approve

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ vendor/
 !ecs_helper/vendor/
 
 # Terraform
-**/.terraform.lock.hcl
 .terraform/
 **/terraform.output.json
 **/terraform.plan*

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ vendor/
 .terraform/
 **/terraform.output.json
 **/terraform.plan*
+**/shared/builds
 
 # Repo-specific excludes
 docker/log

--- a/environment/.terraform.lock.hcl
+++ b/environment/.terraform.lock.hcl
@@ -1,0 +1,59 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.16.0"
+  constraints = "4.16.0"
+  hashes = [
+    "h1:6V8jLqXdtHjCkMIuxg77BrTVchqpaRK1UUYeTuXDPmE=",
+    "zh:0aa204fead7c431796386cc9e73ccda9a185f37e46d4b6475ff3f56ad4f15101",
+    "zh:130396f5da1650f4d6949e67ec44e0f408a529b7f76c48701a7bf21ba6949bbc",
+    "zh:271bfa95bc1332676a81d3f01ba1b5a188abf26df475ca9f25972c68935b6ee9",
+    "zh:51bc600c6c00292c6cb00ca460c555fb2cafd11d5fe9c5dc7d4ce62ec71874f8",
+    "zh:6ece49ba67e484777e1588a08b043c186aa896b5189b0a5056eb7838c566f63e",
+    "zh:994402e0973b12f2266f2d3ad00f000b2e2f3ee6961631aeab32688c0c4e07fd",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e9ef874b11dfb1960aa18e1254ee430142cb583f721a2ed44b608ddf652db57",
+    "zh:bb1755cd1dd39e0caf98efb1ccb5b03323f77ba13b3f5531bfe28aded7750db0",
+    "zh:e5e73ddc1e3d0c0311be90176152c07f0d27af377a95baab72c6f00622461f46",
+    "zh:e7fd8313107ab7f63297b8440b0ccf08a7b56a329ae110ad9b6ef51959939a20",
+    "zh:f095a3f10331b3a91527822a2a881a6714c2e40ee20a14b3c127340c540e37e5",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.2.3"
+  hashes = [
+    "h1:KmHz81iYgw9Xn2L3Carc2uAzvFZ1XsE7Js3qlVeC77k=",
+    "zh:04f0978bb3e052707b8e82e46780c371ac1c66b689b4a23bbc2f58865ab7d5c0",
+    "zh:6484f1b3e9e3771eb7cc8e8bab8b35f939a55d550b3f4fb2ab141a24269ee6aa",
+    "zh:78a56d59a013cb0f7eb1c92815d6eb5cf07f8b5f0ae20b96d049e73db915b238",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8aa9950f4c4db37239bcb62e19910c49e47043f6c8587e5b0396619923657797",
+    "zh:996beea85f9084a725ff0e6473a4594deb5266727c5f56e9c1c7c62ded6addbb",
+    "zh:9a7ef7a21f48fabfd145b2e2a4240ca57517ad155017e86a30860d7c0c109de3",
+    "zh:a63e70ac052aa25120113bcddd50c1f3cfe61f681a93a50cea5595a4b2cc3e1c",
+    "zh:a6e8d46f94108e049ad85dbed60354236dc0b9b5ec8eabe01c4580280a43d3b8",
+    "zh:bb112ce7efbfcfa0e65ed97fa245ef348e0fd5bfa5a7e4ab2091a9bd469f0a9e",
+    "zh:d7bec0da5c094c6955efed100f3fe22fca8866859f87c025be1760feb174d6d9",
+    "zh:fb9f271b72094d07cef8154cd3d50e9aa818a0ea39130bc193132ad7b23076fd",
+  ]
+}

--- a/environment/api_elasticache.tf
+++ b/environment/api_elasticache.tf
@@ -1,16 +1,16 @@
 resource "aws_elasticache_replication_group" "api" {
-  automatic_failover_enabled    = local.account.elasticache_count == 1 ? false : true
-  engine                        = "redis"
-  engine_version                = "5.0.0"
-  replication_group_id          = "api-rep-group-${local.environment}"
-  replication_group_description = "Replication Group for API"
-  node_type                     = "cache.t2.micro"
-  number_cache_clusters         = local.account.elasticache_count
-  parameter_group_name          = "default.redis5.0"
-  port                          = 6379
-  subnet_group_name             = local.account.ec_subnet_group
-  security_group_ids            = [module.api_cache_security_group.id]
-  apply_immediately             = true
+  automatic_failover_enabled = local.account.elasticache_count == 1 ? false : true
+  engine                     = "redis"
+  engine_version             = "5.0.0"
+  replication_group_id       = "api-rep-group-${local.environment}"
+  description                = "Replication Group for API"
+  node_type                  = "cache.t2.micro"
+  num_cache_clusters         = local.account.elasticache_count
+  parameter_group_name       = "default.redis5.0"
+  port                       = 6379
+  subnet_group_name          = local.account.ec_subnet_group
+  security_group_ids         = [module.api_cache_security_group.id]
+  apply_immediately          = true
   tags = merge({
     InstanceName = "api-${local.environment}"
     Stack        = local.environment

--- a/environment/frontend_shared_elasticache.tf
+++ b/environment/frontend_shared_elasticache.tf
@@ -1,17 +1,17 @@
 resource "aws_elasticache_replication_group" "frontend" {
-  automatic_failover_enabled    = local.account.elasticache_count == 1 ? false : true
-  engine                        = "redis"
-  engine_version                = "5.0.0"
-  replication_group_id          = "frontend-rep-group-${local.environment}"
-  replication_group_description = "Replication Group for Front and Admin"
-  node_type                     = "cache.t2.micro"
-  number_cache_clusters         = local.account.elasticache_count
-  parameter_group_name          = "default.redis5.0"
-  port                          = 6379
-  subnet_group_name             = local.account.ec_subnet_group
-  security_group_ids            = [module.frontend_cache_security_group.id]
-  tags                          = local.default_tags
-  apply_immediately             = true
+  automatic_failover_enabled = local.account.elasticache_count == 1 ? false : true
+  engine                     = "redis"
+  engine_version             = "5.0.0"
+  replication_group_id       = "frontend-rep-group-${local.environment}"
+  description                = "Replication Group for Front and Admin"
+  node_type                  = "cache.t2.micro"
+  num_cache_clusters         = local.account.elasticache_count
+  parameter_group_name       = "default.redis5.0"
+  port                       = 6379
+  subnet_group_name          = local.account.ec_subnet_group
+  security_group_ids         = [module.frontend_cache_security_group.id]
+  tags                       = local.default_tags
+  apply_immediately          = true
 }
 
 locals {

--- a/environment/s3_access_logs.tf
+++ b/environment/s3_access_logs.tf
@@ -1,42 +1,28 @@
 resource "aws_s3_bucket" "s3_access_logs" {
   bucket        = "s3-access-logs.${local.environment}"
-  acl           = "log-delivery-write"
   force_destroy = local.account["force_destroy_bucket"]
+}
 
-  versioning {
-    enabled = true
-  }
+resource "aws_s3_bucket_server_side_encryption_configuration" "s3_access_logs" {
+  bucket = aws_s3_bucket.s3_access_logs.bucket
 
-  lifecycle_rule {
-    transition {
-      days          = 30
-      storage_class = "GLACIER"
-    }
-
-    noncurrent_version_transition {
-      days          = 30
-      storage_class = "GLACIER"
-    }
-
-    noncurrent_version_expiration {
-      days = 180
-    }
-
-    expiration {
-      days                         = 180
-      expired_object_delete_marker = true
-    }
-
-    enabled = true
-  }
-
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
+}
+
+resource "aws_s3_bucket_versioning" "s3_access_logs" {
+  bucket = aws_s3_bucket.s3_access_logs.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_acl" "s3_access_logs" {
+  bucket = aws_s3_bucket.s3_access_logs.id
+  acl    = "log-delivery-write"
 }
 
 resource "aws_s3_bucket_public_access_block" "s3_access_logs" {
@@ -46,4 +32,37 @@ resource "aws_s3_bucket_public_access_block" "s3_access_logs" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "s3_access_logs" {
+  bucket = aws_s3_bucket.s3_access_logs.id
+
+  rule {
+    id     = "archive-after-30-days"
+    status = "Enabled"
+
+    transition {
+      days          = 30
+      storage_class = "GLACIER"
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 30
+      storage_class   = "GLACIER"
+    }
+  }
+
+  rule {
+    id     = "expire-after-180-days"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 180
+    }
+
+    expiration {
+      days                         = 180
+      expired_object_delete_marker = true
+    }
+  }
 }

--- a/environment/versions.tf
+++ b/environment/versions.tf
@@ -1,12 +1,12 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.2.1"
   required_providers {
     archive = {
       source = "hashicorp/archive"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "3.72.0"
+      version = "4.16.0"
     }
     local = {
       source = "hashicorp/local"

--- a/shared/.terraform.lock.hcl
+++ b/shared/.terraform.lock.hcl
@@ -1,0 +1,98 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.16.0"
+  constraints = "4.16.0"
+  hashes = [
+    "h1:6V8jLqXdtHjCkMIuxg77BrTVchqpaRK1UUYeTuXDPmE=",
+    "zh:0aa204fead7c431796386cc9e73ccda9a185f37e46d4b6475ff3f56ad4f15101",
+    "zh:130396f5da1650f4d6949e67ec44e0f408a529b7f76c48701a7bf21ba6949bbc",
+    "zh:271bfa95bc1332676a81d3f01ba1b5a188abf26df475ca9f25972c68935b6ee9",
+    "zh:51bc600c6c00292c6cb00ca460c555fb2cafd11d5fe9c5dc7d4ce62ec71874f8",
+    "zh:6ece49ba67e484777e1588a08b043c186aa896b5189b0a5056eb7838c566f63e",
+    "zh:994402e0973b12f2266f2d3ad00f000b2e2f3ee6961631aeab32688c0c4e07fd",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9e9ef874b11dfb1960aa18e1254ee430142cb583f721a2ed44b608ddf652db57",
+    "zh:bb1755cd1dd39e0caf98efb1ccb5b03323f77ba13b3f5531bfe28aded7750db0",
+    "zh:e5e73ddc1e3d0c0311be90176152c07f0d27af377a95baab72c6f00622461f46",
+    "zh:e7fd8313107ab7f63297b8440b0ccf08a7b56a329ae110ad9b6ef51959939a20",
+    "zh:f095a3f10331b3a91527822a2a881a6714c2e40ee20a14b3c127340c540e37e5",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.2.2"
+  constraints = ">= 1.0.0"
+  hashes = [
+    "h1:VUkgcWvCliS0HO4kt7oEQhFD2gcx/59XpwMqxfCU1kE=",
+    "zh:0b84ab0af2e28606e9c0c1289343949339221c3ab126616b831ddb5aaef5f5ca",
+    "zh:10cf5c9b9524ca2e4302bf02368dc6aac29fb50aeaa6f7758cce9aa36ae87a28",
+    "zh:56a016ee871c8501acb3f2ee3b51592ad7c3871a1757b098838349b17762ba6b",
+    "zh:719d6ef39c50e4cffc67aa67d74d195adaf42afcf62beab132dafdb500347d39",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7fbfc4d37435ac2f717b0316f872f558f608596b389b895fcb549f118462d327",
+    "zh:8ac71408204db606ce63fe8f9aeaf1ddc7751d57d586ec421e62d440c402e955",
+    "zh:a4cacdb06f114454b6ed0033add28006afa3f65a0ea7a43befe45fc82e6809fb",
+    "zh:bb5ce3132b52ae32b6cc005bc9f7627b95259b9ffe556de4dad60d47d47f21f0",
+    "zh:bb60d2976f125ffd232a7ccb4b3f81e7109578b23c9c6179f13a11d125dca82a",
+    "zh:f9540ecd2e056d6e71b9ea5f5a5cf8f63dd5c25394b9db831083a9d4ea99b372",
+    "zh:ffd998b55b8a64d4335a090b6956b4bf8855b290f7554dd38db3302de9c41809",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.2.3"
+  hashes = [
+    "h1:KmHz81iYgw9Xn2L3Carc2uAzvFZ1XsE7Js3qlVeC77k=",
+    "zh:04f0978bb3e052707b8e82e46780c371ac1c66b689b4a23bbc2f58865ab7d5c0",
+    "zh:6484f1b3e9e3771eb7cc8e8bab8b35f939a55d550b3f4fb2ab141a24269ee6aa",
+    "zh:78a56d59a013cb0f7eb1c92815d6eb5cf07f8b5f0ae20b96d049e73db915b238",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8aa9950f4c4db37239bcb62e19910c49e47043f6c8587e5b0396619923657797",
+    "zh:996beea85f9084a725ff0e6473a4594deb5266727c5f56e9c1c7c62ded6addbb",
+    "zh:9a7ef7a21f48fabfd145b2e2a4240ca57517ad155017e86a30860d7c0c109de3",
+    "zh:a63e70ac052aa25120113bcddd50c1f3cfe61f681a93a50cea5595a4b2cc3e1c",
+    "zh:a6e8d46f94108e049ad85dbed60354236dc0b9b5ec8eabe01c4580280a43d3b8",
+    "zh:bb112ce7efbfcfa0e65ed97fa245ef348e0fd5bfa5a7e4ab2091a9bd469f0a9e",
+    "zh:d7bec0da5c094c6955efed100f3fe22fca8866859f87c025be1760feb174d6d9",
+    "zh:fb9f271b72094d07cef8154cd3d50e9aa818a0ea39130bc193132ad7b23076fd",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.1"
+  hashes = [
+    "h1:Pctug/s/2Hg5FJqjYcTM0kPyx3AoYK1MpRWO0T9V2ns=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}

--- a/shared/s3_replication.tf
+++ b/shared/s3_replication.tf
@@ -1,34 +1,8 @@
 resource "aws_s3_bucket" "pa_uploads_branch_replication" {
   count         = local.account.name == "development" ? 1 : 0
   bucket        = "pa-uploads-branch-replication"
-  acl           = "private"
   force_destroy = true
-
-  versioning {
-    enabled = true
-  }
-
-  lifecycle_rule {
-    enabled = true
-
-    expiration {
-      days = 10
-    }
-
-    noncurrent_version_expiration {
-      days = 10
-    }
-  }
-
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-
-  tags = local.default_tags
+  tags          = local.default_tags
 }
 
 resource "aws_s3_bucket_public_access_block" "pa_uploads_branch_replication" {
@@ -133,4 +107,48 @@ resource "aws_iam_role_policy_attachment" "replication" {
   count      = local.account.name == "development" ? 1 : 0
   role       = aws_iam_role.replication[0].name
   policy_arn = aws_iam_policy.replication[0].arn
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "pa_uploads_branch_replication" {
+  count  = local.account.name == "development" ? 1 : 0
+  bucket = aws_s3_bucket.pa_uploads_branch_replication[0].bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "pa_uploads_branch_replication" {
+  count  = local.account.name == "development" ? 1 : 0
+  bucket = aws_s3_bucket.pa_uploads_branch_replication[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_acl" "pa_uploads_branch_replication" {
+  count  = local.account.name == "development" ? 1 : 0
+  bucket = aws_s3_bucket.pa_uploads_branch_replication[0].id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "pa_uploads_branch_replication" {
+  count  = local.account.name == "development" ? 1 : 0
+  bucket = aws_s3_bucket.pa_uploads_branch_replication[0].id
+
+  rule {
+    id     = "expire-after-10-days"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 10
+    }
+
+    expiration {
+      days                         = 10
+      expired_object_delete_marker = true
+    }
+  }
 }

--- a/shared/sns.tf
+++ b/shared/sns.tf
@@ -7,7 +7,7 @@ resource "aws_sns_topic" "alerts" {
 }
 
 module "notify_slack" {
-  source = "github.com/terraform-aws-modules/terraform-aws-notify-slack.git?ref=v2.4.0"
+  source = "github.com/terraform-aws-modules/terraform-aws-notify-slack.git?ref=v5.1.0"
 
   sns_topic_name   = aws_sns_topic.alerts.name
   create_sns_topic = false
@@ -35,7 +35,7 @@ resource "aws_sns_topic" "availability-alert" {
 }
 
 module "notify_slack_us-east-1" {
-  source = "github.com/terraform-aws-modules/terraform-aws-notify-slack.git?ref=v2.4.0"
+  source = "github.com/terraform-aws-modules/terraform-aws-notify-slack.git?ref=v5.1.0"
 
   providers = {
     aws = aws.us-east-1

--- a/shared/versions.tf
+++ b/shared/versions.tf
@@ -1,12 +1,12 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.2.1"
   required_providers {
     archive = {
       source = "hashicorp/archive"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "3.72.0"
+      version = "4.16.0"
     }
     local = {
       source = "hashicorp/local"


### PR DESCRIPTION
## Purpose
We are running a bit of an old version of both terraform and the AWS provider. Update them.

Fixes DDPB-4352

## Approach

So as of 4.9 we're not forced to make all the deprecation changes to the s3 providers so I have skipped neatly to latest version. I have however done the changes on the s3 access log bucket. I checked and it doesn't seem to try and destroy the bucket and the applies work fine against an env where bucket is in it's current format.

However, for the purpose of risk mitigation I was going to put this all the way through to prod and then do a small follow up (call it 4352b or something) for the deprecation warnings on our main s3 bucket and follow then plan through very carefully to prod.

Updated a few other deprecation warnings. Also including the lock file as it's best practice:

`Terraform automatically creates or updates the dependency lock file each time you run the terraform init command. You should include this file in your version control repository so that you can discuss potential changes to your external dependencies via code review, just as you would discuss potential changes to your configuration itself.`

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
