### PR TITLE
DDPB-3123: Fix PHPStan errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,10 +143,10 @@ enable-debug: ##@application Puts app in dev mode and enables debug (so the app 
 	done
 
 phpstan-api:
-	docker-compose run --rm api vendor/phpstan/phpstan/phpstan analyse src --memory-limit=0 --level=max
+	docker-compose run --rm api vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=max
 
 phpstan-frontend:
-	docker-compose run --rm frontend vendor/phpstan/phpstan/phpstan analyse src --memory-limit=0 --level=max
+	docker-compose run --rm frontend vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=max
 
 get-audit-logs: ##@localstack Get audit log groups by passing event name e.g. get-audit-logs event_name=ROLE_CHANGED (see client/Audit/src/service/Audit/AuditEvents)
 	docker-compose exec localstack awslocal logs get-log-events --log-group-name audit-local --log-stream-name $(event_name)

--- a/client/phpstan.neon
+++ b/client/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
   - vendor/phpstan/phpstan-mockery/extension.neon
   - vendor/phpstan/phpstan-phpunit/extension.neon
-  - vendor/jangregor/phpstan-prophecy/src/extension.neon
+  - vendor/jangregor/phpstan-prophecy/extension.neon
 parameters:


### PR DESCRIPTION
## Purpose
This is the first stage of fixing Level 1 PHPStan errors. Files have been updated in order for the phpstan make commands to run locally. 

Fixes DDPB-3123

## Approach
- Updated the memory limit in the docker commands for api and frontend 
- Updated the jangregor path in order for the phpstan-frontend command to work

## Checklist
- [x] I have performed a self-review of my own code
