### PR TITLE
amend sync timings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: check-added-large-files # prevents giant files from being committed.
         args: ["--maxkb=20480"]
@@ -18,7 +18,7 @@ repos:
       - id: trailing-whitespace # trims trailing whitespace.
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.56.0
+    rev: v1.72.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -44,7 +44,7 @@ repos:
         args: ["-d", "client/templates", "-c", "1"]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.5.1
+    rev: v2.7.0
     hooks:
       - id: prettier
         args: ["--write"]

--- a/api/src/Controller/ManageController.php
+++ b/api/src/Controller/ManageController.php
@@ -48,6 +48,7 @@ class ManageController extends RestController
 
     /**
      * @param LoggerInterface $logger
+     *
      * @return array [boolean healthy, error string]
      */
     private function dbInfo()
@@ -59,8 +60,8 @@ class ManageController extends RestController
         } catch (\Throwable $e) {
             // customise error message if possible
             $returnMessage = 'Database generic error';
-            if ($e instanceof \PDOException && $e->getCode() === 7) {
-                $returnMessage = 'Database service not reachabe (' . $e->getMessage() . ')';
+            if ($e instanceof \PDOException && 7 === $e->getCode()) {
+                $returnMessage = 'Database service not reachable ('.$e->getMessage().')';
             }
 
             $this->logger->error($e->getMessage());

--- a/environment/checklist_sync.tf
+++ b/environment/checklist_sync.tf
@@ -76,7 +76,7 @@ resource "aws_ecs_service" "checklist_sync" {
 
 resource "aws_cloudwatch_event_rule" "checklist_sync_cron_rule" {
   name                = "${aws_ecs_task_definition.checklist_sync.family}-schedule"
-  schedule_expression = "rate(5 minutes)"
+  schedule_expression = local.document_sync_interval
   tags                = local.default_tags
 }
 

--- a/environment/document_sync.tf
+++ b/environment/document_sync.tf
@@ -29,7 +29,7 @@ locals {
     }
   }
 
-  document_sync_interval = local.environment == "production02" ? "rate(2 minutes)" : "rate(24 hours)"
+  document_sync_interval = local.environment == "production02" ? "rate(5 minutes)" : "rate(24 hours)"
 
 }
 

--- a/environment/monitoring_lambda_event.tf
+++ b/environment/monitoring_lambda_event.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_event_rule" "monitoring_db_queries" {
   name                = "monitor-rds-${local.environment}"
   description         = "Runs bespoke monitoring SQL statements against RDS DB"
-  schedule_expression = "rate(5 minutes)"
+  schedule_expression = local.document_sync_interval
   tags                = local.default_tags
   is_enabled          = local.account == "production02" ? true : false
 }


### PR DESCRIPTION
## Purpose
Costing a whole lot in config because of the creation of multiple resources every time the cloudwatch event triggers

## Approach
For now shall we just set prod to be every 5 mins for both jobs and everything else to be once every 24 hours. Also do we need checklists and reports to be separate commands? Could half the number of calls if we just dumped all the code in one command called sync to sirius or something.

## Learning
NA

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
