### PR TITLE
[DDPB-4346] fixed bug around finished reports showing as not finished

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,9 @@ reset-database: ##@database Resets the DB schema and runs migrations
 reset-fixtures: ##@database Resets the DB contents and reloads fixtures
 	docker-compose run --rm api sh scripts/reset_db_fixtures_local.sh
 
+db-terminal: ##@database Login to the database via the terminal
+	docker exec -it opg-digideps-postgres-1 sh -c "psql -U api"
+
 redis-clear: ##@database Clears out all the data from redis (session related tokens)
 	for c in ${REDIS_CONTAINERS} ; do \
 	  docker-compose exec $$c redis-cli flushall; \

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Once both boxes are checked click `Apply & Restart` then run the `Make` command 
 - Navigate to the root directory of this repository and run `make up-app`
 - Check `https://digideps.local/` (Deputy area) and `https://admin.digideps.local/` (Admin area). Your browser will warn you about a self-signed certificate.
 - Run `./generate_certs.sh` to populate your certs directory
+    - **NB:** Once this has ran it will create a directory called `./certs` inside there are multiple `.crt` files. On a macOS system you need to add these certificates to your keychain. Use the following link if you are unsure how to do that [Adding certificate to macOS keychain](https://support.apple.com/en-gb/guide/keychain-access/kyca2431/mac)
 
 ### Reset the database
 

--- a/api/src/Controller/Report/ClientBenefitsCheckController.php
+++ b/api/src/Controller/Report/ClientBenefitsCheckController.php
@@ -90,6 +90,7 @@ class ClientBenefitsCheckController extends RestController
         if ($clientBenefitsCheck->getReport()) {
             $clientBenefitsCheck->getReport()->updateSectionsStatusCache([Report::SECTION_CLIENT_BENEFITS_CHECK]);
         }
+        $this->getCorrectRepository($reportOrNdr)->persistAndFlush($clientBenefitsCheck);
 
         return $clientBenefitsCheck;
     }

--- a/api/src/Controller/Report/ReportController.php
+++ b/api/src/Controller/Report/ReportController.php
@@ -571,12 +571,12 @@ class ReportController extends RestController
      *
      * @throws NonUniqueResultException
      */
-    public function getAllByUser(Request $request)
+    public function getAllByUser(Request $request): array
     {
         /** @var User $user */
         $user = $this->getUser();
 
-        return $this->getReponseByDeterminant($request, $user->getId(), ReportRepository::USER_DETERMINANT);
+        return $this->getResponseByDeterminant($request, $user->getId(), ReportRepository::USER_DETERMINANT);
     }
 
     /**
@@ -584,7 +584,7 @@ class ReportController extends RestController
      *
      * @throws NonUniqueResultException
      */
-    private function getReponseByDeterminant(Request $request, $orgIdsOrUserId, int $determinant): array
+    private function getResponseByDeterminant(Request $request, $orgIdsOrUserId, int $determinant): array
     {
         /** @var User $user */
         $user = $this->getUser();
@@ -713,7 +713,7 @@ class ReportController extends RestController
             throw new NotFoundHttpException('No organisations found for user');
         }
 
-        return $this->getReponseByDeterminant($request, $organisationIds, ReportRepository::ORG_DETERMINANT);
+        return $this->getResponseByDeterminant($request, $organisationIds, ReportRepository::ORG_DETERMINANT);
     }
 
     /**

--- a/api/src/Entity/Report/Report.php
+++ b/api/src/Entity/Report/Report.php
@@ -531,12 +531,14 @@ class Report implements ReportInterface
         $this->profDeputyPreviousCosts = new ArrayCollection();
         $this->profDeputyInterimCosts = new ArrayCollection();
         $this->profDeputyEstimateCosts = new ArrayCollection();
+        $this->clientBenefitsCheck = new ArrayCollection();
 
         // set sections as notStarted when a new report is created
         $statusCached = [];
         foreach ($this->getAvailableSections() as $sectionId) {
             $statusCached[$sectionId] = ['state' => ReportStatusService::STATE_NOT_STARTED, 'nOfRecords' => 0];
         }
+        
         $this->setSectionStatusesCached($statusCached);
         $this->reportStatusCached = self::STATUS_NOT_STARTED;
     }

--- a/api/src/Entity/Report/Report.php
+++ b/api/src/Entity/Report/Report.php
@@ -531,7 +531,6 @@ class Report implements ReportInterface
         $this->profDeputyPreviousCosts = new ArrayCollection();
         $this->profDeputyInterimCosts = new ArrayCollection();
         $this->profDeputyEstimateCosts = new ArrayCollection();
-        $this->clientBenefitsCheck = new ArrayCollection();
 
         // set sections as notStarted when a new report is created
         $statusCached = [];

--- a/api/src/v2/Fixture/Controller/FixtureController.php
+++ b/api/src/v2/Fixture/Controller/FixtureController.php
@@ -225,6 +225,22 @@ class FixtureController extends AbstractController
         $client->setNamedDeputy($namedDeputy);
         $client->setOrganisation($organisation);
 
+        // if the org size is 1 but we want 10 clients still then create the clients but
+        // we return so we don't create another 10 clients on top if we have a org size > 1
+        if ($fromRequest['orgSizeUsers'] === 1 && $fromRequest['orgSizeClients'] > 1 && !empty($fromRequest['orgSizeClients'])) {
+            foreach (range(1, $fromRequest['orgSizeClients']) as $number) {
+                $orgClient = $this->clientFactory->createGenericOrgClient($namedDeputy, $organisation, $fromRequest['courtDate']);
+                $this->em->persist($orgClient);
+
+                $this->createReport($fromRequest, $orgClient);
+            }
+
+            $this->em->persist($client);
+            $this->em->persist($organisation);
+
+            return;
+        }
+
         if ($fromRequest['orgSizeUsers'] > 1 && !empty($fromRequest['orgSizeUsers'])) {
             foreach (range(1, $fromRequest['orgSizeClients']) as $number) {
                 $orgClient = $this->clientFactory->createGenericOrgClient($namedDeputy, $organisation, $fromRequest['courtDate']);

--- a/generate_certs.sh
+++ b/generate_certs.sh
@@ -1,33 +1,22 @@
 #!/usr/bin/env bash
-openssl req \
-    -newkey rsa:4096 \
-    -x509 \
-    -nodes \
-    -keyout .certs/admin.digideps.local.key \
-    -new \
-    -out .certs/admin.digideps.local.crt \
-    -subj /CN=\admin.digideps.local \
-    -sha256 \
-    -days 3650
+if [ ! -d .certs ]; then
+  mkdir -p .certs;
+fi
 
-openssl req \
-    -newkey rsa:4096 \
-    -x509 \
-    -nodes \
-    -keyout .certs/www.digideps.local.key \
-    -new \
-    -out .certs/www.digideps.local.crt \
-    -subj /CN=\www.digideps.local \
-    -sha256 \
-    -days 3650
+openssl req -x509 -keyout .certs/admin.digideps.local.key -new -out .certs/admin.digideps.local.crt \
+    -newkey rsa:4096 -nodes -sha256 -days 3650 \
+    -subj '/CN=admin.digideps.local' -extensions EXT -config <( \
+    printf "[dn]\nCN=admin.digideps.local\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:admin.digideps.local\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth" \
+    )
 
-openssl req \
-    -newkey rsa:4096 \
-    -x509 \
-    -nodes \
-    -keyout .certs/digideps.local.key \
-    -new \
-    -out .certs/digideps.local.crt \
-    -subj /CN=\digideps.local \
-    -sha256 \
-    -days 3650
+openssl req -x509 -keyout .certs/digideps.local.key -new -out .certs/digideps.local.crt \
+    -newkey rsa:4096 -nodes -sha256 -days 3650 \
+    -subj '/CN=digideps.local' -extensions EXT -config <( \
+    printf "[dn]\nCN=digideps.local\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:digideps.local\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth" \
+    )
+
+openssl req -x509 -keyout .certs/www.digideps.local.key -out .certs/www.digideps.local.crt \
+    -newkey rsa:4096 -nodes -sha256 -days 3650 \
+    -subj '/CN=www.digideps.local' -extensions EXT -config <( \
+    printf "[dn]\nCN=www.digideps.local\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:www.digideps.local\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth" \
+    )


### PR DESCRIPTION
This bug was introduced when creating the client benefits section. As we
was not flushing the db again after updating the report status cache
check we was not getting the client benefit status back as completed and
instead it was returning not done

Also in this PR is a fix for creating multiple client and the SSL cert fix that now gives us a secure connection to the local development server rather than a not secure warning when loading the webpage

Fixes DDPB-4346