### PR TITLE
DDPB-4373 change the teardown schedule on ephemeral envs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,21 +24,20 @@ workflows:
           tf_workspace: development
           tf_command: plan
 
+      - workspace-protection:
+          name: protect branch workspace
+          requires: [cancel redundant builds]
+          filters: { branches: { ignore: [main] } }
+
       - terraform-command:
           name: plan branch env
-          requires: [cancel redundant builds]
+          requires: [protect branch workspace]
           filters: { branches: { ignore: [main] } }
           tf_command: plan
 
       - terraform-command:
           name: initial terraform apply
-          requires:
-            [
-              lint terraform,
-              cancel redundant builds,
-              plan shared-development,
-              plan branch env,
-            ]
+          requires: [lint terraform, plan shared-development, plan branch env]
           filters: { branches: { ignore: [main] } }
           tf_command: apply
           tf_initial_apply: true
@@ -63,11 +62,6 @@ workflows:
           requires: [initial terraform apply, build pr, lambda unit test]
           filters: { branches: { ignore: [main] } }
           tf_command: apply
-
-      - workspace-protection:
-          name: protect branch workspace
-          requires: [terraform apply]
-          filters: { branches: { ignore: [main] } }
 
       - scale-services:
           name: scale up services for integration tests
@@ -532,10 +526,10 @@ workflows:
           requires: [apply integration]
           filters: { branches: { only: [main] } }
 
-  nightly_workspace_deletion:
+  hourly_workspace_deletion:
     triggers:
       - schedule:
-          cron: "00 00 * * *"
+          cron: "00 * * * *"
           filters: { branches: { only: [main] } }
     jobs:
       - destroy-workspaces:
@@ -815,7 +809,7 @@ jobs:
       protect_time:
         description: time to protect workspace
         type: string
-        default: "24"
+        default: "3"
     environment:
       PROTECT_TIME: << parameters.protect_time >>
     steps:


### PR DESCRIPTION
## Purpose
Cut down on costs by being a bit more ruthless with the env teardown

Fixes DDPB-4373

## Approach
Only thing of note here is I put the workspace protection before the plan and all that malarkey. The reason for this is that now that we're running hourly I can imagine a situation where we try and delete at the same time as rerunning a workflow and doing an apply. This should avoid this from happening as the workspace will be protected before it runs the deletes...

However thinking about it, the destroy could happen first and then the job will fail on plan or apply. However there will be a state lock so this shouldn't cause issues and job can be rerun. If it does end up causing issues then we will need to chuck in a waiter script that looks for the deletion runs and checks if they are running but it seems this would be pretty edge case imo.

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
