### PR TITLE
[cert-doc-update] update README docs for certificates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1099,7 +1099,7 @@ jobs:
 
             docker-compose -f docker-compose.yml -f docker-compose.ci.test.yml --project-name client-unit-tests exec frontend sh scripts/client-unit-tests.sh
             docker-compose -f docker-compose.yml -f docker-compose.ci.test.yml --project-name client-unit-tests exec frontend chmod -R 777 tests/phpunit/coverage/client-unit-tests.xml
-            docker cp "client-unit-tests_frontend_1:/var/www/tests/phpunit/coverage/client-unit-tests.xml" "./client-unit-tests.xml"
+            docker cp "client-unit-tests-frontend:/var/www/tests/phpunit/coverage/client-unit-tests.xml" "./client-unit-tests.xml"
 
             docker-compose -f docker-compose.yml -f docker-compose.ci.test.yml --project-name client-unit-tests exec pact-mock cat /tmp/pacts/complete_the_deputy_report-opg_data.json > pact.json
             docker-compose -f docker-compose.yml -f docker-compose.ci.test.yml --project-name client-unit-tests stop pact-mock
@@ -1145,7 +1145,7 @@ jobs:
             docker-compose -f docker-compose.yml -f docker-compose.ci.test.yml --project-name api-unit-tests exec api sh scripts/apiunittest.sh
 
             docker-compose -f docker-compose.yml -f docker-compose.ci.test.yml --project-name api-unit-tests exec api chmod -R 777 tests/coverage/api-unit-tests.xml
-            docker cp "api-unit-tests_api_1:/var/www/tests/coverage/api-unit-tests.xml" "./api-unit-tests.xml"
+            docker cp "api-unit-tests-api:/var/www/tests/coverage/api-unit-tests.xml" "./api-unit-tests.xml"
       - codecov/upload:
           file: ./api-unit-tests.xml
           flags: api

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Once both boxes are checked click `Apply & Restart` then run the `Make` command 
 - Check `https://digideps.local/` (Deputy area) and `https://admin.digideps.local/` (Admin area). Your browser will warn you about a self-signed certificate.
 - Run `./generate_certs.sh` to populate your certs directory
     - **NB:** Once this has ran it will create a directory called `./certs` inside there are multiple `.crt` files. On a macOS system you need to add these certificates to your keychain. Use the following link if you are unsure how to do that [Adding certificate to macOS keychain](https://support.apple.com/en-gb/guide/keychain-access/kyca2431/mac)
+    - Once these have been added to your keychain you need to 'Always Trust' these certificates so Chrome will also trust them.
+        - Open up `Keychain access` find the certificates you have added. These will either live inside `Default Keychains -> login` or `System Keychains -> System` on the sidebar
+        - Once you have located each certificate, double-click them to open the certificate.
+        - Click the `Trust` section and then change `When using this certificate:` from `Use System Defaults` to `Always Trust`. **Do this step for all 3 certificates**
 
 ### Reset the database
 

--- a/docker-compose.ci.test.yml
+++ b/docker-compose.ci.test.yml
@@ -3,10 +3,12 @@ version: '3.2'
 ## Override for tests in CI
 services:
     frontend:
+        container_name: client-unit-tests-frontend
         image: frontend:latest
     admin:
         image: admin:latest
     api:
+        container_name: api-unit-tests-api
         image: api:latest
     htmltopdf:
         image: htmltopdf:latest

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,9 +1,11 @@
 version: "3.2"
 services:
   api:
+    container_name: api-unit-tests-api
     image: ${AWS_REGISTRY}/digideps/api:${VERSION}
     build: ./api
   client:
+    container_name: client-unit-tests-frontend
     image: ${AWS_REGISTRY}/digideps/client:${VERSION}
     build: ./client
   sync:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,11 +1,9 @@
 version: "3.2"
 services:
   api:
-    container_name: api-unit-tests-api
     image: ${AWS_REGISTRY}/digideps/api:${VERSION}
     build: ./api
   client:
-    container_name: client-unit-tests-frontend
     image: ${AWS_REGISTRY}/digideps/client:${VERSION}
     build: ./client
   sync:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
   #            - frontend
 
   frontend:
+    container_name: opg-digideps-frontend
     build:
       context: ./client
       args:
@@ -78,6 +79,7 @@ services:
           - digideps.local
 
   admin:
+    container_name: opg-digideps-admin
     build:
       context: ./client
       args:
@@ -105,6 +107,7 @@ services:
           - admin.digideps.local
 
   api:
+    container_name: opg-digideps-api
     build:
       context: ./api
       args:
@@ -128,6 +131,7 @@ services:
     restart: always
 
   postgres:
+    container_name: opg-digideps-postgres
     image: postgres:10.21
     ports:
       - 5432:5432


### PR DESCRIPTION
After talking @MiaGordon91 through the process of getting a trust SSL certificate for our local sites I noticed I missed a few steps out in the README so Chrome knows to trust the new certificates. I have now added the extra steps into the README so everyone else can follow it.

I've only added steps for the macOS system. I don't have a Windows system on hand to write a README up on how I would get a Windows system to trust the certificates 

Updated the `container_name` for the api/frontend service as the `make db-terminal` command I used I entered the `container_name` which was showing on my environment but found out on other environments it can be different so defining it here allows the command to work for everyone