### PR TITLE
DDPB-4409: Ensure we lowercase casenumbers when matching during lay CSV upload

### DIFF
--- a/api/src/v2/Registration/Uploader/LayDeputyshipUploader.php
+++ b/api/src/v2/Registration/Uploader/LayDeputyshipUploader.php
@@ -26,10 +26,10 @@ class LayDeputyshipUploader
     private $preRegistrationEntriesByCaseNumber = [];
 
     /** @var int */
-    const MAX_UPLOAD = 10000;
+    public const MAX_UPLOAD = 10000;
 
     /** @var int */
-    const FLUSH_EVERY = 5000;
+    public const FLUSH_EVERY = 5000;
 
     public function __construct(
         private EntityManagerInterface $em,
@@ -50,7 +50,7 @@ class LayDeputyshipUploader
 
             foreach ($collection as $index => $layDeputyshipDto) {
                 try {
-                    $caseNumber = (string) $layDeputyshipDto->getCaseNumber();
+                    $caseNumber = strtolower((string) $layDeputyshipDto->getCaseNumber());
                     $this->preRegistrationEntriesByCaseNumber[$caseNumber] = $this->createAndPersistNewPreRegistrationEntity($layDeputyshipDto);
                     ++$added;
                 } catch (PreRegistrationCreationException $e) {

--- a/api/tests/Unit/Entity/Repository/ReportRepositoryTest.php
+++ b/api/tests/Unit/Entity/Repository/ReportRepositoryTest.php
@@ -146,7 +146,7 @@ class ReportRepositoryTest extends ApiBaseTestCase
         $this->entityManager->refresh($client->getUsers()[0]);
 
         $result = $this->repository->findAllActiveReportsByCaseNumbersAndRole(['4932965T'], $client->getUsers()[0]->getRoleName());
-        self::assertEquals($existingReport[0], $result);
+        self::assertEquals($existingReport, $result[0]);
     }
 
     /**


### PR DESCRIPTION
## Purpose
After we started receiving CSVs from Sirius rather than casrec, case numbers with letters were appearing with uppercase letters whereas previously they were lowercased. As we weren't lowercasing when searching on case numbers in the lookup during CSV upload any case with letters was not updated with report type changes. This change ensures we lowercase both the property on Report and the case number in the CSV.

Fixes DDPB-4409.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes