### PR TITLE
DDPB-4431: Stop automatically moving clients into new orgs and updating named deputy name on CSV upload

### DIFF
--- a/api/src/v2/Registration/Uploader/OrgDeputyshipUploader.php
+++ b/api/src/v2/Registration/Uploader/OrgDeputyshipUploader.php
@@ -183,18 +183,18 @@ class OrgDeputyshipUploader
 //                $this->added['clients'][] = $dto->getCaseNumber();
 //            }
 
-            if ($this->clientHasSwitchedOrganisation($this->client)) {
-                $this->currentOrganisation->addClient($this->client);
-                $this->client->setOrganisation($this->currentOrganisation);
-
-                $this->updated['clients'][] = $this->client->getId();
-            }
-
-            if ($this->clientHasNewNamedDeputy($this->client, $this->namedDeputy)) {
-                $this->client->setNamedDeputy($this->namedDeputy);
-
-                $this->updated['clients'][] = $this->client->getId();
-            }
+//            if ($this->clientHasSwitchedOrganisation($this->client)) {
+//                $this->currentOrganisation->addClient($this->client);
+//                $this->client->setOrganisation($this->currentOrganisation);
+//
+//                $this->updated['clients'][] = $this->client->getId();
+//            }
+//
+//            if ($this->clientHasNewNamedDeputy($this->client, $this->namedDeputy)) {
+//                $this->client->setNamedDeputy($this->namedDeputy);
+//
+//                $this->updated['clients'][] = $this->client->getId();
+//            }
         }
 
         $this->em->persist($this->client);

--- a/api/tests/Behat/features-v2/registration/ingest.org.sirius.feature
+++ b/api/tests/Behat/features-v2/registration/ingest.org.sirius.feature
@@ -11,19 +11,19 @@ Feature: Org CSV data ingestion - sirius source data
         Then the new 'org' entities should be added to the database
         And the count of the new 'org' entities added should be displayed on the page
 
-    @super-admin
-    Scenario: Uploading a CSV that contains existing clients and named deputies - new named deputy in same firm
-        Given a super admin user accesses the admin app
-        When I visit the admin upload org users page
-        And I upload an org CSV that has a new named deputy 'MAYOR MCCRACKEN' within the same org as the clients existing name deputy
-        Then the clients named deputy should be updated
+#    @super-admin
+#    Scenario: Uploading a CSV that contains existing clients and named deputies - new named deputy in same firm
+#        Given a super admin user accesses the admin app
+#        When I visit the admin upload org users page
+#        And I upload an org CSV that has a new named deputy 'MAYOR MCCRACKEN' within the same org as the clients existing name deputy
+#        Then the clients named deputy should be updated
 
-    @super-admin
-    Scenario: Uploading a CSV that contains existing clients and named deputies - named deputy address and phone updated
-        Given a super admin user accesses the admin app
-        When I visit the admin upload org users page
-        And I upload an org CSV that has a new address '75 Plutonium Way, Salem, Witchington, Barberaham, Townsville, TW5 V78' for an existing named deputy
-        Then the named deputy's address should be updated
+#    @super-admin
+#    Scenario: Uploading a CSV that contains existing clients and named deputies - named deputy address and phone updated
+#        Given a super admin user accesses the admin app
+#        When I visit the admin upload org users page
+#        And I upload an org CSV that has a new address '75 Plutonium Way, Salem, Witchington, Barberaham, Townsville, TW5 V78' for an existing named deputy
+#        Then the named deputy's address should be updated
 
     @super-admin
     Scenario: Uploading a CSV that contains existing clients and named deputies - report type updated
@@ -32,24 +32,24 @@ Feature: Org CSV data ingestion - sirius source data
         And I upload an org CSV that has a new report type '103-5' for an existing report that has not been submitted or unsubmitted
         Then the report type should be updated
 
-    @super-admin
-    Scenario: Uploading a CSV that contains a new named deputy in a new organisation for an existing client - same case number, same made date
-        Given a super admin user accesses the admin app
-        When I visit the admin upload org users page
-        And I upload an org CSV that has a new named deputy in a new organisation for an existing client
-        Then the named deputy associated with the client should be updated to the new named deputy
-        And the organisation associated with the client should be updated to the new organisation
-        And the report associated with the client should remain the same
+#    @super-admin
+#    Scenario: Uploading a CSV that contains a new named deputy in a new organisation for an existing client - same case number, same made date
+#        Given a super admin user accesses the admin app
+#        When I visit the admin upload org users page
+#        And I upload an org CSV that has a new named deputy in a new organisation for an existing client
+#        Then the named deputy associated with the client should be updated to the new named deputy
+#        And the organisation associated with the client should be updated to the new organisation
+#        And the report associated with the client should remain the same
 
-    @super-admin
-    Scenario: Uploading a CSV where an existing client's named deputy has changed firm  - same case number, same made date
-        Given a super admin user accesses the admin app
-        When I visit the admin upload org users page
-        And I upload an org CSV that contains a new org email and street address but the same deputy number for an existing clients named deputy
-        Then the organisation associated with the client should be updated to the new organisation
-        And the named deputy's address should be updated to '88 BROAD WALK, ALINGHAM, CORK, VALE, TOWNSVILLE, TW8 R55'
-        And the named deputy associated with the client should remain the same
-        And the report associated with the client should remain the same
+#    @super-admin
+#    Scenario: Uploading a CSV where an existing client's named deputy has changed firm  - same case number, same made date
+#        Given a super admin user accesses the admin app
+#        When I visit the admin upload org users page
+#        And I upload an org CSV that contains a new org email and street address but the same deputy number for an existing clients named deputy
+#        Then the organisation associated with the client should be updated to the new organisation
+#        And the named deputy's address should be updated to '88 BROAD WALK, ALINGHAM, CORK, VALE, TOWNSVILLE, TW8 R55'
+#        And the named deputy associated with the client should remain the same
+#        And the report associated with the client should remain the same
 
 #    @super-admin
 #    Scenario: Uploading a CSV that contains a new named deputy in a new organisation for an existing client - same case number, new made date

--- a/api/tests/Unit/v2/Registration/Uploader/OrgDeputyshipUploaderTest.php
+++ b/api/tests/Unit/v2/Registration/Uploader/OrgDeputyshipUploaderTest.php
@@ -225,44 +225,44 @@ class OrgDeputyshipUploaderTest extends KernelTestCase
         );
     }
 
-    /** @test  */
-    public function uploadClientAndNamedDeputyAreAssociatedWhenClientHasSwitchedOrgsAndNamedDeputyHasChanged()
-    {
-        $deputyships = OrgDeputyshipDTOTestHelper::generateSiriusOrgDeputyshipDtos(1, 0);
-
-        $orgIdentifier = explode('@', $deputyships[0]->getDeputyEmail())[1];
-
-        $originalNamedDeputy = OrgDeputyshipDTOTestHelper::ensureNamedDeputyInUploadExists($deputyships[0], $this->em);
-        $originalNamedDeputy->setEmail1(sprintf('different.deputy@%s', $orgIdentifier));
-        $originalNamedDeputy->setDeputyUid('ABCD1234');
-
-        $organisation = OrgDeputyshipDTOTestHelper::ensureOrgInUploadExists($orgIdentifier, $this->em);
-        $organisation->setEmailIdentifier($orgIdentifier);
-
-        $client = OrgDeputyshipDTOTestHelper::ensureClientInUploadExists($deputyships[0], $this->em);
-        $client->setNamedDeputy($originalNamedDeputy)->setOrganisation($organisation);
-
-        $this->em->persist($client);
-        $this->em->flush();
-
-        $actualUploadResults = $this->sut->upload($deputyships);
-
-        self::assertTrue(
-            OrgDeputyshipDTOTestHelper::clientAndNamedDeputyAreAssociated(
-                $deputyships[0],
-                $this->clientRepository,
-                $this->namedDeputyRepository
-            ),
-            sprintf(
-                'Client with case number "%s" and named deputy with uid "%s" are not associated when they should be',
-                $deputyships[0]->getCaseNumber(),
-                $deputyships[0]->getDeputyUid()
-            )
-        );
-
-        self::assertCount(0, $actualUploadResults['added']['clients']);
-        self::assertCount(1, $actualUploadResults['updated']['clients']);
-    }
+//    /** @test  */
+//    public function uploadClientAndNamedDeputyAreAssociatedWhenClientHasSwitchedOrgsAndNamedDeputyHasChanged()
+//    {
+//        $deputyships = OrgDeputyshipDTOTestHelper::generateSiriusOrgDeputyshipDtos(1, 0);
+//
+//        $orgIdentifier = explode('@', $deputyships[0]->getDeputyEmail())[1];
+//
+//        $originalNamedDeputy = OrgDeputyshipDTOTestHelper::ensureNamedDeputyInUploadExists($deputyships[0], $this->em);
+//        $originalNamedDeputy->setEmail1(sprintf('different.deputy@%s', $orgIdentifier));
+//        $originalNamedDeputy->setDeputyUid('ABCD1234');
+//
+//        $organisation = OrgDeputyshipDTOTestHelper::ensureOrgInUploadExists($orgIdentifier, $this->em);
+//        $organisation->setEmailIdentifier($orgIdentifier);
+//
+//        $client = OrgDeputyshipDTOTestHelper::ensureClientInUploadExists($deputyships[0], $this->em);
+//        $client->setNamedDeputy($originalNamedDeputy)->setOrganisation($organisation);
+//
+//        $this->em->persist($client);
+//        $this->em->flush();
+//
+//        $actualUploadResults = $this->sut->upload($deputyships);
+//
+//        self::assertTrue(
+//            OrgDeputyshipDTOTestHelper::clientAndNamedDeputyAreAssociated(
+//                $deputyships[0],
+//                $this->clientRepository,
+//                $this->namedDeputyRepository
+//            ),
+//            sprintf(
+//                'Client with case number "%s" and named deputy with uid "%s" are not associated when they should be',
+//                $deputyships[0]->getCaseNumber(),
+//                $deputyships[0]->getDeputyUid()
+//            )
+//        );
+//
+//        self::assertCount(0, $actualUploadResults['added']['clients']);
+//        self::assertCount(1, $actualUploadResults['updated']['clients']);
+//    }
 
     /** @test */
     public function uploadReportsAreCreatedForNewClients()


### PR DESCRIPTION
## Purpose
Prior to casrec we were automatically updating deputy name and org alongside automatic discharges. As the name and org went in tandem with a discharge this log was sound but now we have disabled that step we are updating the deputy and address before a discharge has happened. This can lead to the wrong people being able to see reports.

Fixes DDPB-4431
