### PR TITLE
DDPB-4435: Only update deputy name and address if they are the existing deputy reporting on a client

### DIFF
--- a/api/src/v2/Registration/Uploader/OrgDeputyshipUploader.php
+++ b/api/src/v2/Registration/Uploader/OrgDeputyshipUploader.php
@@ -107,34 +107,36 @@ class OrgDeputyshipUploader
             $this->added['named_deputies'][] = $namedDeputy->getId();
         }
 
-        if ($namedDeputy->addressHasChanged($dto)) {
-            $namedDeputy
-                ->setAddress1($dto->getDeputyAddress1())
-                ->setAddress2($dto->getDeputyAddress2())
-                ->setAddress3($dto->getDeputyAddress3())
-                ->setAddress4($dto->getDeputyAddress4())
-                ->setAddress5($dto->getDeputyAddress5())
-                ->setAddressPostcode($dto->getDeputyPostcode());
+        if ($namedDeputy->getDeputyUid() === $dto->getDeputyUid()) {
+            if ($namedDeputy->addressHasChanged($dto)) {
+                $namedDeputy
+                    ->setAddress1($dto->getDeputyAddress1())
+                    ->setAddress2($dto->getDeputyAddress2())
+                    ->setAddress3($dto->getDeputyAddress3())
+                    ->setAddress4($dto->getDeputyAddress4())
+                    ->setAddress5($dto->getDeputyAddress5())
+                    ->setAddressPostcode($dto->getDeputyPostcode());
 
-            $this->em->persist($namedDeputy);
-            $this->em->flush();
+                $this->em->persist($namedDeputy);
+                $this->em->flush();
 
-            $this->updated['named_deputies'][] = $namedDeputy->getId();
-        }
-
-        if ($namedDeputy->nameHasChanged($dto)) {
-            if ($dto->deputyIsAnOrganisation()) {
-                $namedDeputy->setFirstname($dto->getOrganisationName());
-                $namedDeputy->setLastname('');
-            } else {
-                $namedDeputy->setFirstname($dto->getDeputyFirstname());
-                $namedDeputy->setLastname($dto->getDeputyLastname());
+                $this->updated['named_deputies'][] = $namedDeputy->getId();
             }
 
-            $this->em->persist($namedDeputy);
-            $this->em->flush();
+            if ($namedDeputy->nameHasChanged($dto)) {
+                if ($dto->deputyIsAnOrganisation()) {
+                    $namedDeputy->setFirstname($dto->getOrganisationName());
+                    $namedDeputy->setLastname('');
+                } else {
+                    $namedDeputy->setFirstname($dto->getDeputyFirstname());
+                    $namedDeputy->setLastname($dto->getDeputyLastname());
+                }
 
-            $this->updated['named_deputies'][] = $namedDeputy->getId();
+                $this->em->persist($namedDeputy);
+                $this->em->flush();
+
+                $this->updated['named_deputies'][] = $namedDeputy->getId();
+            }
         }
 
         $this->namedDeputy = $namedDeputy;

--- a/client/package.json
+++ b/client/package.json
@@ -32,7 +32,7 @@
     "webpack-cli": "^4.9.2"
   },
   "dependencies": {
-    "@ministryofjustice/frontend": "0.0.17-alpha",
+    "@ministryofjustice/frontend": "^1.3.2",
     "govuk-frontend": "^3.14.0",
     "jest-environment-jsdom": "^28.1.1"
   },


### PR DESCRIPTION
## Purpose
A further ticket to tighten up our CSV upload process. We are currently updating the deputy name and address if they have changed. We should only do this if they are the existing deputy for the client.

Fixes DDPB-4435


