### PR TITLE
DDPB-4436: Stop creating new report when deputy and org changes

### DIFF
--- a/api/src/v2/Registration/Uploader/OrgDeputyshipUploader.php
+++ b/api/src/v2/Registration/Uploader/OrgDeputyshipUploader.php
@@ -266,18 +266,18 @@ class OrgDeputyshipUploader
                 }
             }
 
-            if ($this->clientHasNewOrgAndNamedDeputy($this->client, $this->namedDeputy)) {
-                $report = new Report(
-                    $this->client,
-                    $dto->getReportType(),
-                    $dto->getReportStartDate(),
-                    $dto->getReportEndDate()
-                );
-
-                $this->client->addReport($report);
-
-                $this->added['reports'][] = $this->client->getCaseNumber().'-'.$dto->getReportEndDate()->format('Y-m-d');
-            }
+//            if ($this->clientHasNewOrgAndNamedDeputy($this->client, $this->namedDeputy)) {
+//                $report = new Report(
+//                    $this->client,
+//                    $dto->getReportType(),
+//                    $dto->getReportStartDate(),
+//                    $dto->getReportEndDate()
+//                );
+//
+//                $this->client->addReport($report);
+//
+//                $this->added['reports'][] = $this->client->getCaseNumber().'-'.$dto->getReportEndDate()->format('Y-m-d');
+//            }
         } else {
             $report = new Report(
                 $this->client,


### PR DESCRIPTION
## Purpose
Another hangover from when we were auto discharging - we no longer should create a report if an org and deputy are updated on a row but the client has not been discharged.

Fixes DDPB-4436

