### PR TITLE
DDPB-4439: Stop verifying SSL in api client

### DIFF
--- a/client/config/packages/framework.yml
+++ b/client/config/packages/framework.yml
@@ -41,6 +41,9 @@ framework:
         enabled: true
 
     http_client:
+        default_options:
+            verify_host: false
+            verify_peer: false
         scoped_clients:
             # by setting base_uri, relative URLs (e.g. request("GET", "/registration/new"))
             # will default to these options


### PR DESCRIPTION
## Purpose
Temporarily disabling verifying SSL when using the API scoped client. Follow up fix will be made to revert this change once we've fixed the verify problems.

Fixes DDPB-4439
