### PR TITLE
DDPB-4440: Trim names when matching against PreRegistration data

### DIFF
--- a/api/src/Service/PreRegistrationVerificationService.php
+++ b/api/src/Service/PreRegistrationVerificationService.php
@@ -109,7 +109,7 @@ class PreRegistrationVerificationService
         $clientLastnameMatches = [];
 
         foreach ($caseNumberMatches as $match) {
-            if (mb_strtolower($match->getClientLastname()) == mb_strtolower($detailsToMatchOn['clientLastname'])) {
+            if (trim(mb_strtolower($match->getClientLastname())) === trim(mb_strtolower($detailsToMatchOn['clientLastname']))) {
                 $clientLastnameMatches[] = $match;
             }
         }
@@ -123,7 +123,7 @@ class PreRegistrationVerificationService
         $deputyLastnameMatches = [];
 
         foreach ($clientLastnameMatches as $match) {
-            if (mb_strtolower($match->getDeputySurname()) == mb_strtolower($detailsToMatchOn['deputyLastname'])) {
+            if (trim(mb_strtolower($match->getDeputySurname())) === trim(mb_strtolower($detailsToMatchOn['deputyLastname']))) {
                 $deputyLastnameMatches[] = $match;
             }
         }


### PR DESCRIPTION
## Purpose
At some point we stopped trimming the strings we receive from Sirius when matching against them. This reinstates that step to ensure we account for client and deputy last names that contain whitespace from Sirius.

Fixes DDPB-4440
