### PR TITLE
DDPB-4375: Response for checklist question not appearing

### DIFF
--- a/client/templates/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
+++ b/client/templates/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
@@ -401,12 +401,10 @@
             <table class="checkboxes labelvalue inline">
                 <tbody>
                     <tr>
-                        <td class="checkbox value"{% if lodgingChecklist.futureSignificantDecisions == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.futureSignificantDecisions == 'yes' %} aria-label=”Selected”>X{% else %}> {% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value"{% if lodgingChecklist.futureSignificantDecisions == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.futureSignificantDecisions == 'no' %} aria-label=”Selected”>X{% else %}> {% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value"{% if lodgingChecklist.futureSignificantDecisions == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
-                        <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                     </tr>
                 </tbody>
             </table>
@@ -420,8 +418,6 @@
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
                         <td class="checkbox value"{% if lodgingChecklist.hasDeputyRaisedConcerns == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value"{% if lodgingChecklist.hasDeputyRaisedConcerns == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
-                        <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                     </tr>
                 </tbody>
             </table>
@@ -439,8 +435,8 @@
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
                         <td class="checkbox value"{% if lodgingChecklist.caseWorkerSatisified == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value"{% if lodgingChecklist.caseWorkerSatisified == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
-                        <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
+{#                        <td class="checkbox value"{% if lodgingChecklist.caseWorkerSatisified == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>#}
+{#                        <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>#}
                     </tr>
                 </tbody>
             </table>

--- a/client/templates/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
+++ b/client/templates/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
@@ -435,8 +435,6 @@
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
                         <td class="checkbox value"{% if lodgingChecklist.caseWorkerSatisified == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
-{#                        <td class="checkbox value"{% if lodgingChecklist.caseWorkerSatisified == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>#}
-{#                        <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>#}
                     </tr>
                 </tbody>
             </table>

--- a/client/templates/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
+++ b/client/templates/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
@@ -325,6 +325,8 @@
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
                         <td class="checkbox value"{% if lodgingChecklist.paymentsMatchCostCertificate == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.paymentsMatchCostCertificate == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
+                        <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                     </tr>
                 </tbody>
             </table>
@@ -338,6 +340,8 @@
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
                         <td class="checkbox value"{% if lodgingChecklist.profCostsReasonableAndProportionate == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.profCostsReasonableAndProportionate == 'na' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
+                        <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                     </tr>
                 </tbody>
             </table>

--- a/client/templates/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
+++ b/client/templates/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
@@ -401,7 +401,7 @@
             <table class="checkboxes labelvalue inline">
                 <tbody>
                     <tr>
-                        <td class="checkbox value"{% if lodgingChecklist.futureSignificantDecisions == 'yes' %} aria-label=”Selected”>X{% else %}> {% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.futureSignificantDecisions == 'yes' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
                         <td class="checkbox value"{% if lodgingChecklist.futureSignificantDecisions == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>

--- a/client/templates/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
+++ b/client/templates/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
@@ -403,7 +403,7 @@
                     <tr>
                         <td class="checkbox value"{% if lodgingChecklist.futureSignificantDecisions == 'yes' %} aria-label=”Selected”>X{% else %}> {% endif %}</td>
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
-                        <td class="checkbox value"{% if lodgingChecklist.futureSignificantDecisions == 'no' %} aria-label=”Selected”>X{% else %}> {% endif %}</td>
+                        <td class="checkbox value"{% if lodgingChecklist.futureSignificantDecisions == 'no' %} aria-label=”Selected”>X{% else %}>&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
                     </tr>
                 </tbody>

--- a/client/tests/phpunit/Service/ChecklistPdfGeneratorTest.php
+++ b/client/tests/phpunit/Service/ChecklistPdfGeneratorTest.php
@@ -8,7 +8,6 @@ use App\Entity\Report\Checklist;
 use App\Entity\Report\Report;
 use App\Entity\Report\ReviewChecklist;
 use App\Exception\PdfGenerationFailedException;
-use App\Model\Sirius\QueuedChecklistData;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Twig\Environment;
@@ -142,31 +141,4 @@ class ChecklistPdfGeneratorTest extends TestCase
 
         return $this;
     }
-
-    public function ensureNotApplicableAnswerIsVisibleInPDF(): ChecklistPdfGeneratorTest
-    {
-        $report = $this->buildReportInputWithNotApplicableAnswer();
-
-        $this
-            ->ensureHtmlRenderWillSucceed($report)
-            ->ensurePdfGenerationWillSucceed();
-
-        $notApplicableAnswer = $report->getChecklist()->getPaymentsMatchCostCertificate();
-        $this->assertEquals('Not Applicable', $notApplicableAnswer);
-
-        return $this;
-    }
-
-    private function buildReportInputWithNotApplicableAnswer(): Report
-    {
-        $report = new Report();
-        $checklist = new Checklist($report);
-        $reviewChecklist = new ReviewChecklist($report);
-        $checklist->setPaymentsMatchCostCertificate('Not applicable');
-        $report->setChecklist($checklist);
-        $report->setReviewChecklist($reviewChecklist);
-
-        return $report;
-    }
-
 }

--- a/client/tests/phpunit/Service/ChecklistPdfGeneratorTest.php
+++ b/client/tests/phpunit/Service/ChecklistPdfGeneratorTest.php
@@ -8,6 +8,7 @@ use App\Entity\Report\Checklist;
 use App\Entity\Report\Report;
 use App\Entity\Report\ReviewChecklist;
 use App\Exception\PdfGenerationFailedException;
+use App\Model\Sirius\QueuedChecklistData;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Twig\Environment;
@@ -141,4 +142,31 @@ class ChecklistPdfGeneratorTest extends TestCase
 
         return $this;
     }
+
+    public function ensureNotApplicableAnswerIsVisibleInPDF(): ChecklistPdfGeneratorTest
+    {
+        $report = $this->buildReportInputWithNotApplicableAnswer();
+
+        $this
+            ->ensureHtmlRenderWillSucceed($report)
+            ->ensurePdfGenerationWillSucceed();
+
+        $notApplicableAnswer = $report->getChecklist()->getPaymentsMatchCostCertificate();
+        $this->assertEquals('Not Applicable', $notApplicableAnswer);
+
+        return $this;
+    }
+
+    private function buildReportInputWithNotApplicableAnswer(): Report
+    {
+        $report = new Report();
+        $checklist = new Checklist($report);
+        $reviewChecklist = new ReviewChecklist($report);
+        $checklist->setPaymentsMatchCostCertificate('Not applicable');
+        $report->setChecklist($checklist);
+        $report->setReviewChecklist($reviewChecklist);
+
+        return $report;
+    }
+
 }


### PR DESCRIPTION
## Purpose
Bug fix that now ensures that 'non-applicable' answers selected on the report checklist by the case manager is now visible on the pdf once it's saved in Sirius.

Fixes DDPB-4375

## Approach
- Updated the twig template for the non-applicable answers.

- A follow up ticket has been added to the backlog to write a test for this.

## Checklist
- [x] I have performed a self-review of my own code
