### PR TITLE
DDPB-4443: Review and fix EventSubscribers that have multiple event listeners

### DIFF
--- a/client/src/EventSubscriber/ClientUpdatedSubscriber.php
+++ b/client/src/EventSubscriber/ClientUpdatedSubscriber.php
@@ -32,8 +32,10 @@ class ClientUpdatedSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            ClientUpdatedEvent::NAME => 'logEvent',
-            ClientUpdatedEvent::NAME => 'sendEmail',
+            ClientUpdatedEvent::NAME => [
+                ['logEvent', 2],
+                ['sendEmail', 1],
+            ],
         ];
     }
 

--- a/client/src/EventSubscriber/ReportSubmittedSubscriber.php
+++ b/client/src/EventSubscriber/ReportSubmittedSubscriber.php
@@ -35,8 +35,10 @@ class ReportSubmittedSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            ReportSubmittedEvent::NAME => 'logResubmittedReport',
-            ReportSubmittedEvent::NAME => 'sendEmail',
+            ReportSubmittedEvent::NAME => [
+                ['logResubmittedReport', 2],
+                ['sendEmail', 1],
+            ],
         ];
     }
 

--- a/client/src/EventSubscriber/UserUpdatedSubscriber.php
+++ b/client/src/EventSubscriber/UserUpdatedSubscriber.php
@@ -36,8 +36,10 @@ class UserUpdatedSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            UserUpdatedEvent::NAME => 'auditLog',
-            UserUpdatedEvent::NAME => 'sendEmail',
+            UserUpdatedEvent::NAME => [
+                ['auditLog', 2],
+                ['sendEmail', 1],
+            ],
         ];
     }
 

--- a/client/tests/phpunit/EventSubscriber/ClientUpdatedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/ClientUpdatedSubscriberTest.php
@@ -54,7 +54,12 @@ class ClientUpdatedSubscriberTest extends TestCase
     public function getSubscribedEvents()
     {
         self::assertEquals(
-            [ClientUpdatedEvent::NAME => 'logEvent', ClientUpdatedEvent::NAME => 'sendEmail'],
+            [
+                ClientUpdatedEvent::NAME => [
+                        ['logEvent', 2],
+                        ['sendEmail', 1],
+                    ],
+            ],
             ClientUpdatedSubscriber::getSubscribedEvents()
         );
     }
@@ -104,7 +109,7 @@ class ClientUpdatedSubscriberTest extends TestCase
     public function logEventOnlyLogsOnEmailChange()
     {
         $preUpdateClient = ClientHelpers::createClient();
-        $postUpdateClient = (ClientHelpers::createClient())->setEmail($preUpdateClient->getEmail());
+        $postUpdateClient = ClientHelpers::createClient()->setEmail($preUpdateClient->getEmail());
         $changedBy = UserHelpers::createUser();
         $trigger = 'A_TRIGGER';
 
@@ -120,7 +125,7 @@ class ClientUpdatedSubscriberTest extends TestCase
      */
     public function sendEmail(Client $preUpdateClient, Client $postUpdateClient)
     {
-        $changedBy = (UserHelpers::createUser())->setRoleName(User::ROLE_LAY_DEPUTY);
+        $changedBy = UserHelpers::createUser()->setRoleName(User::ROLE_LAY_DEPUTY);
         $trigger = 'A_TRIGGER';
 
         $event = new ClientUpdatedEvent($preUpdateClient, $postUpdateClient, $changedBy, $trigger);
@@ -154,7 +159,7 @@ class ClientUpdatedSubscriberTest extends TestCase
     {
         $preUpdateClient = ClientHelpers::createClient();
         $postUpdateClient = clone $preUpdateClient;
-        $changedBy = (UserHelpers::createUser())->setRoleName(User::ROLE_LAY_DEPUTY);
+        $changedBy = UserHelpers::createUser()->setRoleName(User::ROLE_LAY_DEPUTY);
         $trigger = 'A_TRIGGER';
 
         $event = new ClientUpdatedEvent($preUpdateClient, $postUpdateClient, $changedBy, $trigger);
@@ -167,8 +172,8 @@ class ClientUpdatedSubscriberTest extends TestCase
     public function sendEmailEmailNotSentWhenDetailsChangedButClientsAreDifferent()
     {
         $preUpdateClient = ClientHelpers::createClient();
-        $postUpdateClient = (ClientHelpers::createClient())->setId(12345);
-        $changedBy = (UserHelpers::createUser())->setRoleName(User::ROLE_LAY_DEPUTY);
+        $postUpdateClient = ClientHelpers::createClient()->setId(12345);
+        $changedBy = UserHelpers::createUser()->setRoleName(User::ROLE_LAY_DEPUTY);
         $trigger = 'A_TRIGGER';
 
         $event = new ClientUpdatedEvent($preUpdateClient, $postUpdateClient, $changedBy, $trigger);

--- a/client/tests/phpunit/EventSubscriber/ReportSubmittedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/ReportSubmittedSubscriberTest.php
@@ -28,7 +28,12 @@ class ReportSubmittedSubscriberTest extends TestCase
     public function getSubscribedEvents()
     {
         self::assertEquals(
-            [ReportSubmittedEvent::NAME => 'log', ReportSubmittedEvent::NAME => 'sendEmail'],
+            [
+                ReportSubmittedEvent::NAME => [
+                    ['logEvent', 2],
+                    ['sendEmail', 1],
+                ],
+            ],
             ReportSubmittedSubscriber::getSubscribedEvents()
         );
     }
@@ -99,7 +104,7 @@ class ReportSubmittedSubscriberTest extends TestCase
         $reportApi = self::prophesize(ReportApi::class);
         $mailer = self::prophesize(Mailer::class);
 
-        $submittedReport = (ReportHelpers::createReport())
+        $submittedReport = ReportHelpers::createReport()
             ->setUnSubmitDate(new DateTime());
 
         $nextYearReport = ReportHelpers::createReport();

--- a/client/tests/phpunit/EventSubscriber/ReportSubmittedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/ReportSubmittedSubscriberTest.php
@@ -30,7 +30,7 @@ class ReportSubmittedSubscriberTest extends TestCase
         self::assertEquals(
             [
                 ReportSubmittedEvent::NAME => [
-                    ['logEvent', 2],
+                    ['logResubmittedReport', 2],
                     ['sendEmail', 1],
                 ],
             ],

--- a/client/tests/phpunit/EventSubscriber/UserUpdatedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/UserUpdatedSubscriberTest.php
@@ -55,8 +55,10 @@ class UserUpdatedSubscriberTest extends TestCase
     {
         self::assertEquals(
             [
-                UserUpdatedEvent::NAME => 'auditLog',
-                UserUpdatedEvent::NAME => 'sendEmail',
+                UserUpdatedEvent::NAME => [
+                    ['logEvent', 2],
+                    ['sendEmail', 1],
+                ],
             ],
             UserUpdatedSubscriber::getSubscribedEvents()
         );

--- a/client/tests/phpunit/EventSubscriber/UserUpdatedSubscriberTest.php
+++ b/client/tests/phpunit/EventSubscriber/UserUpdatedSubscriberTest.php
@@ -56,7 +56,7 @@ class UserUpdatedSubscriberTest extends TestCase
         self::assertEquals(
             [
                 UserUpdatedEvent::NAME => [
-                    ['logEvent', 2],
+                    ['auditLog', 2],
                     ['sendEmail', 1],
                 ],
             ],


### PR DESCRIPTION
## Purpose
Some event subscribers had that triggered multiple functions off of a single event were setup incorrectly.
This PR is to update the configuration to have the right structure.

Fixes DDPB-4443

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
