### PR TITLE
DDPB-4471 change log levels to be more generic

### DIFF
--- a/api/config/packages/dev/monolog.yml
+++ b/api/config/packages/dev/monolog.yml
@@ -1,12 +1,12 @@
 monolog:
-    channels: ["csv"]
+    channels: ["verbose"]
     handlers:
         main:
             type: stream
             path: php://stderr
             level: warning
             formatter: line_formatter
-            channels: ["!translation", "!csv"]
+            channels: ["!translation", "!verbose"]
             bubble: false
         csv:
             type: stream
@@ -14,4 +14,4 @@ monolog:
             level: notice
             formatter: line_formatter
             bubble: false
-            channels: ["csv"]
+            channels: ["verbose"]

--- a/api/config/packages/monolog.yml
+++ b/api/config/packages/monolog.yml
@@ -1,15 +1,15 @@
 monolog:
-    channels: ["csv"]
+    channels: ["verbose"]
     handlers:
         main:
             type: stream
             path: php://stderr
             level: "%log_level%"
             formatter: logstash_formatter
-            channels: ["!csv"]
+            channels: ["!verbose"]
         csv:
             type: stream
             path: php://stderr
-            level: "%csv_log_level%"
+            level: "%verbose_log_level%"
             formatter: logstash_formatter
-            channels: ["csv"]
+            channels: ["verbose"]

--- a/api/config/packages/prod/monolog.yml
+++ b/api/config/packages/prod/monolog.yml
@@ -1,5 +1,5 @@
 monolog:
-    channels: ["csv"]
+    channels: ["verbose"]
     handlers:
         main:
             type: stream
@@ -7,11 +7,11 @@ monolog:
             level: "%log_level%"
             formatter: logstash_formatter
             bubble: false
-            channels: ["!csv"]
+            channels: ["!verbose"]
         csv:
             type: stream
             path: php://stdout
-            level: "%csv_log_level%"
+            level: "%verbose_log_level%"
             formatter: logstash_formatter
             bubble: false
-            channels: ["csv"]
+            channels: ["verbose"]

--- a/api/config/packages/test/monolog.yml
+++ b/api/config/packages/test/monolog.yml
@@ -1,15 +1,15 @@
 monolog:
-    channels: ["csv"]
+    channels: ["verbose"]
     handlers:
         main:
             type: stream
             path: "%log_path%"
             level: warning
             formatter: line_formatter
-            channels: ["!csv"]
+            channels: ["!verbose"]
         csv:
             type: stream
             path: "%log_path%"
             level: notice
             formatter: logstash_formatter
-            channels: ["csv"]
+            channels: ["verbose"]

--- a/api/config/parameters.yml.dist
+++ b/api/config/parameters.yml.dist
@@ -21,7 +21,7 @@ parameters:
             permissions: [ROLE_ADMIN, ROLE_LAY_DEPUTY]
 
     log_level: warning
-    csv_log_level: notice
+    verbose_log_level: notice
     log_path: /var/log/app/application.log
 
     cloudwatch_logs_client_params:

--- a/api/docker/confd/templates/parameters.yml.tmpl
+++ b/api/docker/confd/templates/parameters.yml.tmpl
@@ -50,5 +50,5 @@ parameters:
     secret: {{ getv "/secret" }}
     redis_dsn: '{{getv "/redis/dsn" }}'
     log_level: warning
-    csv_log_level: notice
+    verbose_log_level: notice
     log_path: /var/log/app/application.log

--- a/api/src/v2/Registration/Controller/LayDeputyshipUploadController.php
+++ b/api/src/v2/Registration/Controller/LayDeputyshipUploadController.php
@@ -19,7 +19,7 @@ class LayDeputyshipUploadController
         private DataCompression $dataCompression,
         private LayDeputyshipDtoCollectionAssemblerFactory $factory,
         private LayDeputyshipUploader $uploader,
-        private LoggerInterface $csvLogger
+        private LoggerInterface $verboseLogger
     ) {
     }
 
@@ -34,20 +34,20 @@ class LayDeputyshipUploadController
         ini_set('memory_limit', '1024M');
 
         $message = sprintf('Uploading chunk with Id: %s', $request->headers->get('chunkId'));
-        $this->csvLogger->notice($message);
+        $this->verboseLogger->notice($message);
 
         $postedData = $this->dataCompression->decompress($request->getContent());
         $assembler = $this->factory->create();
         $uploadCollection = $assembler->assembleFromArray($postedData);
 
-        $this->csvLogger->notice(sprintf('Assembled DTO collection from chunkId: %s', $request->headers->get('chunkId')));
-        $this->csvLogger->notice(sprintf('Size of DTO Collection: %d', count($uploadCollection['collection'])));
+        $this->verboseLogger->notice(sprintf('Assembled DTO collection from chunkId: %s', $request->headers->get('chunkId')));
+        $this->verboseLogger->notice(sprintf('Size of DTO Collection: %d', count($uploadCollection['collection'])));
 
         $result = $this->uploader->upload($uploadCollection['collection']);
 
         $result['skipped'] = $uploadCollection['skipped'];
 
-        $this->csvLogger->notice(sprintf('Persisted DTO Collection with chunkId: %s', $request->headers->get('chunkId')));
+        $this->verboseLogger->notice(sprintf('Persisted DTO Collection with chunkId: %s', $request->headers->get('chunkId')));
 
         return $result;
     }

--- a/api/src/v2/Registration/Uploader/LayDeputyshipUploader.php
+++ b/api/src/v2/Registration/Uploader/LayDeputyshipUploader.php
@@ -36,7 +36,7 @@ class LayDeputyshipUploader
         private EntityManagerInterface $em,
         private ReportRepository $reportRepository,
         private PreRegistrationFactory $preRegistrationFactory,
-        private LoggerInterface $csvLogger
+        private LoggerInterface $verboseLogger
     ) {
     }
 
@@ -57,7 +57,7 @@ class LayDeputyshipUploader
                     ++$added;
                 } catch (PreRegistrationCreationException $e) {
                     $message = sprintf('ERROR IN LINE %d: %s', $index + 2, $e->getMessage());
-                    $this->csvLogger->error($message);
+                    $this->verboseLogger->error($message);
                     $errors[] = $message;
                     continue;
                 }
@@ -67,7 +67,7 @@ class LayDeputyshipUploader
                 ->updateReportTypes()
                 ->commitTransactionToDatabase();
         } catch (Throwable $e) {
-            $this->csvLogger->error($e->getMessage());
+            $this->verboseLogger->error($e->getMessage());
 
             return ['added' => $added, 'errors' => [$e->getMessage()]];
         }
@@ -124,7 +124,7 @@ class LayDeputyshipUploader
                 }
             }
         } catch (Throwable $e) {
-            $this->csvLogger->error(sprintf('Error whilst updating report type for report with ID: %d, for case number: %s', $currentActiveReportId, $reportCaseNumber));
+            $this->verboseLogger->error(sprintf('Error whilst updating report type for report with ID: %d, for case number: %s', $currentActiveReportId, $reportCaseNumber));
             throw new Exception($e->getMessage());
         }
 

--- a/client/config/packages/dev/monolog.yml
+++ b/client/config/packages/dev/monolog.yml
@@ -1,19 +1,19 @@
 monolog:
-    channels: ["csv"]
+    channels: ["verbose"]
     handlers:
         main:
             type: stream
             path: php://stderr
             level: warning
             formatter: line_formatter
-            channels: ["!translation", "!csv"]
+            channels: ["!translation", "!verbose"]
             bubble: false
         csv:
             type: stream
             path: php://stderr
             level: notice
             formatter: line_formatter
-            channels: ["csv"]
+            channels: ["verbose"]
             bubble: false
         audit:
             type: service

--- a/client/config/packages/prod/monolog.yml
+++ b/client/config/packages/prod/monolog.yml
@@ -1,19 +1,19 @@
 monolog:
-    channels: ["csv"]
+    channels: ["verbose"]
     handlers:
         main:
             type: stream
             path: php://stderr
             level: "%log_level%"
             formatter: logstash_formatter
-            channels: ["!csv"]
+            channels: ["!verbose"]
             bubble: false
         csv:
             type: stream
             path: php://stderr
-            level: "%csv_log_level%"
+            level: "%verbose_log_level%"
             formatter: logstash_formatter
-            channels: ["csv"]
+            channels: ["verbose"]
             bubble: false
         audit:
             type: service

--- a/client/config/parameters.yml.dist
+++ b/client/config/parameters.yml.dist
@@ -25,7 +25,7 @@ parameters:
         gds: null
     opg_docker_tag: 0.0.0
     log_level: warning
-    csv_log_level: notice
+    verbose_log_level: notice
     log_path: /var/log/app/application.log
     # the following two paramters can be set to null on production
     email_params:

--- a/client/docker/confd/templates/parameters.yml.tmpl
+++ b/client/docker/confd/templates/parameters.yml.tmpl
@@ -16,7 +16,7 @@ parameters:
     use_redis: true
     session_engine: redis
     log_level: warning
-    csv_log_level: notice
+    verbose_log_level: notice
     log_path: /var/log/app/application.log
     ga:
         default: {{ getv "/ga/default" }}

--- a/client/src/Controller/Admin/AjaxController.php
+++ b/client/src/Controller/Admin/AjaxController.php
@@ -23,7 +23,7 @@ class AjaxController extends AbstractController
         private RestClient $restClient,
         private PreRegistrationApi $preRegistrationApi,
         private LayDeputyshipApi $layDeputyshipApi,
-        private LoggerInterface $csvLogger
+        private LoggerInterface $verboseLogger
     ) {
     }
 
@@ -55,17 +55,17 @@ class AjaxController extends AbstractController
     public function uploadUsersAjaxAction(Request $request, ClientInterface $redisClient)
     {
         $chunkId = 'chunk'.$request->get('chunk');
-        $this->csvLogger->notice(sprintf('AJAX: Processing chunk with chunkId: %s', $chunkId));
+        $this->verboseLogger->notice(sprintf('AJAX: Processing chunk with chunkId: %s', $chunkId));
 
         try {
             $compressedData = $redisClient->get($chunkId);
             if ($compressedData) {
                 $ret = $this->layDeputyshipApi->uploadLayDeputyShip($compressedData, $chunkId);
-                $this->csvLogger->notice(sprintf('AJAX: Successfully processed chunkId: %s', $chunkId));
+                $this->verboseLogger->notice(sprintf('AJAX: Successfully processed chunkId: %s', $chunkId));
                 $redisClient->del($chunkId); // cleanup for next execution
             } else {
                 $ret['added'] = 0;
-                $this->csvLogger->error(sprintf('AJAX: Unable to process chunkId: %s', $chunkId));
+                $this->verboseLogger->error(sprintf('AJAX: Unable to process chunkId: %s', $chunkId));
             }
 
             return new JsonResponse($ret);

--- a/client/src/Controller/Synchronisation/SynchronisationController.php
+++ b/client/src/Controller/Synchronisation/SynchronisationController.php
@@ -29,7 +29,7 @@ class SynchronisationController extends AbstractController
         private RestClient $restClient,
         private SerializerInterface $serializer,
         private ParameterStoreService $parameterStore,
-        private LoggerInterface $logger,
+        private LoggerInterface $verboseLogger,
         private ReportApi $reportApi
     ) {
     }
@@ -48,7 +48,7 @@ class SynchronisationController extends AbstractController
         /** @var QueuedDocumentData[] $documents */
         $documents = $this->getQueuedDocumentsData($request);
 
-        $this->logger->info(sprintf('%d documents to upload', count($documents)));
+        $this->verboseLogger->notice(sprintf('%d documents to upload', count($documents)));
 
         foreach ($documents as $document) {
             $this->documentSyncService->syncDocument($document);
@@ -60,9 +60,11 @@ class SynchronisationController extends AbstractController
         }
 
         if ($this->documentSyncService->getDocsNotSyncedCount() > 0) {
-            $this->logger->info(sprintf('%d documents failed to sync', $this->documentSyncService->getDocsNotSyncedCount()));
+            $this->verboseLogger->notice(sprintf('%d documents failed to sync', $this->documentSyncService->getDocsNotSyncedCount()));
             $this->documentSyncService->setDocsNotSyncedCount(0);
         }
+
+        $this->verboseLogger->notice(self::COMPLETED_MESSAGE);
 
         return new JsonResponse([self::COMPLETED_MESSAGE]);
     }
@@ -82,15 +84,15 @@ class SynchronisationController extends AbstractController
 
         /** @var array $reports */
         $reports = $this->reportApi->getReportsWithQueuedChecklistsJwt($request, $rowLimit);
-        $this->logger->info(sprintf('%d checklists to upload', count($reports)));
+        $this->verboseLogger->notice(sprintf('%d checklists to upload', count($reports)));
 
         $notSyncedCount = $this->checklistSyncService->syncChecklistsByReports($reports);
 
         if ($notSyncedCount > 0) {
-            $this->logger->info(sprintf('%d checklists failed to sync', $notSyncedCount));
+            $this->verboseLogger->notice(sprintf('%d checklists failed to sync', $notSyncedCount));
         }
 
-        $this->logger->info(self::COMPLETED_MESSAGE);
+        $this->verboseLogger->notice(self::COMPLETED_MESSAGE);
 
         return new JsonResponse([self::COMPLETED_MESSAGE]);
     }


### PR DESCRIPTION
## Purpose
Make the csv logger a bit more generic to avoid us having to have loads of difference (also add it to sync controller)

Fixes DDPB-4471

## Approach

So as part of a previous PR, devs added a new logger as we didn't want to change the log level across the app as it may have meant logging things we didn't want to in prod. Adding the extra logger gave us more fine grained control for individual classes. However, its name made it not very reusable. I think rather than having a new logger every time we want to capture notices, we can have verbose logger and use it for those time we want to capture more but not call it a warning.

## Learning
NA

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
