### PR TITLE
DDPB-4474: Accommodate deputies who move firms and take their clients with them 

### DIFF
--- a/api/src/v2/Registration/Uploader/OrgDeputyshipUploader.php
+++ b/api/src/v2/Registration/Uploader/OrgDeputyshipUploader.php
@@ -173,6 +173,8 @@ class OrgDeputyshipUploader
                 $this->updated['clients'][] = $this->client->getId();
             }
 
+            // TODO - Implement fix for https://opgtransform.atlassian.net/browse/DDPB-4350
+            // TODO - Remove temporary fixes/workarounds after the above issue is fixed
 //            //Temp disabling until we can rely on Sirius data
 //            if ($this->clientHasNewCourtOrder($this->client, $dto)) {
 //                // Discharge clients with a new court order
@@ -198,8 +200,8 @@ class OrgDeputyshipUploader
 //                $this->updated['clients'][] = $this->client->getId();
 //            }
 
+            // Temp fix for deputies that have switched organisation and taken the client with them
             if (!$this->clientHasNewCourtOrder($this->client, $dto)) {
-                // Temp fix for deputies that have switched organisation and taken the client with them
                 if ($this->clientHasSwitchedOrganisation($this->client)) {
                     if (!$this->clientHasNewNamedDeputy($this->client, $this->namedDeputy)) {
                         $this->currentOrganisation->addClient($this->client);
@@ -208,14 +210,14 @@ class OrgDeputyshipUploader
                         $this->updated['clients'][] = $this->client->getId();
                     }
                 }
+            }
 
-                // Temp fix for clients who have new named deputy in same organisation
-                if (!$this->clientHasSwitchedOrganisation($this->client)) {
-                    if ($this->clientHasNewNamedDeputy($this->client, $this->namedDeputy)) {
-                        $this->client->setNamedDeputy($this->namedDeputy);
+            // Temp fix for clients who have new named deputy in same organisation
+            if (!$this->clientHasSwitchedOrganisation($this->client)) {
+                if ($this->clientHasNewNamedDeputy($this->client, $this->namedDeputy)) {
+                    $this->client->setNamedDeputy($this->namedDeputy);
 
-                        $this->updated['clients'][] = $this->client->getId();
-                    }
+                    $this->updated['clients'][] = $this->client->getId();
                 }
             }
         }

--- a/api/src/v2/Registration/Uploader/OrgDeputyshipUploader.php
+++ b/api/src/v2/Registration/Uploader/OrgDeputyshipUploader.php
@@ -198,12 +198,24 @@ class OrgDeputyshipUploader
 //                $this->updated['clients'][] = $this->client->getId();
 //            }
 
-            // Temp fix for clients who have new named deputy in same organisation
-            if (!$this->clientHasSwitchedOrganisation($this->client)) {
-                if ($this->clientHasNewNamedDeputy($this->client, $this->namedDeputy)) {
-                    $this->client->setNamedDeputy($this->namedDeputy);
+            if (!$this->clientHasNewCourtOrder($this->client, $dto)) {
+                // Temp fix for deputies that have switched organisation and taken the client with them
+                if ($this->clientHasSwitchedOrganisation($this->client)) {
+                    if (!$this->clientHasNewNamedDeputy($this->client, $this->namedDeputy)) {
+                        $this->currentOrganisation->addClient($this->client);
+                        $this->client->setOrganisation($this->currentOrganisation);
 
-                    $this->updated['clients'][] = $this->client->getId();
+                        $this->updated['clients'][] = $this->client->getId();
+                    }
+                }
+
+                // Temp fix for clients who have new named deputy in same organisation
+                if (!$this->clientHasSwitchedOrganisation($this->client)) {
+                    if ($this->clientHasNewNamedDeputy($this->client, $this->namedDeputy)) {
+                        $this->client->setNamedDeputy($this->namedDeputy);
+
+                        $this->updated['clients'][] = $this->client->getId();
+                    }
                 }
             }
         }

--- a/api/tests/Behat/features-v2/registration/ingest.org.sirius.feature
+++ b/api/tests/Behat/features-v2/registration/ingest.org.sirius.feature
@@ -51,15 +51,15 @@ Feature: Org CSV data ingestion - sirius source data
         And the organisation associated with the client should remain the same
         And the report associated with the client should remain the same
 
-#    @super-admin
-#    Scenario: Uploading a CSV where an existing client's named deputy has changed firm  - same case number, same made date
-#        Given a super admin user accesses the admin app
-#        When I visit the admin upload org users page
-#        And I upload an org CSV that contains a new org email and street address but the same deputy number for an existing clients named deputy
-#        Then the organisation associated with the client should be updated to the new organisation
-#        And the named deputy's address should be updated to '88 BROAD WALK, ALINGHAM, CORK, VALE, TOWNSVILLE, TW8 R55'
-#        And the named deputy associated with the client should remain the same
-#        And the report associated with the client should remain the same
+    @super-admin
+    Scenario: Uploading a CSV where an existing client's named deputy has changed firm  - same case number, same made date
+        Given a super admin user accesses the admin app
+        When I visit the admin upload org users page
+        And I upload an org CSV that contains a new org email and street address but the same deputy number for an existing clients named deputy
+        Then the organisation associated with the client should be updated to the new organisation
+        And the named deputy's address should be updated to '88 BROAD WALK, ALINGHAM, CORK, VALE, TOWNSVILLE, TW8 R55'
+        And the named deputy associated with the client should remain the same
+        And the report associated with the client should remain the same
 
 #    @super-admin
 #    Scenario: Uploading a CSV that contains a new named deputy in a new organisation for an existing client - same case number, new made date

--- a/api/tests/Unit/v2/Registration/Uploader/OrgDeputyshipUploaderTest.php
+++ b/api/tests/Unit/v2/Registration/Uploader/OrgDeputyshipUploaderTest.php
@@ -225,9 +225,9 @@ class OrgDeputyshipUploaderTest extends KernelTestCase
         );
     }
 
-    // Temporary test to ensure that we are not updating the client if the organisation and named deputy have both changed
+    // Temporary test to ensure that we are not updating the client if court order made date has changed
     /** @test  */
-    public function uploadClientAndNamedDeputyAreNotAssociatedWhenClientHasSwitchedOrgsAndNamedDeputyHasChanged()
+    public function uploadClientAndNamedDeputyAreNotAssociatedWhenClientHasNewCourtOrderMadeDate()
     {
         $deputyships = OrgDeputyshipDTOTestHelper::generateSiriusOrgDeputyshipDtos(1, 0);
 
@@ -242,6 +242,7 @@ class OrgDeputyshipUploaderTest extends KernelTestCase
 
         $client = OrgDeputyshipDTOTestHelper::ensureClientInUploadExists($deputyships[0], $this->em);
         $client->setNamedDeputy($originalNamedDeputy)->setOrganisation($organisation);
+        $client->setCourtDate(new DateTime());
 
         $this->em->persist($client);
         $this->em->flush();
@@ -272,7 +273,7 @@ class OrgDeputyshipUploaderTest extends KernelTestCase
     }
 
     /** @test  */
-    public function uploadClientAndNamedDeputyAreAssociatedWhenClientHasSwitchedOrgsAndNamedDeputyHasNotChanged()
+    public function uploadClientAndNamedDeputyAreAssociatedWhenClientHasSwitchedOrgsAndNamedDeputyHasNotChangedAndMadeDateHasNotChanged()
     {
         $deputyships = OrgDeputyshipDTOTestHelper::generateSiriusOrgDeputyshipDtos(1, 0);
 
@@ -319,7 +320,54 @@ class OrgDeputyshipUploaderTest extends KernelTestCase
     }
 
     /** @test  */
-    public function uploadClientAndNamedDeputyAreAssociatedWhenClientHasNotSwitchedOrgsAndNamedDeputyHasChanged()
+    public function uploadClientAndNamedDeputyAreNotAssociatedWhenClientHasSwitchedOrgsAndNamedDeputyHasNotChangedAndMadeDateHasChanged()
+    {
+        $deputyships = OrgDeputyshipDTOTestHelper::generateSiriusOrgDeputyshipDtos(1, 0);
+
+        $originalOrgIdentifier = 'differentorg.co.uk';
+
+        $originalNamedDeputy = OrgDeputyshipDTOTestHelper::ensureNamedDeputyInUploadExists($deputyships[0], $this->em);
+
+        $organisation = OrgDeputyshipDTOTestHelper::ensureOrgInUploadExists($originalOrgIdentifier, $this->em);
+        $organisation->setEmailIdentifier($originalOrgIdentifier);
+
+        $originalClient = OrgDeputyshipDTOTestHelper::ensureClientInUploadExists($deputyships[0], $this->em);
+        $originalClient->setNamedDeputy($originalNamedDeputy)->setOrganisation($organisation);
+        $originalClient->setCourtDate(new DateTime());
+
+        $this->em->persist($originalClient);
+        $this->em->flush();
+
+        $actualUploadResults = $this->sut->upload($deputyships);
+
+        self::assertTrue(
+            OrgDeputyshipDTOTestHelper::clientAndNamedDeputyAreAssociated(
+                $deputyships[0],
+                $this->clientRepository,
+                $this->namedDeputyRepository
+            ),
+            sprintf(
+                'Client with case number "%s" and named deputy with uid "%s" are not associated when they should be',
+                $deputyships[0]->getCaseNumber(),
+                $deputyships[0]->getDeputyUid()
+            )
+        );
+
+        self::assertCount(0, $actualUploadResults['added']['clients']);
+        self::assertCount(0, $actualUploadResults['updated']['clients']);
+
+        /** @var Client $updatedClient */
+        $updatedClient = $this->em->getRepository(Client::class)->findOneBy(['caseNumber' => $deputyships[0]->getCaseNumber()]);
+        $this->em->refresh($updatedClient);
+
+        self::assertEquals($originalClient->getId(), $updatedClient->getId());
+        self::assertEquals($originalNamedDeputy->getDeputyUid(), $updatedClient->getNamedDeputy()->getDeputyUid());
+
+        self::assertEquals($originalOrgIdentifier, $updatedClient->getOrganisation()->getEmailIdentifier());
+    }
+
+    /** @test  */
+    public function uploadClientAndNamedDeputyAreAssociatedWhenClientHasNotSwitchedOrgsAndNamedDeputyHasChangedAndMadeDateHasChanged()
     {
         $deputyships = OrgDeputyshipDTOTestHelper::generateSiriusOrgDeputyshipDtos(1, 0);
 
@@ -332,10 +380,11 @@ class OrgDeputyshipUploaderTest extends KernelTestCase
         $organisation = OrgDeputyshipDTOTestHelper::ensureOrgInUploadExists($orgIdentifier, $this->em);
         $organisation->setEmailIdentifier($orgIdentifier);
 
-        $client = OrgDeputyshipDTOTestHelper::ensureClientInUploadExists($deputyships[0], $this->em);
-        $client->setNamedDeputy($originalNamedDeputy)->setOrganisation($organisation);
+        $originalClient = OrgDeputyshipDTOTestHelper::ensureClientInUploadExists($deputyships[0], $this->em);
+        $originalClient->setNamedDeputy($originalNamedDeputy)->setOrganisation($organisation);
+        $originalClient->setCourtDate(new DateTime());
 
-        $this->em->persist($client);
+        $this->em->persist($originalClient);
         $this->em->flush();
 
         $actualUploadResults = $this->sut->upload($deputyships);
@@ -355,6 +404,63 @@ class OrgDeputyshipUploaderTest extends KernelTestCase
 
         self::assertCount(0, $actualUploadResults['added']['clients']);
         self::assertCount(1, $actualUploadResults['updated']['clients']);
+
+        /** @var Client $updatedClient */
+        $updatedClient = $this->em->getRepository(Client::class)->findOneBy(['caseNumber' => $deputyships[0]->getCaseNumber()]);
+        $this->em->refresh($updatedClient);
+
+        self::assertEquals($originalClient->getId(), $updatedClient->getId());
+        self::assertEquals($deputyships[0]->getDeputyUid(), $updatedClient->getNamedDeputy()->getDeputyUid());
+
+        self::assertEquals($orgIdentifier, $updatedClient->getOrganisation()->getEmailIdentifier());
+    }
+
+    /** @test  */
+    public function uploadClientAndNamedDeputyAreAssociatedWhenClientHasNotSwitchedOrgsAndNamedDeputyHasChangedAndMadeDateNotChanged()
+    {
+        $deputyships = OrgDeputyshipDTOTestHelper::generateSiriusOrgDeputyshipDtos(1, 0);
+
+        $orgIdentifier = explode('@', $deputyships[0]->getDeputyEmail())[1];
+
+        $originalNamedDeputy = OrgDeputyshipDTOTestHelper::ensureNamedDeputyInUploadExists($deputyships[0], $this->em);
+        $originalNamedDeputy->setEmail1(sprintf('different.deputy@%s', $orgIdentifier));
+        $originalNamedDeputy->setDeputyUid('ABCD1234');
+
+        $organisation = OrgDeputyshipDTOTestHelper::ensureOrgInUploadExists($orgIdentifier, $this->em);
+        $organisation->setEmailIdentifier($orgIdentifier);
+
+        $originalClient = OrgDeputyshipDTOTestHelper::ensureClientInUploadExists($deputyships[0], $this->em);
+        $originalClient->setNamedDeputy($originalNamedDeputy)->setOrganisation($organisation);
+
+        $this->em->persist($originalClient);
+        $this->em->flush();
+
+        $actualUploadResults = $this->sut->upload($deputyships);
+
+        self::assertTrue(
+            OrgDeputyshipDTOTestHelper::clientAndNamedDeputyAreAssociated(
+                $deputyships[0],
+                $this->clientRepository,
+                $this->namedDeputyRepository
+            ),
+            sprintf(
+                'Client with case number "%s" and named deputy with uid "%s" are not associated when they should be',
+                $deputyships[0]->getCaseNumber(),
+                $deputyships[0]->getDeputyUid()
+            )
+        );
+
+        self::assertCount(0, $actualUploadResults['added']['clients']);
+        self::assertCount(1, $actualUploadResults['updated']['clients']);
+
+        /** @var Client $updatedClient */
+        $updatedClient = $this->em->getRepository(Client::class)->findOneBy(['caseNumber' => $deputyships[0]->getCaseNumber()]);
+        $this->em->refresh($updatedClient);
+
+        self::assertEquals($originalClient->getId(), $updatedClient->getId());
+        self::assertEquals($deputyships[0]->getDeputyUid(), $updatedClient->getNamedDeputy()->getDeputyUid());
+
+        self::assertEquals($orgIdentifier, $updatedClient->getOrganisation()->getEmailIdentifier());
     }
 
     /** @test */

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -48,3 +48,7 @@ services:
       APP_ENV: dev
     env_file:
       - .env
+
+  synchronisation:
+    volumes:
+      - ./lambda_functions/functions/synchronisation/.aws-lambda-rie:/aws-lambda


### PR DESCRIPTION
## Purpose

Following on from a previously PR where an automation step was disabled for the Org CSV upload, we implemented a workaround to re-enable the automation for named deputy changes that happen within the same org.

Continuing on from this, this PR implements a similar workaround to automate when a deputy moves organisation and takes their clients with them.

Fixes DDPB-4474

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
