### PR TITLE
DDPB-4454: Reports out of chronological order

### DIFF
--- a/api/src/Entity/Client.php
+++ b/api/src/Entity/Client.php
@@ -61,6 +61,7 @@ class Client implements ClientInterface
      * @JMS\Groups({"client-reports"})
      * @JMS\Type("ArrayCollection<App\Entity\Report\Report>")
      * @ORM\OneToMany(targetEntity="App\Entity\Report\Report", mappedBy="client", cascade={"persist", "remove"})
+     * @ORM\OrderBy({"submitDate"="DESC"})
      */
     private $reports;
 


### PR DESCRIPTION
## Purpose
Currently reports and checklists are not in any particular order once the report is submitted by the deputy. This fix now lists the most recent submitted report at the top of the list to make it easier for the case managers when they view the clients page.

Fixes DDPB-4454

## Approach
Added an @OrderBy annotation to the reports property in the Client entity that sorts the reports by the submitted date. 

## Checklist
- [x] I have performed a self-review of my own code

