### PR TITLE
DDPB-4452: Create more specific document failure errors 

### DIFF
--- a/client/src/Command/DocumentSyncCommand.php
+++ b/client/src/Command/DocumentSyncCommand.php
@@ -1,5 +1,5 @@
 <?php
-
+//test
 declare(strict_types=1);
 
 namespace App\Command;

--- a/client/src/Command/DocumentSyncCommand.php
+++ b/client/src/Command/DocumentSyncCommand.php
@@ -1,5 +1,5 @@
 <?php
-//test
+
 declare(strict_types=1);
 
 namespace App\Command;

--- a/client/src/Model/Sirius/SiriusApiError.php
+++ b/client/src/Model/Sirius/SiriusApiError.php
@@ -9,7 +9,7 @@ class SiriusApiError
     /** @var string */
     private $title;
     private $code;
-    private $description;
+    private $detail;
 
     public function getTitle(): ?string
     {
@@ -41,17 +41,17 @@ class SiriusApiError
         return $this;
     }
 
-    public function getDescription(): ?string
+    public function getDetail(): ?string
     {
-        return $this->description;
+        return $this->detail;
     }
 
     /**
      * @return SiriusApiError
      */
-    public function setDescription(?string $description): self
+    public function setDetail(?string $detail): self
     {
-        $this->description = $description;
+        $this->detail = $detail;
 
         return $this;
     }

--- a/client/src/Service/SiriusApiErrorTranslator.php
+++ b/client/src/Service/SiriusApiErrorTranslator.php
@@ -27,34 +27,8 @@ class SiriusApiErrorTranslator
 
         $apiError = $this->deserializeError($errorString);
 
-        $translations = [
-            'OPGDATA-API-FORBIDDEN' => 'Credentials used for integration lack correct permissions',
-            'OPGDATA-API-API_CONFIGURATION_ERROR' => 'Integration API internal error',
-            'OPGDATA-API-AUTHORIZER_CONFIGURATION_ERROR' => 'Integration API internal error',
-            'OPGDATA-API-AUTHORIZER_FAILURE' => 'Integration API internal error',
-            'OPGDATA-API-INVALIDREQUEST' => 'The body of the request is not valid',
-            'OPGDATA-API-BAD_REQUEST_PARAMETERS' => 'The parameters of the request are not valid',
-            'OPGDATA-API-SERVERERROR' => 'Integration API server error',
-            'OPGDATA-API-EXPIRED_TOKEN' => 'Auth token has expired',
-            'OPGDATA-API-INTEGRATION_FAILURE' => 'There was a problem syncing from the integration to Sirius',
-            'OPGDATA-API-INTEGRATION_TIMEOUT' => 'The sync process timed out while communicating with Sirius',
-            'OPGDATA-API-INVALID_API_KEY' => 'The API key used in the request is not valid',
-            'OPGDATA-API-INVALID_SIGNATURE' => 'The signature of the request is not valid',
-            'OPGDATA-API-MISSING_AUTHENTICATION_TOKEN' => 'Authentication token is missing from the request',
-            'OPGDATA-API-QUOTA_EXCEEDED' => 'API quota has been exceeded',
-            'OPGDATA-API-FILESIZELIMIT' => 'The size of the file exceeded the file size limit (6MB)',
-            'OPGDATA-API-NOTFOUND' => 'Invalid URL used during integration or the resource no longer exists',
-            'OPGDATA-API-THROTTLED' => 'Too many requests made - throttling in action',
-            'OPGDATA-API-UNAUTHORISED' => 'No user/auth provided during requests',
-            'OPGDATA-API-MEDIA' => 'Media type of the file is not supported',
-            'OPGDATA-API-WAF_FILTERED' => 'AWS WAF filtered this request and it was not sent to Sirius',
-        ];
+        return sprintf('%s: %s', $apiError->getCode(), $apiError->getDetail());
 
-        if (is_null($apiError->getCode()) || is_null($translations[$apiError->getCode()] ?? null)) {
-            return $errorString;
-        } else {
-            return sprintf('%s: %s', $apiError->getCode(), $translations[$apiError->getCode()]);
-        }
     }
 
     /**
@@ -62,7 +36,7 @@ class SiriusApiErrorTranslator
      */
     private function deserializeError(string $errorString)
     {
-        $decodedJson = json_decode($errorString, true)['body']['error'];
+        $decodedJson = json_decode($errorString, true)['error'];
 
         return $this->serializer->deserialize(json_encode($decodedJson), 'App\Model\Sirius\SiriusApiError', 'json');
     }
@@ -72,7 +46,9 @@ class SiriusApiErrorTranslator
         $decodedJson = json_decode($errorString, true);
 
         return is_null($decodedJson) ||
-        !array_key_exists('body', $decodedJson) ||
-        (array_key_exists('body', $decodedJson) && (!array_key_exists('error', $decodedJson['body'])));
+        !array_key_exists('error', $decodedJson) ||
+        (array_key_exists('error', $decodedJson) && (!array_key_exists('code', $decodedJson['error']))) ||
+        (array_key_exists('error', $decodedJson) && (!array_key_exists('detail', $decodedJson['error']))) ||
+        (array_key_exists('error', $decodedJson) && (!array_key_exists('title', $decodedJson['error'])));
     }
 }

--- a/client/tests/phpunit/Service/SiriusApiErrorTranslatorTest.php
+++ b/client/tests/phpunit/Service/SiriusApiErrorTranslatorTest.php
@@ -21,62 +21,39 @@ class SiriusApiErrorTranslatorTest extends KernelTestCase
 
     /**
      * @test
-     * @dataProvider errorProvider
      */
-    public function translateApiErrors(?string $apiErrorCode, string $expectedTranslation)
+    public function translateApiErrors_unexpected_format()
     {
         $sut = new SiriusApiErrorTranslator($this->serializer);
-
-        $errorJson = sprintf('{"body":{"error":{"id":"7d0bb9c2-76c5-4cd1-b7a4-6cc28acc197f","code":"%s","title":"Request Too Long","detail":"","meta":{"x-ray":""}}}}', $apiErrorCode);
-        $translation = $sut->translateApiError($errorJson);
-        $expectedError = sprintf('%s: %s', $apiErrorCode, $expectedTranslation);
-
-        self::assertEquals($expectedError, $translation);
-    }
-
-    public function errorProvider()
-    {
-        return [
-            'ACCESS_DENIED' => ['OPGDATA-API-FORBIDDEN', 'Credentials used for integration lack correct permissions'],
-            'API_CONFIGURATION_ERROR' => ['OPGDATA-API-API_CONFIGURATION_ERROR', 'Integration API internal error'],
-            'AUTHORIZER_CONFIGURATION_ERROR' => ['OPGDATA-API-AUTHORIZER_CONFIGURATION_ERROR', 'Integration API internal error'],
-            'AUTHORIZER_FAILURE' => ['OPGDATA-API-AUTHORIZER_FAILURE', 'Integration API internal error'],
-            'BAD_REQUEST_BODY' => ['OPGDATA-API-INVALIDREQUEST', 'The body of the request is not valid'],
-            'BAD_REQUEST_PARAMETERS' => ['OPGDATA-API-BAD_REQUEST_PARAMETERS', 'The parameters of the request are not valid'],
-            'DEFAULT_5XX' => ['OPGDATA-API-SERVERERROR', 'Integration API server error'],
-            'EXPIRED_TOKEN' => ['OPGDATA-API-EXPIRED_TOKEN', 'Auth token has expired'],
-            'INTEGRATION_FAILURE' => ['OPGDATA-API-INTEGRATION_FAILURE', 'There was a problem syncing from the integration to Sirius'],
-            'INTEGRATION_TIMEOUT' => ['OPGDATA-API-INTEGRATION_TIMEOUT', 'The sync process timed out while communicating with Sirius'],
-            'INVALID_API_KEY' => ['OPGDATA-API-INVALID_API_KEY', 'The API key used in the request is not valid'],
-            'INVALID_SIGNATURE' => ['OPGDATA-API-INVALID_SIGNATURE', 'The signature of the request is not valid'],
-            'MISSING_AUTHENTICATION_TOKEN' => ['OPGDATA-API-MISSING_AUTHENTICATION_TOKEN', 'Authentication token is missing from the request'],
-            'QUOTA_EXCEEDED' => ['OPGDATA-API-QUOTA_EXCEEDED', 'API quota has been exceeded'],
-            'REQUEST_TOO_LARGE' => ['OPGDATA-API-FILESIZELIMIT', 'The size of the file exceeded the file size limit (6MB)'],
-            'RESOURCE_NOT_FOUND' => ['OPGDATA-API-NOTFOUND', 'Invalid URL used during integration or the resource no longer exists'],
-            'THROTTLED' => ['OPGDATA-API-THROTTLED', 'Too many requests made - throttling in action'],
-            'UNAUTHORIZED' => ['OPGDATA-API-UNAUTHORISED', 'No user/auth provided during requests'],
-            'UNSUPPORTED_MEDIA_TYPE' => ['OPGDATA-API-MEDIA', 'Media type of the file is not supported'],
-            'WAF_FILTERED' => ['OPGDATA-API-WAF_FILTERED', 'AWS WAF filtered this request and it was not sent to Sirius'],
-        ];
-    }
-
-    /**
-     * @test
-     * @dataProvider unexpectedProvider
-     */
-    public function translateApiErrors_unexpected_error_code(string $unexpectedErrorJson)
-    {
-        $sut = new SiriusApiErrorTranslator($this->serializer);
+        $unexpectedErrorJson = '{"An error occurred"}';
         $translation = $sut->translateApiError($unexpectedErrorJson);
 
         self::assertEquals($unexpectedErrorJson, $translation);
     }
 
-    public function unexpectedProvider()
-    {
-        return [
-            'Unexpected code' => ['{"body":{"error":{"id":"7d0bb9c2-76c5-4cd1-b7a4-6cc28acc197f","code":"AN UNEXPECTED CODE","title":"Request Too Long","detail":"","meta":{"x-ray":""}}}}'],
-            'Unexpected format' => ['{"An error occurred"}'],
-        ];
-    }
+     /**
+      * @test
+      */
+     public function translateApiError()
+     {
+
+         $sut = new SiriusApiErrorTranslator($this->serializer);
+
+         $errorJson = '{
+               "error":{
+                  "code":"OPGDATA-API-INVALIDREQUEST",
+                  "detail":"400 Bad Request: {\'validation_errors\': {\'file -> source\': {\'isEmpty\': \"Value is required and can\'t be empty\"}}, \'type\': \'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html\', \'title\': \'Bad Request\', \'status\': 400, \'detail\': \'Payload failed validation\'}",
+                  "title":"Invalid Request"
+               },
+               "headers":{
+                    "Content-Type":"application/json"
+               },
+               "isBase64Encoded":false,
+               "statusCode":400
+            }';
+         $translation = $sut->translateApiError($errorJson);
+         $expectedError = "OPGDATA-API-INVALIDREQUEST: 400 Bad Request: {'validation_errors': {'file -> source': {'isEmpty': \"Value is required and can't be empty\"}}, 'type': 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html', 'title': 'Bad Request', 'status': 400, 'detail': 'Payload failed validation'}";
+
+         self::assertEquals($expectedError, $translation);
+     }
 }


### PR DESCRIPTION
## Purpose
We still have some documents that get stuck during the sync process to Sirius. One of the error messages that is difficult to interpret is the message OPGDATA-API-INVALIDREQUEST: The body of the request is not valid. This message could be linked to a number of different things. Specific messaging is sent from integration but was not being used in Digideps.

Fixes DDPB-4452

## Approach
- Updated the SiriusAPiError model
- Removed translations from SiriusApiTranslator class and refactored translateApiError function
- Updated the array keys in deserializeError & jsonIsUnexpectedFormat functions
- Removed redundant test and added new tests
- Integration repo was updated to send error messages in a consistent format

## Checklist
- [x] I have performed a self-review of my own code
- [x ] I have added tests to prove my work
