### PR TITLE
DDPB-4475: Data from New Benefits not pulling through to the report PDF

### DIFF
--- a/client/templates/Report/Formatted/_client_benefits_check.html.twig
+++ b/client/templates/Report/Formatted/_client_benefits_check.html.twig
@@ -41,10 +41,16 @@
 
             {% if clientBenefitsCheck.doOthersReceiveMoneyOnClientsBehalf == 'yes' %}
                 <table class="labelvalue money push--top">
+                    <tr>
+                        <th>Type of payment</th>
+                        <th>Person or organisation who received the money</th>
+                        <th style="border-bottom: 0">Total amount for reporting period</th>
+                    </tr>
                     {% for money in clientBenefitsCheck.typesOfMoneyReceivedOnClientsBehalf %}
                         <tr>
                             <td class="label noborder">{{ money.moneyType }}</td>
-                            <td class="value text--right width-fifth">
+                            <td class="label noborder">{{ money.whoReceivedMoney }}</td>
+                            <td class="value text--right width-quarter">
                                 {% if money.amount is null %} {{ 'form.moneyDetails.dontKnowCheckboxLabel' | trans(transOptions) }} {% else %}&pound;{{ money.amount | money_format }}&nbsp;{% endif %}
                             </td>
                         </tr>


### PR DESCRIPTION
## Purpose
Currently the new benefits section on the report pdf does not display all the information the deputy enters on the report.
Specifically, the "Person or organisation who received the money" information is not displayed.

The purpose of this PR is to display that information. I've also added in headings for each section, as the information entered by the deputy may not make it clear what is being represented.

Fixes DDPB-4475

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
