### PR TITLE
DDPB-4501 remove golang vulnerability

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -16,7 +16,7 @@ RUN composer run-script post-install-cmd --no-interaction
 
 RUN composer dump-autoload --optimize
 
-FROM php:8.0.19-fpm-alpine3.15
+FROM php:8.0.23-fpm-alpine3.16
 WORKDIR /var/www
 EXPOSE 80
 EXPOSE 443
@@ -30,8 +30,8 @@ RUN apk --no-cache add \
   nginx \
   nginx-mod-http-headers-more \
   su-exec \
-  php7-igbinary \
-  php7-pecl-redis
+  php8-pecl-igbinary \
+  php8-pecl-redis
 
 RUN docker-php-ext-install pdo pdo_pgsql opcache
 RUN docker-php-ext-enable opcache

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -38,7 +38,7 @@ COPY src src
 RUN composer run-script post-install-cmd --no-interaction
 RUN composer dump-autoload --optimize
 
-FROM php:8.0.19-fpm-alpine3.15
+FROM php:8.0.23-fpm-alpine3.16
 WORKDIR /var/www
 EXPOSE 80
 EXPOSE 443
@@ -118,11 +118,6 @@ COPY docker/extra/commonpasswords.txt /tmp/commonpasswords.txt
 RUN wget -q -O /tmp/commonpasswords.txt "https://www.ncsc.gov.uk/static-assets/documents/PwnedPasswordsTop100k.txt" \
     || echo 'using local copy of pwnedpasswords' \
     && chown www-data /tmp/commonpasswords.txt
-
-#Check for security issues
-RUN wget -q -O local-php-security-checker https://github.com/fabpot/local-php-security-checker/releases/download/v1.0.0/local-php-security-checker_1.0.0_linux_arm64 \
-    && chmod +x local-php-security-checker \
-    && su-exec local-php-security-checker
 
 # Prebuild cache
 RUN su-exec www-data php -d memory_limit=-1 app/console cache:warmup


### PR DESCRIPTION
## Purpose
Fix for vulnerability picked up in ECR scan.

Fixes DDPB-4501

## Approach
Ironically the security vulnerability is in local-php-security-checker which does the same checks as dependabot is what was causing the golang security vulnerability warning from ECR. I tried to update it to latest version but that still had the issue so decided to remove completely as it does just check the composer lock files for know vulnerabilities the same as dependabot does so it's not really adding anything for us.

Updated php version to use latest alpine whilst I was there. 

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
