### PR TITLE
DDPB 4498: PAs users that are submitting reports look inactive by status 

### DIFF
--- a/api/src/Service/ReportService.php
+++ b/api/src/Service/ReportService.php
@@ -90,8 +90,11 @@ class ReportService
                 }
             }
         }
-
+        
         $this->em->persist($submission);
+        
+//      Set user to active once they have submitted a report
+        $user->setActive(true);
         
         $newYearReport = [];
         

--- a/api/tests/Unit/Service/ReportServiceTest.php
+++ b/api/tests/Unit/Service/ReportServiceTest.php
@@ -490,6 +490,24 @@ class ReportServiceTest extends TestCase
             'noUsersAttached' => [$noUserClient, false],
         ];
     }
+    
+    public function testUserStatusIsSetToActiveOnceReportIsSubmitted() 
+    {
+        $user = $this->user->setActive(null);
+       
+        $reportService = Mockery::mock( ReportService::class, [$this->em, $this->reportRepo])->makePartial();
+        
+        $this->em->shouldReceive('detach');
+        $this->em->shouldReceive('persist');
+        $this->em->shouldReceive('flush');
+
+        $this->report->setAgreedBehalfDeputy(true);
+       
+        $reportService->submit($this->report, $user, new DateTime());
+        
+        $this->assertTrue($user->getActive());
+        
+    }
 
     public function tearDown(): void
     {


### PR DESCRIPTION
## Purpose
Bug fix ticket that addresses users that are submitting reports but appear to have an inactive status. 

Fixes DDPB-4498

## Approach
This issue was resolved in a [previous ticket](https://github.com/ministryofjustice/opg-digideps/pull/883/files#diff-9278b433160f7b21d5efaec96b4e224b0d6643f229521933a8e8f90cec42298c), which also covered Lay Deputies. However it didn't resolve this particular user as they registered before the issue was addressed. 

With regards to this ticket, the users active status will be updated and set to 'true' once their report submission has been persisted to the database.
A unit test has also been added to test this.


## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x ] I have added tests to prove my work
- [ ] The product team have approved these changes
