### PR TITLE
DDPB-4456b properly add the jwt secrets

### DIFF
--- a/shared/secrets.tf
+++ b/shared/secrets.tf
@@ -21,7 +21,9 @@ module "environment_secrets" {
     "front-api-client-secret",
     "front-frontend-secret",
     "front-notify-api-key",
-    "synchronisation-jwt-token"
+    "synchronisation-jwt-token",
+    "public-jwt-key-base64",
+    "private-jwt-key-base64"
   ]
   tags = local.default_tags
 }

--- a/shared/sync.tf
+++ b/shared/sync.tf
@@ -54,6 +54,19 @@ data "aws_iam_policy_document" "sync" {
       data.aws_kms_alias.backup.target_key_arn,
     ]
   }
+
+  statement {
+    sid    = "AllowQuerySecretsManager"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+    resources = [
+      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:*/public-jwt-key-base64*",
+      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:*/private-jwt-key-base64*",
+      "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:*/synchronisation-jwt-token*"
+    ]
+  }
 }
 
 data "aws_s3_bucket" "sync" {


### PR DESCRIPTION
## Purpose

When the JWT prototype was initially being worked on, the secrets were not put in terraform, as such we need to push them through so that each env has correct secrets.  

Fixes DDPB-4456b

## Approach

Add the secrets and allow sync task to access them.

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
