### PR TITLE
DDPB-4508 make a container that runs sync commands continuously

### DIFF
--- a/client/scripts/document_and_checklist_sched.sh
+++ b/client/scripts/document_and_checklist_sched.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+# We need below to create the params file on container start
+confd -onetime -backend env
+
+while true
+do
+    echo "performing document sync at: $(date)"
+	su-exec www-data php app/console digideps:document-sync
+	echo "performing checklist sync at: $(date)"
+	su-exec www-data php app/console digideps:checklist-sync
+	sleep 60
+done

--- a/environment/checklist_sync.tf
+++ b/environment/checklist_sync.tf
@@ -76,14 +76,16 @@ resource "aws_ecs_service" "checklist_sync" {
 }
 
 resource "aws_cloudwatch_event_rule" "checklist_sync_cron_rule" {
+  count               = local.document_sync_scheduled
   name                = "${aws_ecs_task_definition.checklist_sync.family}-schedule"
-  schedule_expression = local.document_sync_interval
+  schedule_expression = "rate(24 hours)"
   tags                = local.default_tags
 }
 
 resource "aws_cloudwatch_event_target" "checklist_sync_scheduled_task" {
+  count     = local.document_sync_scheduled
   target_id = "ScheduledChecklistSync"
-  rule      = aws_cloudwatch_event_rule.checklist_sync_cron_rule.name
+  rule      = aws_cloudwatch_event_rule.checklist_sync_cron_rule[0].name
   arn       = aws_ecs_cluster.main.arn
   role_arn  = aws_iam_role.events_task_runner.arn
 

--- a/environment/monitoring_lambda_event.tf
+++ b/environment/monitoring_lambda_event.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_event_rule" "monitoring_db_queries" {
   name                = "monitor-rds-${local.environment}"
   description         = "Runs bespoke monitoring SQL statements against RDS DB"
-  schedule_expression = local.document_sync_interval
+  schedule_expression = "rate(1 hour)"
   tags                = local.default_tags
   is_enabled          = local.account == "production02" ? true : false
 }

--- a/environment/parameters.tf
+++ b/environment/parameters.tf
@@ -17,7 +17,7 @@ resource "aws_ssm_parameter" "sirius_api_base_uri" {
 resource "aws_ssm_parameter" "document_sync_row_limit" {
   name  = "${local.parameter_prefix}document-sync-row-limit"
   type  = "String"
-  value = "100"
+  value = "30"
 
   tags = local.default_tags
 


### PR DESCRIPTION
## Purpose



Fixes DDPB-4508

## Approach

Set it up with opposite settings to mimic prod and did some manual testing.

Put through 3000 docs to check it didn't run into memory or cpu issues (i was more checking that it didn't go up over time which is doesn't seem to) and to check that it processed them properly running in this form.

We can see them going through fine here:

<img width="243" alt="image" src="https://user-images.githubusercontent.com/58939809/194313039-13dd0602-6f45-456e-bf7a-5b5b0ae2b661.png">

<img width="1456" alt="image" src="https://user-images.githubusercontent.com/58939809/194312534-3a689d5b-5d60-43bb-aed6-b129bd0badb0.png">

I just did this in the most straight forward way possible after the frustrations of the previous attempt so that in all envs we do one scheduled run per day but in prod we have a container up constantly that runs every minute.

## Learning
NA

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
