### PR TITLE
DDPB-4508c use the checklist container for the sync setup

### DIFF
--- a/environment/checklist_sync.tf
+++ b/environment/checklist_sync.tf
@@ -62,6 +62,7 @@ resource "aws_ecs_service" "checklist_sync" {
   name                    = aws_ecs_task_definition.checklist_sync.family
   cluster                 = aws_ecs_cluster.main.id
   task_definition         = aws_ecs_task_definition.checklist_sync.arn
+  desired_count           = local.environment == "production02" ? 1 : 0
   launch_type             = "FARGATE"
   platform_version        = "1.4.0"
   enable_ecs_managed_tags = true
@@ -103,11 +104,12 @@ resource "aws_cloudwatch_event_target" "checklist_sync_scheduled_task" {
 }
 
 locals {
+  script_name              = local.environment == "production02" ? "scripts/document_and_checklist_sched.sh" : "scripts/checklistsync.sh"
   checklist_sync_container = <<EOF
   {
     "name": "checklist-sync",
     "image": "${local.images.client}",
-    "command": [ "sh", "scripts/checklistsync.sh" ],
+    "command": [ "sh", "${local.script_name}", "-d" ],
     "logConfiguration": {
       "logDriver": "awslogs",
       "options": {

--- a/environment/htmltopdf_sg.tf
+++ b/environment/htmltopdf_sg.tf
@@ -25,13 +25,6 @@ locals {
       target_type = "security_group_id"
       target      = module.checklist_sync_service_security_group.id
     }
-    document = {
-      port        = 80
-      type        = "ingress"
-      protocol    = "tcp"
-      target_type = "security_group_id"
-      target      = module.document_sync_service_security_group.id
-    }
   }
 }
 

--- a/environment/parameters.tf
+++ b/environment/parameters.tf
@@ -17,7 +17,7 @@ resource "aws_ssm_parameter" "sirius_api_base_uri" {
 resource "aws_ssm_parameter" "document_sync_row_limit" {
   name  = "${local.parameter_prefix}document-sync-row-limit"
   type  = "String"
-  value = "30"
+  value = "100"
 
   tags = local.default_tags
 


### PR DESCRIPTION
## Purpose
Decided to move this setup to the checklist container which is what we should have done in the first place.

Fixes DDPB-4508

## Approach

An oversight on the original ticket meant the setup didn't work properly with checklists. Didn't catch it before we merged but caught before it caused a problem and put in an emergency fix for it. However, with a bit more thought, we should have just switched to checklists container for the script. This ticket addresses that. 

## Learning
NA

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
