### PR TITLE
DDPB-4064 use fargate spot on ephemeral environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -626,8 +626,8 @@ orbs:
               password: $DOCKER_ACCESS_TOKEN
         resource_class: small
         environment:
-          TF_VERSION: 1.2.1
-          TF_SHA256SUM: 8cf8eb7ed2d95a4213fbfd0459ab303f890e79220196d1c4aae9ecf22547302e
+          TF_VERSION: 1.3.5
+          TF_SHA256SUM: ac28037216c3bc41de2c22724e863d883320a770056969b8d211ca8af3d477cf
           TF_CLI_ARGS_plan: -input=false -lock=false
           TF_CLI_ARGS_apply: -input=false -auto-approve
           TF_CLI_ARGS_destroy: -input=false -auto-approve

--- a/environment/.terraform.lock.hcl
+++ b/environment/.terraform.lock.hcl
@@ -6,6 +6,8 @@ provider "registry.terraform.io/hashicorp/archive" {
   hashes = [
     "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
     "h1:62mVchC1L6vOo5QS9uUf52uu0emsMM+LsPQJ1BEaTms=",
+    "h1:CIWi5G6ob7p2wWoThRQbOB8AbmFlCzp7Ka81hR3cVp0=",
+    "h1:mZPzA0bba3fHD0Ht01Qu1r1x8uKHGJbKK1/CJn11vFI=",
     "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
     "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
     "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
@@ -25,7 +27,9 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "4.16.0"
   hashes = [
     "h1:6V8jLqXdtHjCkMIuxg77BrTVchqpaRK1UUYeTuXDPmE=",
+    "h1:cZbnIGtm+YbulhUbrJpQThXAty4EYW41UsQPt8oQie4=",
     "h1:jmf/sbrsF1//4DG3QdPzbjCNsPUCp66g7ysuyj8QECc=",
+    "h1:u1SMSE9I4DL7ODSNbNvNZbOpXm9w6GO34i82YHm/zL0=",
     "zh:0aa204fead7c431796386cc9e73ccda9a185f37e46d4b6475ff3f56ad4f15101",
     "zh:130396f5da1650f4d6949e67ec44e0f408a529b7f76c48701a7bf21ba6949bbc",
     "zh:271bfa95bc1332676a81d3f01ba1b5a188abf26df475ca9f25972c68935b6ee9",
@@ -46,6 +50,9 @@ provider "registry.terraform.io/hashicorp/local" {
   hashes = [
     "h1:FvRIEgCmAezgZUqb2F+PZ9WnSSnR5zbEM2ZI+GLmbMk=",
     "h1:KmHz81iYgw9Xn2L3Carc2uAzvFZ1XsE7Js3qlVeC77k=",
+    "h1:Q3jfOfv6aoLDw/clZGDOaUqUtQjEgeK6Qi8HHMlFO7A=",
+    "h1:UQWvyyVz2Tbjpd2jORuy+lwXv3bqd9DZO+ljU4A9hYI=",
+    "h1:aWp5iSUxBGgPv1UnV5yag9Pb0N+U1I0sZb38AXBFO8A=",
     "zh:04f0978bb3e052707b8e82e46780c371ac1c66b689b4a23bbc2f58865ab7d5c0",
     "zh:6484f1b3e9e3771eb7cc8e8bab8b35f939a55d550b3f4fb2ab141a24269ee6aa",
     "zh:78a56d59a013cb0f7eb1c92815d6eb5cf07f8b5f0ae20b96d049e73db915b238",

--- a/environment/admin_service.tf
+++ b/environment/admin_service.tf
@@ -15,7 +15,6 @@ resource "aws_ecs_service" "admin" {
   cluster                 = aws_ecs_cluster.main.id
   task_definition         = aws_ecs_task_definition.admin.arn
   desired_count           = 1
-  launch_type             = "FARGATE"
   platform_version        = "1.4.0"
   enable_ecs_managed_tags = true
   propagate_tags          = "SERVICE"
@@ -32,6 +31,24 @@ resource "aws_ecs_service" "admin" {
     target_group_arn = aws_lb_target_group.admin.arn
     container_name   = "admin_app"
     container_port   = 443
+  }
+
+  capacity_provider_strategy {
+    capacity_provider = local.capacity_provider
+    weight            = 1
+  }
+
+  deployment_controller {
+    type = "ECS"
+  }
+
+  deployment_circuit_breaker {
+    enable   = false
+    rollback = false
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 
   depends_on = [aws_lb_listener.admin]

--- a/environment/api_service.tf
+++ b/environment/api_service.tf
@@ -44,7 +44,6 @@ resource "aws_ecs_service" "api" {
   cluster                 = aws_ecs_cluster.main.id
   task_definition         = aws_ecs_task_definition.api.arn
   desired_count           = local.account.task_count
-  launch_type             = "FARGATE"
   platform_version        = "1.4.0"
   enable_ecs_managed_tags = true
   propagate_tags          = "SERVICE"
@@ -59,6 +58,24 @@ resource "aws_ecs_service" "api" {
 
   service_registries {
     registry_arn = aws_service_discovery_service.api.arn
+  }
+
+  capacity_provider_strategy {
+    capacity_provider = local.capacity_provider
+    weight            = 1
+  }
+
+  deployment_controller {
+    type = "ECS"
+  }
+
+  deployment_circuit_breaker {
+    enable   = false
+    rollback = false
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 
   depends_on = [aws_service_discovery_service.api]

--- a/environment/check_csv_uploaded.tf
+++ b/environment/check_csv_uploaded.tf
@@ -46,23 +46,6 @@ resource "aws_ecs_task_definition" "check_csv_uploaded" {
   tags                     = local.default_tags
 }
 
-resource "aws_ecs_service" "check_csv_uploaded" {
-  name                    = aws_ecs_task_definition.check_csv_uploaded.family
-  cluster                 = aws_ecs_cluster.main.id
-  task_definition         = aws_ecs_task_definition.check_csv_uploaded.arn
-  launch_type             = "FARGATE"
-  platform_version        = "1.4.0"
-  enable_ecs_managed_tags = true
-  propagate_tags          = "SERVICE"
-  tags                    = local.default_tags
-
-  network_configuration {
-    security_groups  = [module.check_csv_uploaded_service_security_group.id]
-    subnets          = data.aws_subnet.private.*.id
-    assign_public_ip = false
-  }
-}
-
 resource "aws_cloudwatch_event_rule" "check_csv_uploaded_cron_rule" {
   name                = "${aws_ecs_task_definition.check_csv_uploaded.family}-schedule"
   description         = "Check daily which CSVs have been uploaded in ${terraform.workspace}"

--- a/environment/checklist_sync.tf
+++ b/environment/checklist_sync.tf
@@ -74,6 +74,19 @@ resource "aws_ecs_service" "checklist_sync" {
     subnets          = data.aws_subnet.private.*.id
     assign_public_ip = false
   }
+
+  deployment_controller {
+    type = "ECS"
+  }
+
+  deployment_circuit_breaker {
+    enable   = false
+    rollback = false
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_cloudwatch_event_rule" "checklist_sync_cron_rule" {

--- a/environment/document_sync.tf
+++ b/environment/document_sync.tf
@@ -67,6 +67,19 @@ resource "aws_ecs_service" "document_sync" {
     subnets          = data.aws_subnet.private.*.id
     assign_public_ip = false
   }
+
+  deployment_controller {
+    type = "ECS"
+  }
+
+  deployment_circuit_breaker {
+    enable   = false
+    rollback = false
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_cloudwatch_event_rule" "document_sync_cron_rule" {

--- a/environment/front_service.tf
+++ b/environment/front_service.tf
@@ -44,7 +44,6 @@ resource "aws_ecs_service" "front" {
   cluster                 = aws_ecs_cluster.main.id
   task_definition         = aws_ecs_task_definition.front.arn
   desired_count           = local.account.task_count
-  launch_type             = "FARGATE"
   platform_version        = "1.4.0"
   enable_ecs_managed_tags = true
   propagate_tags          = "SERVICE"
@@ -65,6 +64,24 @@ resource "aws_ecs_service" "front" {
 
   service_registries {
     registry_arn = aws_service_discovery_service.front.arn
+  }
+
+  capacity_provider_strategy {
+    capacity_provider = local.capacity_provider
+    weight            = 1
+  }
+
+  deployment_controller {
+    type = "ECS"
+  }
+
+  deployment_circuit_breaker {
+    enable   = false
+    rollback = false
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 
   depends_on = [aws_lb_listener.front_https, aws_service_discovery_service.front]

--- a/environment/htmltopdf.tf
+++ b/environment/htmltopdf.tf
@@ -50,7 +50,6 @@ resource "aws_ecs_service" "htmltopdf" {
   cluster                 = aws_ecs_cluster.main.id
   task_definition         = aws_ecs_task_definition.htmltopdf.arn
   desired_count           = 1
-  launch_type             = "FARGATE"
   platform_version        = "1.4.0"
   enable_ecs_managed_tags = true
   propagate_tags          = "SERVICE"
@@ -64,6 +63,24 @@ resource "aws_ecs_service" "htmltopdf" {
 
   service_registries {
     registry_arn = aws_service_discovery_service.htmltopdf.arn
+  }
+
+  capacity_provider_strategy {
+    capacity_provider = local.capacity_provider
+    weight            = 1
+  }
+
+  deployment_controller {
+    type = "ECS"
+  }
+
+  deployment_circuit_breaker {
+    enable   = false
+    rollback = false
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 
   depends_on = [aws_service_discovery_service.htmltopdf]

--- a/environment/mock_sirius_integration_service.tf
+++ b/environment/mock_sirius_integration_service.tf
@@ -43,8 +43,7 @@ resource "aws_ecs_service" "mock_sirius_integration" {
   name                    = aws_ecs_task_definition.mock_sirius_integration.family
   cluster                 = aws_ecs_cluster.main.id
   task_definition         = aws_ecs_task_definition.mock_sirius_integration.arn
-  desired_count           = 1
-  launch_type             = "FARGATE"
+  desired_count           = local.environment == "production02" ? 0 : 1
   platform_version        = "1.4.0"
   enable_ecs_managed_tags = true
   propagate_tags          = "SERVICE"
@@ -59,6 +58,24 @@ resource "aws_ecs_service" "mock_sirius_integration" {
 
   service_registries {
     registry_arn = aws_service_discovery_service.mock_sirius_integration.arn
+  }
+
+  capacity_provider_strategy {
+    capacity_provider = local.capacity_provider
+    weight            = 1
+  }
+
+  deployment_controller {
+    type = "ECS"
+  }
+
+  deployment_circuit_breaker {
+    enable   = false
+    rollback = false
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 
   depends_on = [aws_service_discovery_service.mock_sirius_integration]

--- a/environment/scan.tf
+++ b/environment/scan.tf
@@ -50,7 +50,6 @@ resource "aws_ecs_service" "scan" {
   cluster                 = aws_ecs_cluster.main.id
   task_definition         = aws_ecs_task_definition.scan.arn
   desired_count           = local.account.scan_count
-  launch_type             = "FARGATE"
   platform_version        = "1.4.0"
   enable_ecs_managed_tags = true
   propagate_tags          = "SERVICE"
@@ -64,6 +63,24 @@ resource "aws_ecs_service" "scan" {
 
   service_registries {
     registry_arn = aws_service_discovery_service.scan.arn
+  }
+
+  capacity_provider_strategy {
+    capacity_provider = local.capacity_provider
+    weight            = 1
+  }
+
+  deployment_controller {
+    type = "ECS"
+  }
+
+  deployment_circuit_breaker {
+    enable   = false
+    rollback = false
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 
   depends_on = [aws_service_discovery_service.scan]

--- a/environment/terraform.tfvars.json
+++ b/environment/terraform.tfvars.json
@@ -38,7 +38,8 @@
       "aurora_enabled": true,
       "s3_backup_replication": true,
       "s3_backup_kms_arn": "8d42ba9a-321c-43ac-a911-5f452d336da5",
-      "associate_alb_with_waf_web_acl_enabled": true
+      "associate_alb_with_waf_web_acl_enabled": true,
+      "fargate_spot": false
     },
     "preproduction": {
       "name": "preproduction",
@@ -78,7 +79,8 @@
       "aurora_enabled": true,
       "s3_backup_replication": true,
       "s3_backup_kms_arn": "5875b77a-043c-41e3-a3c6-84bdd865fedf",
-      "associate_alb_with_waf_web_acl_enabled": true
+      "associate_alb_with_waf_web_acl_enabled": true,
+      "fargate_spot": true
     },
     "training": {
       "name": "production",
@@ -118,7 +120,8 @@
       "aurora_enabled": true,
       "s3_backup_replication": false,
       "s3_backup_kms_arn": "8d42ba9a-321c-43ac-a911-5f452d336da5",
-      "associate_alb_with_waf_web_acl_enabled": true
+      "associate_alb_with_waf_web_acl_enabled": true,
+      "fargate_spot": true
     },
     "integration": {
       "name": "preproduction",
@@ -158,7 +161,8 @@
       "aurora_enabled": true,
       "s3_backup_replication": false,
       "s3_backup_kms_arn": "5875b77a-043c-41e3-a3c6-84bdd865fedf",
-      "associate_alb_with_waf_web_acl_enabled": true
+      "associate_alb_with_waf_web_acl_enabled": true,
+      "fargate_spot": true
     },
     "development": {
       "name": "development",
@@ -199,7 +203,8 @@
       "aurora_enabled": true,
       "s3_backup_replication": true,
       "s3_backup_kms_arn": "f4dd7602-251f-48f8-accb-6d1bec57436f",
-      "associate_alb_with_waf_web_acl_enabled": true
+      "associate_alb_with_waf_web_acl_enabled": true,
+      "fargate_spot": true
     },
     "default": {
       "name": "development",
@@ -240,7 +245,8 @@
       "aurora_enabled": true,
       "s3_backup_replication": false,
       "s3_backup_kms_arn": "f4dd7602-251f-48f8-accb-6d1bec57436f",
-      "associate_alb_with_waf_web_acl_enabled": true
+      "associate_alb_with_waf_web_acl_enabled": true,
+      "fargate_spot": true
     }
   }
 }

--- a/environment/variables.tf
+++ b/environment/variables.tf
@@ -47,6 +47,7 @@ variable "accounts" {
       s3_backup_replication                  = bool
       s3_backup_kms_arn                      = string
       associate_alb_with_waf_web_acl_enabled = bool
+      fargate_spot                           = bool
     })
   )
 }
@@ -87,6 +88,8 @@ locals {
   }
 
   openapi_mock_version = "v0.3.3"
+
+  capacity_provider = local.account.fargate_spot ? "FARGATE_SPOT" : "FARGATE"
 }
 
 data "terraform_remote_state" "shared" {


### PR DESCRIPTION
## Purpose
Use pure fargate spot for now on non prod environments

Fixes DDPB-4064

## Approach
Original ticket was to use them on ephemeral envs but actually why not trial them on everything but prod? Many of the envs are so scarcely used that it would be a big saving. If we find that we are getting interrupt issues in our other non prod environments then we can switch them back by changing the flag in tfvars.

Basically spot will give us 'spare' container in aws and can take our compute to be used for other things. I'm not actually sure how often it will interrupt our service. I think it might be worth just seeing if we notice any issues but I understand if others would prefer not to do that experiment. 

Got rid of the check csv as a service as it doesn't need to be one. 

## Learning
https://aws.amazon.com/blogs/aws/aws-fargate-spot-now-generally-available/

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
