### PR TITLE
DDPB-4552 add resource protection

### DIFF
--- a/environment/alarms.tf
+++ b/environment/alarms.tf
@@ -356,7 +356,7 @@ resource "aws_cloudwatch_metric_alarm" "admin_alb_average_response_time" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "admin_ddos_attack_external" {
-  alarm_name          = "ActorDDoSDetected"
+  alarm_name          = "AdminDDoSDetected"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "3"
   metric_name         = "DDoSDetected"
@@ -366,14 +366,14 @@ resource "aws_cloudwatch_metric_alarm" "admin_ddos_attack_external" {
   threshold           = "0"
   alarm_description   = "Triggers when AWS Shield Advanced detects a DDoS attack"
   treat_missing_data  = "notBreaching"
-  alarm_actions       = [data.aws_sns_topic.availability-alert.arn]
+  alarm_actions       = [data.aws_sns_topic.alerts.arn]
   dimensions = {
     ResourceArn = aws_lb.admin.arn
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "front_ddos_attack_external" {
-  alarm_name          = "ViewerDDoSDetected"
+  alarm_name          = "FrontDDoSDetected"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "3"
   metric_name         = "DDoSDetected"
@@ -383,7 +383,7 @@ resource "aws_cloudwatch_metric_alarm" "front_ddos_attack_external" {
   threshold           = "0"
   alarm_description   = "Triggers when AWS Shield Advanced detects a DDoS attack"
   treat_missing_data  = "notBreaching"
-  alarm_actions       = [data.aws_sns_topic.availability-alert.arn]
+  alarm_actions       = [data.aws_sns_topic.alerts.arn]
   dimensions = {
     ResourceArn = aws_lb.front.arn
   }

--- a/environment/alarms.tf
+++ b/environment/alarms.tf
@@ -354,3 +354,37 @@ resource "aws_cloudwatch_metric_alarm" "admin_alb_average_response_time" {
     }
   }
 }
+
+resource "aws_cloudwatch_metric_alarm" "admin_ddos_attack_external" {
+  alarm_name          = "ActorDDoSDetected"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "DDoSDetected"
+  namespace           = "AWS/DDoSProtection"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "0"
+  alarm_description   = "Triggers when AWS Shield Advanced detects a DDoS attack"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [data.aws_sns_topic.availability-alert.arn]
+  dimensions = {
+    ResourceArn = aws_lb.admin.arn
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "front_ddos_attack_external" {
+  alarm_name          = "ViewerDDoSDetected"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "DDoSDetected"
+  namespace           = "AWS/DDoSProtection"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "0"
+  alarm_description   = "Triggers when AWS Shield Advanced detects a DDoS attack"
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = [data.aws_sns_topic.availability-alert.arn]
+  dimensions = {
+    ResourceArn = aws_lb.front.arn
+  }
+}

--- a/environment/waf.tf
+++ b/environment/waf.tf
@@ -14,3 +14,17 @@ resource "aws_wafv2_web_acl_association" "front" {
   resource_arn = aws_lb.front.arn
   web_acl_arn  = data.aws_wafv2_web_acl.main.arn
 }
+
+resource "aws_shield_protection" "admin_alb_protection" {
+  name         = "admin-alb-protection-${local.environment}"
+  resource_arn = aws_lb.admin.arn
+
+  tags = local.default_tags
+}
+
+resource "aws_shield_protection" "front_alb_protection" {
+  name         = "front-alb-protection-${local.environment}"
+  resource_arn = aws_lb.front.arn
+
+  tags = local.default_tags
+}

--- a/environment/waf.tf
+++ b/environment/waf.tf
@@ -22,9 +22,19 @@ resource "aws_shield_protection" "admin_alb_protection" {
   tags = local.default_tags
 }
 
+resource "aws_shield_protection_health_check_association" "admin" {
+  health_check_arn     = aws_route53_health_check.availability-admin.arn
+  shield_protection_id = aws_shield_protection.admin_alb_protection.id
+}
+
 resource "aws_shield_protection" "front_alb_protection" {
   name         = "front-alb-protection-${local.environment}"
   resource_arn = aws_lb.front.arn
 
   tags = local.default_tags
+}
+
+resource "aws_shield_protection_health_check_association" "front" {
+  health_check_arn     = aws_route53_health_check.availability-front.arn
+  shield_protection_id = aws_shield_protection.front_alb_protection.id
 }


### PR DESCRIPTION
## Purpose
Add the resources for WAF protection with shield advanced 

Fixes DDPB-4552

## Approach
Did the main bit in different repo. 

This is just to add a couple of alarms for when we are being DDOSed and adding the protection. We still need to add the Elastic IP addresses in manually as doesn't seem to be a way in terraform...

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
