### PR TITLE
DDPB-4592: Co-deputy cannot sign up to the service

### DIFF
--- a/api/src/Repository/ClientRepository.php
+++ b/api/src/Repository/ClientRepository.php
@@ -108,15 +108,13 @@ class ClientRepository extends ServiceEntityRepository
     }
 
     /**
-     * @param $caseNumber
-     *
      * @return array<mixed>|null
      */
     public function getArrayByCaseNumber($caseNumber)
     {
         $query = $this
             ->getEntityManager()
-            ->createQuery('SELECT c FROM App\Entity\Client c WHERE c.caseNumber = ?1')
+            ->createQuery('SELECT c FROM App\Entity\Client c WHERE LOWER(c.caseNumber) = LOWER(?1)')
             ->setParameter(1, $caseNumber);
 
         $result = $query->getArrayResult();

--- a/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnFrontendTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/IShouldBeOnFrontendTrait.php
@@ -141,7 +141,7 @@ trait IShouldBeOnFrontendTrait
     }
 
     /**
-     * @Then I should be on the Lay homepage
+     * @Then I/they should be on the Lay homepage
      */
     public function iAmOnLayMainPage(): bool
     {

--- a/api/tests/Behat/bootstrap/v2/Registration/IngestTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Registration/IngestTrait.php
@@ -11,7 +11,6 @@ use App\Entity\PreRegistration;
 use App\Entity\Report\Report;
 use App\Tests\Behat\BehatException;
 use Behat\Gherkin\Node\TableNode;
-use DateTime;
 
 trait IngestTrait
 {
@@ -28,7 +27,7 @@ trait IngestTrait
         'sirius_case_numbers' => [],
     ];
 
-    private ?DateTime $expectedClientCourtDate = null;
+    private ?\DateTime $expectedClientCourtDate = null;
 
     private string $expectedNamedDeputyName = '';
     private string $expectedNamedDeputyAddress = '';
@@ -993,5 +992,22 @@ trait IngestTrait
         if (!$emailMatches) {
             throw new BehatException(sprintf("The deputy's email was not updated. Wanted: '%s', got '%s'", $email, $actualEmail));
         }
+    }
+
+    /**
+     * @Given I upload a lay CSV that contains :newEntitiesCount new pre-registration entities for the same case
+     */
+    public function iUploadALayCSVThatContainsNewPreRegistrationEntitiesForTheSameCase($newEntitiesCount)
+    {
+        $this->iamOnAdminUploadUsersPage();
+
+        $this->preRegistration['expected'] = $newEntitiesCount;
+
+        $this->selectOption('form[type]', 'lay');
+        $this->pressButton('Continue');
+
+        $filePath = 'sirius-csvs/lay-2-rows-co-deputy.csv';
+
+        $this->uploadCsvAndCountCreatedEntities($filePath, 'Upload Lay users');
     }
 }

--- a/api/tests/Behat/bootstrap/v2/Registration/SelfRegistrationTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Registration/SelfRegistrationTrait.php
@@ -14,6 +14,7 @@ trait SelfRegistrationTrait
     private string $invalidDeputyPostcodeError = 'Your last name you provided does not match our records.';
     private string $invalidClientLastnameError = 'The postcode you provided does not match our records.';
     private string $userEmail;
+    private string $coDeputyEmail;
     private string $deputyUid;
 
     /**
@@ -26,20 +27,18 @@ trait SelfRegistrationTrait
         $this->deputyUid = '19371937';
 
         $this->visitFrontendPath('/register');
-        $this->fillInField('self_registration_firstname', 'Brian');
-        $this->fillInField('self_registration_lastname', 'Duck');
-        $this->fillInField('self_registration_email_first', $this->userEmail);
-        $this->fillInField('self_registration_email_second', $this->userEmail);
-        $this->fillInField('self_registration_postcode', 'B1');
-        $this->fillInField('self_registration_clientFirstname', 'Billy');
-        $this->fillInField('self_registration_clientLastname', 'Huey');
-        $this->fillInField('self_registration_caseNumber', '31313131');
-        $this->pressButton('self_registration_save');
+        $this->fillInSelfRegistrationFieldsAndSubmit(
+            'Brian',
+            'Duck',
+            $this->userEmail,
+            'B1',
+            'Billy',
+            'Huey',
+            '31313131',
+        );
 
         $this->clickActivationOrPasswordResetLinkInEmail(false, 'activation', $this->userEmail);
-        $this->fillInField('set_password_password_first', 'DigidepsPass1234');
-        $this->fillInField('set_password_password_second', 'DigidepsPass1234');
-        $this->checkOption('set_password_showTermsAndConditions');
+        $this->setPasswordAndTickTAndCs();
         $this->pressButton('set_password_save');
 
         $this->assertPageContainsText('Sign in to your new account');
@@ -47,33 +46,11 @@ trait SelfRegistrationTrait
         $this->fillInField('login_password', 'DigidepsPass1234');
         $this->pressButton('login_login');
 
-        $this->fillInField('user_details_address1', '102 Petty France');
-        $this->fillInField('user_details_address2', 'MOJ');
-        $this->fillInField('user_details_address3', 'London');
-        $this->fillInField('user_details_addressCountry', 'GB');
-        $this->fillInField('user_details_phoneMain', '01789 321234');
-        $this->pressButton('user_details_save');
+        $this->fillUserDetailsAndSubmit();
 
-        $this->fillInField('client_address', '1 South Parade');
-        $this->fillInField('client_address2', 'First Floor');
-        $this->fillInField('client_address3', 'Big Building');
-        $this->fillInField('client_address4', 'Large Town');
-        $this->fillInField('client_address5', 'Notts');
-        $this->fillInField('client_postcode', 'NG1 2HT');
-        $this->fillInField('client_country', 'GB');
-        $this->fillInField('client_phone', '01789432876');
-        $this->fillInField('client_courtDate_day', '01');
-        $this->fillInField('client_courtDate_month', '01');
-        $this->fillInField('client_courtDate_year', '2016');
-        $this->pressButton('client_save');
+        $this->fillClientDetailsAndSubmit();
 
-        $this->fillInField('report_startDate_day', '01');
-        $this->fillInField('report_startDate_month', '01');
-        $this->fillInField('report_startDate_year', '2016');
-        $this->fillInField('report_endDate_day', '31');
-        $this->fillInField('report_endDate_month', '12');
-        $this->fillInField('report_endDate_year', '2016');
-        $this->pressButton('report_save');
+        $this->fillInReportDetailsAndSubmit();
     }
 
     /**
@@ -82,15 +59,15 @@ trait SelfRegistrationTrait
     public function aLayDeputyRegistersToDeputiseForAClientWithAnInvalidCaseNumber()
     {
         $this->visitFrontendPath('/register');
-        $this->fillInField('self_registration_firstname', 'Brian');
-        $this->fillInField('self_registration_lastname', 'Duck');
-        $this->fillInField('self_registration_email_first', 'brian2@duck.co.uk');
-        $this->fillInField('self_registration_email_second', 'brian2@duck.co.uk');
-        $this->fillInField('self_registration_postcode', 'B1');
-        $this->fillInField('self_registration_clientFirstname', 'Billy');
-        $this->fillInField('self_registration_clientLastname', 'Huey');
-        $this->fillInField('self_registration_caseNumber', '31313137');
-        $this->pressButton('self_registration_save');
+        $this->fillInSelfRegistrationFieldsAndSubmit(
+            'Brian',
+            'Duck',
+            'brian2@duck.co.uk',
+            'B1',
+            'Billy',
+            'Huey',
+            '31313137',
+        );
     }
 
     /**
@@ -99,14 +76,34 @@ trait SelfRegistrationTrait
     public function aLayDeputyRegistersToDeputiseForAClientWithAnValidCaseNumberAndInvalidCaseDetails()
     {
         $this->visitFrontendPath('/register');
-        $this->fillInField('self_registration_firstname', 'Wrong');
-        $this->fillInField('self_registration_lastname', 'Name');
-        $this->fillInField('self_registration_email_first', 'brian3@duck.co.uk');
-        $this->fillInField('self_registration_email_second', 'brian3@duck.co.uk');
-        $this->fillInField('self_registration_postcode', 'ABC 123');
-        $this->fillInField('self_registration_clientFirstname', 'Wrong');
-        $this->fillInField('self_registration_clientLastname', 'Name');
-        $this->fillInField('self_registration_caseNumber', '31313131');
+        $this->fillInSelfRegistrationFieldsAndSubmit(
+            'Wrong',
+            'Name',
+            'brian3@duck.co.uk',
+            'ABC 123',
+            'Wrong',
+            'Name',
+            '31313131',
+        );
+    }
+
+    private function fillInSelfRegistrationFieldsAndSubmit(
+        string $firstname,
+        string $lastname,
+        string $email,
+        string $postcode,
+        string $clientFirstname,
+        string $clientLastname,
+        string $caseNumber
+    ) {
+        $this->fillInField('self_registration_firstname', $firstname);
+        $this->fillInField('self_registration_lastname', $lastname);
+        $this->fillInField('self_registration_email_first', $email);
+        $this->fillInField('self_registration_email_second', $email);
+        $this->fillInField('self_registration_postcode', $postcode);
+        $this->fillInField('self_registration_clientFirstname', $clientFirstname);
+        $this->fillInField('self_registration_clientLastname', $clientLastname);
+        $this->fillInField('self_registration_caseNumber', $caseNumber);
         $this->pressButton('self_registration_save');
     }
 
@@ -157,9 +154,7 @@ trait SelfRegistrationTrait
     {
         $this->deputyUid = '19371938';
 
-        $this->fillInField('set_password_password_first', 'DigidepsPass1234');
-        $this->fillInField('set_password_password_second', 'DigidepsPass1234');
-        $this->checkOption('set_password_showTermsAndConditions');
+        $this->setPasswordAndTickTAndCs();
 
         $this->pressButton('Submit');
 
@@ -167,12 +162,7 @@ trait SelfRegistrationTrait
         $this->fillField('login_password', 'DigidepsPass1234');
         $this->pressButton('login_login');
 
-        $this->fillInField('user_details_address1', '102 Petty France');
-        $this->fillInField('user_details_address2', 'MOJ');
-        $this->fillInField('user_details_address3', 'London');
-        $this->fillInField('user_details_addressCountry', 'GB');
-        $this->fillInField('user_details_phoneMain', '01789 321234');
-        $this->pressButton('user_details_save');
+        $this->fillUserDetailsAndSubmit();
 
         $this->fillInField('client_firstname', $this->faker->firstName());
         $this->fillInField('client_lastname', 'DEWEY');
@@ -190,13 +180,7 @@ trait SelfRegistrationTrait
         $this->fillInField('client_courtDate_year', '2016');
         $this->pressButton('client_save');
 
-        $this->fillInField('report_startDate_day', '01');
-        $this->fillInField('report_startDate_month', '01');
-        $this->fillInField('report_startDate_year', '2016');
-        $this->fillInField('report_endDate_day', '31');
-        $this->fillInField('report_endDate_month', '12');
-        $this->fillInField('report_endDate_year', '2016');
-        $this->pressButton('report_save');
+        $this->fillInReportDetailsAndSubmit();
     }
 
     /**
@@ -240,5 +224,130 @@ trait SelfRegistrationTrait
         $this->assertStringEqualsString('London', $deputy->getAddress3(), 'Asserting Address Line 3 is the same');
         $this->assertStringEqualsString('GB', $deputy->getAddressCountry(), 'Asserting Address Country is the same');
         $this->assertStringEqualsString('01789 321234', $deputy->getPhoneMain(), 'Asserting Main Phone is the same');
+    }
+
+    /**
+     * @Given one of the Lay Deputies registers to deputise for a client with valid details
+     */
+    public function oneOfTheLayDeputiesRegistersToDeputiseForAClientWithValidDetails()
+    {
+        $this->userEmail = 'brian@mcduck.co.uk';
+        $this->interactingWithUserDetails = new UserDetails(['userEmail' => $this->userEmail]);
+        $this->deputyUid = '35672419';
+
+        $this->visitFrontendPath('/register');
+        $this->fillInSelfRegistrationFieldsAndSubmit(
+            'Brian',
+            'McDuck',
+            $this->userEmail,
+            'B73',
+            'Billy',
+            'Louie',
+            '1717171T',
+        );
+
+        $this->clickActivationOrPasswordResetLinkInEmail(false, 'activation', $this->userEmail);
+        $this->setPasswordAndTickTAndCs();
+        $this->pressButton('set_password_save');
+
+        $this->assertPageContainsText('Sign in to your new account');
+        $this->fillInField('login_email', $this->userEmail);
+        $this->fillInField('login_password', 'DigidepsPass1234');
+        $this->pressButton('login_login');
+
+        $this->fillUserDetailsAndSubmit();
+
+        $this->fillClientDetailsAndSubmit();
+
+        $this->fillInReportDetailsAndSubmit();
+    }
+
+    /**
+     * @When I invite a Co-Deputy to the service
+     */
+    public function iInviteACoDeputyToTheService()
+    {
+        $matches = [];
+        preg_match('/[^\/]+$/', $this->getCurrentUrl(), $matches);
+        $clientId = $matches[0];
+
+        $this->getCurrentUrl();
+        $this->visitPath(sprintf('/codeputy/%s/add', $clientId));
+
+        $this->coDeputyEmail = 'liam@mcquack.co.uk';
+
+        $this->fillInField('co_deputy_invite_email', $this->coDeputyEmail);
+        $this->pressButton('co_deputy_invite_submit');
+    }
+
+    /**
+     * @Then /^they should be able to register to deputise for a client with valid details$/
+     */
+    public function theyShouldBeAbleToRegisterToDeputiseForAClientWithValidDetails()
+    {
+        $this->visitPath('/logout');
+        $this->clickActivationOrPasswordResetLinkInEmail(false, 'activation', $this->coDeputyEmail);
+        $this->setPasswordAndTickTAndCs();
+        $this->pressButton('set_password_save');
+
+        $this->assertPageContainsText('Sign in to your new account');
+        $this->fillInField('login_email', $this->coDeputyEmail);
+        $this->fillInField('login_password', 'DigidepsPass1234');
+        $this->pressButton('login_login');
+
+        $this->fillInField('co_deputy_firstname', 'Liam');
+        $this->fillInField('co_deputy_lastname', 'McQuack');
+        $this->fillInField('co_deputy_address1', 'Fieldag');
+        $this->fillInField('co_deputy_addressPostcode', 'Y73');
+        $this->fillInField('co_deputy_addressCountry', 'GB');
+        $this->fillInField('co_deputy_phoneMain', '01789432876');
+        $this->fillInField('co_deputy_clientLastname', 'Louie');
+        $this->fillInField('co_deputy_clientCaseNumber', '1717171T');
+
+        $this->pressButton('co_deputy_save');
+    }
+
+    private function setPasswordAndTickTAndCs(): void
+    {
+        $this->fillInField('set_password_password_first', 'DigidepsPass1234');
+        $this->fillInField('set_password_password_second', 'DigidepsPass1234');
+        $this->checkOption('set_password_showTermsAndConditions');
+    }
+
+    private function fillUserDetailsAndSubmit(): void
+    {
+        $this->fillInField('user_details_address1', '102 Petty France');
+        $this->fillInField('user_details_address2', 'MOJ');
+        $this->fillInField('user_details_address3', 'London');
+        $this->fillInField('user_details_addressCountry', 'GB');
+        $this->fillInField('user_details_phoneMain', '01789 321234');
+        $this->pressButton('user_details_save');
+    }
+
+    private function fillClientDetailsAndSubmit(): void
+    {
+        $this->fillInField('client_address', '1 South Parade');
+        $this->fillInField('client_address2', 'First Floor');
+        $this->fillInField('client_address3', 'Big Building');
+        $this->fillInField('client_address4', 'Large Town');
+        $this->fillInField('client_address5', 'Notts');
+        $this->fillInField('client_postcode', 'NG1 2HT');
+        $this->fillInField('client_country', 'GB');
+        $this->fillInField('client_phone', '01789432876');
+        $this->fillInField('client_courtDate_day', '01');
+        $this->fillInField('client_courtDate_month', '01');
+        $this->fillInField('client_courtDate_year', '2016');
+        $this->pressButton('client_save');
+    }
+
+    private function fillInReportDetailsAndSubmit(): void
+    {
+        $this->fillInField('report_startDate_day', '01');
+        $this->fillInField('report_startDate_month', '01');
+        $this->fillInField('report_startDate_year', '2016');
+        $this->fillInField('report_endDate_day', '31');
+        $this->fillInField('report_endDate_month', '12');
+        $this->fillInField('report_endDate_year', '2016');
+        $this->pressButton('report_save');
     }
 }

--- a/api/tests/Behat/features-v2/registration/self-register.feature
+++ b/api/tests/Behat/features-v2/registration/self-register.feature
@@ -38,3 +38,15 @@ Feature: Lay Deputy Self Registration
         And I complete the case manager user registration flow with valid deputyship details
         Then my deputy details should be saved to my account
         And I should be on the Lay homepage
+
+    @super-admin
+    Scenario: A Lay user with an existing pre-registration record can self register
+        Given a super admin user accesses the admin app
+        When I navigate to the upload users page
+        And I upload a lay CSV that contains 2 new pre-registration entities for the same case
+        And one of the Lay Deputies registers to deputise for a client with valid details
+        Then my deputy details should be saved to my account
+        And I should be on the Lay homepage
+        When I invite a Co-Deputy to the service
+        Then they should be able to register to deputise for a client with valid details
+        And they should be on the Lay homepage

--- a/api/tests/Behat/fixtures/sirius-csvs/lay-2-rows-co-deputy.csv
+++ b/api/tests/Behat/fixtures/sirius-csvs/lay-2-rows-co-deputy.csv
@@ -1,0 +1,3 @@
+Case,ClientSurname,DeputyUid,DeputySurname,DeputyAddress1,DeputyAddress2,DeputyAddress3,DeputyAddress4,DeputyAddress5,DeputyPostcode,ReportType,MadeDate,OrderType,CoDeputy,Hybrid
+1717171T,LOUIE,35672419,MCDUCK,Shieldaig,Northamptonshire,,,,B73,OPG102,2011-04-16,pfa,no,SINGLE
+1717171T,LOUIE,85462817,MCQUACK,Fieldag,Southamptonshire,,,,Y73,OPG102,2011-04-16,pfa,no,SINGLE


### PR DESCRIPTION
## Purpose
A co-deputy could not sign up to the service.
The reason for this was because the deputy was entering their case number with a capital T which did not match the lower case t in the database.

We are doing lowercase comparisons on case numbers elsewhere in the app, so this needs updating to match this.

Fixes DDPB-4592

## Approach
Updated comparison to lowercase both the input parameter, and the values from the database.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
