### PR TITLE
remove setuptools after pip installs

### DIFF
--- a/disaster_recovery/backup/Dockerfile
+++ b/disaster_recovery/backup/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-alpine3.16
 COPY requirements.txt /requirements.txt
 RUN apk update && apk upgrade && pip install --upgrade pip \
     \ pip install -r /requirements.txt
-RUN pip uninstall -y wheel
+RUN pip uninstall -y wheel setuptools
 COPY ./dr_backup.py /dr_backup.py
 RUN chmod 755 dr_backup.py
 CMD ["python3", "dr_backup.py"]

--- a/disaster_recovery/restore/Dockerfile
+++ b/disaster_recovery/restore/Dockerfile
@@ -4,6 +4,6 @@ COPY requirements.txt /requirements.txt
 RUN apk update && apk upgrade && pip install --upgrade pip \
     \ pip install -r /requirements.txt
 COPY ./disaster_recovery.py /disaster_recovery.py
-RUN pip uninstall -y wheel
+RUN pip uninstall -y wheel setuptools
 RUN chmod 755 disaster_recovery.py
 CMD ["python3", "disaster_recovery.py", "--help"]


### PR DESCRIPTION
## Purpose
Don't need setuptools once we've installed all packages and sometimes has vulnerabilities in the package.

## Approach
Remove setup tools

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
