### PR TITLE
DDPB-4610: Logging for deputies who have archived clients 

### DIFF
--- a/api/config/packages/dev/monolog.yml
+++ b/api/config/packages/dev/monolog.yml
@@ -15,3 +15,6 @@ monolog:
             formatter: line_formatter
             bubble: false
             channels: ["verbose"]
+        audit:
+            type: service
+            id: App\Service\Audit\AwsAuditLogHandler

--- a/api/config/packages/prod/monolog.yml
+++ b/api/config/packages/prod/monolog.yml
@@ -15,3 +15,6 @@ monolog:
             formatter: logstash_formatter
             bubble: false
             channels: ["verbose"]
+        audit:
+            type: service
+            id: App\Service\Audit\AwsAuditLogHandler

--- a/api/config/services.yml
+++ b/api/config/services.yml
@@ -3,6 +3,10 @@ parameters:
         account_password: "%env(FIXTURES_ACCOUNTPASSWORD)%"
         legacy_password_hash: "%env(FIXTURES_LEGACYPASSWORDHASH)%"
 
+    # To avoid undefined variable errors at build time during clear-cache, we can define default values for env vars
+    # At runtime Symfony will fetch the actual value from the environment
+    env(AUDIT_LOG_GROUP_NAME): "dummy-build-time-value-overridden-at-runtime"
+
     # set this param to a higher value than session_expire_seconds on the client
     user_provider_timeout_seconds: 3901
     client_permissions:
@@ -364,3 +368,16 @@ services:
                 '@Aws\SecretsManager\SecretsManagerClient',
                 "%env(SECRETS_PREFIX)%",
             ]
+
+    Aws\CloudWatchLogs\CloudWatchLogsClient:
+        class: Aws\CloudWatchLogs\CloudWatchLogsClient
+        arguments: ["%cloudwatch_logs_client_params%"]
+
+    App\Service\Audit\AwsAuditLogHandler:
+        class: App\Service\Audit\AwsAuditLogHandler
+        arguments:
+            - '@Aws\CloudWatchLogs\CloudWatchLogsClient'
+            - "%env(AUDIT_LOG_GROUP_NAME)%"
+
+    App\Service\Audit\LocalAuditLogHandler:
+        class: App\Service\Audit\LocalAuditLogHandler

--- a/api/src/Event/ClientArchivedEvent.php
+++ b/api/src/Event/ClientArchivedEvent.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Event;
+
+use App\Entity\Client;
+use App\Entity\User;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class ClientArchivedEvent extends Event
+{
+    public const NAME = 'client.archived';
+
+    /** @var User */
+    private $currentUser;
+
+    /** @var Client */
+    private $client;
+
+    /** @var string */
+    private $trigger;
+
+    /**
+     * ClientDeletedEvent constructor.
+     */
+    public function __construct(Client $client, User $currentUser, string $trigger)
+    {
+        $this->setClient($client);
+        $this->setCurrentUser($currentUser);
+        $this->setTrigger($trigger);
+    }
+
+    public function getTrigger(): string
+    {
+        return $this->trigger;
+    }
+
+    public function setTrigger(string $trigger): ClientArchivedEvent
+    {
+        $this->trigger = $trigger;
+
+        return $this;
+    }
+
+    public function getClient(): Client
+    {
+        return $this->client;
+    }
+
+    public function setClient(Client $client): ClientArchivedEvent
+    {
+        $this->client = $client;
+
+        return $this;
+    }
+
+    public function getCurrentUser(): User
+    {
+        return $this->currentUser;
+    }
+
+    public function setCurrentUser(User $currentUser): ClientArchivedEvent
+    {
+        $this->currentUser = $currentUser;
+
+        return $this;
+    }
+}

--- a/api/src/EventDispatcher/ObservableEventDispatcher.php
+++ b/api/src/EventDispatcher/ObservableEventDispatcher.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventDispatcher;
+
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class ObservableEventDispatcher
+{
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    /** @var array */
+    private $dispatchedEvents = [];
+
+    public function __construct(EventDispatcherInterface $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+    public function dispatch(Event $event, string $eventName)
+    {
+        $this->dispatcher->dispatch($event, $eventName);
+        $this->dispatchedEvents[] = $event;
+    }
+
+    public function getDispatchedEvents(): array
+    {
+        return $this->dispatchedEvents;
+    }
+}

--- a/api/src/EventSubscriber/ClientArchivedSubscriber.php
+++ b/api/src/EventSubscriber/ClientArchivedSubscriber.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventSubscriber;
+
+use App\Event\ClientArchivedEvent;
+use App\Service\Audit\AuditEvents;
+use App\Service\Time\DateTimeProvider;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ClientArchivedSubscriber implements EventSubscriberInterface
+{
+    /** @var LoggerInterface */
+    private $logger;
+
+    /** @var DateTimeProvider */
+    private $dateTimeProvider;
+
+    public function __construct(LoggerInterface $logger, DateTimeProvider $dateTimeProvider)
+    {
+        $this->logger = $logger;
+        $this->dateTimeProvider = $dateTimeProvider;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            ClientArchivedEvent::NAME => 'logEvent',
+        ];
+    }
+
+    public function logEvent(ClientArchivedEvent $event)
+    {
+        $this->logger->notice('', (new AuditEvents($this->dateTimeProvider))->clientArchived(
+            $event->getTrigger(),
+            $event->getClient()->getCaseNumber(),
+            $event->getCurrentUser()->getEmail(),
+        ));
+    }
+}

--- a/api/src/EventSubscriber/ClientArchivedSubscriber.php
+++ b/api/src/EventSubscriber/ClientArchivedSubscriber.php
@@ -36,6 +36,7 @@ class ClientArchivedSubscriber implements EventSubscriberInterface
         $this->logger->notice('', (new AuditEvents($this->dateTimeProvider))->clientArchived(
             $event->getTrigger(),
             $event->getClient()->getCaseNumber(),
+            $event->getClient()->getCourtDate(),
             $event->getCurrentUser()->getEmail(),
         ));
     }

--- a/api/src/Service/Audit/AbstractAuditLogHandler.php
+++ b/api/src/Service/Audit/AbstractAuditLogHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Service\Audit;
+
+use Monolog\Formatter\JsonFormatter;
+use Monolog\Handler\AbstractProcessingHandler;
+
+abstract class AbstractAuditLogHandler extends AbstractProcessingHandler
+{
+    protected function shallHandle(array $record): bool
+    {
+        return
+            isset($record['context']['event']) &&
+            isset($record['context']['type']) &&
+            'audit' === $record['context']['type'];
+    }
+
+    protected function getDefaultFormatter(): JsonFormatter
+    {
+        return new JsonFormatter();
+    }
+}

--- a/api/src/Service/Audit/AuditEvents.php
+++ b/api/src/Service/Audit/AuditEvents.php
@@ -28,14 +28,14 @@ final class AuditEvents
     public function clientArchived(
         string $trigger,
         string $caseNumber,
-        \DateTime $deputyshipStartDate,
+        ?\DateTime $deputyshipStartDate,
         string $archivedBy,
     ): array {
         $event = [
             'trigger' => $trigger,
             'case_number' => $caseNumber,
             'archived_by' => $archivedBy,
-            'deputyship_start_date' => $deputyshipStartDate->format(\DateTime::ATOM),
+            'deputyship_start_date' => $deputyshipStartDate?->format(\DateTime::ATOM),
             'archived_on' => $this->dateTimeProvider->getDateTime()->format(\DateTime::ATOM),
         ];
 

--- a/api/src/Service/Audit/AuditEvents.php
+++ b/api/src/Service/Audit/AuditEvents.php
@@ -28,12 +28,14 @@ final class AuditEvents
     public function clientArchived(
         string $trigger,
         string $caseNumber,
+        \DateTime $deputyshipStartDate,
         string $archivedBy,
     ): array {
         $event = [
             'trigger' => $trigger,
             'case_number' => $caseNumber,
             'archived_by' => $archivedBy,
+            'deputyship_start_date' => $deputyshipStartDate->format(\DateTime::ATOM),
             'archived_on' => $this->dateTimeProvider->getDateTime()->format(\DateTime::ATOM),
         ];
 

--- a/api/src/Service/Audit/AuditEvents.php
+++ b/api/src/Service/Audit/AuditEvents.php
@@ -34,7 +34,7 @@ final class AuditEvents
             'trigger' => $trigger,
             'case_number' => $caseNumber,
             'archived_by' => $archivedBy,
-            'discharged_on' => $this->dateTimeProvider->getDateTime()->format(\DateTime::ATOM),
+            'archived_on' => $this->dateTimeProvider->getDateTime()->format(\DateTime::ATOM),
         ];
 
         return $event + $this->baseEvent(AuditEvents::EVENT_CLIENT_ARCHIVED);

--- a/api/src/Service/Audit/AuditEvents.php
+++ b/api/src/Service/Audit/AuditEvents.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Audit;
+
+use App\Service\Time\DateTimeProvider;
+
+final class AuditEvents
+{
+    public const EVENT_CLIENT_ARCHIVED = 'CLIENT_ARCHIVED';
+
+    public const TRIGGER_USER_ARCHIVED_CLIENT = 'USER_ARCHIVED_CLIENT';
+
+    /**
+     * @var DateTimeProvider
+     */
+    private $dateTimeProvider;
+
+    public function __construct(DateTimeProvider $dateTimeProvider)
+    {
+        $this->dateTimeProvider = $dateTimeProvider;
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function clientArchived(
+        string $trigger,
+        string $caseNumber,
+        string $archivedBy,
+    ): array {
+        $event = [
+            'trigger' => $trigger,
+            'case_number' => $caseNumber,
+            'archived_by' => $archivedBy,
+            'discharged_on' => $this->dateTimeProvider->getDateTime()->format(\DateTime::ATOM),
+        ];
+
+        return $event + $this->baseEvent(AuditEvents::EVENT_CLIENT_ARCHIVED);
+    }
+
+    private function baseEvent(string $eventName): array
+    {
+        return [
+            'event' => $eventName,
+            'type' => 'audit',
+        ];
+    }
+}

--- a/api/src/Service/Audit/AwsAuditLogHandler.php
+++ b/api/src/Service/Audit/AwsAuditLogHandler.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Service\Audit;
+
+use Aws\CloudWatchLogs\CloudWatchLogsClient;
+use Aws\CloudWatchLogs\Exception\CloudWatchLogsException;
+use Aws\Result;
+use Monolog\Logger;
+
+class AwsAuditLogHandler extends AbstractAuditLogHandler
+{
+    /** @var CloudWatchLogsClient */
+    private $client;
+
+    /** @var string */
+    private $group;
+
+    /**
+     * @param int  $level
+     * @param bool $bubble
+     */
+    public function __construct(CloudWatchLogsClient $client, $group, $level = Logger::NOTICE, $bubble = true)
+    {
+        $this->client = $client;
+        $this->group = $group;
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function write(array $entry): void
+    {
+        if (!$this->shallHandle($entry)) {
+            return;
+        }
+
+        $stream = $entry['context']['event'];
+        $sequenceToken = $this->initialize($stream);
+        $entry = $this->formatEntry($entry);
+
+        // send items, retry once with a fresh sequence token
+        try {
+            $this->send($entry, $stream, $sequenceToken);
+        } catch (CloudWatchLogsException $e) {
+            if ('InvalidSequenceTokenException' === $e->getAwsErrorCode()) {
+                $this->send($entry, $stream, $e->get('expectedSequenceToken'));
+            }
+
+            throw $e;
+        }
+    }
+
+    private function formatEntry(array $entry): array
+    {
+        return [
+            [
+                'message' => $entry['formatted'],
+                'timestamp' => $entry['datetime']->format('U.u') * 1000,
+            ],
+        ];
+    }
+
+    private function initialize(string $stream): ?string
+    {
+        $describeStreamsResponse = $this->describeStreams($stream);
+
+        $existingStreams = $describeStreamsResponse->get('logStreams');
+        $existingStreamsNames = $this->extractExistingStreamNames($existingStreams);
+
+        if (!in_array($stream, $existingStreamsNames, true)) {
+            $this->createLogStream($stream);
+        } else {
+            return $existingStreams[0]['uploadSequenceToken'];
+        }
+
+        return null;
+    }
+
+    private function describeStreams(string $stream): Result
+    {
+        return $this
+            ->client
+            ->describeLogStreams(
+                [
+                    'logGroupName' => $this->group,
+                    'logStreamNamePrefix' => $stream,
+                ]
+            );
+    }
+
+    private function extractExistingStreamNames(array $streams): array
+    {
+        return array_map(
+            function ($stream) {
+                return $stream['logStreamName'] ?? null;
+            },
+            $streams
+        );
+    }
+
+    private function createLogStream(string $stream): void
+    {
+        $this
+            ->client
+            ->createLogStream(
+                [
+                    'logGroupName' => $this->group,
+                    'logStreamName' => $stream,
+                ]
+            );
+    }
+
+    private function send(array $entry, string $stream, ?string $sequenceToken): void
+    {
+        $data = [
+            'logGroupName' => $this->group,
+            'logStreamName' => $stream,
+            'logEvents' => $entry,
+        ];
+
+        if (!empty($sequenceToken)) {
+            $data['sequenceToken'] = $sequenceToken;
+        }
+
+        $this->client->putLogEvents($data);
+    }
+
+    public function getLogEventsByLogStream(string $streamName, int $logStartTime, int $logEndTime, string $groupName): Result
+    {
+        return $this->client->getLogEvents(
+            [
+                'logGroupName' => $groupName,
+                'logStreamName' => $streamName,
+                'startTime' => $logStartTime,
+                'endTime' => $logEndTime,
+            ]
+        );
+    }
+
+    public function getLogStreams(string $logGroupName)
+    {
+        return $this
+            ->client
+            ->describeLogStreams(
+                [
+                    'logGroupName' => $logGroupName,
+                ]
+            )->get('logStreams');
+    }
+}

--- a/api/src/Service/Audit/LocalAuditLogHandler.php
+++ b/api/src/Service/Audit/LocalAuditLogHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Service\Audit;
+
+class LocalAuditLogHandler extends AbstractAuditLogHandler
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function write(array $entry): void
+    {
+        if (!$this->shallHandle($entry)) {
+            return;
+        }
+
+        $fh = fopen('php://stderr', 'a');
+        fwrite($fh, $entry['formatted']);
+        fclose($fh);
+    }
+}

--- a/api/tests/Behat/run-tests-parallel.sh
+++ b/api/tests/Behat/run-tests-parallel.sh
@@ -15,7 +15,7 @@ runtime=$(( end - start))
 
 echo "Time taken: ${runtime} secs"
 
-if [ $runtime -gt 360 ]
+if [ $runtime -gt 420 ]
 then
     echo "Stage taking too long. Failing the build!"
     echo "Please split out your tests to a new container"

--- a/api/tests/Unit/Service/Audit/AuditEventsTest.php
+++ b/api/tests/Unit/Service/Audit/AuditEventsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Audit;
+
+use App\Service\Time\DateTimeProvider;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+
+class AuditEventsTest extends TestCase
+{
+    use ProphecyTrait;
+
+    private ObjectProphecy|DateTimeProvider $dateTimeProvider;
+
+    public function setUp(): void
+    {
+        $this->now = new \DateTime();
+        $this->dateTimeProvider = self::prophesize(DateTimeProvider::class);
+        $this->dateTimeProvider->getDateTime()->shouldBeCalled()->willReturn($this->now);
+    }
+
+    /**
+     * @test
+     */
+    public function clientDischarged(): void
+    {
+        $expected = [
+            'trigger' => 'USER_ARCHIVED_CLIENT',
+            'case_number' => '12345678',
+            'archived_by' => 'me@test.com',
+            'archived_on' => $this->now->format(\DateTime::ATOM),
+            'event' => 'CLIENT_ARCHIVED',
+            'type' => 'audit',
+        ];
+
+        $actual = (new AuditEvents($this->dateTimeProvider->reveal()))->clientArchived(
+            'USER_ARCHIVED_CLIENT',
+            '12345678',
+            'me@test.com',
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/api/tests/Unit/Service/Audit/AuditEventsTest.php
+++ b/api/tests/Unit/Service/Audit/AuditEventsTest.php
@@ -25,12 +25,13 @@ class AuditEventsTest extends TestCase
     /**
      * @test
      */
-    public function clientDischarged(): void
+    public function clientArchived(): void
     {
         $expected = [
             'trigger' => 'USER_ARCHIVED_CLIENT',
             'case_number' => '12345678',
             'archived_by' => 'me@test.com',
+            'deputyship_start_date' => '2023-01-01T00:00:00+00:00',
             'archived_on' => $this->now->format(\DateTime::ATOM),
             'event' => 'CLIENT_ARCHIVED',
             'type' => 'audit',
@@ -39,6 +40,7 @@ class AuditEventsTest extends TestCase
         $actual = (new AuditEvents($this->dateTimeProvider->reveal()))->clientArchived(
             'USER_ARCHIVED_CLIENT',
             '12345678',
+            new \DateTime('2023-01-01T00:00:00+00:00'),
             'me@test.com',
         );
 


### PR DESCRIPTION
## Purpose

We've had a few reports that clients were being archived without being action by users.
Unfortunately, we did not have the visibility to track whether these were done by a user or if there is some flaw in our archiving logic which causes this issue.

To help get better visibility of this issue, we are adding in audit logging to be able to track when and who is archiving which clients.

Fixes DDPB-4610

## Approach
I followed the same pattern we have used previously for audit logging tickets which involves using the Event Dispatcher component provided by Symfony. 
The documentation for this can be found [here](https://symfony.com/doc/5.4/components/event_dispatcher.html).

However this time, I decided to implement this on the API instead of the client.
The reason behind this is that we are wanting to move certain features/components which don't align with the purpose of the client, which include our current audit logging features.

Having done the groundwork now in this ticket, we should be able to move the rest of the audit logging to the API.


## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
