### PR TITLE
Match on parent with .js-autosize not a textarea with that feature

### DIFF
--- a/client/assets/javascripts/modules_new/TextAreaAutoSize.js
+++ b/client/assets/javascripts/modules_new/TextAreaAutoSize.js
@@ -7,7 +7,7 @@ const TextAreaAutoSize = {
   },
 
   resizeTextArea: function (event) {
-    if (event.target.closest('.js-auto-size')) {
+    if (event.target.matches('textarea') && event.target.closest('.js-auto-size')) {
       const textArea = event.target
       const scrollHeight = (textArea.scrollHeight) || 120
       const height = textArea.clientHeight

--- a/client/assets/javascripts/modules_new/TextAreaAutoSize.js
+++ b/client/assets/javascripts/modules_new/TextAreaAutoSize.js
@@ -7,7 +7,7 @@ const TextAreaAutoSize = {
   },
 
   resizeTextArea: function (event) {
-    if (event.target.matches('textarea.js-auto-size')) {
+    if (event.target.closest('.js-auto-size')) {
       const textArea = event.target
       const scrollHeight = (textArea.scrollHeight) || 120
       const height = textArea.clientHeight


### PR DESCRIPTION
Fix based on Product feedback on [[DDPB-4115](https://opgtransform.atlassian.net/browse/DDPB-4115)] 



[DDPB-4115]: https://opgtransform.atlassian.net/browse/DDPB-4115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ