### PR TITLE
Bump node from 18.13.0-alpine to 18.14.2-alpine in /client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,13 @@ workflows:
                     value: << pipeline.git.branch >>,
                   },
               },
+              {
+                matches:
+                  {
+                    pattern: "^dependabot/docker.+$",
+                    value: << pipeline.git.branch >>,
+                  },
+              },
             ]
         - not: { equal: [main, << pipeline.git.branch >>] }
     jobs:

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.13.0-alpine AS webpack
+FROM node:18.14.2-alpine AS webpack
 WORKDIR /app
 
 COPY package.json .


### PR DESCRIPTION
Bumps node from 18.13.0-alpine to 18.14.2-alpine.

---
updated-dependencies:
- dependency-name: node dependency-type: direct:production update-type: version-update:semver-minor ...

## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes DDPB-####

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
