### PR TITLE
match prod ver of elasticache

### DIFF
--- a/environment/frontend_shared_elasticache.tf
+++ b/environment/frontend_shared_elasticache.tf
@@ -1,7 +1,7 @@
 resource "aws_elasticache_replication_group" "frontend" {
   automatic_failover_enabled = local.account.elasticache_count == 1 ? false : true
   engine                     = "redis"
-  engine_version             = "5.0.0"
+  engine_version             = "5.0.6"
   replication_group_id       = "frontend-rep-group-${local.environment}"
   description                = "Replication Group for Front and Admin"
   node_type                  = "cache.t2.micro"


### PR DESCRIPTION
## Purpose
Somehow prod version has been updated but only for frontend. This is strange as auto update of minor versions should apply only for ver 6 and above. Having said that, it's not clear if this applies to patch updates. Strange that it hasn't updated the other api redis though.

In either case, lets upgrade this to 5.0.6 so production release will work then we can look to upgrade redis to 6.x version

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
