### PR TITLE
DDPB-4660 quieten down those alarms a bit

### DIFF
--- a/disaster-recovery/restore/dr-restore.py
+++ b/disaster-recovery/restore/dr-restore.py
@@ -14,6 +14,7 @@ environments = {
 
 key_alias = 'alias/digideps-ca-db-backup'
 
+
 class SnapshotManagement:
     def __init__(
         self,
@@ -618,6 +619,7 @@ def main(
         restore_from_remote=restore_from_remote
     )
     dr_job.restore()
+
 
 if __name__ == "__main__":
     main()

--- a/environment/alarms.tf
+++ b/environment/alarms.tf
@@ -103,7 +103,7 @@ resource "aws_cloudwatch_metric_alarm" "availability-front" {
   statistic           = "Minimum"
   metric_name         = "HealthCheckStatus"
   comparison_operator = "LessThanThreshold"
-  datapoints_to_alarm = 2
+  datapoints_to_alarm = 5
   threshold           = 1
   period              = 60
   evaluation_periods  = 5
@@ -134,7 +134,7 @@ resource "aws_cloudwatch_metric_alarm" "availability-admin" {
   statistic           = "Minimum"
   metric_name         = "HealthCheckStatus"
   comparison_operator = "LessThanThreshold"
-  datapoints_to_alarm = 2
+  datapoints_to_alarm = 5
   threshold           = 1
   period              = 60
   evaluation_periods  = 5
@@ -284,8 +284,8 @@ resource "aws_cloudwatch_metric_alarm" "frontend_alb_average_response_time" {
   dimensions = {
     "LoadBalancer" = trimprefix(split(":", aws_lb.front.arn)[5], "loadbalancer/")
   }
-  datapoints_to_alarm       = 3
-  evaluation_periods        = 3
+  datapoints_to_alarm       = 7
+  evaluation_periods        = 10
   threshold                 = 1
   period                    = 60
   namespace                 = "AWS/ApplicationELB"
@@ -314,8 +314,8 @@ resource "aws_cloudwatch_metric_alarm" "admin_alb_average_response_time" {
   alarm_actions             = [data.aws_sns_topic.alerts.arn]
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   alarm_description         = "Response Time for Admin ALB in ${local.environment} (ignoring csv upload)"
-  datapoints_to_alarm       = 3
-  evaluation_periods        = 3
+  datapoints_to_alarm       = 7
+  evaluation_periods        = 10
   threshold                 = 1
   insufficient_data_actions = []
   treat_missing_data        = "notBreaching"

--- a/file-scanner/Dockerfile
+++ b/file-scanner/Dockerfile
@@ -27,7 +27,8 @@ COPY --from=build /go/src/clamav-rest/file-scanner /usr/bin/
 # Install ClamAV
 RUN apk update && apk --no-cache add clamav clamav-libunrar \
     && mkdir /run/clamav \
-    && chown clamav:clamav /run/clamav
+    && chown clamav:clamav /run/clamav \
+    && apk upgrade openssl
 
 # Configure clamAV to run in foreground with port 3310
 RUN sed -i 's/^#Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf \


### PR DESCRIPTION
## Purpose
Alarms are a bit too responsive

Fixes DDPB-4660

## Approach

Currently small blips in one of the adjoining services cause us to look up in the logs what's going wrong. I have made it so that we need to be getting back bad health checks for 5 minutes before we get alarms in the main channel.

On the basis that slow responses sometimes happen outside of some service affecting issue but often happen in conjunction with it, I have put them up to 10 minutes of slow response activity. I feel this way they won't just clog up the channel more when we have some service down issue but they may appear on there own when we have a real slow down in the service that needs looking in to. 

These figures are a bit haphazard but based on having looked at a lot of the alarms in the past and seen that it almost always doesn't affect users but one of our adjoining services has become flakey for a couple of minutes. This will at least mean that an alarm is more likely to be something that we want to be aware of rather than something to look into.

Second part of this is a ticket like I did on Use an LPA is to look at all the 5xx messages we get over a months period, find out the causes and put them in order of occurrence and then spin up tickets to fix each where necessary. 

## Learning
NA

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
