### PR TITLE
DDPB-4661: Disable capturing of Form Validation Errors in Google Analytics

### DIFF
--- a/client/assets/javascripts/common.js
+++ b/client/assets/javascripts/common.js
@@ -51,7 +51,6 @@ window.addEventListener('DOMContentLoaded', () => {
   uploadFile.init(document)
 
   GoogleAnalyticsEvents.init()
-  GoogleAnalyticsEvents.initFormValidationErrors()
 
   MoneyTransfer.init(document)
 


### PR DESCRIPTION
## Purpose
[Incident](https://incident.opg.service.justice.gov.uk/incident/694/) created as we were capturing some personal data in Google Analytics.
This fix should disable the capturing of form validation errors altogether to prevent any event data being sent to GA.

Fixes DDPB-4661

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
