### PR TITLE
DDPB-4635 : Corrected navigation from summary page in the deputy report

### DIFF
--- a/api/src/Service/ReportStatusService.php
+++ b/api/src/Service/ReportStatusService.php
@@ -13,12 +13,12 @@ use JMS\Serializer\Annotation as JMS;
  */
 class ReportStatusService
 {
-    const STATE_NOT_STARTED = 'not-started';
-    const STATE_INCOMPLETE = 'incomplete';
-    const STATE_DONE = 'done';
-    const STATE_NOT_MATCHING = 'not-matching'; //only used for balance section
-    const STATE_EXPLAINED = 'explained'; //only used for balance section
-    const ENABLE_STATUS_CACHE = true;
+    public const STATE_NOT_STARTED = 'not-started';
+    public const STATE_INCOMPLETE = 'incomplete';
+    public const STATE_DONE = 'done';
+    public const STATE_NOT_MATCHING = 'not-matching'; // only used for balance section
+    public const STATE_EXPLAINED = 'explained'; // only used for balance section
+    public const ENABLE_STATUS_CACHE = true;
 
     /**
      * @JMS\Exclude
@@ -38,8 +38,6 @@ class ReportStatusService
     }
 
     /**
-     * @param $useStatusCache
-     *
      * @return $this
      */
     public function setUseStatusCache($useStatusCache)
@@ -330,7 +328,7 @@ class ReportStatusService
                 count($this->report->getDebtsWithValidAmount()) > 0) &&
                 !empty($this->report->getDebtManagement())
         ) {
-            return ['state' => self::STATE_DONE];
+            return ['state' => self::STATE_DONE, 'nOfRecords' => count($this->report->getDebtsWithValidAmount())];
         } else {
             return ['state' => self::STATE_INCOMPLETE, 'nOfRecords' => count($this->report->getDebtsWithValidAmount())];
         }
@@ -588,7 +586,7 @@ class ReportStatusService
                 return $this->getVisitsCareState();
             case Report::SECTION_LIFESTYLE:
                 return $this->getLifestyleState();
-            // money
+                // money
             case Report::SECTION_CLIENT_BENEFITS_CHECK:
                 return $this->getClientBenefitsCheckState();
             case Report::SECTION_BALANCE:
@@ -611,24 +609,24 @@ class ReportStatusService
                 return $this->getDebtsState();
             case Report::SECTION_GIFTS:
                 return $this->getGiftsState();
-            // end money
+                // end money
             case Report::SECTION_ACTIONS:
                 return $this->getActionsState();
             case Report::SECTION_OTHER_INFO:
                 return $this->getOtherInfoState();
             case Report::SECTION_DEPUTY_EXPENSES:
                 return $this->getExpensesState();
-            // pa
+                // pa
             case Report::SECTION_PA_DEPUTY_EXPENSES:
                 return $this->getPaFeesExpensesState();
-            // prof
+                // prof
             case Report::SECTION_PROF_CURRENT_FEES:
                 return $this->getProfCurrentFeesState();
             case Report::SECTION_PROF_DEPUTY_COSTS:
                 return $this->getProfDeputyCostsState();
             case Report::SECTION_PROF_DEPUTY_COSTS_ESTIMATE:
                 return $this->getProfDeputyCostsEstimateState();
-            // documents
+                // documents
             case Report::SECTION_DOCUMENTS:
                 return $this->getDocumentsState();
             default:
@@ -651,7 +649,7 @@ class ReportStatusService
 
         $ret = [];
         foreach ($this->report->getAvailableSections() as $sectionId) {
-            if (self::ENABLE_STATUS_CACHE && $this->useStatusCache) { //get cached value if exists
+            if (self::ENABLE_STATUS_CACHE && $this->useStatusCache) { // get cached value if exists
                 $ret[$sectionId] = isset($statusCached[$sectionId]['state'])
                     ? $statusCached[$sectionId]['state']
                     : self::STATE_NOT_STARTED; // should never happen, unless cron didn't update when this feature was firstly introduced
@@ -688,7 +686,7 @@ class ReportStatusService
         }
     }
 
- /**
+    /**
      * @JMS\VirtualProperty
      * @JMS\Type("array")
      * @JMS\Groups({"status", "client-benefits-check-state"})
@@ -708,7 +706,7 @@ class ReportStatusService
                 return ['state' => self::STATE_NOT_STARTED, 'nOfRecords' => 0];
             case 2:
                 if (in_array($answers['doOthersReceiveIncome'], [ClientBenefitsCheck::OTHER_MONEY_DONT_KNOW, ClientBenefitsCheck::OTHER_MONEY_NO])) {
-                     return ['state' => self::STATE_DONE, 'nOfRecords' => 0];
+                    return ['state' => self::STATE_DONE, 'nOfRecords' => 0];
                 } else {
                     return ['state' => self::STATE_INCOMPLETE, 'nOfRecords' => 0];
                 }
@@ -718,7 +716,7 @@ class ReportStatusService
             default:
                 return ['state' => self::STATE_INCOMPLETE, 'nOfRecords' => 0];
         }
-    }    
+    }
 
     /**
      * @JMS\Exclude

--- a/client/src/Service/ReportSectionsLinkService.php
+++ b/client/src/Service/ReportSectionsLinkService.php
@@ -29,9 +29,12 @@ class ReportSectionsLinkService
         if ($report instanceof Ndr) {
             $routeParams = ['ndrId' => $report->getId()];
 
+            $clientBenefitsRouteParams = ['reportId' => $report->getId(), 'reportOrNdr' => 'ndr'];
+
             return [
                 ['section' => 'visitsCare', 'link' => $this->router->generate('ndr_visits_care', $routeParams)],
                 ['section' => 'deputyExpenses', 'link' => $this->router->generate('ndr_deputy_expenses', $routeParams)],
+                ['section' => 'clientBenefitsCheck', 'link' => $this->router->generate('client_benefits_check', $clientBenefitsRouteParams)],
                 ['section' => 'incomeBenefits', 'link' => $this->router->generate('ndr_income_benefits', $routeParams)],
                 ['section' => 'bankAccounts', 'link' => $this->router->generate('ndr_bank_accounts', $routeParams)],
                 ['section' => 'assets', 'link' => $this->router->generate('ndr_assets', $routeParams)],
@@ -69,7 +72,7 @@ class ReportSectionsLinkService
             'visitsCare' => ['section' => 'visitsCare', 'link' => $this->router->generate('visits_care', $routeParams)],
         ];
 
-        //TODO ask the business if links can follow a single order
+        // TODO ask the business if links can follow a single order
 
         // defined order for Client profile page (PROF or PA)
         if ($report->hasSection('paDeputyExpenses')) { // PAs
@@ -130,7 +133,6 @@ class ReportSectionsLinkService
     }
 
     /**
-     * @param $sectionId
      * @param int $offset
      *
      * @return array empty if it's the last or first section

--- a/client/templates/Macros/macros.html.twig
+++ b/client/templates/Macros/macros.html.twig
@@ -283,7 +283,7 @@
                             {% if isOrgUser %}
                                 {{ 'clientProfile' | trans({}, 'common' ) }}
                             {% else %}
-                                {{ 'deputyReportOverview' | trans({}, 'common' ) }}
+                                {{ 'deputyReportOverview' | trans({ 'startYear': report.startDate | date('Y'),'endYear': report.endDate | date('Y') }, 'common' ) }}
                             {% endif %}
                         </a>
                     {% endif %}

--- a/client/templates/Report/ClientBenefitsCheck/summary.html.twig
+++ b/client/templates/Report/ClientBenefitsCheck/summary.html.twig
@@ -18,7 +18,6 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-{#        <div class="govuk-grid-column-three-quarters">#}
             <p class="govuk-body">{{ 'summaryPage.pageDescription' | trans(transOptions) }}</p>
             <p class="govuk-body govuk-!-font-weight-bold">{{ 'summaryPage.listedAnswers' | trans(transOptions) }}</p>
             <p class="govuk-body">{{ 'summaryPage.checkAnswers' | trans(transOptions) }}</p>

--- a/client/templates/Report/ClientBenefitsCheck/summary.html.twig
+++ b/client/templates/Report/ClientBenefitsCheck/summary.html.twig
@@ -16,12 +16,16 @@
 
 {% block pageContent %}
 
-
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-three-quarters">
+        <div class="govuk-grid-column-two-thirds">
+{#        <div class="govuk-grid-column-three-quarters">#}
             <p class="govuk-body">{{ 'summaryPage.pageDescription' | trans(transOptions) }}</p>
             <p class="govuk-body govuk-!-font-weight-bold">{{ 'summaryPage.listedAnswers' | trans(transOptions) }}</p>
             <p class="govuk-body">{{ 'summaryPage.checkAnswers' | trans(transOptions) }}</p>
+        </div>
+
+        <div class="column-third">
+            {{ macros.relatedSections(report, 'clientBenefitsCheck') }}
         </div>
     </div>
 


### PR DESCRIPTION
## Purpose
The hyperlinks that takes deputies from a sections summary page back to the overview page wasn't rendering correctly resulting in the start and end year failing to display.

Navigation on the benefits summary page needed correcting as it there were no links available to navigate the user back to the overview page or to the previous or next section of the report. 

Fixes DDPB-4635

## Approach
- updated twig files to correctly render years in hyperlink
- Added hyperlinks to the benefit check summary page for deputy report and ndr


## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
