### PR TITLE
DDPB-4662: Replace the word 'transfer' in Money Out list on report to avoid confusion

### DIFF
--- a/client/translations/report-money-transaction.en.yml
+++ b/client/translations/report-money-transaction.en.yml
@@ -361,7 +361,7 @@ form:
       arrears:
         label: Arrears
       transfers-out-to-other-accounts:
-        label: Transfers from %client%'s account to other accounts
+        label: Payments from %client%'s account to other accounts
         moreInformations: Please enter the bank or building society name, the last 4 digits of the account number and the amount transferred
       cash-withdrawn:
         label: Cash withdrawn from %client%'s account


### PR DESCRIPTION
## Purpose
Update the radio option in the Money Out section so that it reads  'Payments from [Client]’s accounts to other accounts' instead of 'Transfers from [Client]’s accounts to other accounts'. 

This should create a clearer distinction between payments to other accounts belonging to the client and transfers between accounts belonging to the client (which we handle  in a separate section).

Fixes DDPB-4662

## Approach
- Changed wording in translation file so it's reflected in Money out section and the report pdf


## Checklist
- [x ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
