### PR TITLE
DDPB-4562: Phone telephone and broadband combination option added to Money Out 

### DIFF
--- a/api/src/Entity/Report/MoneyTransaction.php
+++ b/api/src/Entity/Report/MoneyTransaction.php
@@ -15,7 +15,7 @@ class MoneyTransaction implements MoneyTransactionInterface
     use HasBankAccountTrait;
 
     /**
-     * Static list of possible money transaction categories
+     * Static list of possible money transaction categories.
      *
      * hasMoreDetails, order are not used any longer,
      *  but are left here for simplicity on future refactors / changes
@@ -70,6 +70,7 @@ class MoneyTransaction implements MoneyTransactionInterface
 
         ['broadband', false, 'household-bills', 'out'],
         ['council-tax', false, 'household-bills', 'out'],
+        ['telephone-and-broadband', false, 'household-bills', 'out'],
         ['dual-fuel', false, 'household-bills', 'out'],
         ['electricity', false, 'household-bills', 'out'],
         ['food', false, 'household-bills', 'out'],
@@ -113,7 +114,6 @@ class MoneyTransaction implements MoneyTransactionInterface
         ['transfers-out-to-other-accounts', true, 'moving-money', 'out'],
 
         ['anything-else-paid-out', true, 'moneyout-other', 'out'],
-
     ];
 
     /**
@@ -123,7 +123,6 @@ class MoneyTransaction implements MoneyTransactionInterface
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      * @ORM\SequenceGenerator(sequenceName="transaction_id_seq", allocationSize=1, initialValue=1)
-     *
      * @JMS\Groups({"transaction", "transactionsIn", "transactionsOut"})
      */
     private $id;
@@ -138,12 +137,11 @@ class MoneyTransaction implements MoneyTransactionInterface
 
     /**
      * Category (e.g. "dividends")
-     * Once the category is known, group (income and dividends) and type (in) are known as well, see self::$categories
+     * Once the category is known, group (income and dividends) and type (in) are known as well, see self::$categories.
      *
      * @var string
      *
      * @JMS\Groups({"transaction", "transactionsIn", "transactionsOut"})
-     *
      * @ORM\Column(name="category", type="string", length=255, nullable=false)
      */
     private $category;
@@ -153,7 +151,6 @@ class MoneyTransaction implements MoneyTransactionInterface
      *
      * @JMS\Type("string")
      * @JMS\Groups({"transaction", "transactionsIn", "transactionsOut"})
-     *
      * @ORM\Column(name="amount", type="decimal", precision=14, scale=2, nullable=false)
      */
     private $amount;
@@ -162,17 +159,15 @@ class MoneyTransaction implements MoneyTransactionInterface
      * @var string
      *
      * @JMS\Groups({"transaction", "transactionsIn", "transactionsOut"})
-     *
      * @ORM\Column(name="description", type="text", nullable=true)
      */
     private $description;
 
     /**
      * Used to serve migrations and recover data in case of errors
-     * Remove when DDPB-1852 is fully released
+     * Remove when DDPB-1852 is fully released.
      *
      * @var string
-     *
      *
      * @ORM\Column(name="meta", type="text", nullable=true)
      */
@@ -180,8 +175,6 @@ class MoneyTransaction implements MoneyTransactionInterface
 
     /**
      * MoneyTransaction constructor.
-     *
-     * @param Report $report
      */
     public function __construct(Report $report)
     {
@@ -276,7 +269,7 @@ class MoneyTransaction implements MoneyTransactionInterface
     }
 
     /**
-     * Get the group based on the category
+     * Get the group based on the category.
      *
      * @JMS\VirtualProperty
      * @JMS\SerializedName("group")
@@ -297,7 +290,7 @@ class MoneyTransaction implements MoneyTransactionInterface
     }
 
     /**
-     * Get the type (in/out) based on the category
+     * Get the type (in/out) based on the category.
      *
      * @JMS\VirtualProperty
      * @JMS\SerializedName("type")

--- a/client/src/Entity/Report/MoneyTransaction.php
+++ b/client/src/Entity/Report/MoneyTransaction.php
@@ -80,6 +80,7 @@ class MoneyTransaction
 
         ['broadband', false, 'household-bills', 'out'],
         ['council-tax', false, 'household-bills', 'out'],
+        ['telephone-and-broadband', false, 'household-bills', 'out'],
         ['dual-fuel', false, 'household-bills', 'out'],
         ['electricity', false, 'household-bills', 'out'],
         ['food', false, 'household-bills', 'out'],
@@ -153,7 +154,6 @@ class MoneyTransaction
      *
      * @JMS\Type("string")
      * @JMS\Groups({"transaction"})
-     *
      * @Assert\NotBlank(message="moneyTransaction.form.amount.notBlank", groups={"transaction-amount"})
      * @Assert\Range(min=0.01, max=100000000000, notInRangeMessage = "moneyTransaction.form.amount.notInRangeMessage", groups={"transaction-amount"})
      */
@@ -161,10 +161,9 @@ class MoneyTransaction
 
     /**
      * @var string
+     *
      * @JMS\Groups({"transaction"})
-     *
      * @Assert\NotBlank(message="moneyTransaction.form.description.notBlank", groups={"transaction-description"})
-     *
      * @JMS\Type("string")
      */
     private $description;

--- a/client/translations/report-money-transaction.en.yml
+++ b/client/translations/report-money-transaction.en.yml
@@ -372,3 +372,5 @@ form:
       moneyout-other:
         label: Anything else paid out
         moreInformation: Give us more information
+      telephone-and-broadband:
+        label: Combined telephone and broadband


### PR DESCRIPTION
## Purpose
Telephone and broadband combination option added to Household bills list in Money Out, to provide an additional option for clients that are billed for these together.

Fixes DDPB-4562

## Approach
- Option added to MoneyTransaction entities and translation files

## Checklist
- [x ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
