### PR TITLE
enforce unit tests pass before carrying on path to live

### DIFF
--- a/.github/workflows/workflow-path-to-live.yml
+++ b/.github/workflows/workflow-path-to-live.yml
@@ -104,6 +104,10 @@ jobs:
       - docker_build_scan_push
       - monitoring_lambda_unit_tests
       - workflow_variables
+      - api_unit_tests
+      - client_unit_tests
+      - monitoring_lambda_unit_tests
+      - synchronisation_unit_tests
     with:
       workspace: development
       terraform_path: environment


### PR DESCRIPTION
Enforce unit tests pass before carrying on path to live.  Set the block as apply to development to stop us deploying bad containers to any env if there's an issue.