### PR TITLE
DDPB-4685 - set ecs root to read-only

### DIFF
--- a/environment/admin_service.tf
+++ b/environment/admin_service.tf
@@ -57,6 +57,7 @@ locals {
     "essential": true,
     "image": "${local.images.client}",
     "mountPoints": [],
+    "readonlyRootFilesystem": true,
     "name": "admin_app",
     "portMappings": [{
       "containerPort": 443,

--- a/environment/api_service.tf
+++ b/environment/api_service.tf
@@ -84,6 +84,7 @@ locals {
     "essential": true,
     "image": "${local.images.api}",
     "mountPoints": [],
+    "readonlyRootFilesystem": true,
     "name": "api_app",
     "portMappings": [{
       "containerPort": 443,

--- a/environment/check_csv_uploaded.tf
+++ b/environment/check_csv_uploaded.tf
@@ -78,6 +78,7 @@ locals {
   {
     "name": "check-csv-uploaded",
     "image": "${local.images.client}",
+    "readonlyRootFilesystem": true,
     "command": [ "sh", "scripts/check-csv-uploaded.sh", "-d" ],
     "logConfiguration": {
       "logDriver": "awslogs",

--- a/environment/checklist_sync.tf
+++ b/environment/checklist_sync.tf
@@ -122,6 +122,7 @@ locals {
   {
     "name": "checklist-sync",
     "image": "${local.images.client}",
+    "readonlyRootFilesystem": true,
     "command": [ "sh", "${local.script_name}", "-d" ],
     "logConfiguration": {
       "logDriver": "awslogs",

--- a/environment/disaster_recovery/ecs.tf
+++ b/environment/disaster_recovery/ecs.tf
@@ -14,10 +14,11 @@ resource "aws_ecs_task_definition" "dr_backup" {
 
 locals {
   dr_backup = jsonencode({
-    cpu       = 0,
-    essential = true,
-    image     = var.images.drbackup,
-    name      = "dr_backup",
+    cpu                    = 0,
+    essential              = true,
+    image                  = var.images.drbackup,
+    readonlyRootFilesystem = true,
+    name                   = "dr_backup",
     healthCheck = {
       command     = ["CMD-SHELL", "echo healthy || exit 1"],
       startPeriod = 30,

--- a/environment/document_sync.tf
+++ b/environment/document_sync.tf
@@ -114,6 +114,7 @@ locals {
   {
     "name": "document-sync",
     "image": "${local.images.client}",
+    "readonlyRootFilesystem": true,
     "command": [ "sh", "scripts/documentsync.sh", "-d" ],
     "logConfiguration": {
       "logDriver": "awslogs",

--- a/environment/front_service.tf
+++ b/environment/front_service.tf
@@ -90,6 +90,7 @@ locals {
     "essential": true,
     "image": "${local.images.client}",
     "mountPoints": [],
+    "readonlyRootFilesystem": true,
     "name": "front_app",
     "portMappings": [{
       "containerPort": 443,

--- a/environment/htmltopdf_service.tf
+++ b/environment/htmltopdf_service.tf
@@ -91,6 +91,7 @@ locals {
       "essential": true,
       "image": "${local.images.htmltopdf}",
       "mountPoints": [],
+      "readonlyRootFilesystem": true,
       "name": "htmltopdf",
       "volumesFrom": [],
       "healthCheck": {

--- a/environment/mock_sirius_integration_service.tf
+++ b/environment/mock_sirius_integration_service.tf
@@ -82,6 +82,7 @@ locals {
   {
     "name": "mock-sirius-integration",
     "image": "muonsoft/openapi-mock:${local.openapi_mock_version}",
+    "readonlyRootFilesystem": true,
     "portMappings": [{
           "containerPort": 8080,
           "hostPort": 8080,

--- a/environment/scan_service.tf
+++ b/environment/scan_service.tf
@@ -98,6 +98,7 @@ locals {
       "image": "${local.images.file-scanner}",
       "mountPoints": [],
       "volumesFrom": [],
+      "readonlyRootFilesystem": true,
       "healthCheck": {
         "command": [
           "CMD-SHELL",


### PR DESCRIPTION
Sets the root filesystem all of our ECS containers to read-only
