### PR TITLE
DDPB-4692 - update trivy input

### DIFF
--- a/.github/workflows/_build-and-push.yml
+++ b/.github/workflows/_build-and-push.yml
@@ -96,7 +96,7 @@ jobs:
           image-ref: ${{ matrix.svc_name }}:latest
           severity: "HIGH,CRITICAL"
           format: "sarif"
-          security-checks: "vuln"
+          scanners: "vuln"
           output: "trivy-results.sarif"
           timeout: 15m
 


### PR DESCRIPTION
The `security-checks` input for the trivy action was deprecated, this uses the updated `scanners` input - which is the same thing
