### PR TITLE
DDPB-4680: Create new data field for transfer description 

### DIFF
--- a/api/src/Controller/Report/MoneyTransferController.php
+++ b/api/src/Controller/Report/MoneyTransferController.php
@@ -6,9 +6,9 @@ use App\Controller\RestController;
 use App\Entity as EntityDir;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
 
 class MoneyTransferController extends RestController
 {
@@ -40,7 +40,13 @@ class MoneyTransferController extends RestController
 
         $transfer = new EntityDir\Report\MoneyTransfer();
         $transfer->setReport($report);
+
+        if (array_key_exists('description', $data)) {
+            $transfer->setDescription($data['description']);
+        }
+
         $report->setNoTransfersToAdd(false);
+
         $this->fillEntity($transfer, $data);
 
         $this->em->persist($transfer);
@@ -70,6 +76,11 @@ class MoneyTransferController extends RestController
         ]);
 
         $transfer = $this->findEntityBy(EntityDir\Report\MoneyTransfer::class, $transferId);
+
+        if (array_key_exists('description', $data)) {
+            $transfer->setDescription($data['description']);
+        }
+
         $this->fillEntity($transfer, $data);
 
         $this->em->persist($transfer);

--- a/api/src/Entity/Report/MoneyTransfer.php
+++ b/api/src/Entity/Report/MoneyTransfer.php
@@ -15,6 +15,7 @@ class MoneyTransfer
 {
     /**
      * @var int
+     *
      * @JMS\Groups({"money-transfer"})
      * @ORM\Column(name="id", type="integer")
      * @ORM\Id
@@ -24,6 +25,7 @@ class MoneyTransfer
 
     /**
      * @var string
+     *
      * @JMS\Groups({"money-transfer"})
      * @ORM\Column(name="amount", type="decimal", precision=14, scale=2, nullable=true)
      */
@@ -31,6 +33,7 @@ class MoneyTransfer
 
     /**
      * @var Account
+     *
      * @JMS\Groups({"account"})
      * @JMS\SerializedName("accountFrom")
      * @ORM\ManyToOne(targetEntity="App\Entity\Report\BankAccount")
@@ -40,6 +43,7 @@ class MoneyTransfer
 
     /**
      * @var Account
+     *
      * @JMS\Groups({"account"})
      * @JMS\SerializedName("accountTo")
      * @ORM\ManyToOne(targetEntity="App\Entity\Report\BankAccount")
@@ -49,10 +53,19 @@ class MoneyTransfer
 
     /**
      * @var Report
+     *
      * @ORM\ManyToOne(targetEntity="App\Entity\Report\Report", inversedBy="moneyTransfers")
      * @ORM\JoinColumn(name="report_id", referencedColumnName="id", onDelete="CASCADE")
      */
     private $report;
+
+    /**
+     * @var string
+     *
+     * @JMS\Groups({"money-transfer"})
+     * @ORM\Column(name="description", type="text", nullable=true)
+     */
+    private $description;
 
     /**
      * Get id.
@@ -105,8 +118,6 @@ class MoneyTransfer
     }
 
     /**
-     * @param BankAccount $from
-     *
      * @return MoneyTransfer
      */
     public function setFrom(BankAccount $from)
@@ -117,8 +128,6 @@ class MoneyTransfer
     }
 
     /**
-     * @param BankAccount $to
-     *
      * @return MoneyTransfer
      */
     public function setTo(BankAccount $to)
@@ -147,6 +156,30 @@ class MoneyTransfer
     public function setReport(Report $report)
     {
         $this->report = $report;
+
+        return $this;
+    }
+
+    /**
+     * Get description.
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * Set description.
+     *
+     * @param string $description
+     *
+     * @return MoneyTransfer
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
 
         return $this;
     }

--- a/api/src/Migrations/Version269.php
+++ b/api/src/Migrations/Version269.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version269 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add description column to money transfer table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE money_transfer ADD description VARCHAR(50) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE money_transfer DROP description');
+    }
+}

--- a/api/src/Migrations/Version269.php
+++ b/api/src/Migrations/Version269.php
@@ -20,7 +20,7 @@ final class Version269 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('ALTER TABLE money_transfer ADD description VARCHAR(50) DEFAULT NULL');
+        $this->addSql('ALTER TABLE money_transfer ADD description VARCHAR(75) DEFAULT NULL');
     }
 
     public function down(Schema $schema): void

--- a/client/src/Controller/Report/MoneyTransferController.php
+++ b/client/src/Controller/Report/MoneyTransferController.php
@@ -280,6 +280,7 @@ class MoneyTransferController extends AbstractController
                 ['label' => 'deletePage.summary.accountFrom', 'value' => $transfer->getAccountFrom()->getNameOneLine()],
                 ['label' => 'deletePage.summary.accountTo', 'value' => $transfer->getAccountTo()->getNameOneLine()],
                 ['label' => 'deletePage.summary.amount', 'value' => $transfer->getAmount(), 'format' => 'money'],
+                ['label' => 'deletePage.summary.description', 'value' => $transfer->getDescription()],
             ],
             'backLink' => $this->generateUrl('money_transfers_summary', ['reportId' => $reportId]),
         ];

--- a/client/src/Entity/Report/MoneyTransfer.php
+++ b/client/src/Entity/Report/MoneyTransfer.php
@@ -19,9 +19,9 @@ class MoneyTransfer
 
     /**
      * @var string
+     *
      * @Assert\NotBlank(message="transfer.amount.notBlank", groups={"money-transfer-amount"})
      * @Assert\Range(min=0, max=100000000000, notInRangeMessage = "transfer.amount.notInRangeMessage", groups={"money-transfer-amount"})
-     *
      * @JMS\Type("string")
      * @JMS\Groups({"money-transfer"})
      */
@@ -29,6 +29,7 @@ class MoneyTransfer
 
     /**
      * @var BankAccount
+     *
      * @JMS\SerializedName("accountFrom")
      * @JMS\Type("App\Entity\Report\BankAccount")
      */
@@ -37,13 +38,13 @@ class MoneyTransfer
     /**
      * @JMS\Type("integer")
      * @JMS\Groups({"money-transfer"})
-     *
      * @Assert\NotBlank(message="transfer.accountFrom.notBlank", groups={"money-transfer-account-from"})
      */
     private $accountFromId;
 
     /**
      * @var BankAccount
+     *
      * @JMS\SerializedName("accountTo")
      * @JMS\Type("App\Entity\Report\BankAccount")
      */
@@ -52,7 +53,6 @@ class MoneyTransfer
     /**
      * @JMS\Type("integer")
      * @JMS\Groups({"money-transfer"})
-     *
      * @Assert\NotBlank(message="transfer.accountTo.notBlank", groups={"money-transfer-account-to"})
      * @Assert\Expression(
      *     "(value == '' or value != this.getAccountFromId() )",
@@ -61,6 +61,14 @@ class MoneyTransfer
      * )
      */
     private $accountToId;
+
+    /**
+     * @var string
+     *
+     * @JMS\Type("string")
+     * @JMS\Groups({"money-transfer"})
+     */
+    private $description;
 
     /**
      * Get id.
@@ -166,5 +174,23 @@ class MoneyTransfer
     public function setAccountToId($accountToId)
     {
         $this->accountToId = $accountToId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return MoneyTransfer
+     */
+    public function setDescription($description)
+    {
+        $this->description = $description;
+
+        return $this;
     }
 }

--- a/client/src/Form/Report/MoneyTransferType.php
+++ b/client/src/Form/Report/MoneyTransferType.php
@@ -37,6 +37,12 @@ class MoneyTransferType extends AbstractType
                     'grouping' => true,
                     'error_bubbling' => false,
                     'invalid_message' => 'transfer.amount.notNumeric', ]
+            )->add(
+                'description',
+                FormTypes\TextareaType::class,
+                [
+                    'required' => false,
+                    'attr' => ['maxlength' => 50]]
             );
 
         $builder

--- a/client/src/Form/Report/MoneyTransferType.php
+++ b/client/src/Form/Report/MoneyTransferType.php
@@ -39,7 +39,7 @@ class MoneyTransferType extends AbstractType
                     'invalid_message' => 'transfer.amount.notNumeric', ]
             )->add(
                 'description',
-                FormTypes\TextareaType::class,
+                FormTypes\TextType::class,
                 [
                     'required' => false,
                     'attr' => ['maxlength' => 50]]

--- a/client/src/Form/Report/MoneyTransferType.php
+++ b/client/src/Form/Report/MoneyTransferType.php
@@ -42,7 +42,7 @@ class MoneyTransferType extends AbstractType
                 FormTypes\TextType::class,
                 [
                     'required' => false,
-                    'attr' => ['maxlength' => 50]]
+                    'attr' => ['maxlength' => 75]]
             );
 
         $builder

--- a/client/templates/Components/Form/_input.html.twig
+++ b/client/templates/Components/Form/_input.html.twig
@@ -4,7 +4,12 @@
 {% endif %}
 <div id="form-group-{{ element.vars.id }}"
      class="govuk-form-group{% if not element.vars.valid %} govuk-form-group--error{% endif %}{% if formGroupClass is defined %} {{formGroupClass}}{% endif %}{% if displayCountdown is defined %}govuk-character-count{% endif %}"
-    {% if displayCountdown is defined %} data-module="govuk-character-count" data-maxlength="{{ element.vars.attr.maxlength }}"{% endif %}>
+
+    {% if displayCountdown is defined %}
+        {% set describedby = element.vars.id ~ '-info' %}
+            data-module="govuk-character-count" data-maxlength="
+        {{ element.vars.attr.maxlength }}"
+    {% endif %}>
 
     {% if label.isPageHeading %}
         <h1 class="govuk-label-wrapper">

--- a/client/templates/Components/Form/_input.html.twig
+++ b/client/templates/Components/Form/_input.html.twig
@@ -1,5 +1,10 @@
 {% set describedby = '' %}
-<div id="form-group-{{ element.vars.id }}" class="govuk-form-group{% if not element.vars.valid %} govuk-form-group--error{% endif %}{% if formGroupClass is defined %} {{formGroupClass}}{% endif %}">
+{% if 'govuk-js-character-count' in inputClass and element.vars.attr.maxlength is defined %}
+    {% set displayCountdown = 'character' %}
+{% endif %}
+<div id="form-group-{{ element.vars.id }}"
+     class="govuk-form-group{% if not element.vars.valid %} govuk-form-group--error{% endif %}{% if formGroupClass is defined %} {{formGroupClass}}{% endif %}{% if displayCountdown is defined %}govuk-character-count{% endif %}"
+    {% if displayCountdown is defined %} data-module="govuk-character-count" data-maxlength="{{ element.vars.attr.maxlength }}"{% endif %}>
 
     {% if label.isPageHeading %}
         <h1 class="govuk-label-wrapper">
@@ -64,6 +69,12 @@
                 'aria-describedby': describedby ~ ' ' ~ element.vars.id ~ '-error',
             }
         }) }}
+    {% endif %}
+
+    {% if displayCountdown is defined %}
+        <div class="govuk-hint govuk-character-count__message" id="{{ element.vars.id }}-info">
+            You can enter up to {{ element.vars.attr.maxlength }} characters
+        </div>
     {% endif %}
 
 </div>

--- a/client/templates/Report/MoneyTransfer/_list.html.twig
+++ b/client/templates/Report/MoneyTransfer/_list.html.twig
@@ -66,6 +66,9 @@
                 <th scope="col" class="govuk-table__header">
                     Transferred to
                 </th>
+                <th scope="col" class="govuk-table__header">
+                    Description
+                </th>
                 <th scope="col" class="govuk-table__header govuk-table__header--numeric">
                     Amount
                 </th>
@@ -85,6 +88,9 @@
                     </th>
                     <td class="govuk-table__cell">
                         {{ _self.accountDetails(transfer.accountTo) }}
+                    </td>
+                    <td class="govuk-table__cell">
+                        {{ transfer.description | nl2br }}
                     </td>
                     <td class="govuk-table__cell govuk-table__cell--numeric">
                         £{{ transfer.amount | money_format }}

--- a/client/templates/Report/MoneyTransfer/step.html.twig
+++ b/client/templates/Report/MoneyTransfer/step.html.twig
@@ -36,6 +36,15 @@
         'labelClass' : 'text'
         }) }}
 
+    <div class="govuk-character-count" data-module="govuk-textarea govuk-js-character-count" data-maxlength="50">
+        {{ form_input(form.description, 'form.description.' ~ (form.description.vars.required ? 'mandatory' : 'optional'), {
+            'labelParameters' : transOptions
+        }) }}
+        <div class="govuk-hint govuk-character-count__message">
+            You can enter up to 50 characters
+        </div>
+    </div>
+
 
     {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/templates/Report/MoneyTransfer/step.html.twig
+++ b/client/templates/Report/MoneyTransfer/step.html.twig
@@ -36,15 +36,10 @@
         'labelClass' : 'text'
         }) }}
 
-    <div class="govuk-character-count" data-module="govuk-textarea govuk-js-character-count" data-maxlength="50">
         {{ form_input(form.description, 'form.description.' ~ (form.description.vars.required ? 'mandatory' : 'optional'), {
-            'labelParameters' : transOptions
+            'labelParameters': transOptions,
+            'inputClass': 'govuk-js-character-count'
         }) }}
-        <div class="govuk-hint govuk-character-count__message">
-            You can enter up to 50 characters
-        </div>
-    </div>
-
 
     {{ macros.saveAndContinueButton(form.save) }}
 

--- a/client/templates/Report/MoneyTransfer/step.html.twig
+++ b/client/templates/Report/MoneyTransfer/step.html.twig
@@ -37,7 +37,7 @@
         }) }}
 
         {{ form_input(form.description, 'form.description', {
-            'inputClass': 'govuk-js-character-count',
+            'inputClass': 'govuk-js-character-count govuk-!-width-two-thirds',
         }) }}
 
     {{ macros.saveAndContinueButton(form.save) }}

--- a/client/templates/Report/MoneyTransfer/step.html.twig
+++ b/client/templates/Report/MoneyTransfer/step.html.twig
@@ -36,9 +36,8 @@
         'labelClass' : 'text'
         }) }}
 
-        {{ form_input(form.description, 'form.description.' ~ (form.description.vars.required ? 'mandatory' : 'optional'), {
-            'labelParameters': transOptions,
-            'inputClass': 'govuk-js-character-count'
+        {{ form_input(form.description, 'form.description', {
+            'inputClass': 'govuk-js-character-count',
         }) }}
 
     {{ macros.saveAndContinueButton(form.save) }}

--- a/client/translations/report-money-transfer.en.yml
+++ b/client/translations/report-money-transfer.en.yml
@@ -46,6 +46,7 @@ deletePage:
     accountFrom: Transferred from
     accountTo: Transferred to
     amount: Amount
+    description: Description
 
 errorPage:
   htmlTitle: "Money transfers - Complete the deputy report | GOV.UK"

--- a/client/translations/report-money-transfer.en.yml
+++ b/client/translations/report-money-transfer.en.yml
@@ -65,3 +65,6 @@ form:
   amount:
     label: How much money was transferred?
     hint: ""
+  description:
+    optional:
+      label: Description (optional)

--- a/client/translations/report-money-transfer.en.yml
+++ b/client/translations/report-money-transfer.en.yml
@@ -67,5 +67,4 @@ form:
     label: How much money was transferred?
     hint: ""
   description:
-    optional:
-      label: Description (optional)
+    label: Description (optional)


### PR DESCRIPTION
## Purpose
As part of the 'transfers' epic, add an optional description field to the money transfer section and display input on the summary page. 

Fixes DDPB-4680

## Approach
- Description column added to money_transfer table 
- Optional description field added to money transfers page
- Character count component applied
- Description rendered on the summary page and transfer deletion page

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [x] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [x] There are no deprecated CSS classes noted in the profiler
- [x] Translations are used and the profiler doesn't identify any missing
- [x] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
