### PR TITLE
DDPB-4317 make secrets consistent - part 1

### DIFF
--- a/shared/certificates.tf
+++ b/shared/certificates.tf
@@ -3,6 +3,7 @@ data "aws_route53_zone" "digideps_service_justice" {
   provider = aws.management
 }
 
+#Base URLs
 resource "aws_route53_record" "certificate_validation_app" {
   provider = aws.management
   for_each = {
@@ -29,4 +30,33 @@ resource "aws_acm_certificate" "digideps_service_justice" {
 resource "aws_acm_certificate_validation" "digideps_service_justice" {
   certificate_arn         = aws_acm_certificate.digideps_service_justice.arn
   validation_record_fqdns = [for record in aws_route53_record.certificate_validation_app : record.fqdn]
+}
+
+#Admin URLs
+resource "aws_route53_record" "certificate_validation_admin" {
+  provider = aws.management
+  for_each = {
+    for dvo in aws_acm_certificate.digideps_service_justice_admin.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.digideps_service_justice.zone_id
+}
+
+resource "aws_acm_certificate" "digideps_service_justice_admin" {
+  domain_name       = "*.admin.digideps.opg.service.justice.gov.uk"
+  validation_method = "DNS"
+}
+
+resource "aws_acm_certificate_validation" "digideps_service_justice_admin" {
+  certificate_arn         = aws_acm_certificate.digideps_service_justice_admin.arn
+  validation_record_fqdns = [for record in aws_route53_record.certificate_validation_admin : record.fqdn]
 }

--- a/shared/terraform.tfvars.json
+++ b/shared/terraform.tfvars.json
@@ -5,7 +5,7 @@
       "name": "production",
       "db_subnet_group": "rds-private-subnets-prod-vpc",
       "ec_subnet_group": "ec-pvt-subnets-prod-vpc",
-      "environments": ["production02", "training"],
+      "environments": ["production02"],
       "dns_firewall": {
         "enabled": true,
         "domains_allowed": ["deputy-reporting.api.opg.service.justice.gov.uk."],
@@ -18,7 +18,7 @@
       "name": "preproduction",
       "db_subnet_group": "private",
       "ec_subnet_group": "private",
-      "environments": ["integration", "preproduction"],
+      "environments": ["integration", "preproduction", "training"],
       "dns_firewall": {
         "enabled": false,
         "domains_allowed": [


### PR DESCRIPTION
## Purpose
make secrets consistent part 1.

Fixes DDPB-4317

## Approach
Seems we started the work to make our secrets consistent across envs. 

This part just moves training to preproduction as this was missed as part of our move.

Next part will then use the environment names secrets prefix for respective secrets for each env and default for our default environments. 

This is good as our secret rotation can then ignore default.

I also added a wildcard cert in here for a pattern that follows what they do on modernise and use an lpa.

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
