### PR TITLE
DDPB-3661 rework to amend replication group

### DIFF
--- a/environment/api_elasticache.tf
+++ b/environment/api_elasticache.tf
@@ -3,7 +3,7 @@ resource "aws_elasticache_replication_group" "api" {
   automatic_failover_enabled = local.account.elasticache_count == 1 ? false : true
   engine                     = "redis"
   engine_version             = "6.x"
-  parameter_group_name       = "default.redis6.x"
+  parameter_group_name       = "api-cache-params"
   replication_group_id       = "api-rep-group-${local.environment}"
   description                = "Replication Group for API"
   node_type                  = "cache.t2.micro"


### PR DESCRIPTION
When we pushed this out, our bespoke rep group was still at 5.x, it's been updated in all envs since so this can go out now.

This will perform a change rather than a recreate (screenshot below):

<img width="339" alt="image" src="https://github.com/ministryofjustice/opg-digideps/assets/58939809/dfc32d3d-2c2d-407b-96c7-3c00af60ec7a">
