### PR TITLE
DDPB-4747 add containerinsights to tf managed state

### DIFF
--- a/environment/ecs.tf
+++ b/environment/ecs.tf
@@ -5,7 +5,15 @@ resource "aws_ecs_cluster" "main" {
     name  = "containerInsights"
     value = "enabled"
   }
+  depends_on = [aws_cloudwatch_log_group.container_insights]
 }
+
+resource "aws_cloudwatch_log_group" "container_insights" {
+  name       = "/aws/ecs/containerinsights/${local.environment}/performance"
+  kms_key_id = aws_kms_key.cloudwatch_logs.arn
+  tags       = local.default_tags
+}
+
 
 data "aws_iam_policy_document" "task_role_assume_policy" {
   statement {

--- a/environment/s3_iam_replication.tf
+++ b/environment/s3_iam_replication.tf
@@ -1,7 +1,7 @@
 // CREATE BACKUP ROLE USED FOR LOCAL AND CROSS ACCOUNT REPLICATION
 resource "aws_iam_role" "backup_role" {
-  name_prefix        = "digideps-backup-role"
-  description        = "IAM Role for s3 replication in ${terraform.workspace}"
+  name               = "digideps-backup-role.${local.environment}"
+  description        = "IAM Role for s3 replication in ${local.environment}"
   assume_role_policy = data.aws_iam_policy_document.backup_role_policy.json
 }
 

--- a/environment/scripts/workspace_cleanup.sh
+++ b/environment/scripts/workspace_cleanup.sh
@@ -31,9 +31,13 @@ do
         terraform destroy -auto-approve
         if [ $? != 0 ]; then
           export TF_EXIT_CODE="1"
+        else
+          terraform import aws_cloudwatch_log_group.container_insights "/aws/ecs/containerinsights/${workspace}/performance"
+          # Second destroy to remove performance log group as first destroy recreates it
+          terraform destroy -auto-approve
+          terraform workspace select default
+          terraform workspace delete $workspace
         fi
-        terraform workspace select default
-        terraform workspace delete $workspace
       fi
       ;;
   esac


### PR DESCRIPTION
## Purpose
add containerinsights to tf managed state

Fixes DDPB-4747

## Approach
add to log group so it creates destroys it properly when env is taken down. Also was hard to see what env backup role belonged to so added env to name.

Sadly whilst destroying the log group is recreated even if you do a targeted destroy. The easiest solution is to import it again and destroy it which does seem to work.
 
## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
