### PR TITLE
DDPB-4597 add db secret rotation to cyclesecrets script

### DIFF
--- a/.github/workflows/_cycle_secrets.yml
+++ b/.github/workflows/_cycle_secrets.yml
@@ -1,12 +1,8 @@
 on:
   workflow_call:
     inputs:
-      workspace:
-        description: "Workspace"
-        required: true
-        type: string
-      account:
-        description: "Account to use"
+      account_environment:
+        description: "Environment to run against"
         required: true
         type: string
 jobs:
@@ -34,7 +30,7 @@ jobs:
 
       - name: cycle secrets
         env:
-          WORKSPACE: ${{ inputs.workspace }}
+          ACCOUNT_ENVIRONMENT: ${{ inputs.account_environment }}
           AWS_REGION: eu-west-1
         working-directory: environment/scripts/cycle_secrets
-        run: python3 cycle_secrets.py ${WORKSPACE}
+        run: python3 cycle_secrets.py ${ACCOUNT_ENVIRONMENT}

--- a/.github/workflows/scheduled-cycle-secrets.yml
+++ b/.github/workflows/scheduled-cycle-secrets.yml
@@ -1,108 +1,107 @@
-#name: "[Scheduled] Cycle Secrets"
-#
-#on:
-#  schedule:
-#    # 5AM from Monday to Friday
-#    - cron: "0 5 * * 1-5"
-#
-#permissions:
-#  contents: read
-#  security-events: none
-#  pull-requests: none
-#  actions: none
-#  checks: none
-#  deployments: none
-#  issues: none
-#  packages: none
-#  repository-projects: none
-#  statuses: none
-#
-#jobs:
-#  rotate_secrets_development:
-#    name: rotate secrets for development account
-#    uses: ./.github/workflows/_cycle_secrets.yml
-#    with:
-#      account: 248804316466
-#      workspace: development
-#    secrets: inherit
-#
-#  latest_deployed_image:
-#    name: development environment apply terraform
-#    uses: ./.github/workflows/_latest_deployed_image.yml
-#    with:
-#      workspace: training
-#      terraform_path: environment
-#    secrets: inherit
-#
-#  monitoring_lambda_unit_tests:
-#    name: monitoring lambda unit tests
-#    uses: ./.github/workflows/_unit-tests-monitoring-lambda.yml
-#
-#  terraform_apply_development:
-#    name: development environment apply terraform
-#    uses: ./.github/workflows/_run-terraform.yml
-#    needs:
-#      - rotate_secrets_development
-#      - latest_deployed_image
-#      - monitoring_lambda_unit_tests
-#    with:
-#      workspace: development
-#      terraform_path: environment
-#      apply: true
-#      container_version: ${{ needs.latest_deployed_image.outputs.image_tag }}
-#    secrets: inherit
-#
-#  rotate_secrets_preproduction:
-#    name: rotate secrets for preproduction account
-#    uses: ./.github/workflows/_cycle_secrets.yml
-#    needs:
-#      - terraform_apply_development
-#    with:
-#      account: 454262938596
-#      workspace: preproduction
-#    secrets: inherit
-#
-#  terraform_apply_integration:
-#    name: integration environment apply terraform
-#    uses: ./.github/workflows/_run-terraform.yml
-#    needs:
-#      - rotate_secrets_preproduction
-#      - latest_deployed_image
-#      - terraform_apply_development
-#    with:
-#      workspace: integration
-#      terraform_path: environment
-#      apply: true
-#      container_version: ${{ needs.latest_deployed_image.outputs.image_tag }}
-#    secrets: inherit
-#
-#  terraform_apply_training:
-#    name: training environment apply terraform
-#    uses: ./.github/workflows/_run-terraform.yml
-#    needs:
-#      - rotate_secrets_preproduction
-#      - latest_deployed_image
-#      - terraform_apply_development
-#    with:
-#      workspace: training
-#      terraform_path: environment
-#      apply: true
-#      container_version: ${{ needs.latest_deployed_image.outputs.image_tag }}
-#    secrets: inherit
-#
-#  terraform_apply_preproduction:
-#    name: preproduction environment apply terraform
-#    uses: ./.github/workflows/_run-terraform.yml
-#    needs:
-#      - rotate_secrets_preproduction
-#      - latest_deployed_image
-#      - terraform_apply_development
-#    with:
-#      workspace: preproduction
-#      terraform_path: environment
-#      apply: true
-#      container_version: ${{ needs.latest_deployed_image.outputs.image_tag }}
-#    secrets: inherit
+name: "[Scheduled] Cycle Secrets"
+
+on:
+  schedule:
+    # 5AM from Monday to Friday
+    - cron: "0 5 * * 1-5"
+
+permissions:
+  contents: read
+  security-events: none
+  pull-requests: none
+  actions: none
+  checks: none
+  deployments: none
+  issues: none
+  packages: none
+  repository-projects: none
+  statuses: none
+
+jobs:
+  latest_deployed_image:
+    name: get latest deployed image from training
+    uses: ./.github/workflows/_latest_deployed_image.yml
+    with:
+      workspace: training
+      terraform_path: environment
+    secrets: inherit
+
+  monitoring_lambda_unit_tests:
+    name: monitoring lambda unit tests
+    uses: ./.github/workflows/_unit-tests-monitoring-lambda.yml
+
+  rotate_secrets_development:
+    name: rotate secrets for development account
+    uses: ./.github/workflows/_cycle_secrets.yml
+    needs:
+      - latest_deployed_image
+      - monitoring_lambda_unit_tests
+    with:
+      account_environment: development
+    secrets: inherit
+
+  terraform_apply_development:
+    name: development environment apply terraform
+    uses: ./.github/workflows/_run-terraform.yml
+    needs:
+      - rotate_secrets_development
+    with:
+      workspace: development
+      terraform_path: environment
+      apply: true
+      container_version: ${{ needs.latest_deployed_image.outputs.image_tag }}
+    secrets: inherit
+
+  rotate_secrets_preproduction:
+    name: rotate secrets for preproduction account
+    uses: ./.github/workflows/_cycle_secrets.yml
+    needs:
+      - terraform_apply_development
+    with:
+      account_environment: preproduction
+    secrets: inherit
+
+  terraform_apply_integration:
+    name: integration environment apply terraform
+    uses: ./.github/workflows/_run-terraform.yml
+    needs:
+      - rotate_secrets_preproduction
+      - latest_deployed_image
+      - terraform_apply_development
+    with:
+      workspace: integration
+      terraform_path: environment
+      apply: true
+      container_version: ${{ needs.latest_deployed_image.outputs.image_tag }}
+    secrets: inherit
+
+  terraform_apply_training:
+    name: training environment apply terraform
+    uses: ./.github/workflows/_run-terraform.yml
+    needs:
+      - rotate_secrets_preproduction
+      - latest_deployed_image
+      - terraform_apply_development
+    with:
+      workspace: training
+      terraform_path: environment
+      apply: true
+      container_version: ${{ needs.latest_deployed_image.outputs.image_tag }}
+    secrets: inherit
+
+  terraform_apply_preproduction:
+    name: preproduction environment apply terraform
+    uses: ./.github/workflows/_run-terraform.yml
+    needs:
+      - rotate_secrets_preproduction
+      - latest_deployed_image
+      - terraform_apply_development
+    with:
+      workspace: preproduction
+      terraform_path: environment
+      apply: true
+      container_version: ${{ needs.latest_deployed_image.outputs.image_tag }}
+    secrets: inherit
 #
 #  rotate_secrets_production:
 #    name: rotate secrets for production account
@@ -110,8 +109,7 @@
 #    needs:
 #      - terraform_apply_preproduction
 #    with:
-#      account: 515688267891
-#      workspace: production
+#      account_environment: production
 #    secrets: inherit
 #
 #  terraform_apply_production:

--- a/environment/scripts/cycle_secrets/cycle_secrets.py
+++ b/environment/scripts/cycle_secrets/cycle_secrets.py
@@ -1,8 +1,12 @@
+import time
+
 import boto3
 import os
 import sys
 from botocore.config import Config
 import secrets
+
+db_password_suffix = "database-password"
 
 
 def get_session(account_id):
@@ -28,65 +32,132 @@ def get_session(account_id):
     return session
 
 
-def cycle_secrets(session, secrets_list):
-    aws_config = Config(
-        region_name=os.environ.get('AWS_REGION'),
-    )
-
+def cycle_secrets(session, workspaces, aws_config):
     secret_manager = session.client('secretsmanager', config=aws_config)
 
     # Retrieve all secrets in the Secrets Manager service
-    secrets_response = secret_manager.list_secrets()
+    all_secrets = []
 
-    all_secrets = secrets_response['SecretList']
+    paginator = secret_manager.get_paginator('list_secrets')
+    for page in paginator.paginate():
+        all_secrets.extend(page['SecretList'])
+
+    # Rewrite using list of secret names when we are rotating more than one type
+    secrets_list = []
+    for workspace in workspaces:
+        secrets_list.append(f"{workspace}/{db_password_suffix}")
+
+    print(f"Attempting to find the following secrets: {secrets_list}")
 
     # Filter the secrets based on the list of secrets that you specify
     filtered_secrets = [s for s in all_secrets if s['Name'] in secrets_list]
 
-    # Loop through the filtered secrets and update each one to a random 32 character string
+    if len(filtered_secrets) == 0:
+        print("No matching secrets found.. Exiting")
+        exit(1)
+
+    # Loop through the filtered secrets and update each one to a random 43 character string
     for secret in filtered_secrets:
         print(f"rotating secret: {secret['Name']}")
         secret_manager.update_secret(SecretId=secret['Name'], SecretString=secrets.token_urlsafe(32))
         print(f"rotated secret: {secret['Name']}")
 
 
-def main(workspace):
+def wait_for_cluster_update(client, cluster_identifier):
+    # takes a while for it to start the update!
+    time.sleep(30)
+    sleep_time = 30
+    total_time = 0
+    while True:
+        response = client.describe_db_clusters(DBClusterIdentifier=cluster_identifier)
+        db_cluster = response['DBClusters'][0]
+        db_cluster_status = db_cluster['Status']
+        if db_cluster_status == 'available':
+            print("RDS cluster update complete.")
+            break
+        elif total_time > 900:
+            print("Update timing out. Exiting")
+            exit(1)
+        else:
+            print(f"RDS cluster is {db_cluster_status}. Waiting...")
+            time.sleep(sleep_time)  # Wait for 30 seconds before checking again
+            total_time += sleep_time
+
+
+def modify_db_instances_password(session, workspaces, aws_config):
+    rds_client = session.client('rds', config=aws_config)
+    secrets_client = session.client('secretsmanager', config=aws_config)
+
+    for workspace in workspaces:
+
+        secret_name = f"{workspace}/{db_password_suffix}"
+        cluster_identifier = f"api-{workspace}"
+
+        try:
+            # Fetch the secret value from AWS Secrets Manager
+            secret_response = secrets_client.get_secret_value(SecretId=secret_name)
+            secret_string = secret_response['SecretString']
+
+            if len(secret_string) != 43:
+                print(f"Secret string not 43 characters. It is {len(secret_string)}")
+
+            # Apply the RDS modification with the fetched password
+            rds_client.modify_db_cluster(
+                DBClusterIdentifier=cluster_identifier,
+                MasterUserPassword=secret_string,
+                ApplyImmediately=True
+            )
+            print("RDS modification initiated successfully.")
+            wait_for_cluster_update(rds_client, cluster_identifier)
+        except Exception as e:
+            print("Error occurred:")
+            print(str(e))
+
+
+def main(environment):
     accounts = {
         'development': {
             'id': '248804316466',
-            'secrets_list': [
-                'development/database-password'
+            'workspaces': [
+                'development'
             ]
         },
         'preproduction': {
             'id': '454262938596',
-            'secrets_list': [
-                'integration/database-password',
-                'training/database-password',
-                'preproduction/database-password'
+            'workspaces': [
+                'integration',
+                'training',
+                'preproduction'
             ]
         },
         'production': {
             'id': '515688267891',
-            'secrets_list': [
-                'production02/database-password'
+            'workspaces': [
+                'production02'
             ]
         }
     }
-    account_id = accounts[workspace]["id"]
-    secrets_list = accounts[workspace]["secrets_list"]
+    region_name = os.environ.get('AWS_REGION', 'eu-west-1')
+    aws_config = Config(region_name=region_name)
+    try:
+        account_id = accounts[environment]["id"]
+        workspaces = accounts[environment]["workspaces"]
+    except KeyError as e:
+        print(f"Key error: {e}")
+        exit(1)
     session = get_session(account_id)
-    cycle_secrets(session, secrets_list)
+    cycle_secrets(session, workspaces, aws_config)
+    modify_db_instances_password(session, workspaces, aws_config)
 
 
 if __name__ == "__main__":
     # Check if the correct number of arguments are provided
     if len(sys.argv) > 2:
-        print("Usage: python script.py <workspace>")
+        print("Usage: python script.py <environment>")
         sys.exit(1)
 
     # Retrieve the command-line arguments
-    workspace = sys.argv[1]
-    print(workspace)
+    environment = sys.argv[1]
+    print(f"Running in environment: {environment}")
     # Call the main function with the arguments
-    main(workspace)
+    main(environment)


### PR DESCRIPTION
## Purpose

Rotate the db password at same time as secrets

Fixes DDPB-4597

## Approach
There were issues in some environments due to 2 factors:

- Secrets are paginated so we need to bring them all back.
- Apply immediately is turned off by default on some of our envs to stop patches getting applied during normal hours.

Only solution for the second issue that I could think of is to apply the DB secret update as part of the rotation job as there's no way of doing this in a non messy way in terraform. This should have the affect that connections will continue to work even if the tf apply fails. The TF apply is simply to update the container specs so everything is fully synced though it's not totally necessary now.

## Learning
NA

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
