### PR TITLE
change retention in days for performance insights

### DIFF
--- a/environment/ecs.tf
+++ b/environment/ecs.tf
@@ -9,9 +9,10 @@ resource "aws_ecs_cluster" "main" {
 }
 
 resource "aws_cloudwatch_log_group" "container_insights" {
-  name       = "/aws/ecs/containerinsights/${local.environment}/performance"
-  kms_key_id = aws_kms_key.cloudwatch_logs.arn
-  tags       = local.default_tags
+  name              = "/aws/ecs/containerinsights/${local.environment}/performance"
+  retention_in_days = 1
+  kms_key_id        = aws_kms_key.cloudwatch_logs.arn
+  tags              = local.default_tags
 }
 
 


### PR DESCRIPTION
By default this was always 1 day. The PR to bring into terraform set it to 0 (keep forever). This simply puts it back to what it's default value was.