### PR TITLE
DDPB-3295 path to live amendment

### DIFF
--- a/.github/workflows/_codecov.yml
+++ b/.github/workflows/_codecov.yml
@@ -17,8 +17,6 @@ jobs:
         with:
           name: client-unit-tests
           path: ./
-      - name: Make API dir
-        run: mkdir api-coverage
       - name: download artifact for api tests 1
         uses: actions/download-artifact@e9ef242655d12993efdcda9058dee2db83a2cb9b
         with:

--- a/.github/workflows/workflow-path-to-live.yml
+++ b/.github/workflows/workflow-path-to-live.yml
@@ -49,13 +49,6 @@ jobs:
       push_to_ecr: true
     secrets: inherit
 
-  api_unit_tests:
-    name: api unit tests
-    uses: ./.github/workflows/_unit-tests-api.yml
-    needs:
-      - workflow_variables
-      - docker_build_scan_push
-
   api_unit_tests_1:
     name: api unit tests 1
     uses: ./.github/workflows/_unit-tests-api.yml
@@ -170,6 +163,10 @@ jobs:
     name: scale up integration services
     uses: ./.github/workflows/_scale-services.yml
     needs:
+      - client_unit_tests
+      - api_unit_tests_1
+      - api_unit_tests_2
+      - api_unit_tests_3
       - workflow_variables
       - terraform_apply_integration
     with:


### PR DESCRIPTION
Path to live needed amending as path was invalid. Did 3 things. Removed redundant dir creation as ended up not needing it for final PR. Added unit tests in needs block before doing integration tests as we want to see failure early in case there is some weird oddity failing unit tests on merge to main. Removed the old api unit test block that I had accidentally left in.