### PR TITLE
DDPB-4757 - add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# Override for Makefile
+[{Makefile, makefile, GNUmakefile, Makefile.*}]
+indent_style = tab
+indent_size = 4
+
+[*.yaml]
+intent_style = space
+indent_size = 2
+
+[*.sh]
+indent_style = tab
+indent_size = 4
+
+[*.{tf,tfvars,tpl}]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
Adds a .editorconfig file for consistent terraform formatting as per the OPG Terraform guidance


https://docs.opg.service.justice.gov.uk/documentation/guides/terraform_practices.html#use-editorconfig-in-all-repos-for-consistent-whitespace
