### PR TITLE
DDPB-4729: Allow users to change the inactivity period for the inactive admin users report 

### DIFF
--- a/api/src/Repository/UserRepository.php
+++ b/api/src/Repository/UserRepository.php
@@ -296,11 +296,6 @@ SQL;
         return $query->getResult();
     }
 
-    public function getAllAdminUserAccountsNotUsedWithin(string $timeframe)
-    {
-        return $this->getAllRoleBasedUsers(['ROLE_ADMIN'], $timeframe);
-    }
-
     public function getAllAdminAccountsNotUsedWithin(string $timeframe)
     {
         return $this->getAllRoleBasedUsers(['ROLE_ADMIN', 'ROLE_ADMIN_MANAGER', 'ROLE_SUPER_ADMIN'], $timeframe);

--- a/api/src/Repository/UserRepository.php
+++ b/api/src/Repository/UserRepository.php
@@ -4,8 +4,6 @@ namespace App\Repository;
 
 use App\Entity\Client;
 use App\Entity\User;
-use DateInterval;
-use DateTime;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
@@ -164,8 +162,8 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
      */
     public function findInactive($select = null)
     {
-        $thirtyDaysAgo = new DateTime();
-        $thirtyDaysAgo->sub(new DateInterval('P30D'));
+        $thirtyDaysAgo = new \DateTime();
+        $thirtyDaysAgo->sub(new \DateInterval('P30D'));
 
         $reportSubquery = $this->_em->createQueryBuilder()
             ->select('1')
@@ -196,7 +194,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
      */
     public function findActiveLaysInLastYear()
     {
-        $oneYearAgo = (new DateTime())->modify('-1 Year')->format('Y-m-d');
+        $oneYearAgo = (new \DateTime())->modify('-1 Year')->format('Y-m-d');
 
         $conn = $this->getEntityManager()->getConnection();
 
@@ -256,7 +254,7 @@ SQL;
 
     public function getAllAdminAccountsCreatedButNotActivatedWithin(string $timeframe)
     {
-        $date = (new DateTime())->modify($timeframe);
+        $date = (new \DateTime())->modify($timeframe);
 
         $dql = "SELECT u FROM App\Entity\User u WHERE u.roleName IN('ROLE_ADMIN', 'ROLE_SUPER_ADMIN', 'ROLE_ADMIN_MANAGER')
                 AND u.lastLoggedIn IS NULL
@@ -284,7 +282,7 @@ SQL;
 
     public function getAllAdminAccountsNotUsedWithin(string $timeframe)
     {
-        $date = (new DateTime())->modify($timeframe);
+        $date = (new \DateTime())->modify($timeframe);
 
         $dql = "SELECT u FROM App\Entity\User u WHERE u.roleName IN('ROLE_ADMIN', 'ROLE_SUPER_ADMIN', 'ROLE_ADMIN_MANAGER')
                 AND u.lastLoggedIn < :date ";
@@ -299,7 +297,7 @@ SQL;
 
     public function getAllAdminAccountsUsedWithin(string $timeframe)
     {
-        $date = (new DateTime())->modify($timeframe);
+        $date = (new \DateTime())->modify($timeframe);
 
         $dql = "SELECT u FROM App\Entity\User u WHERE u.roleName IN('ROLE_ADMIN', 'ROLE_SUPER_ADMIN', 'ROLE_ADMIN_MANAGER')
                 AND u.lastLoggedIn > :date ";
@@ -314,9 +312,9 @@ SQL;
 
     public function getAllAdminUserAccountsNotUsedWithin(string $timeframe)
     {
-        $date = (new DateTime())->modify($timeframe);
+        $date = (new \DateTime())->modify($timeframe);
 
-        $dql = "SELECT u FROM App\Entity\User u WHERE u.roleName IN('ROLE_ADMIN') AND u.lastLoggedIn < :date ";
+        $dql = "SELECT u FROM App\Entity\User u WHERE u.roleName IN('ROLE_ADMIN', 'ROLE_ADMIN_MANAGER', 'ROLE_SUPER_ADMIN') AND u.lastLoggedIn < :date ";
 
         $query = $this
             ->getEntityManager()

--- a/api/tests/Behat/bootstrap/v2/ACL/ACLTrait.php
+++ b/api/tests/Behat/bootstrap/v2/ACL/ACLTrait.php
@@ -74,8 +74,8 @@ trait ACLTrait
             case 'view reports':
                 $this->iVisitAdminStatsReportsPage();
                 break;
-            case 'admin users not logged in within last 13 months report':
-                $this->iVisitOldAdminUsersReportsPage();
+            case 'inactive admin users report':
+                $this->iVisitInactiveAdminUsersReportsPage();
                 break;
             default:
                 throw new BehatException(sprintf('Analytics page "%s" unrecognised', $lowercasePageName));

--- a/api/tests/Behat/bootstrap/v2/Common/IVisitAdminTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/IVisitAdminTrait.php
@@ -205,11 +205,11 @@ trait IVisitAdminTrait
     }
 
     /**
-     * @When I visit the admin users not logged in within last 13 months report page
+     * @When I visit the inactive admin users report page
      */
-    public function iVisitOldAdminUsersReportsPage()
+    public function iVisitInactiveAdminUsersReportsPage()
     {
-        $this->visitAdminPath($this->getOldAdminUsersReportUrl());
+        $this->visitAdminPath($this->getInactiveAdminusersReportUrl());
     }
 
     /**

--- a/api/tests/Behat/bootstrap/v2/Common/PageUrlsTrait.php
+++ b/api/tests/Behat/bootstrap/v2/Common/PageUrlsTrait.php
@@ -75,7 +75,7 @@ trait PageUrlsTrait
     private string $adminNotificationUrl = '/admin/settings/service-notification';
     private string $adminDATReportUrl = '/admin/stats';
     private string $adminActiveLaysReportUrl = '/admin/stats/downloadActiveLaysCsv';
-    private string $adminOldAdminUsersReportUrl = '/admin/stats/reports/downloadOldAdminUsersCsv';
+    private string $adminInactiveAdminUsersReportUrl = '/admin/stats/reports/inactive-admin-users-report';
     private string $adminAnalyticsUrl = '/admin/stats/metrics';
     private string $adminStatsReportsUrl = '/admin/stats/reports';
     private string $adminSatisfactionReportUrl = '/admin/stats/satisfaction';
@@ -238,9 +238,9 @@ trait PageUrlsTrait
         return $this->adminActiveLaysReportUrl;
     }
 
-    public function getOldAdminUsersReportUrl(): string
+    public function getInactiveAdminusersReportUrl(): string
     {
-        return $this->adminOldAdminUsersReportUrl;
+        return $this->adminInactiveAdminUsersReportUrl;
     }
 
     public function getAdminFixturesUrl(): string

--- a/api/tests/Behat/features-v2/acl/admin/super-admin-only.feature
+++ b/api/tests/Behat/features-v2/acl/admin/super-admin-only.feature
@@ -16,7 +16,7 @@ Feature: Limiting access to sections of the app to super admins
         When I visit the admin stats reports page
         Then I should be able to access the "user research report"
         When I visit the admin stats reports page
-        Then I should be able to access the "admin users not logged in within last 13 months report"
+        Then I should be able to access the "inactive admin users report"
         When I visit the admin stats reports page
         Then I should be able to access the 'Fixtures' page
         Then I should be able to access the 'Notifications' page

--- a/api/tests/Unit/Controller/StatsControllerTest.php
+++ b/api/tests/Unit/Controller/StatsControllerTest.php
@@ -90,7 +90,7 @@ class StatsControllerTest extends AbstractTestController
         foreach ($unauthorisedUserTokens as $token) {
             $this->assertJsonRequest(
                 'GET',
-                '/stats/admins/old_report_data',
+                '/stats/admins/inactive_admin_users',
                 [
                    'mustFail' => true,
                    'AuthToken' => $token,

--- a/api/tests/Unit/Entity/Repository/UserRepositoryTest.php
+++ b/api/tests/Unit/Entity/Repository/UserRepositoryTest.php
@@ -321,7 +321,7 @@ class UserRepositoryTest extends WebTestCase
         $expectedLoggedInAdminUsers = [$notRecentlyLoggedInAdminUser, $notRecentlyLoggedInSuperAdminManagerUser];
         $expectedRecentlyLoggedInUsersNotReturned = [$recentlyLoggedInAdminUser, $recentlyLoggedInAdminManagerUser, $recentlyLoggedInDeputyUser];
 
-        $actualLoggedInAdminUsers = $this->sut->getAllAdminUserAccountsNotUsedWithin('-12 months');
+        $actualLoggedInAdminUsers = $this->sut->getAllAdminAccountsNotUsedWithin('-12 months');
 
         self::assertEquals($expectedLoggedInAdminUsers, $actualLoggedInAdminUsers);
 

--- a/api/tests/Unit/Entity/Repository/UserRepositoryTest.php
+++ b/api/tests/Unit/Entity/Repository/UserRepositoryTest.php
@@ -8,7 +8,6 @@ use App\TestHelpers\ClientTestHelper;
 use App\TestHelpers\ReportTestHelper;
 use App\TestHelpers\UserTestHelper;
 use App\Tests\Unit\Fixtures;
-use DateTime;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -40,32 +39,32 @@ class UserRepositoryTest extends WebTestCase
     public function testCountsInactiveUsers()
     {
         $oldUserWithNoClient = $this->fixtures->createUser();
-        $oldUserWithNoClient->setRegistrationDate(DateTime::createFromFormat('Y-m-d', '2019-03-03'));
+        $oldUserWithNoClient->setRegistrationDate(\DateTime::createFromFormat('Y-m-d', '2019-03-03'));
         $oldUserWithNoClient->setRoleName(User::ROLE_LAY_DEPUTY);
 
         $oldUserWithNoReports = $this->fixtures->createUser();
-        $oldUserWithNoReports->setRegistrationDate(DateTime::createFromFormat('Y-m-d', '2019-03-03'));
+        $oldUserWithNoReports->setRegistrationDate(\DateTime::createFromFormat('Y-m-d', '2019-03-03'));
         $oldUserWithNoReports->setRoleName(User::ROLE_LAY_DEPUTY);
         $this->fixtures->createClient($oldUserWithNoReports);
 
         $oldUserWithReport = $this->fixtures->createUser();
-        $oldUserWithReport->setRegistrationDate(DateTime::createFromFormat('Y-m-d', '2019-03-03'));
+        $oldUserWithReport->setRegistrationDate(\DateTime::createFromFormat('Y-m-d', '2019-03-03'));
         $oldUserWithReport->setRoleName(User::ROLE_LAY_DEPUTY);
         $oldClientWithReport = $this->fixtures->createClient($oldUserWithReport);
         $this->fixtures->createReport($oldClientWithReport);
 
         $oldUserWithNdr = $this->fixtures->createUser();
-        $oldUserWithNdr->setRegistrationDate(DateTime::createFromFormat('Y-m-d', '2019-03-03'));
+        $oldUserWithNdr->setRegistrationDate(\DateTime::createFromFormat('Y-m-d', '2019-03-03'));
         $oldUserWithNdr->setRoleName(User::ROLE_LAY_DEPUTY);
         $oldClientWithNdr = $this->fixtures->createClient($oldUserWithNdr);
         $this->fixtures->createNdr($oldClientWithNdr);
 
         $oldProfUserWithNoClient = $this->fixtures->createUser();
-        $oldProfUserWithNoClient->setRegistrationDate(DateTime::createFromFormat('Y-m-d', '2019-03-03'));
+        $oldProfUserWithNoClient->setRegistrationDate(\DateTime::createFromFormat('Y-m-d', '2019-03-03'));
         $oldProfUserWithNoClient->setRoleName(User::ROLE_PROF_ADMIN);
 
         $recentUserWithNoClient = $this->fixtures->createUser();
-        $recentUserWithNoClient->setRegistrationDate(new DateTime());
+        $recentUserWithNoClient->setRegistrationDate(new \DateTime());
         $recentUserWithNoClient->setRoleName(User::ROLE_LAY_DEPUTY);
         $this->fixtures->createClient($recentUserWithNoClient);
 
@@ -83,22 +82,22 @@ class UserRepositoryTest extends WebTestCase
         $clientHelper = new ClientTestHelper();
 
         $clientOne = $clientHelper->generateClient($this->em);
-        $activeUserOne = ($userHelper->createAndPersistUser($this->em, $clientOne));
-        $reportOne = ($reportHelper->generateReport($this->em, $clientOne))->setSubmitDate(new DateTime());
+        $activeUserOne = $userHelper->createAndPersistUser($this->em, $clientOne);
+        $reportOne = $reportHelper->generateReport($this->em, $clientOne)->setSubmitDate(new \DateTime());
 
         $clientTwo = $clientHelper->generateClient($this->em);
         $activeUserTwo = $userHelper->createAndPersistUser($this->em, $clientTwo);
-        $reportTwo = ($reportHelper->generateReport($this->em, $clientTwo))->setSubmitDate(new DateTime());
+        $reportTwo = $reportHelper->generateReport($this->em, $clientTwo)->setSubmitDate(new \DateTime());
 
         $clientThree = $clientHelper->generateClient($this->em);
-        $reportThree = ($reportHelper->generateReport($this->em, $clientThree))->setSubmitDate(new DateTime());
+        $reportThree = $reportHelper->generateReport($this->em, $clientThree)->setSubmitDate(new \DateTime());
         $inactiveUserOne = $userHelper->createAndPersistUser($this->em, $clientThree);
-        $inactiveUserOne->setLastLoggedIn(new DateTime('-380 days'));
+        $inactiveUserOne->setLastLoggedIn(new \DateTime('-380 days'));
 
         $clientFour = $clientHelper->generateClient($this->em);
         $reportFour = $reportHelper->generateReport($this->em, $clientFour);
         $inactiveUserTwo = $userHelper->createAndPersistUser($this->em, $clientFour);
-        $inactiveUserTwo->setLastLoggedIn(new DateTime());
+        $inactiveUserTwo->setLastLoggedIn(new \DateTime());
 
         $this->em->persist($inactiveUserOne);
         $this->em->persist($inactiveUserTwo);
@@ -163,15 +162,15 @@ class UserRepositoryTest extends WebTestCase
         $usersToAdd[] = $adminUserLessThan60Days = $userHelper->createUser(null, User::ROLE_ADMIN);
         $usersToAdd[] = $nonAdminUserLessThan60Days = $userHelper->createUser(null, User::ROLE_LAY_DEPUTY);
 
-        $adminUserMoreThan60Days->setRegistrationDate(new DateTime('-61 days'));
+        $adminUserMoreThan60Days->setRegistrationDate(new \DateTime('-61 days'));
         $adminUserMoreThan60Days->setLastLoggedIn(null);
-        $superAdminUserMoreThan60Days->setRegistrationDate(new DateTime('-61 days'));
+        $superAdminUserMoreThan60Days->setRegistrationDate(new \DateTime('-61 days'));
         $superAdminUserMoreThan60Days->setLastLoggedIn(null);
-        $adminManagerUserMoreThan60Days->setRegistrationDate(new DateTime('-61 days'));
+        $adminManagerUserMoreThan60Days->setRegistrationDate(new \DateTime('-61 days'));
         $adminManagerUserMoreThan60Days->setLastLoggedIn(null);
-        $adminUserLessThan60Days->setRegistrationDate(new DateTime('-5 days'));
-        $adminUserLessThan60Days->setLastLoggedIn(new DateTime());
-        $nonAdminUserLessThan60Days->setRegistrationDate(new DateTime('-61 days'));
+        $adminUserLessThan60Days->setRegistrationDate(new \DateTime('-5 days'));
+        $adminUserLessThan60Days->setLastLoggedIn(new \DateTime());
+        $nonAdminUserLessThan60Days->setRegistrationDate(new \DateTime('-61 days'));
         $nonAdminUserLessThan60Days->setLastLoggedIn(null);
 
         foreach ($usersToAdd as $user) {
@@ -202,11 +201,11 @@ class UserRepositoryTest extends WebTestCase
         $usersToAdd[] = $inactiveAdminManagerUser = $userHelper->createUser(null, User::ROLE_ADMIN_MANAGER);
         $usersToAdd[] = $activeDeputyUser = $userHelper->createUser(null, User::ROLE_LAY_DEPUTY);
 
-        $activeAdminUser->setLastLoggedIn(new DateTime());
-        $activeSuperAdminUser->setLastLoggedIn(new DateTime());
-        $activeAdminManagerUser->setLastLoggedIn(new DateTime());
+        $activeAdminUser->setLastLoggedIn(new \DateTime());
+        $activeSuperAdminUser->setLastLoggedIn(new \DateTime());
+        $activeAdminManagerUser->setLastLoggedIn(new \DateTime());
         $inactiveAdminManagerUser->setLastLoggedIn();
-        $activeDeputyUser->setLastLoggedIn(new DateTime());
+        $activeDeputyUser->setLastLoggedIn(new \DateTime());
 
         foreach ($usersToAdd as $user) {
             $this->em->persist($user);
@@ -236,11 +235,11 @@ class UserRepositoryTest extends WebTestCase
         $usersToAdd[] = $recentlyLoggedInAdminManagerUser = $userHelper->createUser(null, User::ROLE_ADMIN_MANAGER);
         $usersToAdd[] = $recentlyLoggedInDeputyUser = $userHelper->createUser(null, User::ROLE_LAY_DEPUTY);
 
-        $loggedInAdminUser->setLastLoggedIn(new DateTime('-95 days'));
-        $loggedInSuperAdminUser->setLastLoggedIn(new DateTime('-91 days'));
-        $loggedInAdminManagerUser->setLastLoggedIn(new DateTime('-91 days'));
-        $recentlyLoggedInAdminManagerUser->setLastLoggedIn(new DateTime('-1 day'));
-        $recentlyLoggedInDeputyUser->setLastLoggedIn(new DateTime('-1 day'));
+        $loggedInAdminUser->setLastLoggedIn(new \DateTime('-95 days'));
+        $loggedInSuperAdminUser->setLastLoggedIn(new \DateTime('-91 days'));
+        $loggedInAdminManagerUser->setLastLoggedIn(new \DateTime('-91 days'));
+        $recentlyLoggedInAdminManagerUser->setLastLoggedIn(new \DateTime('-1 day'));
+        $recentlyLoggedInDeputyUser->setLastLoggedIn(new \DateTime('-1 day'));
 
         foreach ($usersToAdd as $user) {
             $this->em->persist($user);
@@ -270,11 +269,11 @@ class UserRepositoryTest extends WebTestCase
         $usersToAdd[] = $notRecentlyLoggedInAdminManagerUser = $userHelper->createUser(null, User::ROLE_ADMIN_MANAGER);
         $usersToAdd[] = $notRecentlyLoggedInDeputyUser = $userHelper->createUser(null, User::ROLE_LAY_DEPUTY);
 
-        $loggedInAdminUser->setLastLoggedIn(new DateTime('-50 days'));
-        $loggedInSuperAdminUser->setLastLoggedIn(new DateTime('-50 days'));
-        $loggedInAdminManagerUser->setLastLoggedIn(new DateTime('-50 days'));
-        $notRecentlyLoggedInAdminManagerUser->setLastLoggedIn(new DateTime('-100 days'));
-        $notRecentlyLoggedInDeputyUser->setLastLoggedIn(new DateTime('-100 days'));
+        $loggedInAdminUser->setLastLoggedIn(new \DateTime('-50 days'));
+        $loggedInSuperAdminUser->setLastLoggedIn(new \DateTime('-50 days'));
+        $loggedInAdminManagerUser->setLastLoggedIn(new \DateTime('-50 days'));
+        $notRecentlyLoggedInAdminManagerUser->setLastLoggedIn(new \DateTime('-100 days'));
+        $notRecentlyLoggedInDeputyUser->setLastLoggedIn(new \DateTime('-100 days'));
 
         foreach ($usersToAdd as $user) {
             $this->em->persist($user);
@@ -293,20 +292,24 @@ class UserRepositoryTest extends WebTestCase
             self::assertNotContains($user, $actualLoggedInUsers);
         }
     }
-    
+
     public function testGetAllAdminUserAccountsNotUsedWithin()
     {
         $userHelper = new UserTestHelper();
         $usersToAdd = [];
         $usersToAdd[] = $notRecentlyLoggedInAdminUser = $userHelper->createUser(null, User::ROLE_ADMIN);
+        $usersToAdd[] = $notRecentlyLoggedInSuperAdminManagerUser = $userHelper->createUser(null, User::ROLE_SUPER_ADMIN);
         $usersToAdd[] = $recentlyLoggedInAdminUser = $userHelper->createUser(null, User::ROLE_ADMIN);
         $usersToAdd[] = $recentlyLoggedInAdminManagerUser = $userHelper->createUser(null, User::ROLE_ADMIN_MANAGER);
+        $usersToAdd[] = $recentlyLoggedInSuperAdminManagerUser = $userHelper->createUser(null, User::ROLE_SUPER_ADMIN);
         $usersToAdd[] = $recentlyLoggedInDeputyUser = $userHelper->createUser(null, User::ROLE_LAY_DEPUTY);
 
-        $notRecentlyLoggedInAdminUser->setLastLoggedIn(new DateTime('-14 months'));
-        $recentlyLoggedInAdminUser->setLastLoggedIn(new DateTime('-10 days'));
-        $recentlyLoggedInAdminManagerUser->setLastLoggedIn(new DateTime('-10 days'));
-        $recentlyLoggedInDeputyUser->setLastLoggedIn(new DateTime('-10 days'));
+        $notRecentlyLoggedInAdminUser->setLastLoggedIn(new \DateTime('-13 months'));
+        $notRecentlyLoggedInSuperAdminManagerUser->setLastLoggedIn(new \DateTime('-24 months'));
+        $recentlyLoggedInAdminUser->setLastLoggedIn(new \DateTime('-10 days'));
+        $recentlyLoggedInAdminManagerUser->setLastLoggedIn(new \DateTime('-10 days'));
+        $recentlyLoggedInSuperAdminManagerUser->setLastLoggedIn(new \DateTime('-10 days'));
+        $recentlyLoggedInDeputyUser->setLastLoggedIn(new \DateTime('-10 days'));
 
         foreach ($usersToAdd as $user) {
             $this->em->persist($user);
@@ -314,16 +317,16 @@ class UserRepositoryTest extends WebTestCase
 
         $this->em->flush();
 
-        $expectedLoggedInAdminUsers = [$notRecentlyLoggedInAdminUser];
+        $expectedLoggedInAdminUsers = [$notRecentlyLoggedInAdminUser, $notRecentlyLoggedInSuperAdminManagerUser];
         $expectedRecentlyLoggedInUsersNotReturned = [$recentlyLoggedInAdminUser, $recentlyLoggedInAdminManagerUser, $recentlyLoggedInDeputyUser];
 
-        $actualLoggedInAdminUsers = $this->sut->getAllAdminUserAccountsNotUsedWithin('-13 months');
+        $actualLoggedInAdminUsers = $this->sut->getAllAdminUserAccountsNotUsedWithin('-12 months');
 
         self::assertEquals($expectedLoggedInAdminUsers, $actualLoggedInAdminUsers);
 
         foreach ($expectedRecentlyLoggedInUsersNotReturned as $user) {
             self::assertNotContains($user, $actualLoggedInAdminUsers);
-        } 
+        }
     }
 
     protected function tearDown(): void

--- a/client/src/Controller/Admin/StatsController.php
+++ b/client/src/Controller/Admin/StatsController.php
@@ -20,7 +20,7 @@ use App\Service\Client\RestClient;
 use App\Service\Csv\ActiveLaysCsvGenerator;
 use App\Service\Csv\AssetsTotalsCSVGenerator;
 use App\Service\Csv\ClientBenefitMetricsCsvGenerator;
-use App\Service\Csv\OldAdminUserCsvGenerator;
+use App\Service\Csv\InactiveAdminUsersCsvGenerator;
 use App\Service\Csv\ReportImbalanceCsvGenerator;
 use App\Service\Csv\SatisfactionCsvGenerator;
 use App\Service\Csv\UserResearchResponseCsvGenerator;
@@ -45,7 +45,7 @@ class StatsController extends AbstractController
         private readonly UserResearchResponseCsvGenerator $userResearchResponseCsvGenerator,
         private readonly AssetsTotalsCSVGenerator $assetsTotalsCSVGenerator,
         private readonly ClientBenefitMetricsCsvGenerator $clientBenefitMetricsCsvGenerator,
-        private readonly OldAdminUserCsvGenerator $inactiveAdminUserCsvGenerator,
+        private readonly InactiveAdminUsersCsvGenerator $inactiveAdminUserCsvGenerator,
         private readonly ReportImbalanceCsvGenerator $reportImbalanceCsvGenerator
     ) {
     }
@@ -298,7 +298,7 @@ class StatsController extends AbstractController
 
                 $fileName = 'inactiveAdminUsers.csv';
                 $reportData = $this->statsApi->getInactiveAdminUsers($append);
-                $csv = $this->inactiveAdminUserCsvGenerator->generateOldAdminUsersCsv($reportData);
+                $csv = $this->inactiveAdminUserCsvGenerator->generateInactiveAdminUsersCsv($reportData);
 
                 return $this->csvResponseGeneration($fileName, $csv);
             } catch (\Throwable $e) {

--- a/client/src/Controller/Admin/StatsController.php
+++ b/client/src/Controller/Admin/StatsController.php
@@ -6,6 +6,7 @@ use App\Controller\AbstractController;
 use App\Exception\DisplayableException;
 use App\Form\Admin\BenefitsMetricsFilterType;
 use App\Form\Admin\ImbalanceMetricsFilterType;
+use App\Form\Admin\InactiveAdminReportFilterType;
 use App\Form\Admin\ReportSubmissionDownloadFilterType;
 use App\Form\Admin\SatisfactionFilterType;
 use App\Form\Admin\StatPeriodType;
@@ -53,7 +54,6 @@ class StatsController extends AbstractController
      * @Route("", name="admin_stats")
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
      * @Template("@App/Admin/Stats/stats.html.twig")
-     *
      */
     public function stats(
         Request $request,
@@ -82,7 +82,6 @@ class StatsController extends AbstractController
      * @Route("/satisfaction", name="admin_satisfaction")
      * @Security("is_granted('ROLE_SUPER_ADMIN')")
      * @Template("@App/Admin/Stats/satisfaction.html.twig")
-     *
      */
     public function satisfaction(Request $request, ReportSatisfactionSummaryMapper $mapper): array|Response
     {
@@ -110,7 +109,6 @@ class StatsController extends AbstractController
      * @Route("/user-research", name="admin_user_research")
      * @Security("is_granted('ROLE_SUPER_ADMIN')")
      * @Template("@App/Admin/Stats/urResponses.html.twig")
-     *
      */
     public function userResearchResponses(Request $request, UserResearchResponseSummaryMapper $mapper): array|Response
     {
@@ -152,7 +150,6 @@ class StatsController extends AbstractController
      * @Route("/metrics", name="admin_metrics")
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
      * @Template("@App/Admin/Stats/metrics.html.twig")
-     *
      */
     public function metricsAction(Request $request): array|Response
     {
@@ -206,7 +203,6 @@ class StatsController extends AbstractController
      * @Route("/reports", name="admin_reports")
      * @Security("is_granted('ROLE_SUPER_ADMIN')")
      * @Template("@App/Admin/Stats/reports.html.twig")
-     *
      */
     public function reports(): void
     {
@@ -216,7 +212,6 @@ class StatsController extends AbstractController
      * @Route("/reports/user_accounts", name="admin_user_account_reports")
      * @Security("is_granted('ROLE_SUPER_ADMIN')")
      * @Template("@App/Admin/Stats/userAccountReports.html.twig")
-     *
      */
     public function userAccountReports(): array|Response
     {
@@ -227,7 +222,6 @@ class StatsController extends AbstractController
      * @Route("/reports/benefits-report-metrics", name="benefits_report_metrics")
      * @Security("is_granted('ROLE_SUPER_ADMIN')")
      * @Template("@App/Admin/Stats/benefitsReportMetrics.html.twig")
-     *
      */
     public function benefitsReportMetrics(Request $request): array|Response
     {
@@ -262,7 +256,6 @@ class StatsController extends AbstractController
     /**
      * @Route("/downloadActiveLaysCsv", name="admin_active_lays_csv")
      * @Security("is_granted('ROLE_SUPER_ADMIN')")
-     *
      */
     public function downloadActiveLayCsv(): Response
     {
@@ -276,7 +269,6 @@ class StatsController extends AbstractController
     /**
      * @Route("/downloadAssetsTotalValues", name="admin_total_assets_values")
      * @Security("is_granted('ROLE_SUPER_ADMIN')")
-     *
      */
     public function downloadAssetsTotalValues(): Response
     {
@@ -288,24 +280,41 @@ class StatsController extends AbstractController
     }
 
     /**
-     * @Route("/reports/downloadOldAdminUsersCsv", name="admin_old_user_account_report")
+     * @Route("/reports/inactive-admin-users-report", name="inactive_admin_users_report")
      * @Security("is_granted('ROLE_SUPER_ADMIN')")
-     *
+     * @Template("@App/Admin/Stats/inactiveAdminUsersReport.html.twig")
      */
-    public function downloadOldAdminUsersCsv(): Response
+    public function inactiveAdminUsersReport(Request $request): array|Response
     {
-        $fileName = 'inactiveAdminUsers.csv';
-        $reportData = $this->statsApi->getOldAdminUsers();
-        $csv = $this->inactiveAdminUserCsvGenerator->generateOldAdminUsersCsv($reportData);
+        $form = $this->createForm(InactiveAdminReportFilterType::class);
 
-        return $this->csvResponseGeneration($fileName, $csv);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            try {
+                $inactivityPeriod = $form->get('inactivityPeriod')->getData();
+
+                $append = '?inactivityPeriod='.$inactivityPeriod;
+
+                $fileName = 'inactiveAdminUsers.csv';
+                $reportData = $this->statsApi->getInactiveAdminUsers($append);
+                $csv = $this->inactiveAdminUserCsvGenerator->generateOldAdminUsersCsv($reportData);
+
+                return $this->csvResponseGeneration($fileName, $csv);
+            } catch (\Throwable $e) {
+                throw new DisplayableException($e);
+            }
+        }
+
+        return [
+            'form' => $form->createView(),
+        ];
     }
 
     /**
      * @Route("/reports/imbalanceMetrics", name="report_imbalance_metrics")
      * @Security("is_granted('ROLE_SUPER_ADMIN')")
      * @Template("@App/Admin/Stats/imbalanceReportMetrics.html.twig")
-     *
      */
     public function reportImbalanceCsv(Request $request): array|Response
     {

--- a/client/src/Form/Admin/InactiveAdminReportFilterType.php
+++ b/client/src/Form/Admin/InactiveAdminReportFilterType.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form\Admin;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type as FormTypes;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class InactiveAdminReportFilterType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('inactivityPeriod',
+                FormTypes\TextType::class,
+                [
+                    'required' => true,
+                    'attr' => ['maxlength' => 2],
+                ]
+            )
+            ->add('submitAndDownload', FormTypes\SubmitType::class);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'translation_domain' => 'admin-metrics',
+        ]);
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'admin';
+    }
+}

--- a/client/src/Service/Client/Internal/StatsApi.php
+++ b/client/src/Service/Client/Internal/StatsApi.php
@@ -10,7 +10,7 @@ class StatsApi
 {
     protected const GET_ACTIVE_LAY_REPORT_DATA_ENDPOINT = 'stats/deputies/lay/active';
     protected const GET_ADMIN_USER_ACCOUNT_REPORT_DATA = 'stats/admins/report_data';
-    protected const GET_OLD_ADMIN_USER_REPORT_DATA = 'stats/admins/old_report_data';
+    protected const GET_INACTIVE_ADMIN_USER_REPORT_DATA = 'stats/admins/inactive_admin_users';
     protected const GET_ASSETS_TOTAL_VALUES = 'stats/assets/total_values';
     protected const GET_BENEFITS_REPORT_METRICS = 'stats/report/benefits-report-metrics';
     protected const GET_DEPUTY_IMBALANCE_REPORT_DATA = 'stats/report/imbalance';
@@ -65,10 +65,15 @@ class StatsApi
         );
     }
 
-    public function getOldAdminUsers(): array
+    public function getInactiveAdminUsers(?string $append = null): array
     {
+        $link = self::GET_INACTIVE_ADMIN_USER_REPORT_DATA;
+        if (!empty($append)) {
+            $link = self::GET_INACTIVE_ADMIN_USER_REPORT_DATA.$append;
+        }
+
         return $this->restClient->get(
-            self::GET_OLD_ADMIN_USER_REPORT_DATA,
+            $link,
             'array',
             ['user']
         );
@@ -78,7 +83,7 @@ class StatsApi
     {
         $link = self::GET_DEPUTY_IMBALANCE_REPORT_DATA;
         if (!empty($append)) {
-            $link = self::GET_DEPUTY_IMBALANCE_REPORT_DATA . $append;
+            $link = self::GET_DEPUTY_IMBALANCE_REPORT_DATA.$append;
         }
 
         return $this->restClient->get(

--- a/client/src/Service/Csv/InactiveAdminUsersCsvGenerator.php
+++ b/client/src/Service/Csv/InactiveAdminUsersCsvGenerator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service\Csv;
 
-class OldAdminUserCsvGenerator
+class InactiveAdminUsersCsvGenerator
 {
     private CsvBuilder $csvBuilder;
 
@@ -16,7 +16,7 @@ class OldAdminUserCsvGenerator
     /**
      * @return string
      */
-    public function generateOldAdminUsersCsv(array $adminUsers)
+    public function generateInactiveAdminUsersCsv(array $adminUsers)
     {
         $headers = [
             'Id',
@@ -37,10 +37,11 @@ class OldAdminUserCsvGenerator
                     $user['email'],
                     $user['last_logged_in'],
                     $user['active'] ? 'Yes' : 'No',
-                    $user['role_name']
+                    $user['role_name'],
                 ];
             }
         }
+
         return $this->csvBuilder->buildCsv($headers, $rows);
     }
 }

--- a/client/templates/Admin/Stats/inactiveAdminUsersReport.html.twig
+++ b/client/templates/Admin/Stats/inactiveAdminUsersReport.html.twig
@@ -1,0 +1,18 @@
+{% extends '@App/Layouts/application.html.twig' %}
+
+{% set translationDomain = "admin-metrics" %}
+{% trans_default_domain translationDomain %}
+{% set page = 'inactiveAdminUsersReport' %}
+
+{% set navSection = 'reports' %}
+
+{% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
+{% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
+{% block supportTitleTop %}{{ (page ~ '.supportTitle') | trans }}{% endblock %}
+
+{% block pageContent %}
+    {{ form_start(form) }}
+    {{ form_input(form.inactivityPeriod, page ~ '.form.inactivityPeriod') }}
+    {{ form_submit(form.submitAndDownload, page ~ '.form.submitAndDownload') }}
+    {{ form_end(form) }}
+{% endblock %}

--- a/client/templates/Admin/Stats/reports.html.twig
+++ b/client/templates/Admin/Stats/reports.html.twig
@@ -38,6 +38,6 @@
         </a>
     </p>
     <p>
-        <a href="{{ path('admin_old_user_account_report') }}" class="govuk-link">{{ (page ~ '.oldUserAccountReports')|trans }}</a>
+        <a href="{{ path('inactive_admin_users_report') }}" class="govuk-link">{{ (page ~ '.inactiveAdminUsersReport')|trans }}</a>
     </p>
 {% endblock %}

--- a/client/translations/admin-metrics.en.yml
+++ b/client/translations/admin-metrics.en.yml
@@ -17,7 +17,7 @@ reports:
   downloadSatisfaction: Download satisfaction report
   downloadUserResearch: Download user research report
   userAccountReports: View admin account metrics
-  oldUserAccountReports: Download admin users not logged in within last 13 months report
+  inactiveAdminUsersReport: Download inactive admin users report
   benefitsSectionMetrics: View benefits report metrics
   reportImbalanceMetrics: Download report imbalance metrics
 
@@ -39,19 +39,29 @@ benefitsReportMetrics:
     clear: Clear filter
 
 reportSectionImbalanceMetrics:
- htmlTitle: Administration - Report Financial Imbalance Metrics
- pageTitle: Financial Imbalance Metrics
- supportTitle: Analytics
- form:
-   fromDate:
-     legend: Start date
-     hint: For example, 31 3 2015
-   toDate:
-     legend: End date
-     hint: For example, 31 3 2016
-   submitAndDownload:
-     label: Download
-   clear: Clear filter
+  htmlTitle: Administration - Report Financial Imbalance Metrics
+  pageTitle: Financial Imbalance Metrics
+  supportTitle: Analytics
+  form:
+    fromDate:
+      legend: Start date
+      hint: For example, 31 3 2015
+    toDate:
+      legend: End date
+      hint: For example, 31 3 2016
+    submitAndDownload:
+      label: Download
+    clear: Clear filter
+
+inactiveAdminUsersReport:
+  htmlTitle: Administration - Inactive Admin Users Report
+  pageTitle: Inactive Admin Users Report
+  supportTitle: Analytics
+  form:
+    inactivityPeriod:
+      label: Months inactive
+    submitAndDownload:
+      label: Download
 
 form:
   title: Change reporting period


### PR DESCRIPTION
## Purpose
Allows us to tailor the report to our needs to find which admin accounts are inactive.

Fixes DDPB-4729

## Approach
Making a use of the existing endpoint which takes in a time period to bring back a list of admin users that haven't logged in since that time period.

Renamed various methods/endpoints/variables to be consistent and clear about what they are.

Updated report to include super admins and admin managers.

Updated tests to reflect the above changes.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [x] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
