### PR TITLE
DDPB-4570: Delete Staff users who don't exist in Sirius 

### DIFF
--- a/api/src/Command/StaffUserDeletionCommand.php
+++ b/api/src/Command/StaffUserDeletionCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Command;
+
+use App\Repository\UserRepository;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class StaffUserDeletionCommand extends Command
+{
+    public static $defaultName = 'digideps:nonexistent-sirius-staff-accounts';
+
+    public static array $digidepsStaffToExcludeFromDeletion =
+        [
+            35636 => 'gugandeep.chani@digital.justice.gov.uk',
+            34368 => 'james.warren@digital.justice.gov.uk',
+            49768 => 'nicola.mcmillan@digital.justice.gov.uk',
+            46417 => 'oludara.oginni@digital.justice.gov.uk',
+            29876 => 'jack.goodby@digital.justice.gov.uk',
+            45515 => 'mia.gordon@digital.justice.gov.uk',
+            33833 => 'caroline.hufton@digital.justice.gov.uk',
+            43009 => 'jude.rattle@digital.justice.gov.uk',
+            43411 => 'tom.gulliver@digital.justice.gov.uk',
+            43177 => 'peter.scottreid@digital.justice.gov.uk',
+        ];
+
+    public function __construct(
+        private UserRepository $userRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Deletes staff accounts that do not exist in Sirius')
+            ->addArgument('id', InputArgument::IS_ARRAY, 'Pass the id of staff users to be deleted');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $usersToBeDeleted = $input->getArgument('id');
+
+        foreach ($usersToBeDeleted as $key => $id) {
+            if (is_string($id)) {
+                $usersToBeDeleted[$key] = intval($id);
+            }
+
+            foreach (self::$digidepsStaffToExcludeFromDeletion as $digidepsUserId => $digidepsUserEmail) {
+                if ($id == $digidepsUserId) {
+                    unset($usersToBeDeleted[$key]);
+                }
+            }
+        }
+
+        $this->userRepository->deleteStaffUsersThatAreNotInSirius($usersToBeDeleted);
+
+        $output->writeln(sprintf(' %d users deleted', count($usersToBeDeleted)));
+
+        return 1;
+    }
+}

--- a/api/src/Repository/UserRepository.php
+++ b/api/src/Repository/UserRepository.php
@@ -341,4 +341,20 @@ SQL;
 
         return $result->getResult();
     }
+
+    public function deleteStaffUsersThatAreNotInSirius(array $staffUsersToBeDeleted)
+    {
+        $em = $this->getEntityManager();
+        $rsm = new ResultSetMappingBuilder($em);
+
+        $sql = 'DELETE FROM dd_user WHERE id IN (:ids)';
+        $params = [
+            'ids' => $staffUsersToBeDeleted,
+        ];
+
+        $stmt = $em->createNativeQuery($sql, $rsm);
+        $result = $stmt->setParameters($params);
+
+        return $result->getResult();
+    }
 }


### PR DESCRIPTION
## Purpose
Remove staff accounts that have been inactivate for less than 2 years, yet do not exist in Sirius as we use Sirius as a source of truth for user accounts. 

Fixes DDPB-4570

## Approach
- Created a delete sql query 
- Query is called by a custom command 
- Added logic in the command that excludes current digideps team

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

