### PR TITLE
DDPB-4782 throw error if no user or password entered

### DIFF
--- a/client/src/Security/LoginFormAuthenticator.php
+++ b/client/src/Security/LoginFormAuthenticator.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
@@ -42,6 +43,11 @@ class LoginFormAuthenticator extends AbstractAuthenticator
         $email = $request->get('login')['email'];
         $password = $request->get('login')['password'];
         $csrfToken = $request->request->get('login')['_token'];
+
+        if (null === $email || null === $password || null == $csrfToken) {
+            $exception = new BadCredentialsException();
+            throw $exception;
+        }
 
         return new Passport(
             new UserBadge($email, function ($userEmail) use ($password) {
@@ -73,9 +79,9 @@ class LoginFormAuthenticator extends AbstractAuthenticator
     {
         $redirectUrl = $this->redirector->getFirstPageAfterLogin($request->getSession());
 
-        if ($request->query->has('lastPage')){
+        if ($request->query->has('lastPage')) {
             $decodedURL = urldecode($request->query->get('lastPage'));
-            if (RouteValidator::validateRoute($this->router, $decodedURL)){
+            if (RouteValidator::validateRoute($this->router, $decodedURL)) {
                 $redirectUrl = $decodedURL;
             }
         }


### PR DESCRIPTION
## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes DDPB-####

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
