### PR TITLE
DDPB-4773: Reduce token time limit for a password reset request

### DIFF
--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -9,7 +9,6 @@ use App\Entity\UserResearch\UserResearchResponse;
 use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
-use Exception;
 use JMS\Serializer\Annotation as JMS;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -26,7 +25,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     use CreateUpdateTimestamps;
     use AddressTrait;
 
-    public const TOKEN_EXPIRE_HOURS = 48;
+    public const ACTIVATE_TOKEN_EXPIRE_HOURS = 48;
 
     public const ROLE_ADMIN = 'ROLE_ADMIN';
     public const ROLE_ADMIN_MANAGER = 'ROLE_ADMIN_MANAGER';
@@ -96,9 +95,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     /**
      * @var int
+     *
      * @JMS\Type("integer")
      * @JMS\Groups({"user", "report-submitted-by", "user-id", "user-list"})
-     *
      * @ORM\Column(name="id", type="integer", nullable=false)
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
@@ -125,9 +124,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     /**
      * @var string
+     *
      * @JMS\Type("string")
      * @JMS\Groups({ "user", "report-submitted-by", "user-name", "user-list"})
-     *
      * @ORM\Column(name="firstname", type="string", length=100, nullable=false)
      */
     private $firstname;
@@ -143,6 +142,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     /**
      * @var string
+     *
      * @ORM\Column(name="password", type="string", length=100, nullable=false)
      * @JMS\Groups({ "user-login"})
      * @JMS\Exclude
@@ -151,18 +151,18 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     /**
      * @var string
+     *
      * @JMS\Groups({"user", "report-submitted-by", "user-email", "user-list"})
      * @JMS\Type("string")
-     *
      * @ORM\Column(name="email", type="string", length=60, nullable=false, unique=true)
      */
     private $email;
 
     /**
      * @var bool
+     *
      * @JMS\Type("boolean")
      * @JMS\Groups({"user", "user-list"})
-     *
      * @ORM\Column(name="active", type="boolean", nullable=true, options = { "default": false })
      */
     private $active;
@@ -175,16 +175,17 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     private $salt;
 
     /**
-     * @var DateTime
+     * @var \DateTime
+     *
      * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
      * @JMS\Groups({"user"})
-     *
      * @ORM\Column(name="registration_date", type="datetime", nullable=true)
      */
     private $registrationDate;
 
     /**
      * @var string
+     *
      * @JMS\Type("string")
      * @JMS\Groups({"user"})
      * @ORM\Column(name="registration_token", type="string", length=100, nullable=true)
@@ -192,10 +193,10 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     private $registrationToken;
 
     /**
-     * @var DateTime
+     * @var \DateTime
+     *
      * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
      * @JMS\Groups({"user"})
-     *
      * @ORM\Column(name="token_date", type="datetime", nullable=true)
      */
     private $tokenDate;
@@ -206,7 +207,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      *
      * @JMS\Type("string")
      * @JMS\Groups({"user", "report-submitted-by", "user-rolename", "user-list", "team-users"})
-     *
      * @ORM\Column(name="role_name", type="string", length=50, nullable=true)
      */
     private $roleName;
@@ -216,6 +216,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      * does not get stored in the database.
      *
      * @var string
+     *
      * @JMS\Type("string")
      * @JMS\Groups({"user"})
      */
@@ -240,10 +241,10 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     private $phoneAlternative;
 
     /**
-     * @var DateTime
+     * @var \DateTime
+     *
      * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
      * @JMS\Groups({"user"})
-     *
      * @ORM\Column(name="last_logged_in", type="datetime", nullable=true)
      */
     private $lastLoggedIn;
@@ -259,18 +260,18 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     /**
      * @var bool
+     *
      * @JMS\Type("boolean")
      * @JMS\Groups({"user", "user-login"})
-     *
      * @ORM\Column(name="odr_enabled", type="boolean", nullable=true, options = { "default": false })
      */
     private $ndrEnabled;
 
     /**
      * @var bool
+     *
      * @JMS\Type("boolean")
      * @JMS\Groups({"user"})
-     *
      * @ORM\Column(name="ad_managed", type="boolean", nullable=true, options = { "default": false })
      */
     private $adManaged;
@@ -286,45 +287,45 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     /**
      * @var bool
+     *
      * @JMS\Type("boolean")
      * @JMS\Groups({"user"})
-     *
      * @ORM\Column(name="agree_terms_use", type="boolean", nullable=true, options = { "default": false })
      */
     private $agreeTermsUse;
 
     /**
-     * @var DateTime
+     * @var \DateTime
+     *
      * @JMS\Type("DateTime<'Y-m-d'>")
      * @JMS\Groups({"user"})
-     *
      * @ORM\Column(name="agree_terms_use_date", type="datetime", nullable=true)
      */
     private $agreeTermsUseDate;
 
     /**
      * @var bool
+     *
      * @JMS\Type("boolean")
      * @JMS\Groups({"user"})
-     *
      * @ORM\Column(name="codeputy_client_confirmed", type="boolean", nullable=false, options = { "default": false })
      */
     private $coDeputyClientConfirmed;
 
     /**
      * @var UserResearchResponse|null
+     *
      * @JMS\Type("App\Entity\UserResearch\UserResearchResponse")
      * @JMS\Groups({"user", "satisfaction", "user-research"})
-     *
      * @ORM\OneToMany(targetEntity="App\Entity\UserResearch\UserResearchResponse", mappedBy="user", cascade={"persist"})
      */
     private $userResearchResponse;
 
     /**
      * @var User|null
+     *
      * @ORM\OneToOne(targetEntity="App\Entity\User")
      * @ORM\JoinColumn(name="created_by_id", referencedColumnName="id")
-     *
      * @JMS\Type("App\Entity\User")
      * @JMS\Groups({"user", "created-by"})
      * @JMS\MaxDepth(3)
@@ -465,7 +466,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * Set registrationDate.
      *
-     * @param DateTime $registrationDate
+     * @param \DateTime $registrationDate
      *
      * @return User
      */
@@ -479,7 +480,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * Get registrationDate.
      *
-     * @return DateTime
+     * @return \DateTime
      */
     public function getRegistrationDate()
     {
@@ -491,12 +492,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      *
      * @return User
      *
-     * @throws Exception
+     * @throws \Exception
      */
     public function recreateRegistrationToken()
     {
         $this->setRegistrationToken(bin2hex(random_bytes(16)));
-        $this->setTokenDate(new DateTime());
+        $this->setTokenDate(new \DateTime());
 
         return $this;
     }
@@ -552,7 +553,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * Set tokenDate.
      *
-     * @param DateTime $tokenDate
+     * @param \DateTime $tokenDate
      *
      * @return User
      */
@@ -566,7 +567,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * Get tokenDate.
      *
-     * @return DateTime
+     * @return \DateTime
      */
     public function getTokenDate()
     {
@@ -785,8 +786,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
-     * @param $phoneMain
-     *
      * @return $this
      */
     public function setPhoneMain($phoneMain)
@@ -797,8 +796,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
-     * @param $phoneAlternative
-     *
      * @return $this
      */
     public function setPhoneAlternative($phoneAlternative)
@@ -809,7 +806,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
-     * @return DateTime
+     * @return \DateTime
      */
     public function getLastLoggedIn()
     {
@@ -817,9 +814,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
-     * @param DateTime $lastLoggedIn
+     * @param \DateTime $lastLoggedIn
      */
-    public function setLastLoggedIn(DateTime $lastLoggedIn = null)
+    public function setLastLoggedIn(\DateTime $lastLoggedIn = null)
     {
         $this->lastLoggedIn = $lastLoggedIn;
 
@@ -836,8 +833,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     /**
      * convert 7 into 00000007.
-     *
-     * @param $deputyNo
      *
      * @return string
      */
@@ -1006,14 +1001,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $this->agreeTermsUse = $agreeTermsUse;
 
         if ($agreeTermsUse) {
-            $this->agreeTermsUseDate = new DateTime('now');
+            $this->agreeTermsUseDate = new \DateTime('now');
         }
 
         return $this;
     }
 
     /**
-     * @return DateTime
+     * @return \DateTime
      */
     public function getAgreeTermsUseDate()
     {
@@ -1292,7 +1287,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      */
     public function regBeforeToday(User $user): bool
     {
-        return $user->getRegistrationDate() < (new DateTime())->setTime(00, 00, 00);
+        return $user->getRegistrationDate() < (new \DateTime())->setTime(00, 00, 00);
     }
 
     public function getCreatedBy(): ?User

--- a/client/src/Controller/UserController.php
+++ b/client/src/Controller/UserController.php
@@ -63,12 +63,19 @@ class UserController extends AbstractController
         }
 
         // token expired
-        if (!$user->isTokenSentInTheLastHours(EntityDir\User::TOKEN_EXPIRE_HOURS)) {
-            $template = $isActivatePage ? '@App/User/activateTokenExpired.html.twig' : '@App/User/passwordResetTokenExpired.html.twig';
+        if (!$user->isTokenSentInTheLastHours(EntityDir\User::ACTIVATE_TOKEN_EXPIRE_HOURS) && $isActivatePage) {
+            $template = '@App/User/activateTokenExpired.html.twig';
 
             return $this->render($template, [
                 'token' => $token,
-                'tokenExpireHours' => EntityDir\User::TOKEN_EXPIRE_HOURS,
+                'tokenExpireHours' => EntityDir\User::ACTIVATE_TOKEN_EXPIRE_HOURS,
+            ]);
+        } elseif (!$user->isTokenSentInTheLastHours(EntityDir\User::PASSWORD_TOKEN_EXPIRE_HOURS) && !$isActivatePage) {
+            $template = '@App/User/passwordResetTokenExpired.html.twig';
+
+            return $this->render($template, [
+                'token' => $token,
+                'tokenExpireHours' => EntityDir\User::PASSWORD_TOKEN_EXPIRE_HOURS,
             ]);
         }
 
@@ -150,6 +157,7 @@ class UserController extends AbstractController
 
     /**
      * @return array<mixed>
+     *
      * @Route("/user/activate/password/sent/{token}", name="activation_link_sent")
      * @Template("@App/User/activateLinkSent.html.twig")
      */
@@ -157,7 +165,7 @@ class UserController extends AbstractController
     {
         return [
             'token' => $token,
-            'tokenExpireHours' => EntityDir\User::TOKEN_EXPIRE_HOURS,
+            'tokenExpireHours' => EntityDir\User::ACTIVATE_TOKEN_EXPIRE_HOURS,
         ];
     }
 
@@ -170,6 +178,7 @@ class UserController extends AbstractController
      * - PA.
      *
      * @return array<mixed>|Response
+     *
      * @Route("/user/details", name="user_details")
      * @Template("@App/User/details.html.twig")
      */
@@ -208,6 +217,7 @@ class UserController extends AbstractController
 
     /**
      * @return array<mixed>|Response
+     *
      * @Route("/password-managing/forgotten", name="password_forgotten")
      * @Template("@App/User/passwordForgotten.html.twig")
      **/
@@ -235,6 +245,7 @@ class UserController extends AbstractController
 
     /**
      * @return array<mixed>
+     *
      * @Route("/password-managing/sent", name="password_sent")
      * @Template("@App/User/passwordSent.html.twig")
      */
@@ -245,6 +256,7 @@ class UserController extends AbstractController
 
     /**
      * @return array<mixed>|Response
+     *
      * @Route("/register", name="register")
      * @Template("@App/User/register.html.twig")
      */

--- a/client/src/Entity/User.php
+++ b/client/src/Entity/User.php
@@ -75,7 +75,8 @@ class User implements UserInterface, DeputyInterface, PasswordAuthenticatedUserI
         self::ROLE_PROF_TEAM_MEMBER => 'Professional Deputy team member',
     ];
 
-    public const TOKEN_EXPIRE_HOURS = 48;
+    public const ACTIVATE_TOKEN_EXPIRE_HOURS = 48;
+    public const PASSWORD_TOKEN_EXPIRE_HOURS = 1;
 
     /**
      * @JMS\Type("integer")
@@ -174,7 +175,7 @@ class User implements UserInterface, DeputyInterface, PasswordAuthenticatedUserI
      * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
      * @JMS\Groups({"user"})
      *
-     * @var DateTime|null
+     * @var \DateTime|null
      */
     private $registrationDate;
 
@@ -190,7 +191,7 @@ class User implements UserInterface, DeputyInterface, PasswordAuthenticatedUserI
      * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
      * @JMS\Groups({"registrationToken"})
      *
-     * @var DateTime|null
+     * @var \DateTime|null
      */
     private $tokenDate;
 
@@ -289,7 +290,7 @@ class User implements UserInterface, DeputyInterface, PasswordAuthenticatedUserI
      * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
      * @JMS\Groups({"lastLoggedIn"})
      *
-     * @var DateTime|null
+     * @var \DateTime|null
      */
     private $lastLoggedIn;
 
@@ -310,6 +311,7 @@ class User implements UserInterface, DeputyInterface, PasswordAuthenticatedUserI
 
     /**
      * @var bool|null
+     *
      * @JMS\Type("boolean")
      * @JMS\Groups({"ad_managed", "ad_add_user"})
      */
@@ -326,9 +328,9 @@ class User implements UserInterface, DeputyInterface, PasswordAuthenticatedUserI
 
     /**
      * @var bool
+     *
      * @JMS\Type("boolean")
      * @JMS\Groups({"agree_terms_use", "update_terms_use"})
-     *
      * @Assert\NotBlank( message="user.agreeTermsUse.notBlank", groups={"agree-terms-use"} )
      */
     private $agreeTermsUse;
@@ -551,7 +553,7 @@ class User implements UserInterface, DeputyInterface, PasswordAuthenticatedUserI
     }
 
     /**
-     * @return DateTime|null $registrationDate
+     * @return \DateTime|null $registrationDate
      */
     public function getRegistrationDate()
     {
@@ -559,11 +561,11 @@ class User implements UserInterface, DeputyInterface, PasswordAuthenticatedUserI
     }
 
     /**
-     * @param DateTime $registrationDate
+     * @param \DateTime $registrationDate
      *
      * @return User
      */
-    public function setRegistrationDate(DateTime $registrationDate = null)
+    public function setRegistrationDate(\DateTime $registrationDate = null)
     {
         $this->registrationDate = $registrationDate;
 
@@ -591,7 +593,7 @@ class User implements UserInterface, DeputyInterface, PasswordAuthenticatedUserI
     }
 
     /**
-     * @return DateTime $tokenDate
+     * @return \DateTime $tokenDate
      */
     public function getTokenDate()
     {
@@ -599,7 +601,7 @@ class User implements UserInterface, DeputyInterface, PasswordAuthenticatedUserI
     }
 
     /**
-     * @param DateTime $tokenDate
+     * @param \DateTime $tokenDate
      *
      * @return User
      */
@@ -662,8 +664,6 @@ class User implements UserInterface, DeputyInterface, PasswordAuthenticatedUserI
 
     /**
      * @param bool $isCoDeputyClientConfirmed
-     *
-     * @return User
      */
     public function setCoDeputyClientConfirmed($isCoDeputyClientConfirmed): self
     {
@@ -713,7 +713,7 @@ class User implements UserInterface, DeputyInterface, PasswordAuthenticatedUserI
     {
         $expiresSeconds = $hoursExpires * 3600;
 
-        $timeStampNow = (new DateTime())->getTimestamp();
+        $timeStampNow = (new \DateTime())->getTimestamp();
         $timestampToken = $this->getTokenDate()->getTimestamp();
 
         $diffSeconds = $timeStampNow - $timestampToken;
@@ -831,7 +831,7 @@ class User implements UserInterface, DeputyInterface, PasswordAuthenticatedUserI
     }
 
     /**
-     * @return DateTime|null
+     * @return \DateTime|null
      */
     public function getLastLoggedIn()
     {
@@ -839,9 +839,9 @@ class User implements UserInterface, DeputyInterface, PasswordAuthenticatedUserI
     }
 
     /**
-     * @param DateTime $lastLoggedIn
+     * @param \DateTime $lastLoggedIn
      */
-    public function setLastLoggedIn(DateTime $lastLoggedIn = null)
+    public function setLastLoggedIn(\DateTime $lastLoggedIn = null)
     {
         $this->lastLoggedIn = $lastLoggedIn;
     }
@@ -1240,8 +1240,6 @@ class User implements UserInterface, DeputyInterface, PasswordAuthenticatedUserI
 
     /**
      * @param ArrayCollection $organisations
-     *
-     * @return User
      */
     public function setOrganisations($organisations): self
     {
@@ -1287,12 +1285,10 @@ class User implements UserInterface, DeputyInterface, PasswordAuthenticatedUserI
 
     /**
      * Check if a user registration was before today.
-     *
-     * @param $user
      */
     public function regBeforeToday(User $user): bool
     {
-        return $user->getRegistrationDate() < (new DateTime())->setTime(00, 00, 00);
+        return $user->getRegistrationDate() < (new \DateTime())->setTime(00, 00, 00);
     }
 
     public function getAddress4()

--- a/client/translations/password-reset-expired.en.yml
+++ b/client/translations/password-reset-expired.en.yml
@@ -1,5 +1,5 @@
 page:
   htmlTitle: "This page has expired - Complete the deputy report | GOV.UK"
 pageTitle: This page has expired
-subtitle: The link we sent you was only active for %tokenExpireHours% hours, and this page has now expired.
+subtitle: The link we sent you was only active for %tokenExpireHours% hour, and this page has now expired.
 goBackLink: Go back to 'reset password form'


### PR DESCRIPTION
## Purpose
Reduce the 48 hour time limit to 1 hour when a user requests a password reset. This will reduce the risk of attackers intercepting the generated token. 

Fixes DDPB-4773

## Approach
- Created new const for password reset and set to 1 hour
- Split controller logic to handle expired activation and password reset tokens separately.

- Will need to manually update Notify email template to reflect the updated time limit.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [x] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
