### PR TITLE
DDPB-4789 enable snapshots for elasticache - sec hub warning

### DIFF
--- a/environment/api_elasticache.tf
+++ b/environment/api_elasticache.tf
@@ -11,6 +11,8 @@ resource "aws_elasticache_replication_group" "api" {
   port                       = 6379
   subnet_group_name          = local.account.ec_subnet_group
   security_group_ids         = [module.api_cache_security_group.id]
+  snapshot_retention_limit   = 1
+  snapshot_window            = "03:00-06:00"
   apply_immediately          = true
   at_rest_encryption_enabled = true
   #tfsec:ignore:aws-elasticache-enable-in-transit-encryption - too much of a performance hit. To be re-evaluated.

--- a/environment/frontend_shared_elasticache.tf
+++ b/environment/frontend_shared_elasticache.tf
@@ -12,6 +12,8 @@ resource "aws_elasticache_replication_group" "frontend" {
   subnet_group_name          = local.account.ec_subnet_group
   security_group_ids         = [module.frontend_cache_security_group.id]
   tags                       = local.default_tags
+  snapshot_retention_limit   = 1
+  snapshot_window            = "03:00-06:00"
   at_rest_encryption_enabled = true
   #tfsec:ignore:aws-elasticache-enable-in-transit-encryption - too much of a performance hit. To be re-evaluated
   transit_encryption_enabled = false


### PR DESCRIPTION
## Purpose
Redis clusters should have automatic backup enabled

Fixes DDPB-4789

## Approach
Security hub fix: Redis clusters should have automatic backup enabled

Just put it for 1 day as to be honest I can't see many reasons to need it for longer as we would always recreate in case of disaster.

## Learning
NA
## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
