### PR TITLE
DDPB-4735c update tg and development image

### DIFF
--- a/environment/admin_tg.tf
+++ b/environment/admin_tg.tf
@@ -1,5 +1,5 @@
 resource "aws_lb_target_group" "admin" {
-  name                 = "admin-${local.environment}"
+  name                 = "admin-tg-${local.environment}"
   port                 = 80
   protocol             = "HTTP"
   target_type          = "ip"

--- a/environment/ecr.tf
+++ b/environment/ecr.tf
@@ -1,11 +1,11 @@
 locals {
   docker_tag_elems = split("-", var.OPG_DOCKER_TAG)
-  client_tag       = local.environment == "development" ? "development-${local.docker_tag_elems[1]}" : var.OPG_DOCKER_TAG
+  client_web_tag   = local.environment == "development" ? "development-${local.docker_tag_elems[1]}" : var.OPG_DOCKER_TAG
 
   images = {
     api              = "${data.aws_ecr_repository.images["api"].repository_url}:${var.OPG_DOCKER_TAG}"
-    client           = "${data.aws_ecr_repository.images["client"].repository_url}:${local.client_tag}"
-    client-webserver = "${data.aws_ecr_repository.images["client-webserver"].repository_url}:${var.OPG_DOCKER_TAG}"
+    client           = "${data.aws_ecr_repository.images["client"].repository_url}:${var.OPG_DOCKER_TAG}"
+    client-webserver = "${data.aws_ecr_repository.images["client-webserver"].repository_url}:${local.client_web_tag}"
     sync             = "${data.aws_ecr_repository.images["sync"].repository_url}:${var.OPG_DOCKER_TAG}"
     htmltopdf        = "${data.aws_ecr_repository.images["htmltopdf"].repository_url}:${var.OPG_DOCKER_TAG}"
     drbackup         = "${data.aws_ecr_repository.images["dr-backup"].repository_url}:${var.OPG_DOCKER_TAG}"

--- a/environment/front_tg.tf
+++ b/environment/front_tg.tf
@@ -1,5 +1,5 @@
 resource "aws_lb_target_group" "front" {
-  name                 = "front-${local.environment}"
+  name                 = "front-tg-${local.environment}"
   port                 = 80
   protocol             = "HTTP"
   target_type          = "ip"


### PR DESCRIPTION
Because of lifecycle policy (and to avoid downtime) I have change the tg group name. Couldn't use name_prefix as it was max 6 chars and I really want to use the env name as part of it for identification so this is a compromise.

Additionally the tag was on the app image of development rather than the webserver image (another issue that is hard to test before path to live)