### PR TITLE
DDPB-4832 add extra filter for user research table to fix cleanup script

### DIFF
--- a/api/src/Repository/UserRepository.php
+++ b/api/src/Repository/UserRepository.php
@@ -181,6 +181,11 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             ->from('App\Entity\UserResearch\UserResearchResponse', 'urr')
             ->andWhere('urr.user = u');
 
+        $createdBySubquery = $this->_em->createQueryBuilder()
+            ->select('1')
+            ->from('App\Entity\User', 'us')
+            ->andWhere('us.createdBy = u');
+
         $qb = $this->createQueryBuilder('u');
         $qb
             ->select($select)
@@ -190,6 +195,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             ->andWhere($qb->expr()->not($qb->expr()->exists($feedbackSubquery->getDQL())))
             ->andWhere($qb->expr()->not($qb->expr()->exists($reportSubquery->getDQL())))
             ->andWhere($qb->expr()->not($qb->expr()->exists($ndrSubquery->getDQL())))
+            ->andWhere($qb->expr()->not($qb->expr()->exists($createdBySubquery->getDQL())))
             ->setParameter('reg_cutoff', $thirtyDaysAgo)
             ->setParameter('lay_deputy_role', User::ROLE_LAY_DEPUTY);
 

--- a/api/src/Repository/UserRepository.php
+++ b/api/src/Repository/UserRepository.php
@@ -176,12 +176,18 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             ->from('App\Entity\Ndr\Ndr', 'n')
             ->andWhere('n.client = c');
 
+        $feedbackSubquery = $this->_em->createQueryBuilder()
+            ->select('1')
+            ->from('App\Entity\UserResearch\UserResearchResponse', 'urr')
+            ->andWhere('urr.user = u');
+
         $qb = $this->createQueryBuilder('u');
         $qb
             ->select($select)
             ->leftJoin('u.clients', 'c')
             ->andWhere('u.registrationDate < :reg_cutoff')
             ->andWhere('u.roleName = :lay_deputy_role')
+            ->andWhere($qb->expr()->not($qb->expr()->exists($feedbackSubquery->getDQL())))
             ->andWhere($qb->expr()->not($qb->expr()->exists($reportSubquery->getDQL())))
             ->andWhere($qb->expr()->not($qb->expr()->exists($ndrSubquery->getDQL())))
             ->setParameter('reg_cutoff', $thirtyDaysAgo)


### PR DESCRIPTION
## Purpose

Script failing on join deletion.

Fixes DDPB-4832

## Approach
The logic was supposed to be anything that doesn't have a report or NDR 30 days after registering, ditch it. However a user had left feedback and this was a foreign key constraint that was causing this job to fail. 

As we may want to see user feedback from users that had issues signing up, we decided to just not delete those users that have left feedback independent of reports or NDRs.

Tested in preprod, saw we needed to add an extra bit and restested... now we get:

<img width="459" alt="image" src="https://github.com/ministryofjustice/opg-digideps/assets/58939809/3f394fd6-1090-4e75-82cf-31a6c8f6f374">

This will work equally in live

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
