### PR TITLE
Remove missing assets path

### DIFF
--- a/client/docker/app/Dockerfile
+++ b/client/docker/app/Dockerfile
@@ -66,7 +66,6 @@ COPY --chown=www-data:www-data --from=composer /app/composer.lock composer.lock
 COPY --chown=www-data:www-data --from=composer /app/config/parameters.yml config/parameters.yml
 COPY --chown=www-data:www-data client/app/config config
 COPY --chown=www-data:www-data client/app/public public
-COPY --chown=www-data:www-data client/resources/public/ public/
 COPY --chown=www-data:www-data client/app/scripts scripts
 COPY --chown=www-data:www-data client/app/src src
 COPY --chown=www-data:www-data client/app/templates templates

--- a/client/docker/web/Dockerfile
+++ b/client/docker/web/Dockerfile
@@ -15,7 +15,6 @@ RUN wget -q -O /usr/local/bin/waitforit https://github.com/maxcnunes/waitforit/r
   && chmod +x /usr/local/bin/waitforit
 
 COPY --chown=nginx client/docker/web/confd /etc/confd
-COPY --chown=nginx client/resources/public/ public/
 
 RUN apk --no-cache add libcap && \
     setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx && \


### PR DESCRIPTION
## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

This commit add path client/resources/public/
https://github.com/ministryofjustice/opg-digideps/pull/1405

This commit removes it again...
https://github.com/ministryofjustice/opg-digideps/pull/1438
...in favour of storing assets in client/resources/assets/ assets/

Docker files still have old path so local build breaks. This PR removes the redundant path

Fixes DDLS-1

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
