### PR TITLE
Revert "DDPB-4846 - re-add XSS waf rule (#1443)"

### DIFF
--- a/terraform/account/waf.tf
+++ b/terraform/account/waf.tf
@@ -70,6 +70,13 @@ resource "aws_wafv2_web_acl" "main" {
           name = "SizeRestrictions_BODY"
         }
 
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+          name = "CrossSiteScripting_BODY"
+        }
+
       }
     }
     visibility_config {


### PR DESCRIPTION
This reverts commit c31a9379d6b84b3038e9638a559fcc42eaf31df3.

Still an issue, pdfs get blocked without this.
