### PR TITLE
DDLS-40 move to shared cache part2

### DIFF
--- a/terraform/environment/admin_sg.tf
+++ b/terraform/environment/admin_sg.tf
@@ -30,13 +30,13 @@ locals {
       target_type = "security_group_id"
       target      = module.frontend_cache_security_group.id
     }
-    #    cache_front = {
-    #      port        = 6379
-    #      type        = "egress"
-    #      protocol    = "tcp"
-    #      target_type = "security_group_id"
-    #      target      = data.aws_security_group.front_cache_sg.id
-    #    }
+    cache_front = {
+      port        = 6379
+      type        = "egress"
+      protocol    = "tcp"
+      target_type = "security_group_id"
+      target      = data.aws_security_group.front_cache_sg.id
+    }
     api = {
       port        = 80
       type        = "egress"

--- a/terraform/environment/api_sg.tf
+++ b/terraform/environment/api_sg.tf
@@ -13,13 +13,13 @@ locals {
       target_type = "security_group_id"
       target      = module.api_cache_security_group.id
     }
-    #    cache_api = {
-    #      port        = 6379
-    #      type        = "egress"
-    #      protocol    = "tcp"
-    #      target_type = "security_group_id"
-    #      target      = data.aws_security_group.api_cache_sg.id
-    #    }
+    cache_api = {
+      port        = 6379
+      type        = "egress"
+      protocol    = "tcp"
+      target_type = "security_group_id"
+      target      = data.aws_security_group.api_cache_sg.id
+    }
     rds = {
       port        = 5432
       type        = "egress"

--- a/terraform/environment/dns_private.tf
+++ b/terraform/environment/dns_private.tf
@@ -13,16 +13,14 @@ resource "aws_route53_record" "frontend_redis" {
   name    = "frontend-redis"
   type    = "CNAME"
   zone_id = aws_route53_zone.internal.id
-  records = [aws_elasticache_replication_group.frontend.primary_endpoint_address]
-  #  records = [data.aws_elasticache_replication_group.front_cache_cluster.primary_endpoint_address]
-  ttl = 300
+  records = [data.aws_elasticache_replication_group.front_cache_cluster.primary_endpoint_address]
+  ttl     = 300
 }
 
 resource "aws_route53_record" "api_redis" {
   name    = "api-redis"
   type    = "CNAME"
   zone_id = aws_route53_zone.internal.id
-  #  records = [data.aws_elasticache_replication_group.api_cache_cluster.primary_endpoint_address]
-  records = [aws_elasticache_replication_group.api.primary_endpoint_address]
+  records = [data.aws_elasticache_replication_group.api_cache_cluster.primary_endpoint_address]
   ttl     = 300
 }

--- a/terraform/environment/elasticache.tf
+++ b/terraform/environment/elasticache.tf
@@ -1,49 +1,49 @@
-## Frontend Elasticache
-#
-#data "aws_elasticache_replication_group" "front_cache_cluster" {
-#  replication_group_id = "frontend-redis-${local.account.name}"
-#}
-#
-#data "aws_security_group" "front_cache_sg" {
-#  name = "${local.account.name}-account-cache-frontend"
-#}
-#
-#resource "aws_security_group_rule" "admin_to_redis" {
-#  description              = "Admin to to front cache cluster"
-#  from_port                = 6379
-#  to_port                  = 6379
-#  type                     = "ingress"
-#  protocol                 = "tcp"
-#  security_group_id        = data.aws_security_group.front_cache_sg.id
-#  source_security_group_id = module.admin_service_security_group.id
-#}
-#
-#resource "aws_security_group_rule" "front_to_redis" {
-#  description              = "Frontend to front cache cluster"
-#  from_port                = 6379
-#  to_port                  = 6379
-#  type                     = "ingress"
-#  protocol                 = "tcp"
-#  security_group_id        = data.aws_security_group.front_cache_sg.id
-#  source_security_group_id = module.front_service_security_group.id
-#}
-#
-## API Elasticache
-#
-#data "aws_elasticache_replication_group" "api_cache_cluster" {
-#  replication_group_id = "api-redis-${local.account.name}"
-#}
-#
-#data "aws_security_group" "api_cache_sg" {
-#  name = "${local.account.name}-account-cache-api"
-#}
-#
-#resource "aws_security_group_rule" "api_to_redis" {
-#  description              = "Api to Api cache cluster"
-#  from_port                = 6379
-#  to_port                  = 6379
-#  type                     = "ingress"
-#  protocol                 = "tcp"
-#  security_group_id        = data.aws_security_group.api_cache_sg.id
-#  source_security_group_id = module.api_service_security_group.id
-#}
+# Frontend Elasticache
+
+data "aws_elasticache_replication_group" "front_cache_cluster" {
+  replication_group_id = "frontend-redis-${local.account.name}"
+}
+
+data "aws_security_group" "front_cache_sg" {
+  name = "${local.account.name}-account-cache-frontend"
+}
+
+resource "aws_security_group_rule" "admin_to_redis" {
+  description              = "Admin to to front cache cluster"
+  from_port                = 6379
+  to_port                  = 6379
+  type                     = "ingress"
+  protocol                 = "tcp"
+  security_group_id        = data.aws_security_group.front_cache_sg.id
+  source_security_group_id = module.admin_service_security_group.id
+}
+
+resource "aws_security_group_rule" "front_to_redis" {
+  description              = "Frontend to front cache cluster"
+  from_port                = 6379
+  to_port                  = 6379
+  type                     = "ingress"
+  protocol                 = "tcp"
+  security_group_id        = data.aws_security_group.front_cache_sg.id
+  source_security_group_id = module.front_service_security_group.id
+}
+
+# API Elasticache
+
+data "aws_elasticache_replication_group" "api_cache_cluster" {
+  replication_group_id = "api-redis-${local.account.name}"
+}
+
+data "aws_security_group" "api_cache_sg" {
+  name = "${local.account.name}-account-cache-api"
+}
+
+resource "aws_security_group_rule" "api_to_redis" {
+  description              = "Api to Api cache cluster"
+  from_port                = 6379
+  to_port                  = 6379
+  type                     = "ingress"
+  protocol                 = "tcp"
+  security_group_id        = data.aws_security_group.api_cache_sg.id
+  source_security_group_id = module.api_service_security_group.id
+}

--- a/terraform/environment/front_sg.tf
+++ b/terraform/environment/front_sg.tf
@@ -30,13 +30,13 @@ locals {
       target_type = "security_group_id"
       target      = module.frontend_cache_security_group.id
     }
-    #    cache_front = {
-    #      port        = 6379
-    #      type        = "egress"
-    #      protocol    = "tcp"
-    #      target_type = "security_group_id"
-    #      target      = data.aws_security_group.front_cache_sg.id
-    #    }
+    cache_front = {
+      port        = 6379
+      type        = "egress"
+      protocol    = "tcp"
+      target_type = "security_group_id"
+      target      = data.aws_security_group.front_cache_sg.id
+    }
     api = {
       port        = 80
       type        = "egress"


### PR DESCRIPTION
## Purpose
Move the used cache from environment specific cache to shared cache

Fixes DDLS-40

## Approach
This is part 2. In part 1 we created the shared cache and changed all the keys to prepend the environment. We talked about how this did not change the functionality of production as it's a single environment account but would be a good saving for dev and preprod.

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
