### PR TITLE
DDLS-59 resubmit resubmittable documents on a nightly basis

### DIFF
--- a/api/app/src/Command/ResyncResubmittableErrorDocuments.php
+++ b/api/app/src/Command/ResyncResubmittableErrorDocuments.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Command;
+
+use App\Repository\DocumentRepository;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ResyncResubmittableErrorDocuments extends Command
+{
+    protected static $defaultName = 'digideps:resync-resubmittable-error-documents';
+
+    /** @var DocumentRepository */
+    private $documentRepository;
+
+    public function __construct(DocumentRepository $documentRepository)
+    {
+        $this->documentRepository = $documentRepository;
+
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            $updatedDocuments = $this->documentRepository->getResubmittableErrorDocumentsAndSetToQueued('100');
+            $output->writeln('resync_resubmittable_error_documents - success - Updated '.count($updatedDocuments).' documents back to QUEUED status');
+
+            return 0;
+        } catch (Exception $e) {
+            $output->writeln('resync_resubmittable_error_documents - failure - Failed to update documents back to QUEUED status');
+            $output->writeln($e);
+
+            return 1;
+        }
+    }
+}

--- a/terraform/account/elasticache.tf
+++ b/terraform/account/elasticache.tf
@@ -12,7 +12,8 @@ resource "aws_elasticache_replication_group" "cache_api" {
   subnet_group_name          = local.account.ec_subnet_group
   security_group_ids         = [aws_security_group.cache_api_sg.id]
   snapshot_retention_limit   = 1
-  apply_immediately          = true
+  apply_immediately          = local.account.apply_immediately
+  maintenance_window         = local.account.name == "production" ? "wed:04:00-wed:06:00" : "tue:04:00-tue:06:00"
   at_rest_encryption_enabled = true
   #tfsec:ignore:aws-elasticache-enable-in-transit-encryption - too much of a performance hit. To be re-evaluated.
   transit_encryption_enabled = false
@@ -46,7 +47,8 @@ resource "aws_elasticache_replication_group" "front_api" {
   subnet_group_name          = local.account.ec_subnet_group
   security_group_ids         = [aws_security_group.cache_front_sg.id]
   snapshot_retention_limit   = 1
-  apply_immediately          = true
+  apply_immediately          = local.account.apply_immediately
+  maintenance_window         = local.account.name == "production" ? "wed:04:00-wed:06:00" : "tue:04:00-tue:06:00"
   at_rest_encryption_enabled = true
   #tfsec:ignore:aws-elasticache-enable-in-transit-encryption - too much of a performance hit. To be re-evaluated.
   transit_encryption_enabled = false

--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -11,7 +11,8 @@
         "domains_allowed": ["deputy-reporting.api.opg.service.justice.gov.uk."],
         "domains_blocked": ["*."]
       },
-      "sirius_account_id": "649098267436"
+      "sirius_account_id": "649098267436",
+      "apply_immediately": false
     },
     "preproduction": {
       "account_id": "454262938596",
@@ -26,7 +27,8 @@
         ],
         "domains_blocked": ["*."]
       },
-      "sirius_account_id": "492687888235"
+      "sirius_account_id": "492687888235",
+      "apply_immediately": false
     },
     "development": {
       "account_id": "248804316466",
@@ -41,7 +43,8 @@
         ],
         "domains_blocked": ["*."]
       },
-      "sirius_account_id": "288342028542"
+      "sirius_account_id": "288342028542",
+      "apply_immediately": true
     }
   }
 }

--- a/terraform/account/variables.tf
+++ b/terraform/account/variables.tf
@@ -16,6 +16,7 @@ variable "accounts" {
         domains_blocked = list(string)
       })
       sirius_account_id = string
+      apply_immediately = bool
     })
   )
 }

--- a/terraform/environment/scheduled_events.tf
+++ b/terraform/environment/scheduled_events.tf
@@ -74,6 +74,43 @@ resource "aws_cloudwatch_event_target" "delete_zero_activity_users" {
   )
 }
 
+# Resubmit re-submittable error documents
+resource "aws_cloudwatch_event_rule" "resubmit_error_documents" {
+  name                = "resync-resubmittable-error-documents-${local.environment}"
+  description         = "Resync resubmittable error documents in ${terraform.workspace}"
+  schedule_expression = "cron(00 08 * * ? *)"
+  tags                = local.default_tags
+}
+
+resource "aws_cloudwatch_event_target" "resubmit_error_documents" {
+  rule     = aws_cloudwatch_event_rule.resubmit_error_documents.name
+  arn      = aws_ecs_cluster.main.arn
+  role_arn = aws_iam_role.events_task_runner.arn
+
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.api.arn
+    launch_type         = "FARGATE"
+    platform_version    = "1.4.0"
+
+    network_configuration {
+      security_groups  = [module.api_service_security_group.id]
+      subnets          = data.aws_subnet.private.*.id
+      assign_public_ip = false
+    }
+  }
+  input = jsonencode(
+    {
+      "containerOverrides" : [
+        {
+          "name" : "api_app",
+          "command" : ["sh", "scripts/task_run_console_command.sh", "digideps:resync-resubmittable-error-documents"]
+        }
+      ]
+    }
+  )
+}
+
 # Redeploy file scanner
 
 data "aws_lambda_function" "redeployer_lambda" {


### PR DESCRIPTION
## Purpose
Sync docs nightly

Fixes DDLS-59

## Approach
Some docs fail to sync sometimes because of an outage on sirius side or some other networking issue. We know which error statuses will likely resync when we try again so this is a nightly job that sets them back to queued. 

Another thing I am pushing through as part of this ticket is to change the elasticache to have a maintenance window and not apply immediately. I have set them 1 day apart for pre and prod to show any issues in pre the previous day. This will make upgrades easier.

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
