### PR TITLE
DDLS-68 add default tags to resources

### DIFF
--- a/terraform/account/provider.tf
+++ b/terraform/account/provider.tf
@@ -11,7 +11,9 @@ terraform {
 
 provider "aws" {
   region = "eu-west-1"
-
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::${var.accounts[terraform.workspace].account_id}:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
@@ -21,7 +23,9 @@ provider "aws" {
 provider "aws" {
   region = "eu-west-1"
   alias  = "management"
-
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::311462405659:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
@@ -31,7 +35,9 @@ provider "aws" {
 provider "aws" {
   region = "us-east-1"
   alias  = "us-east-1"
-
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account["account_id"]}:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"

--- a/terraform/environment/provider.tf
+++ b/terraform/environment/provider.tf
@@ -11,7 +11,9 @@ terraform {
 
 provider "aws" {
   region = "eu-west-1"
-
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account["account_id"]}:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
@@ -21,7 +23,9 @@ provider "aws" {
 provider "aws" {
   region = "eu-west-1"
   alias  = "management"
-
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::311462405659:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
@@ -32,7 +36,9 @@ provider "aws" {
 provider "aws" {
   region = "eu-west-1"
   alias  = "dns"
-
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::515688267891:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
@@ -42,7 +48,9 @@ provider "aws" {
 provider "aws" {
   region = "eu-west-1"
   alias  = "development"
-
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::248804316466:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
@@ -52,7 +60,9 @@ provider "aws" {
 provider "aws" {
   region = "eu-west-1"
   alias  = "preproduction"
-
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::454262938596:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
@@ -62,7 +72,9 @@ provider "aws" {
 provider "aws" {
   region = "eu-west-1"
   alias  = "production"
-
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::515688267891:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
@@ -72,7 +84,9 @@ provider "aws" {
 provider "aws" {
   region = "us-east-1"
   alias  = "us-east-1"
-
+  default_tags {
+    tags = local.default_tags
+  }
   assume_role {
     role_arn     = "arn:aws:iam::${local.account["account_id"]}:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"


### PR DESCRIPTION
I've checked with plans against preproduction for account and environment and it doesn't remove any tagging or recreate anything unexpected.