### PR TITLE
DDLS-74: CSV upload pages missing status

### DIFF
--- a/client/app/src/Controller/Admin/IndexController.php
+++ b/client/app/src/Controller/Admin/IndexController.php
@@ -470,8 +470,8 @@ class IndexController extends AbstractController
             $this->addFlash('error', 'There was a problem locating the file inside the S3 Bucket. Please contact an administrator.');
         }
 
-        $processStatus = $redisClient->get('lay-csv-processing');
-        $processCompletedDate = $redisClient->get('lay-csv-completed-date');
+        $processStatus = $redisClient->get($this->workspace.'-lay-csv-processing');
+        $processCompletedDate = $redisClient->get($this->workspace.'-lay-csv-completed-date');
 
         return [
             'nOfChunks' => $request->get('nOfChunks'),
@@ -575,8 +575,8 @@ class IndexController extends AbstractController
             $this->addFlash('error', 'There was a problem locating the file inside the S3 Bucket. Please contact an administrator.');
         }
 
-        $processStatus = $redisClient->get('org-csv-processing');
-        $processCompletedDate = $redisClient->get('org-csv-completed-date');
+        $processStatus = $redisClient->get($this->workspace.'-org-csv-processing');
+        $processCompletedDate = $redisClient->get($this->workspace.'-org-csv-completed-date');
 
         return [
             'form' => $form->createView(),


### PR DESCRIPTION
## Purpose
The CSV upload pages were missing their statuses as a result of a recent change to how we use redis.
Redis keys are now stored in with the workspace (environment) name prepending the key name - `environment_keyname`

The setting of the keys were changed in the initial PR, however the retrieval wasn't updated along side this.

Fixes DDLS-74

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
