### PR TITLE
DDLS-37 - update RDS certs

### DIFF
--- a/terraform/environment/api_rds.tf
+++ b/terraform/environment/api_rds.tf
@@ -5,6 +5,7 @@ module "api_aurora" {
   account_id             = data.aws_caller_identity.current.account_id
   apply_immediately      = local.account.deletion_protection ? false : true
   cluster_identifier     = "api"
+  ca_cert_identifier     = "rds-ca-2019"
   db_subnet_group_name   = local.account.db_subnet_group
   deletion_protection    = local.account.deletion_protection ? true : false
   database_name          = "api"

--- a/terraform/environment/api_rds.tf
+++ b/terraform/environment/api_rds.tf
@@ -5,7 +5,7 @@ module "api_aurora" {
   account_id             = data.aws_caller_identity.current.account_id
   apply_immediately      = local.account.deletion_protection ? false : true
   cluster_identifier     = "api"
-  ca_cert_identifier     = "rds-ca-2019"
+  ca_cert_identifier     = "rds-ca-rsa2048-g1"
   db_subnet_group_name   = local.account.db_subnet_group
   deletion_protection    = local.account.deletion_protection ? true : false
   database_name          = "api"

--- a/terraform/environment/modules/aurora/main.tf
+++ b/terraform/environment/modules/aurora/main.tf
@@ -38,6 +38,7 @@ resource "aws_rds_cluster_instance" "cluster_instances" {
   engine                          = var.engine
   engine_version                  = var.engine_version
   identifier                      = "${var.cluster_identifier}-${terraform.workspace}-${count.index}"
+  ca_cert_identifier              = var.ca_cert_identifier
   instance_class                  = var.instance_class
   monitoring_interval             = 30
   monitoring_role_arn             = "arn:aws:iam::${var.account_id}:role/rds-enhanced-monitoring"
@@ -99,6 +100,7 @@ resource "aws_rds_cluster_instance" "serverless_instances" {
   engine                          = var.engine
   engine_version                  = var.engine_version
   identifier                      = "${var.cluster_identifier}-${terraform.workspace}-${count.index}"
+  ca_cert_identifier              = var.ca_cert_identifier
   instance_class                  = "db.serverless"
   monitoring_interval             = 30
   monitoring_role_arn             = "arn:aws:iam::${var.account_id}:role/rds-enhanced-monitoring"

--- a/terraform/environment/modules/aurora/variables.tf
+++ b/terraform/environment/modules/aurora/variables.tf
@@ -35,6 +35,11 @@ variable "cluster_identifier" {
   type        = string
 }
 
+variable "ca_cert_identifier" {
+  description = "Identifier of the CA certificate for the DB instance."
+  type        = string
+}
+
 variable "deletion_protection" {
   description = "Indicates whether deletion protection is enabled for the cluster."
   type        = bool


### PR DESCRIPTION
Updates our RDS to use the latest AWS CA cert.

This shouldn't require any downtime as can be updated in place - checked in branch env