### PR TITLE
DDLS-83 : Console command for generating the Satisfaction score

### DIFF
--- a/api/app/config/parameters.yml.dist
+++ b/api/app/config/parameters.yml.dist
@@ -43,11 +43,12 @@ parameters:
     api_base_url: https://api.digideps.local/
     s3_bucket_name: pa-uploads-local
     s3_sirius_bucket: sirius-bucket-local
+    s3_satisfaction_bucket: opg-performance-data
     s3_client_params:
         version: 'latest'
         region: 'eu-west-1'
         validate: true
 
     workspace: local
-    
+
     session_prefix: 'dd_api'

--- a/api/app/config/services.yml
+++ b/api/app/config/services.yml
@@ -206,25 +206,30 @@ services:
         class: App\Security\UserVoter
         tags:
             - { name: security.voter }
-          
+
     App\Service\Client\TokenStorage\RedisStorage:
         arguments:
-          $redis: "@snc_redis.default"
+            $redis: "@snc_redis.default"
 
     App\Service\DataImporter\CsvToArray: ~
 
     # Disable autowiring for these helper classes
     App\Service\ReportStatusService: ~
     App\Service\Stats\StatsQueryParameters: ~
-    
+
     Aws\S3\S3ClientInterface:
         alias: Aws\S3\S3Client
-    
+
     Aws\S3\S3Client:
         arguments: ["%s3_client_params%"]
-        
+
     App\Service\File\Storage\S3Storage:
-        arguments: [ '@Aws\S3\S3Client', "%s3_sirius_bucket%", "@logger" ]
+        arguments: ['@Aws\S3\S3Client', "%s3_sirius_bucket%", "@logger"]
+
+    App\Service\File\Storage\S3SatisfactionDataStorage:
+        parent: App\Service\File\Storage\S3Storage
+        arguments:
+            index_1: "%s3_satisfaction_bucket%"
 
     Symfony\Component\Security\Core\Role\RoleHierarchyInterface: "@security.role_hierarchy"
 

--- a/api/app/src/Command/SatisfactionPerformanceStatsCommand.php
+++ b/api/app/src/Command/SatisfactionPerformanceStatsCommand.php
@@ -58,6 +58,9 @@ class SatisfactionPerformanceStatsCommand extends Command
             $satisfactionScores = [];
             $statsStartDate = (new \DateTime('FIRST DAY OF PREVIOUS MONTH'))->format('Y-m-d');
 
+            $statsYear = (new \DateTime('FIRST DAY OF PREVIOUS MONTH'))->format('y');
+            $statsMonth = (new \DateTime('FIRST DAY OF PREVIOUS MONTH'))->format('m');
+
             foreach ($satisfactionScoresResults[0] as $satisfactionScoreKey => $satisfactionScoreRow) {
                 $satisfactionScores[] = [
                     '_timestamp' => $statsStartDate.'T00:00:00+00:00',
@@ -71,7 +74,9 @@ class SatisfactionPerformanceStatsCommand extends Command
 
             $satisfactionScoresJson = json_encode($satisfactionScores, JSON_PRETTY_PRINT);
 
-            $this->s3SatisfactionDataStorage->store('digideps_satisfaction_data.json', $satisfactionScoresJson);
+            $s3FileName = 'complete_the_deputy_report_'.$statsYear.'_'.$statsMonth.'.json';
+
+            $this->s3SatisfactionDataStorage->store($s3FileName, $satisfactionScoresJson);
 
             $output->writeln('satisfaction_performance_stats - success - Successfully extracted the satisfaction scores for Digideps');
 

--- a/api/app/src/Command/SatisfactionPerformanceStatsCommand.php
+++ b/api/app/src/Command/SatisfactionPerformanceStatsCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Command;
+
+use App\Service\File\Storage\S3SatisfactionDataStorage;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SatisfactionPerformanceStatsCommand extends Command
+{
+    protected static $defaultName = 'digideps:satisfaction-performance-stats';
+
+    /** @var EntityManagerInterface */
+    private $em;
+
+    /** @var S3SatisfactionDataStorage */
+    private $s3SatisfactionDataStorage;
+
+    public function __construct(EntityManagerInterface $em, S3SatisfactionDataStorage $s3SatisfactionDataStorage)
+    {
+        $this->em = $em;
+        $this->s3SatisfactionDataStorage = $s3SatisfactionDataStorage;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Fetches the satisfaction scores for Digideps and prepares the json data for update on the Opg Services Performance Data repo')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            $satisfactionScoresQuery = "
+                    SELECT
+                        ROUND(AVG(score - 1) * 25) AS user_satisfaction_percent,
+                        count(CASE WHEN score = 1 THEN 1 END) AS very_dissatisfied,
+                        count(CASE WHEN score = 2 THEN 1 END) AS dissatisfied,
+                        count(CASE WHEN score = 3 THEN 1 END) AS neither,
+                        count(CASE WHEN score = 4 THEN 1 END) AS satisfied,
+                        count(CASE WHEN score = 5 THEN 1 END) AS very_satisfied
+                    FROM satisfaction
+                    WHERE (report_id IS NOT NULL OR ndr_id IS NOT NULL)
+                    AND created_at >= date_trunc('month', CURRENT_DATE - INTERVAL '1' month)
+                    AND created_at <= date_trunc('month', CURRENT_DATE) - INTERVAL '1' second
+            ";
+
+            $conn = $this->em->getConnection();
+            $statsStmt = $conn->prepare($satisfactionScoresQuery);
+            $result = $statsStmt->executeQuery();
+            $satisfactionScoresResults = $result->fetchAllAssociative();
+
+            $satisfactionScores = [];
+            $statsStartDate = (new \DateTime('FIRST DAY OF PREVIOUS MONTH'))->format('Y-m-d');
+
+            foreach ($satisfactionScoresResults[0] as $satisfactionScoreKey => $satisfactionScoreRow) {
+                $satisfactionScores[] = [
+                    '_timestamp' => $statsStartDate.'T00:00:00+00:00',
+                    'service' => 'deputy-reporting',
+                    'channel' => 'digital',
+                    'count' => $satisfactionScoreRow,
+                    'dataType' => str_replace('-', '_', $satisfactionScoreKey),
+                    'period' => 'month',
+                ];
+            }
+
+            $satisfactionScoresJson = json_encode($satisfactionScores, JSON_PRETTY_PRINT);
+
+            $this->s3SatisfactionDataStorage->store('data.json', $satisfactionScoresJson);
+
+            $output->writeln('Done');
+
+            return 0;
+        } catch (Exception $e) {
+            $output->writeln('delete_zero_activity_users - failure - Failed to delete lay user(s) that have never had any activity after 30 days of registration');
+            $output->writeln($e);
+
+            return 1;
+        }
+    }
+}

--- a/api/app/src/Command/SatisfactionPerformanceStatsCommand.php
+++ b/api/app/src/Command/SatisfactionPerformanceStatsCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SatisfactionPerformanceStatsCommand extends Command
 {
-    protected static $defaultName = 'digideps:satisfaction-performance-stats';
+    public static $defaultName = 'digideps:satisfaction-performance-stats';
 
     /** @var EntityManagerInterface */
     private $em;
@@ -71,13 +71,13 @@ class SatisfactionPerformanceStatsCommand extends Command
 
             $satisfactionScoresJson = json_encode($satisfactionScores, JSON_PRETTY_PRINT);
 
-            $this->s3SatisfactionDataStorage->store('data.json', $satisfactionScoresJson);
+            $this->s3SatisfactionDataStorage->store('digideps_satisfaction_data.json', $satisfactionScoresJson);
 
-            $output->writeln('Done');
+            $output->writeln('satisfaction_performance_stats - success - Successfully extracted the satisfaction scores for Digideps');
 
             return 0;
-        } catch (Exception $e) {
-            $output->writeln('delete_zero_activity_users - failure - Failed to delete lay user(s) that have never had any activity after 30 days of registration');
+        } catch (\Exception $e) {
+            $output->writeln('satisfaction_performance_stats - failure - Failed to extract the satisfaction scores for Digideps');
             $output->writeln($e);
 
             return 1;

--- a/api/app/src/Service/File/Storage/S3SatisfactionDataStorage.php
+++ b/api/app/src/Service/File/Storage/S3SatisfactionDataStorage.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Service\File\Storage;
+
+use Aws\S3\S3ClientInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class to upload/download/delete files from S3.
+ *
+ * Original logic
+ * https://github.com/ministryofjustice/opg-av-test/blob/master/public/index.php
+ */
+class S3SatisfactionDataStorage extends S3Storage
+{
+    /**
+     * S3SatisfactionDataStorage constructor.
+     *
+     * https://github.com/aws/aws-sdk-php
+     * http://docs.aws.amazon.com/aws-sdk-php/v2/api/class-Aws.S3.S3Client.html.
+     *
+     * for fake s3:
+     * https://github.com/jubos/fake-s3
+     * https://github.com/jubos/fake-s3/wiki/Supported-Clients
+     */
+    public function __construct(S3ClientInterface $s3Client, string $bucketName, LoggerInterface $logger)
+    {
+        parent::__construct($s3Client, $bucketName, $logger);
+    }
+}

--- a/api/app/tests/Unit/Command/SatisfactionPerformanceStatsCommandTest.php
+++ b/api/app/tests/Unit/Command/SatisfactionPerformanceStatsCommandTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Tests\Unit\Entity\Command;
+
+use App\Command\SatisfactionPerformanceStatsCommand;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class SatisfactionPerformanceStatsCommandTest extends KernelTestCase
+{
+    public function setUp(): void
+    {
+        $kernel = static::createKernel();
+        $app = new Application($kernel);
+
+        $command = $app->find(SatisfactionPerformanceStatsCommand::$defaultName);
+        $this->commandTester = new CommandTester($command);
+    }
+
+    public function testExecuteSuccessful()
+    {
+        $this->commandTester->execute([]);
+        $output = $this->commandTester->getDisplay();
+        self::assertStringContainsString('satisfaction_performance_stats - success - Successfully extracted the satisfaction scores for Digideps', $output);
+    }
+}

--- a/api/docker/app/confd/templates/parameters.yml.tmpl
+++ b/api/docker/app/confd/templates/parameters.yml.tmpl
@@ -68,6 +68,7 @@ parameters:
     {{ else }}
         validate: true
     {{ end }}
+    s3_satisfaction_bucket: opg-performance-data
     s3_sirius_bucket: {{ if exists "/s3/sirius/bucket" }}{{ getv "/s3/sirius/bucket" }}{{ else }}not_set{{ end }}
     pa_pro_report_csv_filename: {{ if exists "/pa/pro/report/csv/filename" }}{{ getv "/pa/pro/report/csv/filename" }}{{ else }}not_set{{ end }}
     lay_report_csv_filename: {{ if exists "/lay/report/csv/filename" }}{{ getv "/lay/report/csv/filename" }}{{ else }}not_set{{ end }}

--- a/local-resources/localstack/localstack-init.sh
+++ b/local-resources/localstack/localstack-init.sh
@@ -10,6 +10,7 @@ fi
 
 awslocal s3 mb s3://pa-uploads-local
 awslocal s3 mb s3://sirius-bucket-local
+awslocal s3 mb s3://opg-performance-data
 
 awslocal s3 cp /tmp/paProDeputyReport.csv s3://sirius-bucket-local/paProDeputyReport.csv
 awslocal s3 cp /tmp/layDeputyReport.csv s3://sirius-bucket-local/layDeputyReport.csv
@@ -21,6 +22,10 @@ awslocal s3api put-bucket-policy \
 awslocal s3api put-bucket-policy \
     --policy '{ "Statement": [ { "Sid": "DenyUnEncryptedObjectUploads", "Effect": "Deny", "Principal": { "AWS": "*" }, "Action": "s3:PutObject", "Resource": "arn:aws:s3:eu-west-1::sirius-bucket/*", "Condition":  { "StringNotEquals": { "s3:x-amz-server-side-encryption": "AES256" } } }, { "Sid": "DenyUnEncryptedObjectUploads", "Effect": "Deny", "Principal": { "AWS": "*" }, "Action": "s3:PutObject", "Resource": "arn:aws:s3:eu-west-1::sirius-bucket/*", "Condition":  { "Bool": { "aws:SecureTransport": false } } } ] }' \
     --bucket "sirius-bucket-local"
+
+awslocal s3api put-bucket-policy \
+    --policy '{ "Statement": [ { "Sid": "DenyUnEncryptedObjectUploads", "Effect": "Deny", "Principal": { "AWS": "*" }, "Action": "s3:PutObject", "Resource": "arn:aws:s3:eu-west-1::opg-performance-data/*", "Condition":  { "StringNotEquals": { "s3:x-amz-server-side-encryption": "AES256" } } }, { "Sid": "DenyUnEncryptedObjectUploads", "Effect": "Deny", "Principal": { "AWS": "*" }, "Action": "s3:PutObject", "Resource": "arn:aws:s3:eu-west-1::opg-performance-data/*", "Condition":  { "Bool": { "aws:SecureTransport": false } } } ] }' \
+    --bucket "opg-performance-data"
 
 awslocal ssm put-parameter --name "/local/flag/checklist-sync" --value "1" --type String --overwrite
 awslocal ssm put-parameter --name "/local/flag/document-sync" --value "1" --type String --overwrite

--- a/terraform/environment/region/cloudwatch_scheduled_events.tf
+++ b/terraform/environment/region/cloudwatch_scheduled_events.tf
@@ -56,7 +56,7 @@ resource "aws_cloudwatch_event_target" "csv_automation_org_processing" {
 
     network_configuration {
       security_groups  = [module.api_service_security_group.id]
-      subnets          = data.aws_subnet.private.*.id
+      subnets          = data.aws_subnet.private[*].id
       assign_public_ip = false
     }
   }
@@ -302,4 +302,42 @@ resource "aws_cloudwatch_event_target" "document_sync" {
       security_groups  = [module.document_sync_service_security_group.id]
     }
   }
+}
+
+# Extract Satisfaction Scores
+
+resource "aws_cloudwatch_event_rule" "satisfaction_performance_stats" {
+  name                = "satisfaction-performance-stats-${local.environment}"
+  description         = "Extract Satisfaction Scores in ${terraform.workspace}"
+  schedule_expression = "cron(0 10 1 * ? *)"
+  tags                = var.default_tags
+}
+
+resource "aws_cloudwatch_event_target" "satisfaction_performance_stats" {
+  rule     = aws_cloudwatch_event_rule.satisfaction_performance_stats.name
+  arn      = aws_ecs_cluster.main.arn
+  role_arn = aws_iam_role.events_task_runner.arn
+
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.api.arn
+    launch_type         = "FARGATE"
+    platform_version    = "1.4.0"
+
+    network_configuration {
+      security_groups  = [module.api_service_security_group.id]
+      subnets          = data.aws_subnet.private[*].id
+      assign_public_ip = false
+    }
+  }
+  input = jsonencode(
+    {
+      "containerOverrides" : [
+        {
+          "name" : "api_app",
+          "command" : ["sh", "scripts/task_run_console_command.sh", "digideps:satisfaction-performance-stats"]
+        }
+      ]
+    }
+  )
 }


### PR DESCRIPTION
## Purpose

Fixes [DDLS-83](https://opgtransform.atlassian.net/browse/DDLS-83)

This change creates a console command to extract the satisfaction performance scores at the start of every month and upload the stats in the desired format to S3. A github action on the performance repo (opg-performance-data) would then pick up the extracted file from S3 merge it into the Digideps satisfaction scores file on the performance repo.

This automation change will eliminate the manual process at the start of every month.

## Approach

The code runs a raw query on the Digideps database to extract the figures and then uses the S3 service to upload the file into a new S3 bucket created specifically for this purpose. 

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values


[DDLS-83]: https://opgtransform.atlassian.net/browse/DDLS-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ