### PR TITLE
DDLS-84 : Satisfaction data cloudwatch event schedule updates

### DIFF
--- a/terraform/environment/region/cloudwatch_iam_events.tf
+++ b/terraform/environment/region/cloudwatch_iam_events.tf
@@ -28,6 +28,7 @@ locals {
   events_task_role_list = [
     aws_iam_role.front.arn,
     aws_iam_role.api.arn,
+    aws_iam_role.performance_data.arn,
     data.aws_iam_role.sync.arn,
     aws_iam_role.execution_role.arn,
   ]
@@ -39,7 +40,8 @@ locals {
     aws_ecs_task_definition.checklist_sync.arn,
     aws_ecs_task_definition.api.arn,
     aws_ecs_task_definition.document_sync.arn,
-    module.analyse.task_definition_arn
+    module.analyse.task_definition_arn,
+    module.performance_data.task_definition_arn
   ]
   combined_events_task_list = tolist(concat(local.events_task_list, local.events_dr_task_list))
 }

--- a/terraform/environment/region/cloudwatch_scheduled_events.tf
+++ b/terraform/environment/region/cloudwatch_scheduled_events.tf
@@ -316,7 +316,7 @@ resource "aws_cloudwatch_event_rule" "satisfaction_performance_stats" {
 resource "aws_cloudwatch_event_target" "satisfaction_performance_stats" {
   rule     = aws_cloudwatch_event_rule.satisfaction_performance_stats.name
   arn      = aws_ecs_cluster.main.arn
-  role_arn = aws_iam_role.events_task_runner.arn
+  role_arn = aws_iam_role.performance_data.arn
 
   ecs_target {
     task_count          = 1

--- a/terraform/environment/region/cloudwatch_scheduled_events_checks.tf
+++ b/terraform/environment/region/cloudwatch_scheduled_events_checks.tf
@@ -216,7 +216,7 @@ resource "aws_cloudwatch_event_target" "sync_checklists_check" {
 resource "aws_cloudwatch_event_rule" "satisfaction_performance_stats_check" {
   name                = "check-satisfaction-performance-stats-${terraform.workspace}"
   description         = "Extract Satisfaction Scores for ${terraform.workspace}"
-  schedule_expression = local.sync_service_cron_schedule
+  schedule_expression = "cron(0 12 1 * ? *)"
   is_enabled          = var.account.is_production == 1 ? true : false
 }
 

--- a/terraform/environment/region/ecs_iam_performance_data.tf
+++ b/terraform/environment/region/ecs_iam_performance_data.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role" "performance_data" {
-  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_policy.json
   name               = "performance-data.${local.environment}"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_policy.json
   tags               = var.default_tags
 }
 
@@ -29,5 +29,17 @@ data "aws_iam_policy_document" "performance_data" {
 resource "aws_iam_role_policy" "performance_data" {
   name   = "performance-data.${local.environment}"
   policy = data.aws_iam_policy_document.performance_data.json
+  role   = aws_iam_role.performance_data.id
+}
+
+resource "aws_iam_role_policy" "performance_data_task_logs" {
+  name   = "performance-data-task-logs.${local.environment}"
+  policy = data.aws_iam_policy_document.ecs_task_logs.json
+  role   = aws_iam_role.performance_data.id
+}
+
+resource "aws_iam_role_policy" "performance_data_query_ssm" {
+  name   = "performance-data-query-ssm.${local.environment}"
+  policy = data.aws_iam_policy_document.api_permissions.json
   role   = aws_iam_role.performance_data.id
 }

--- a/terraform/environment/region/ecs_task_performance_data.tf
+++ b/terraform/environment/region/ecs_task_performance_data.tf
@@ -39,6 +39,21 @@ locals {
       ],
       environment = [
         {
+          name  = "ADMIN_HOST",
+          value = "https://${var.admin_fully_qualified_domain_name}"
+        },
+        {
+          name  = "FRONTEND_HOST",
+          value = "https://${var.front_fully_qualified_domain_name}"
+        },
+        { name  = "JWT_HOST",
+          value = "https://${var.front_fully_qualified_domain_name}"
+        },
+        {
+          name  = "AUDIT_LOG_GROUP_NAME",
+          value = "audit-${local.environment}"
+        },
+        {
           name  = "DATABASE_HOSTNAME",
           value = local.db.endpoint
         },
@@ -55,12 +70,60 @@ locals {
           value = local.db.username
         },
         {
+          name  = "DATABASE_SSL",
+          value = "verify-full"
+        },
+        {
+          name  = "FEATURE_FLAG_PREFIX",
+          value = local.feature_flag_prefix
+        },
+        {
           name  = "FIXTURES_ACCOUNTPASSWORD",
           value = "DigidepsPass1234"
         },
         {
+          name  = "NGINX_APP_NAME",
+          value = "api"
+        },
+        {
+          name  = "OPG_DOCKER_TAG",
+          value = var.docker_tag
+        },
+        {
+          name  = "PARAMETER_PREFIX",
+          value = local.parameter_prefix
+        },
+        {
           name  = "REDIS_DSN",
           value = "redis://${aws_route53_record.api_redis.fqdn}"
+        },
+        {
+          name  = "SECRETS_PREFIX",
+          value = join("", [var.secrets_prefix, "/"])
+        },
+        {
+          name  = "SESSION_PREFIX",
+          value = "dd_api"
+        },
+        {
+          name  = "WORKSPACE",
+          value = local.environment
+        },
+        {
+          name  = "S3_BUCKETNAME",
+          value = "pa-uploads-${local.environment}"
+        },
+        {
+          name  = "S3_SIRIUS_BUCKET",
+          value = "digideps.${var.account.sirius_environment}.eu-west-1.sirius.opg.justice.gov.uk"
+        },
+        {
+          name  = "PA_PRO_REPORT_CSV_FILENAME",
+          value = "paProDeputyReport.csv"
+        },
+        {
+          name  = "LAY_REPORT_CSV_FILENAME",
+          value = "layDeputyReport.csv"
         }
       ]
     }


### PR DESCRIPTION
## Purpose
Cloudwatch events for satisfaction data
Fixes DDLS-84

## Approach
Create the scheduled events in terraform to run it.

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
