### PR TITLE
DDLS-130 add resubs for docs stuck in progress

### DIFF
--- a/api/app/src/Repository/DocumentRepository.php
+++ b/api/app/src/Repository/DocumentRepository.php
@@ -148,12 +148,21 @@ LEFT JOIN odr AS o on d.ndr_id = o.id
 LEFT JOIN report_submission AS rs on d.report_submission_id  = rs.id
 LEFT JOIN client AS c1 on r.client_id = c1.id
 LEFT JOIN client AS c2 on o.client_id = c2.id
-WHERE d.synchronisation_status='PERMANENT_ERROR'
-AND (
-    d.synchronisation_error LIKE 'Report PDF failed to sync%'
-    OR
-    d.synchronisation_error LIKE 'Document failed to sync after%'
-)
+WHERE
+    (
+        d.synchronisation_status='PERMANENT_ERROR'
+        AND
+            (
+                d.synchronisation_error LIKE 'Report PDF failed to sync%'
+                OR
+                d.synchronisation_error LIKE 'Document failed to sync after%'
+            )
+    ) OR
+    (
+        d.synchronisation_status='IN_PROGRESS'
+        AND
+        rs.created_on < (CURRENT_DATE - 1)
+    )
 ORDER BY is_report_pdf DESC, report_submission_id ASC
 LIMIT $limit;";
 


### PR DESCRIPTION
## Purpose
Handle docs stuck in IN_PROGRESS

Fixes DDLS-130

## Approach
Whilst rare (I've seen this maybe 3 or 4 times ever), we occasionally get docs stuck in progress. I didn't have the data to work out why but we had some old ones from a particular day. My only thought is that there was some network or container fail between setting them to in progress and setting them to SUCCESS or PERMANENT_ERROR.

If a doc is in progress then there shouldn't be any higher chance of anything being wrong with it than if it was queued so the solution is to set them back to queued. 

My approach was to add docs stuck in IN_PROGRESS for more than a day to be set back to queued along with the re-submittable error docs. This should take out some of the manual effort and investigation needed.

## Learning
NA

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
