### PR TITLE
DDLS-154 Create tests for money in and out for lay and organisational users

### DIFF
--- a/api/app/tests/Behat/bootstrap/v2/Common/BaseFeatureContext.php
+++ b/api/app/tests/Behat/bootstrap/v2/Common/BaseFeatureContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Behat\v2\Common;
 
+use App\Entity\User;
 use App\Service\File\Storage\S3Storage;
 use App\Service\ParameterStoreService;
 use App\TestHelpers\ReportTestHelper;
@@ -83,6 +84,8 @@ class BaseFeatureContext extends MinkContext
     public UserDetails $profAdminDeputyHealthWelfareNotStartedDetails;
     public UserDetails $profAdminDeputyHealthWelfareCompletedDetails;
     public UserDetails $profAdminDeputyHealthWelfareSubmittedDetails;
+    public UserDetails $profAdminDeputyNotStartedPfaLowAssetsDetails;
+    public UserDetails $profAdminDeputyCompletedPfaLowAssetsDetails;
 
     public UserDetails $profAdminCombinedHighNotStartedDetails;
     public UserDetails $profAdminCombinedHighCompletedDetails;
@@ -193,6 +196,15 @@ class BaseFeatureContext extends MinkContext
     }
 
     /**
+     * @BeforeScenario @prof-pfa-low-not-started
+     */
+    public function createProfPfaLowNotStarted()
+    {
+        $userDetails = $this->fixtureHelper->createProfPfaLowAssetsNotStarted($this->testRunId);
+        $this->fixtureUsers[] = $this->profAdminDeputyNotStartedPfaLowAssetsDetails = new UserDetails($userDetails);
+    }
+    
+    /**
      * @BeforeScenario @lay-pfa-low-completed
      */
     public function createPfaLowCompleted()
@@ -201,6 +213,15 @@ class BaseFeatureContext extends MinkContext
         $this->fixtureUsers[] = $this->layDeputyCompletedPfaLowAssetsDetails = new UserDetails($userDetails);
     }
 
+    /**
+     * @BeforeScenario @prof-pfa-low-completed
+     */
+    public function createProfPfaLowCompleted()
+    {
+        $userDetails = $this->fixtureHelper->createProfPfaLowAssetsCompleted($this->testRunId);
+        $this->fixtureUsers[] = $this->profAdminDeputyCompletedPfaLowAssetsDetails = new UserDetails($userDetails);
+    }
+    
     /**
      * @BeforeScenario @lay-health-welfare-not-started
      */

--- a/api/app/tests/Behat/bootstrap/v2/Common/ReportTrait.php
+++ b/api/app/tests/Behat/bootstrap/v2/Common/ReportTrait.php
@@ -225,6 +225,19 @@ trait ReportTrait
     }
 
     /**
+     * @Given a Professional Admin has not started a Pfa Low Assets report
+     */
+    public function aProfDeputyHasNotStartedAPfaLowAssetsReport()
+    {
+        if (empty($this->profAdminDeputyNotStartedPfaLowAssetsDetails)) {
+            throw new \Exception('It looks like fixtures are not loaded - missing $profAdminDeputyNotStartedPfaLowAssetsDetails');
+        }
+
+        $this->loginToFrontendAs($this->profAdminDeputyNotStartedPfaLowAssetsDetails->getUserEmail());
+        $this->interactingWithUserDetails = $this->profAdminDeputyNotStartedPfaLowAssetsDetails;
+    }
+    
+    /**
      * @Given a Lay Deputy has completed a Pfa Low Assets report
      */
     public function aLayDeputyHasCompletedAPfaLowAssetsReport()
@@ -235,6 +248,19 @@ trait ReportTrait
 
         $this->loginToFrontendAs($this->layDeputyCompletedPfaLowAssetsDetails->getUserEmail());
         $this->interactingWithUserDetails = $this->layDeputyCompletedPfaLowAssetsDetails;
+    }
+
+    /**
+     * @Given a Professional Admin has completed a Pfa Low Assets report
+     */
+    public function aProfAdminDeputyHasCompletedAPfaLowAssetsReport()
+    {
+        if (empty($this->profAdminDeputyCompletedPfaLowAssetsDetails)) {
+            throw new \Exception('It looks like fixtures are not loaded - missing $profAdminDeputyCompletedPfaLowAssetsDetails');
+        }
+
+        $this->loginToFrontendAs($this->profAdminDeputyCompletedPfaLowAssetsDetails->getUserEmail());
+        $this->interactingWithUserDetails = $this->profAdminDeputyCompletedPfaLowAssetsDetails;
     }
 
     /**

--- a/api/app/tests/Behat/bootstrap/v2/Helpers/FixtureHelper.php
+++ b/api/app/tests/Behat/bootstrap/v2/Helpers/FixtureHelper.php
@@ -431,6 +431,20 @@ class FixtureHelper
         return self::buildUserDetails($user);
     }
 
+    public function createProfPfaLowAssetsNotStarted(string $testRunId): array
+    {
+        $user = $this->createOrgUserClientNamedDeputyAndReport(
+            $testRunId,
+            User::ROLE_PROF_ADMIN,
+            'prof-pfa-low-assets-not-started',
+            Report::PROF_PFA_LOW_ASSETS_TYPE,
+            false,
+            false
+        );
+
+        return self::buildUserDetails($user);
+    }
+
     public function createLayPfaLowAssetsCompleted(string $testRunId): array
     {
         $user = $this->createDeputyClientAndReport(
@@ -438,6 +452,20 @@ class FixtureHelper
             User::ROLE_LAY_DEPUTY,
             'lay-pfa-low-assets-completed',
             Report::LAY_PFA_LOW_ASSETS_TYPE,
+            true,
+            false
+        );
+
+        return self::buildUserDetails($user);
+    }
+
+    public function createProfPfaLowAssetsCompleted(string $testRunId): array
+    {
+        $user = $this->createOrgUserClientNamedDeputyAndReport(
+            $testRunId,
+            User::ROLE_PROF_ADMIN,
+            'prof-pfa-low-assets-completed',
+            Report::PROF_PFA_LOW_ASSETS_TYPE,
             true,
             false
         );

--- a/api/app/tests/Behat/bootstrap/v2/Reporting/Sections/MoneyInShortSectionTrait.php
+++ b/api/app/tests/Behat/bootstrap/v2/Reporting/Sections/MoneyInShortSectionTrait.php
@@ -166,6 +166,16 @@ trait MoneyInShortSectionTrait
     }
 
     /**
+     * @When I edit the money in short summary section
+     */
+    public function iEditTheMoneyInShortSummarySection()
+    {
+        $this->iAmOnMoneyInShortSummaryPage();
+        $urlRegex = sprintf('/%s\/.*\/money-in-short\/exist\?from\=summary$/', $this->reportUrlPrefix);
+        $this->iClickOnNthElementBasedOnRegex($urlRegex, 0);
+    }
+
+    /**
      * @When I add a one off money in payment that is less than £1k
      */
     public function iAddAOneOffMoneyInPaymentThatIsLessThan1k()

--- a/api/app/tests/Behat/bootstrap/v2/Reporting/Sections/MoneyOutShortSectionTrait.php
+++ b/api/app/tests/Behat/bootstrap/v2/Reporting/Sections/MoneyOutShortSectionTrait.php
@@ -256,4 +256,16 @@ trait MoneyOutShortSectionTrait
         $this->iAmOnMoneyOutShortSummaryPage();
         
     }
+
+    /**
+     * @When I edit the money out short summary section
+     */
+    public function iEditTheMoneyOutShortSummarySection()
+    {
+        $this->iVisitMoneyOutShortSummarySection();
+        $this->iAmOnMoneyOutShortSummaryPage();
+
+        $urlRegex = sprintf('/%s\/.*\/money-out-short\/exist\?from\=summary$/', $this->reportUrlPrefix);
+        $this->iClickOnNthElementBasedOnRegex($urlRegex, 0);
+    }
 }

--- a/api/app/tests/Behat/features-v2/reporting/sections/money-in/money-in-short.lay.feature
+++ b/api/app/tests/Behat/features-v2/reporting/sections/money-in/money-in-short.lay.feature
@@ -1,0 +1,89 @@
+@v2 @v2_reporting_2 @money-in-low-assets
+Feature: Money in Low Assets - Lay users
+
+    @lay-pfa-low-not-started
+    Scenario: A user has had no money go in
+        Given a Lay Deputy has not started a Pfa Low Assets report
+        And I visit the report overview page
+        Then I should see "money-in-short" as "not started"
+        When I view and start the money in short report section
+        And I confirm "No" to adding money in on the clients behalf
+        And I enter a reason for no money in short
+        Then I should see the expected money in section summary
+        When I follow link back to report overview page
+        Then I should see "money-in-short" as "no money in"
+
+    @lay-pfa-low-not-started
+    Scenario: A user has had a single item of money go in but nothing over £1k
+        Given a Lay Deputy has not started a Pfa Low Assets report
+        When I view and start the money in short report section
+        And I answer "Yes" to adding money in on the clients behalf
+        And I am reporting on:
+            | Benefit Type    |
+            | Salary or wages |
+        And I have no one-off payments over £1k
+        Then I should see the expected money in section summary
+        When I follow link back to report overview page
+        Then I should see "money-in-short" as "money in"
+
+    @lay-pfa-low-not-started
+    Scenario: A user has had a multiple items of money go in but nothing over £1k
+        Given a Lay Deputy has not started a Pfa Low Assets report
+        When I view and start the money in short report section
+        And I answer "Yes" to adding money in on the clients behalf
+        And I am reporting on:
+            | Benefit Type                                        |
+            | State pension and benefits                          |
+            | Bequests - for example, inheritance, gifts received |
+            | Income from investments, dividends, property rental |
+            | Sale of investments, property or assets             |
+            | Salary or wages                                     |
+            | Compensations and damages awards                    |
+            | Personal pension                                    |
+        And I have no one-off payments over £1k
+        Then I should see the expected money in section summary
+        When I follow link back to report overview page
+        Then I should see "money-in-short" as "money in"
+
+    @lay-pfa-low-not-started
+    Scenario: A user has had a single item of money go in and payment over £1k
+        Given a Lay Deputy has not started a Pfa Low Assets report
+        When I view and start the money in short report section
+        And I answer "Yes" to adding money in on the clients behalf
+        And I am reporting on:
+            | Benefit Type    |
+            | Salary or wages |
+        And I have a single one-off payments over £1k
+        Then I should see the expected money in section summary
+        When I follow link back to report overview page
+        Then I should see "money-in-short" as "1 item over £1,000"
+
+    @lay-pfa-low-completed
+    Scenario: A user edits money in section and adds a one off payment
+        Given a Lay Deputy has completed a Pfa Low Assets report
+        When I edit the money in short section and add a payment
+        Then I should see the expected money in section summary
+
+    @lay-pfa-low-completed
+    Scenario: A user tries to add a one off payment of less than £1k
+        Given a Lay Deputy has completed a Pfa Low Assets report
+        When I add a one off money in payment that is less than £1k
+        Then I should the see correct validation message
+
+    @lay-pfa-low-completed
+    Scenario: A user adds a single item of money in but nothing over £1k and submits report successfully
+        Given a Lay Deputy has completed a Pfa Low Assets report
+        And I visit the report overview page
+        Then I should see "money-in-short" as "no money in"
+        When I visit the short money in summary section
+        And I edit the money in short summary section
+        And I answer "Yes" to adding money in on the clients behalf
+        And I am reporting on:
+            | Benefit Type    |
+            | Salary or wages |
+        And I have no one-off payments over £1k
+        Then I should see the expected money in section summary
+        When I follow link back to report overview page
+        Then I should see "money-in-short" as "money in"
+        Given I submit the report
+        Then my report should be submitted

--- a/api/app/tests/Behat/features-v2/reporting/sections/money-in/money-in-short.org.feature
+++ b/api/app/tests/Behat/features-v2/reporting/sections/money-in/money-in-short.org.feature
@@ -1,9 +1,9 @@
 @v2 @v2_reporting_2 @money-in-low-assets
-Feature: Money in Low Assets
+Feature: Money in Low Assets - Org users
 
-    @lay-pfa-low-not-started
+    @prof-pfa-low-not-started
     Scenario: A user has had no money go in
-        Given a Lay Deputy has not started a Pfa Low Assets report
+        Given a Professional Admin has not started a Pfa Low Assets report
         And I visit the report overview page
         Then I should see "money-in-short" as "not started"
         When I view and start the money in short report section
@@ -13,9 +13,9 @@ Feature: Money in Low Assets
         When I follow link back to report overview page
         Then I should see "money-in-short" as "no money in"
 
-    @lay-pfa-low-not-started
+    @prof-pfa-low-not-started
     Scenario: A user has had a single item of money go in but nothing over £1k
-        Given a Lay Deputy has not started a Pfa Low Assets report
+        Given a Professional Admin has not started a Pfa Low Assets report
         When I view and start the money in short report section
         And I answer "Yes" to adding money in on the clients behalf
         And I am reporting on:
@@ -26,9 +26,9 @@ Feature: Money in Low Assets
         When I follow link back to report overview page
         Then I should see "money-in-short" as "money in"
 
-    @lay-pfa-low-not-started
+    @prof-pfa-low-not-started
     Scenario: A user has had a multiple items of money go in but nothing over £1k
-        Given a Lay Deputy has not started a Pfa Low Assets report
+        Given a Professional Admin has not started a Pfa Low Assets report
         When I view and start the money in short report section
         And I answer "Yes" to adding money in on the clients behalf
         And I am reporting on:
@@ -45,9 +45,9 @@ Feature: Money in Low Assets
         When I follow link back to report overview page
         Then I should see "money-in-short" as "money in"
 
-    @lay-pfa-low-not-started
+    @prof-pfa-low-not-started
     Scenario: A user has had a single item of money go in and payment over £1k
-        Given a Lay Deputy has not started a Pfa Low Assets report
+        Given a Professional Admin has not started a Pfa Low Assets report
         When I view and start the money in short report section
         And I answer "Yes" to adding money in on the clients behalf
         And I am reporting on:
@@ -58,14 +58,32 @@ Feature: Money in Low Assets
         When I follow link back to report overview page
         Then I should see "money-in-short" as "1 item over £1,000"
 
-    @lay-pfa-low-completed
+    @prof-pfa-low-completed
     Scenario: A user edits money in section and adds a one off payment
-        Given a Lay Deputy has completed a Pfa Low Assets report
+        Given a Professional Admin has completed a Pfa Low Assets report
         When I edit the money in short section and add a payment
         Then I should see the expected money in section summary
 
-    @lay-pfa-low-completed
+    @prof-pfa-low-completed
     Scenario: A user tries to add a one off payment of less than £1k
-        Given a Lay Deputy has completed a Pfa Low Assets report
+        Given a Professional Admin has completed a Pfa Low Assets report
         When I add a one off money in payment that is less than £1k
         Then I should the see correct validation message
+
+    @prof-pfa-low-completed
+    Scenario: A user adds a single item of money in but nothing over £1k and submits report successfully
+        Given a Professional Admin has completed a Pfa Low Assets report
+        And I visit the report overview page
+        Then I should see "money-in-short" as "no money in"
+        When I visit the short money in summary section
+        And I edit the money in short summary section
+        And I answer "Yes" to adding money in on the clients behalf
+        And I am reporting on:
+            | Benefit Type    |
+            | Salary or wages |
+        And I have no one-off payments over £1k
+        Then I should see the expected money in section summary
+        When I follow link back to report overview page
+        Then I should see "money-in-short" as "money in"
+        Given I submit the report
+        Then my report should be submitted

--- a/api/app/tests/Behat/features-v2/reporting/sections/money-out/money-out-short.lay.feature
+++ b/api/app/tests/Behat/features-v2/reporting/sections/money-out/money-out-short.lay.feature
@@ -1,5 +1,5 @@
 @v2 @v2_reporting_2 @money-out-short
-Feature: Money Out Short
+Feature: Money Out Short - Lay users
 
     @lay-pfa-low-not-started
     Scenario: A user has had no money go out
@@ -77,3 +77,19 @@ Feature: Money Out Short
         Given a Lay Deputy has completed a Pfa Low Assets report
         When I edit the money out short section and add a payment
         Then I should see the expected money out section summary
+
+    @lay-pfa-low-completed
+    Scenario: A user has had some money go out but nothing over £1k and submits report successfully
+        Given a Lay Deputy has completed a Pfa Low Assets report
+        And I visit the report overview page
+        Then I should see "money-out-short" as "no money out"
+        When I visit the short money out summary section
+        And I edit the money out short summary section
+        And I answer "Yes" to taking money out on the clients behalf
+        When I add one category of money paid out
+        And I answer that there are not any one-off payments over £1k
+        Then I should see the expected money out section summary
+        When I follow link back to report overview page
+        Then I should see "money-out-short" as "money out"
+        Given I submit the report
+        Then my report should be submitted

--- a/api/app/tests/Behat/features-v2/reporting/sections/money-out/money-out-short.org.feature
+++ b/api/app/tests/Behat/features-v2/reporting/sections/money-out/money-out-short.org.feature
@@ -1,0 +1,95 @@
+@v2 @v2_reporting_2 @money-out-short
+Feature: Money Out Short - Org users
+
+    @prof-pfa-low-not-started
+    Scenario: A user has had no money go out
+        Given a Professional Admin has not started a Pfa Low Assets report
+        And I visit the report overview page
+        Then I should see "money-out-short" as "not started"
+        When I view and start the money out short report section
+        And I answer "No" to taking money out on the clients behalf
+        And I enter a reason for no money out short
+        Then I should see the expected money out section summary
+        When I follow link back to report overview page
+        Then I should see "money-out-short" as "no money out"
+
+    @prof-pfa-low-not-started
+    Scenario: A user has had some money go out but nothing over £1k
+        Given a Professional Admin has not started a Pfa Low Assets report
+        When I view and start the money out short report section
+        And I answer "Yes" to taking money out on the clients behalf
+        And I add all the categories of money paid out
+        And I answer that there are not any one-off payments over £1k
+        Then I should see the expected money out section summary
+        When I follow link back to report overview page
+        Then I should see "money-out-short" as "money out"
+
+    @prof-pfa-low-not-started
+    Scenario: A user has had some money go out including payments over £1k
+        Given a Professional Admin has not started a Pfa Low Assets report
+        When I view and start the money out short report section
+        And I answer "Yes" to taking money out on the clients behalf
+        And I add all the categories of money paid out
+        And I answer that there are 4 one-off payments over £1k
+        Then I should see the expected money out section summary
+        When I follow link back to report overview page
+        Then I should see "money-out-short" as "4 items over £1,000"
+
+    @prof-pfa-low-not-started
+    Scenario: A user removes a one off payment
+        Given a Professional Admin has not started a Pfa Low Assets report
+        When I view and start the money out short report section
+        And I answer "Yes" to taking money out on the clients behalf
+        And I add one category of money paid out
+        And I answer that there are 2 one-off payments over £1k
+        And I remove an existing money out short payment
+        Then I should see the expected money out section summary
+
+    @prof-pfa-low-not-started
+    Scenario: A user edits a one off payment
+        Given a Professional Admin has not started a Pfa Low Assets report
+        When I view and start the money out short report section
+        And I answer "Yes" to taking money out on the clients behalf
+        And I add one category of money paid out
+        And I answer that there are 2 one-off payments over £1k
+        And I edit an existing money out short payment
+        Then I should see the expected money out section summary
+
+    @prof-pfa-low-not-started
+    Scenario: A user adds an additional one off payment
+        Given a Professional Admin has not started a Pfa Low Assets report
+        When I view and start the money out short report section
+        And I answer "Yes" to taking money out on the clients behalf
+        And I add a payment and state no further payments
+        And I change my mind and add another payment
+        Then I should see the expected money out section summary
+
+    @prof-pfa-low-not-started
+    Scenario: A user tries to add a one off payment of less than £1k
+        Given a Professional Admin has not started a Pfa Low Assets report
+        When I view and start the money out short report section
+        And I answer "Yes" to taking money out on the clients behalf
+        And I answer that there are 1 one-off payments over £1k but add a payment of less than £1K
+        Then I should see correct validation message
+
+    @prof-pfa-low-completed
+    Scenario: A user edits money out section and adds a one off payment
+        Given a Professional Admin has completed a Pfa Low Assets report
+        When I edit the money out short section and add a payment
+        Then I should see the expected money out section summary
+
+    @prof-pfa-low-completed
+    Scenario: A user has had some money go out but nothing over £1k and submits report successfully
+        Given a Professional Admin has completed a Pfa Low Assets report
+        And I visit the report overview page
+        Then I should see "money-out-short" as "no money out"
+        When I visit the short money out summary section
+        And I edit the money out short summary section
+        And I answer "Yes" to taking money out on the clients behalf
+        When I add one category of money paid out
+        And I answer that there are not any one-off payments over £1k
+        Then I should see the expected money out section summary
+        When I follow link back to report overview page
+        Then I should see "money-out-short" as "money out"
+        Given I submit the report
+        Then my report should be submitted

--- a/client/app/templates/Org/ClientProfile/_subsection.html.twig
+++ b/client/app/templates/Org/ClientProfile/_subsection.html.twig
@@ -27,6 +27,8 @@
         <span class="opg-overview-section__status govuk-tag opg-tag--small {{ state.state | status_to_tag_css }} behat-region-{{ subSection }}-state-{{ state.state }}">
             {% if state.state == 'done' or customiseAllLabels | default(false) %}
                 {{ (subSection ~ '.label.' ~ state.state) | trans({'%count%': state.nOfRecords}) }}
+            {% elseif state.state == 'low-assets-done' %}
+                {{ (subSection ~ '.label.' ~ state.state) | trans }}
             {% else %}
                 {{ ('labels.' ~ state.state) | trans }}
             {% endif %}


### PR DESCRIPTION
## Purpose
Users were seeing an untranslated label for Money In and Money Out for report type 103. The reason for this was that different templates are used for the lay and organisational users. Previously, tests were created for the lay users but not for organisational users.

Also as part of this ticket we also added in tests to ensure that reports can be submitted by both lay and organisational users when the "money in" or "money out" labels are present in completed reports.  

Fixes DDLS-154

## Approach

- Added in same logic to translate money in and money out label when user is an organisational user.

- Created new organisational fixtures to use in the behat tests. One was for a report that has not been started and one was with a completed report.

- Created new organisational feature files for money in and money out to test the same scenarios as currently tested for lay users. I also changed names of current money in and out short feature files to include lay so as to distinguish between the two groups of users.

- Added in scenarios to test reports can be submitted when money in or money out label is present for both lay and organisational users.

## Learning
There are slightly different names for the review and submit buttons for lay and organisational journey which came up as part of creating the behat tests.

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [X] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
