### PR TITLE
DDLS-165c prepreq secret in account for DDLS-165

### DIFF
--- a/terraform/account/region/secrets.tf
+++ b/terraform/account/region/secrets.tf
@@ -13,7 +13,8 @@ module "environment_secrets" {
     "front-notify-api-key",
     "synchronisation-jwt-token",
     "public-jwt-key-base64",
-    "private-jwt-key-base64"
+    "private-jwt-key-base64",
+    "smoke-test-variables"
   ]
   tags = var.default_tags
 }


### PR DESCRIPTION
We need this secret to go through the accounts before we can add the smoke tests (already tested with the secret in branch)