### PR TITLE
DDLS-156: Client firstnames with special characters not being displayed correctly in certain areas of the app

### DIFF
--- a/api/app/src/DataFixtures/UserPasswordFixtures.php
+++ b/api/app/src/DataFixtures/UserPasswordFixtures.php
@@ -17,12 +17,17 @@ class UserPasswordFixtures extends AbstractDataFixture implements OrderedFixture
     {
         // Set all user passwords
         $userRepository = $manager->getRepository(User::class);
-        $users = $userRepository->findAll('');
+        $users = $userRepository->findAll();
 
         $password = $this->container->getParameter('fixtures')['account_password'];
 
+        $passwordHash = null;
         foreach ($users as $user) {
-            $user->setPassword($this->passwordHasher->hashPassword($user, $password));
+            if (!$passwordHash) {
+                // Re-use the same password hash for all users for efficiency purposes
+                $passwordHash = $this->passwordHasher->hashPassword($user, $password);
+            }
+            $user->setPassword($passwordHash);
             $manager->persist($user);
         }
 

--- a/client/app/config/packages/twig.yml
+++ b/client/app/config/packages/twig.yml
@@ -9,7 +9,7 @@ twig:
     #       Set Google Analytics IDs as global twig var - see parameters.yml
     ga: "%ga%"
   debug: "%kernel.debug%"
-  autoescape: true
+  autoescape: "html"
   strict_variables: "%kernel.debug%"
   form_themes:
     - "@App/Form/fields.html.twig"

--- a/client/app/config/packages/twig.yml
+++ b/client/app/config/packages/twig.yml
@@ -9,6 +9,7 @@ twig:
     #       Set Google Analytics IDs as global twig var - see parameters.yml
     ga: "%ga%"
   debug: "%kernel.debug%"
+  autoescape: true
   strict_variables: "%kernel.debug%"
   form_themes:
     - "@App/Form/fields.html.twig"

--- a/client/app/templates/Admin/Client/Report/checklist.html.twig
+++ b/client/app/templates/Admin/Client/Report/checklist.html.twig
@@ -6,7 +6,7 @@
 {% trans_default_domain translationDomain %}
 
 {% set page = 'checklistPage' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 {% set append104 = report.get104TransSuffix %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}

--- a/client/app/templates/Admin/Client/Report/checklist.html.twig
+++ b/client/app/templates/Admin/Client/Report/checklist.html.twig
@@ -6,7 +6,7 @@
 {% trans_default_domain translationDomain %}
 
 {% set page = 'checklistPage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 {% set append104 = report.get104TransSuffix %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}

--- a/client/app/templates/Ndr/Action/_answers.html.twig
+++ b/client/app/templates/Ndr/Action/_answers.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = "ndr-actions" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 
 <h2 class="govuk-heading-l">{{ 'stepPage.gifts.pageTitle' | trans(transOptions) }}</h2>

--- a/client/app/templates/Ndr/Action/start.html.twig
+++ b/client/app/templates/Ndr/Action/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-actions" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Ndr/Action/step.html.twig
+++ b/client/app/templates/Ndr/Action/step.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-actions" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}
     {{ 'stepPage.htmlTitle' | trans }}

--- a/client/app/templates/Ndr/Action/summary.html.twig
+++ b/client/app/templates/Ndr/Action/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-actions" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Ndr/Asset/Other/add.html.twig
+++ b/client/app/templates/Ndr/Asset/Other/add.html.twig
@@ -11,7 +11,7 @@
     {% set assetTitle = asset.title | lcfirst %}
 {% endif %}
 
-{% set transOptions = {'%client%': ndr.client.firstname | e, '%assetTitle%': assetTitle } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags, '%assetTitle%': assetTitle } %}
 
 {% block htmlTitle %}{{ 'addPage.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageTitle %}{{ 'addPage.pageTitle' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Ndr/Asset/Other/edit.html.twig
+++ b/client/app/templates/Ndr/Asset/Other/edit.html.twig
@@ -11,7 +11,7 @@
     {% set assetTitle = asset.title | lcfirst %}
 {% endif %}
 
-{% set transOptions = {'%client%': ndr.client.firstname | e, '%assetTitle%': assetTitle } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags, '%assetTitle%': assetTitle } %}
 
 {% block htmlTitle %}{{ 'editPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'editPage.pageTitle' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Ndr/Asset/Property/_list_item.html.twig
+++ b/client/app/templates/Ndr/Asset/Property/_list_item.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "ndr-assets" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags %}
 {% set hideEditLink = hideEditLink | default(false) %}
 
 {% for asset in assetsInGroup.items %}

--- a/client/app/templates/Ndr/Asset/Property/_list_item.html.twig
+++ b/client/app/templates/Ndr/Asset/Property/_list_item.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "ndr-assets" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | striptags %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 {% set hideEditLink = hideEditLink | default(false) %}
 
 {% for asset in assetsInGroup.items %}

--- a/client/app/templates/Ndr/Asset/Property/step.html.twig
+++ b/client/app/templates/Ndr/Asset/Property/step.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-assets" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | striptags %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 {% set translationPrefix = "form.property." %}
 
 {% block htmlTitle %}{{ 'stepPageProperty.htmlTitle' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Ndr/Asset/Property/step.html.twig
+++ b/client/app/templates/Ndr/Asset/Property/step.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-assets" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags %}
 {% set translationPrefix = "form.property." %}
 
 {% block htmlTitle %}{{ 'stepPageProperty.htmlTitle' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Ndr/Asset/addAnother.html.twig
+++ b/client/app/templates/Ndr/Asset/addAnother.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-assets" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'addAnotherPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Ndr/Asset/exist.html.twig
+++ b/client/app/templates/Ndr/Asset/exist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-assets" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'existPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Ndr/Asset/start.html.twig
+++ b/client/app/templates/Ndr/Asset/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-assets" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Ndr/Asset/summary.html.twig
+++ b/client/app/templates/Ndr/Asset/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-assets" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Ndr/Asset/type.html.twig
+++ b/client/app/templates/Ndr/Asset/type.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-assets" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'typePage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'typePage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Ndr/BankAccount/add_another.html.twig
+++ b/client/app/templates/Ndr/BankAccount/add_another.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-bank-accounts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'addAnotherPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Ndr/BankAccount/start.html.twig
+++ b/client/app/templates/Ndr/BankAccount/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-bank-accounts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Ndr/BankAccount/step.html.twig
+++ b/client/app/templates/Ndr/BankAccount/step.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-bank-accounts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageTitle %}{{ ('stepPage.pageTitle.' ~ (account.id ? 'edit' : 'add')) | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Ndr/BankAccount/summary.html.twig
+++ b/client/app/templates/Ndr/BankAccount/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-bank-accounts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Ndr/Debt/edit.html.twig
+++ b/client/app/templates/Ndr/Debt/edit.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-debts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'editPage.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageTitle %}{{ 'editPage.pageTitle' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Ndr/Debt/exist.html.twig
+++ b/client/app/templates/Ndr/Debt/exist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-debts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'existPage.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Ndr/Debt/management.html.twig
+++ b/client/app/templates/Ndr/Debt/management.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-debts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'managementPage.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Ndr/Debt/start.html.twig
+++ b/client/app/templates/Ndr/Debt/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-debts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Ndr/Debt/summary.html.twig
+++ b/client/app/templates/Ndr/Debt/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-debts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Ndr/DeputyExpense/add.html.twig
+++ b/client/app/templates/Ndr/DeputyExpense/add.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-deputy-expenses" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'addPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Ndr/DeputyExpense/addAnother.html.twig
+++ b/client/app/templates/Ndr/DeputyExpense/addAnother.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-deputy-expenses" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'addAnotherPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Ndr/DeputyExpense/edit.html.twig
+++ b/client/app/templates/Ndr/DeputyExpense/edit.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-deputy-expenses" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'editPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'editPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Ndr/DeputyExpense/exist.html.twig
+++ b/client/app/templates/Ndr/DeputyExpense/exist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-deputy-expenses" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'existPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Ndr/DeputyExpense/start.html.twig
+++ b/client/app/templates/Ndr/DeputyExpense/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-deputy-expenses" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Ndr/DeputyExpense/summary.html.twig
+++ b/client/app/templates/Ndr/DeputyExpense/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-deputy-expenses" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Ndr/Formatted/formatted_body.html.twig
+++ b/client/app/templates/Ndr/Formatted/formatted_body.html.twig
@@ -1,6 +1,6 @@
 {% set client = ndr.client %}
 {% set isEmailAttachment = true %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 <div id="wrapper">
     <div class="formatted-report content">

--- a/client/app/templates/Ndr/IncomeBenefit/_answers.html.twig
+++ b/client/app/templates/Ndr/IncomeBenefit/_answers.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = "ndr-income-benefits" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 <h2 class="govuk-heading-l">{{ 'stepPage.pageTitle.stateBenefits' | trans(transOptions) }}</h2>
 

--- a/client/app/templates/Ndr/IncomeBenefit/_checkboxes_list.html.twig
+++ b/client/app/templates/Ndr/IncomeBenefit/_checkboxes_list.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = "ndr-income-benefits" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 <div class="govuk-form-group">
 {% for sbSingleForm in elements %}

--- a/client/app/templates/Ndr/IncomeBenefit/start.html.twig
+++ b/client/app/templates/Ndr/IncomeBenefit/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-income-benefits" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Ndr/IncomeBenefit/step.html.twig
+++ b/client/app/templates/Ndr/IncomeBenefit/step.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-income-benefits" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ ('stepPage.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}

--- a/client/app/templates/Ndr/IncomeBenefit/summary.html.twig
+++ b/client/app/templates/Ndr/IncomeBenefit/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-income-benefits" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Ndr/OtherInfo/_answers.html.twig
+++ b/client/app/templates/Ndr/OtherInfo/_answers.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = "ndr-more-info" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 <dl class="govuk-summary-list">
     <div class="govuk-summary-list__row">

--- a/client/app/templates/Ndr/OtherInfo/start.html.twig
+++ b/client/app/templates/Ndr/OtherInfo/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-more-info" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Ndr/OtherInfo/step.html.twig
+++ b/client/app/templates/Ndr/OtherInfo/step.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-more-info" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Ndr/OtherInfo/summary.html.twig
+++ b/client/app/templates/Ndr/OtherInfo/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-more-info" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Ndr/VisitsCare/_answers.html.twig
+++ b/client/app/templates/Ndr/VisitsCare/_answers.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = "ndr-visits-care" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 <dl class="govuk-summary-list">
 {# STEP 1 #}

--- a/client/app/templates/Ndr/VisitsCare/start.html.twig
+++ b/client/app/templates/Ndr/VisitsCare/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-visits-care" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Ndr/VisitsCare/step.html.twig
+++ b/client/app/templates/Ndr/VisitsCare/step.html.twig
@@ -5,7 +5,7 @@
 
 {% set translationDomain = "ndr-visits-care" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Ndr/VisitsCare/summary.html.twig
+++ b/client/app/templates/Ndr/VisitsCare/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "ndr-visits-care" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': ndr.client.firstname | e } %}
+{% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Org/ClientProfile/_subsection.html.twig
+++ b/client/app/templates/Org/ClientProfile/_subsection.html.twig
@@ -2,7 +2,7 @@
 {# @param client App\Entity\Client #}
 {% set translationDomain = "report-overview" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': client.firstname | e } %}
+{% set transOptions = {'%client%': client.firstname | striptags } %}
 {% set sectionId = sectionId | default(null) %}
 {% set sectionNeedsAttention = report.isSectionFlaggedForAttention(sectionId) %}
 

--- a/client/app/templates/Org/ClientProfile/overview.html.twig
+++ b/client/app/templates/Org/ClientProfile/overview.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-overview" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': client.firstname | e } %}
+{% set transOptions = {'%client%': client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'htmlTitle-ORG' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'pageTitle' | trans({}, 'client-profile') }}{% endblock %}

--- a/client/app/templates/Org/Index/dashboard.html.twig
+++ b/client/app/templates/Org/Index/dashboard.html.twig
@@ -93,7 +93,7 @@
 
             <tr class="behat-region-client behat-region-client-{{ report.client.caseNumber | upper }}{{ clientRegionAppend }}">
                 <td>
-                    <a href="{{ linkToReportOverviewPage }}" class="behat-link-pa-report-open behat-link-pa-report-{{ report.getPeriod() | behat_namify }}-open">{{ report.client.lastName | title | e }}, {{ report.client.firstName | title | e }}</a>
+                    <a href="{{ linkToReportOverviewPage }}" class="behat-link-pa-report-open behat-link-pa-report-{{ report.getPeriod() | behat_namify }}-open">{{ report.client.lastName | title | striptags }}, {{ report.client.firstName | title | striptags }}</a>
                 </td>
                 {% if app.user.organisations | length > 1 %}
                     <td>

--- a/client/app/templates/Report/Action/_answers.html.twig
+++ b/client/app/templates/Report/Action/_answers.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-actions" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 {% set append104 = report.get104TransSuffix %}
 
 {% set hideEditLink = hideEditLink | default(false) %}

--- a/client/app/templates/Report/Action/start.html.twig
+++ b/client/app/templates/Report/Action/start.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-actions" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'startPage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 {% set append104 = report.get104TransSuffix %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Action/step.html.twig
+++ b/client/app/templates/Report/Action/step.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-actions" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 {% set append104 = report.get104TransSuffix %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/Action/summary.html.twig
+++ b/client/app/templates/Report/Action/summary.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-actions" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'summaryPage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 {% set append104 = report.get104TransSuffix %}
 
 {# Page Titles #}

--- a/client/app/templates/Report/Asset/Other/add.html.twig
+++ b/client/app/templates/Report/Asset/Other/add.html.twig
@@ -12,7 +12,7 @@
     {% set assetTitle = asset.title | lcfirst %}
 {% endif %}
 
-{% set transOptions = {'%client%': report.client.firstname | e, '%assetTitle%': assetTitle } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags, '%assetTitle%': assetTitle } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/Asset/Other/edit.html.twig
+++ b/client/app/templates/Report/Asset/Other/edit.html.twig
@@ -12,7 +12,7 @@
     {% set assetTitle = asset.title | lcfirst %}
 {% endif %}
 
-{% set transOptions = {'%client%': report.client.firstname | e, '%assetTitle%': assetTitle } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags, '%assetTitle%': assetTitle } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/Asset/Property/_list_item.html.twig
+++ b/client/app/templates/Report/Asset/Property/_list_item.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-assets" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 {% set page = 'summaryPage' %}
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/Asset/Property/_list_item.html.twig
+++ b/client/app/templates/Report/Asset/Property/_list_item.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-assets" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 {% set page = 'summaryPage' %}
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/Asset/Property/step.html.twig
+++ b/client/app/templates/Report/Asset/Property/step.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-assets" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'stepPageProperty' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags } } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 {% set translationPrefix = "form.property." %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/Asset/Property/step.html.twig
+++ b/client/app/templates/Report/Asset/Property/step.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-assets" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'stepPageProperty' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 {% set translationPrefix = "form.property." %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/Asset/Property/step.html.twig
+++ b/client/app/templates/Report/Asset/Property/step.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-assets" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'stepPageProperty' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } } %}
 {% set translationPrefix = "form.property." %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/Asset/addAnother.html.twig
+++ b/client/app/templates/Report/Asset/addAnother.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-assets" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'addAnotherPage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Asset/exist.html.twig
+++ b/client/app/templates/Report/Asset/exist.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-assets" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'existPage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/Asset/start.html.twig
+++ b/client/app/templates/Report/Asset/start.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-assets" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'startPage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Asset/summary.html.twig
+++ b/client/app/templates/Report/Asset/summary.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-assets" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'summaryPage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Asset/type.html.twig
+++ b/client/app/templates/Report/Asset/type.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-assets" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'typePage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Balance/_balance_table.html.twig
+++ b/client/app/templates/Report/Balance/_balance_table.html.twig
@@ -3,7 +3,7 @@
 {% set showBalanceCalculations = report.status.bankAccountsState['state'] != 'not-started' %}
 
 {% set transOptions = {
-    '%client%': report.client.firstname | e,
+    '%client%': report.client.firstname | striptags,
     '%moreless%': report.totalsOffset < 0 ? "less" : "more"
 } %}
 

--- a/client/app/templates/Report/Balance/_difference_table.html.twig
+++ b/client/app/templates/Report/Balance/_difference_table.html.twig
@@ -2,7 +2,7 @@
 {% trans_default_domain translationDomain %}
 
 {% set transOptions = {
-    '%client%': report.client.firstname | e,
+    '%client%': report.client.firstname | striptags,
     '%moreless%': report.totalsOffset < 0 ? "less" : "more"
 } %}
 

--- a/client/app/templates/Report/Balance/balance.html.twig
+++ b/client/app/templates/Report/Balance/balance.html.twig
@@ -6,7 +6,7 @@
 {% trans_default_domain translationDomain %}
 
 {% set transOptions = {
-    '%client%': report.client.firstname | e,
+    '%client%': report.client.firstname | striptags,
     '%moreless%': report.totalsOffset < 0 ? "less" : "more"
 } %}
 

--- a/client/app/templates/Report/BankAccount/add_another.html.twig
+++ b/client/app/templates/Report/BankAccount/add_another.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-bank-accounts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } } %}
 
 {% block htmlTitle %}{{ 'addAnotherPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/BankAccount/add_another.html.twig
+++ b/client/app/templates/Report/BankAccount/add_another.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-bank-accounts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'addAnotherPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/BankAccount/add_another.html.twig
+++ b/client/app/templates/Report/BankAccount/add_another.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-bank-accounts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags } } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'addAnotherPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/BankAccount/start.html.twig
+++ b/client/app/templates/Report/BankAccount/start.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-bank-accounts" %}
 {% trans_default_domain translationDomain %}
 {% set transOptions = {
-    '%client%': report.client.firstname | e,
+    '%client%': report.client.firstname | striptags,
     '%moneyInPath%': path('money_in', {reportId: report.id})
 } %}
 

--- a/client/app/templates/Report/BankAccount/step.html.twig
+++ b/client/app/templates/Report/BankAccount/step.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-bank-accounts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageTitle %}{{ ('stepPage.pageTitle.' ~ (account.id ? 'edit' : 'add')) | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/BankAccount/step.html.twig
+++ b/client/app/templates/Report/BankAccount/step.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-bank-accounts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageTitle %}{{ ('stepPage.pageTitle.' ~ (account.id ? 'edit' : 'add')) | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/BankAccount/summary.html.twig
+++ b/client/app/templates/Report/BankAccount/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-bank-accounts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags } } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/BankAccount/summary.html.twig
+++ b/client/app/templates/Report/BankAccount/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-bank-accounts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/BankAccount/summary.html.twig
+++ b/client/app/templates/Report/BankAccount/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-bank-accounts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/ClientBenefitsCheck/start.html.twig
+++ b/client/app/templates/Report/ClientBenefitsCheck/start.html.twig
@@ -6,7 +6,7 @@
 {% trans_default_domain translationDomain %}
 
 {% set transOptions = {
-    '%client%': report.client.firstname | e,
+    '%client%': report.client.firstname | striptags,
 } %}
 
 {% block htmlTitle %}{{ 'common.htmlTitle' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/ClientBenefitsCheck/summary.html.twig
+++ b/client/app/templates/Report/ClientBenefitsCheck/summary.html.twig
@@ -6,7 +6,7 @@
 {% trans_default_domain translationDomain %}
 
 {% set transOptions = {
-    '%client%': report.client.firstname | e,
+    '%client%': report.client.firstname | striptags,
 } %}
 
 {% block htmlTitle %}{{ 'common.htmlTitle' | trans(transOptions, translationDomain) }}{% endblock %}

--- a/client/app/templates/Report/Contact/_form.html.twig
+++ b/client/app/templates/Report/Contact/_form.html.twig
@@ -4,7 +4,7 @@
 {% trans_default_domain translationDomain %}
 {% set translationPrefix = "form." %}
 
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {{ form_start(form, {attr: {novalidate: 'novalidate'} }) }}
 

--- a/client/app/templates/Report/Contact/add.html.twig
+++ b/client/app/templates/Report/Contact/add.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-contacts" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'addPage' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags } } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Contact/add.html.twig
+++ b/client/app/templates/Report/Contact/add.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-contacts" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'addPage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Contact/add.html.twig
+++ b/client/app/templates/Report/Contact/add.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-contacts" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'addPage' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Contact/addAnother.html.twig
+++ b/client/app/templates/Report/Contact/addAnother.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-contacts" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'addAnotherPage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Contact/edit.html.twig
+++ b/client/app/templates/Report/Contact/edit.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-contacts" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'editPage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Contact/exist.html.twig
+++ b/client/app/templates/Report/Contact/exist.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-contacts" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'existPage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/Contact/exist.html.twig
+++ b/client/app/templates/Report/Contact/exist.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-contacts" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'existPage' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags } } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/Contact/exist.html.twig
+++ b/client/app/templates/Report/Contact/exist.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-contacts" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'existPage' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/Contact/start.html.twig
+++ b/client/app/templates/Report/Contact/start.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-contacts" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'startPage' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Contact/start.html.twig
+++ b/client/app/templates/Report/Contact/start.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-contacts" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'startPage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Contact/start.html.twig
+++ b/client/app/templates/Report/Contact/start.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-contacts" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'startPage' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags } } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Contact/summary.html.twig
+++ b/client/app/templates/Report/Contact/summary.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-contacts" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'summaryPage' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Contact/summary.html.twig
+++ b/client/app/templates/Report/Contact/summary.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-contacts" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'summaryPage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Debt/_answers.html.twig
+++ b/client/app/templates/Report/Debt/_answers.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-debts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/Debt/edit.html.twig
+++ b/client/app/templates/Report/Debt/edit.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-debts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'editPage.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageTitle %}{{ 'editPage.pageTitle' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/Debt/exist.html.twig
+++ b/client/app/templates/Report/Debt/exist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-debts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'existPage.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/Debt/management.html.twig
+++ b/client/app/templates/Report/Debt/management.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-debts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'managementPage.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/Debt/start.html.twig
+++ b/client/app/templates/Report/Debt/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-debts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/Debt/summary.html.twig
+++ b/client/app/templates/Report/Debt/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-debts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/Decision/_form.html.twig
+++ b/client/app/templates/Report/Decision/_form.html.twig
@@ -1,6 +1,6 @@
 {% import '@App/Macros/macros.html.twig' as macros %}
 
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {{ form_start(form, {attr: {novalidate: 'novalidate'} }) }}
 

--- a/client/app/templates/Report/Decision/_form.html.twig
+++ b/client/app/templates/Report/Decision/_form.html.twig
@@ -1,6 +1,6 @@
 {% import '@App/Macros/macros.html.twig' as macros %}
 
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {{ form_start(form, {attr: {novalidate: 'novalidate'} }) }}
 

--- a/client/app/templates/Report/Decision/_list.html.twig
+++ b/client/app/templates/Report/Decision/_list.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-decisions" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 {% set append104 = report.get104TransSuffix %}
 {% set page = 'summaryPage' %}
 {% set hideEditLink = hideEditLink | default(false) %}

--- a/client/app/templates/Report/Decision/add.html.twig
+++ b/client/app/templates/Report/Decision/add.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-decisions" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'addPage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Decision/add.html.twig
+++ b/client/app/templates/Report/Decision/add.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-decisions" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'addPage' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Decision/addAnother.html.twig
+++ b/client/app/templates/Report/Decision/addAnother.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-decisions" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'addAnotherPage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Decision/addAnother.html.twig
+++ b/client/app/templates/Report/Decision/addAnother.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-decisions" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'addAnotherPage' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Decision/edit.html.twig
+++ b/client/app/templates/Report/Decision/edit.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-decisions" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'editPage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Decision/edit.html.twig
+++ b/client/app/templates/Report/Decision/edit.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-decisions" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'editPage' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Decision/exist.html.twig
+++ b/client/app/templates/Report/Decision/exist.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-decisions" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'existPage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 {% set append104 = report.get104TransSuffix %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Decision/exist.html.twig
+++ b/client/app/templates/Report/Decision/exist.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-decisions" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'existPage' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 {% set append104 = report.get104TransSuffix %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Decision/mentalAssessment.html.twig
+++ b/client/app/templates/Report/Decision/mentalAssessment.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-decisions" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'mentalCapacity' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/Decision/mentalAssessment.html.twig
+++ b/client/app/templates/Report/Decision/mentalAssessment.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-decisions" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'mentalCapacity' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/Decision/mentalCapacity.html.twig
+++ b/client/app/templates/Report/Decision/mentalCapacity.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-decisions" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'mentalCapacity' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 {% set append104 = report.get104TransSuffix %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Decision/mentalCapacity.html.twig
+++ b/client/app/templates/Report/Decision/mentalCapacity.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-decisions" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'mentalCapacity' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 {% set append104 = report.get104TransSuffix %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Decision/start.html.twig
+++ b/client/app/templates/Report/Decision/start.html.twig
@@ -6,7 +6,7 @@
 {% trans_default_domain translationDomain %}
 {% set page = 'startPage' %}
 {% set clientName = report.client.firstname %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 {% set append104 = report.get104TransSuffix %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Decision/start.html.twig
+++ b/client/app/templates/Report/Decision/start.html.twig
@@ -6,7 +6,7 @@
 {% trans_default_domain translationDomain %}
 {% set page = 'startPage' %}
 {% set clientName = report.client.firstname %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 {% set append104 = report.get104TransSuffix %}
 
 {% block htmlTitle %}{{ (page ~ '.htmlTitle') | trans }}{% endblock %}

--- a/client/app/templates/Report/Decision/summary.html.twig
+++ b/client/app/templates/Report/Decision/summary.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-decisions" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'summaryPage' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 {% set append104 = report.get104TransSuffix %}
 
 {# Page Titles #}

--- a/client/app/templates/Report/Decision/summary.html.twig
+++ b/client/app/templates/Report/Decision/summary.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-decisions" %}
 {% trans_default_domain translationDomain %}
 {% set page = 'summaryPage' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 {% set append104 = report.get104TransSuffix %}
 
 {# Page Titles #}

--- a/client/app/templates/Report/DeputyExpense/add.html.twig
+++ b/client/app/templates/Report/DeputyExpense/add.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-deputy-expenses" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'addPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/DeputyExpense/add.html.twig
+++ b/client/app/templates/Report/DeputyExpense/add.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-deputy-expenses" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'addPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/DeputyExpense/addAnother.html.twig
+++ b/client/app/templates/Report/DeputyExpense/addAnother.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-deputy-expenses" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'addAnotherPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/DeputyExpense/addAnother.html.twig
+++ b/client/app/templates/Report/DeputyExpense/addAnother.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-deputy-expenses" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'addAnotherPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/DeputyExpense/edit.html.twig
+++ b/client/app/templates/Report/DeputyExpense/edit.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-deputy-expenses" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'editPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'editPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/DeputyExpense/edit.html.twig
+++ b/client/app/templates/Report/DeputyExpense/edit.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-deputy-expenses" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'editPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'editPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/DeputyExpense/exist.html.twig
+++ b/client/app/templates/Report/DeputyExpense/exist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-deputy-expenses" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'existPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/DeputyExpense/exist.html.twig
+++ b/client/app/templates/Report/DeputyExpense/exist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-deputy-expenses" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'existPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/DeputyExpense/start.html.twig
+++ b/client/app/templates/Report/DeputyExpense/start.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-deputy-expenses" %}
 {% trans_default_domain translationDomain %}
 {% set transOptions = {
-    '%client%': report.client.firstname | e,
+    '%client%': report.client.firstname | striptags,
     '%accountsPath%': path('bank_accounts', {reportId: report.id})
 } %}
 

--- a/client/app/templates/Report/DeputyExpense/summary.html.twig
+++ b/client/app/templates/Report/DeputyExpense/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-deputy-expenses" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/DeputyExpense/summary.html.twig
+++ b/client/app/templates/Report/DeputyExpense/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-deputy-expenses" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/Document/start.html.twig
+++ b/client/app/templates/Report/Document/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-documents" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/Document/start.html.twig
+++ b/client/app/templates/Report/Document/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-documents" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/Document/step1.html.twig
+++ b/client/app/templates/Report/Document/step1.html.twig
@@ -6,7 +6,7 @@
 {% set page = "attachPage" %}
 
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'stepPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/Document/step1.html.twig
+++ b/client/app/templates/Report/Document/step1.html.twig
@@ -6,7 +6,7 @@
 {% set page = "attachPage" %}
 
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'stepPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/Document/summary.html.twig
+++ b/client/app/templates/Report/Document/summary.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-documents" %}
 {% set page = "summaryPage" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/Document/summary.html.twig
+++ b/client/app/templates/Report/Document/summary.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-documents" %}
 {% set page = "summaryPage" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/Formatted/Accounts/_category.html.twig
+++ b/client/app/templates/Report/Formatted/Accounts/_category.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 <div class="dont-break">
     <div class="box box-heading flush--bottom">

--- a/client/app/templates/Report/Formatted/Accounts/_category.html.twig
+++ b/client/app/templates/Report/Formatted/Accounts/_category.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 <div class="dont-break">
     <div class="box box-heading flush--bottom">

--- a/client/app/templates/Report/Formatted/Accounts/_transaction.html.twig
+++ b/client/app/templates/Report/Formatted/Accounts/_transaction.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 <tr>
     <td class="label">

--- a/client/app/templates/Report/Formatted/Accounts/_transaction.html.twig
+++ b/client/app/templates/Report/Formatted/Accounts/_transaction.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 <tr>
     <td class="label">

--- a/client/app/templates/Report/Formatted/Accounts/_transfers.html.twig
+++ b/client/app/templates/Report/Formatted/Accounts/_transfers.html.twig
@@ -41,7 +41,7 @@
         {% else %}
             <div class="box">
                 <dl class="labelvalue">
-                    <dt class="label">Tick this box if you did not move any money between {{ report.client.firstname | e }}'s
+                    <dt class="label">Tick this box if you did not move any money between {{ report.client.firstname | striptags}'s
                         accounts.
                     </dt>
                     <dd class="value checkbox" id="money-transfers-no-transfers-add">{{ report.noTransfersToAdd ? 'X' : '' }}</dd>

--- a/client/app/templates/Report/Formatted/Accounts/_transfers.html.twig
+++ b/client/app/templates/Report/Formatted/Accounts/_transfers.html.twig
@@ -41,7 +41,7 @@
         {% else %}
             <div class="box">
                 <dl class="labelvalue">
-                    <dt class="label">Tick this box if you did not move any money between {{ report.client.firstname | striptags}'s
+                    <dt class="label">Tick this box if you did not move any money between {{ report.client.firstname | striptags }}'s
                         accounts.
                     </dt>
                     <dd class="value checkbox" id="money-transfers-no-transfers-add">{{ report.noTransfersToAdd ? 'X' : '' }}</dd>

--- a/client/app/templates/Report/Formatted/_client_benefits_check.html.twig
+++ b/client/app/templates/Report/Formatted/_client_benefits_check.html.twig
@@ -2,7 +2,7 @@
 {% trans_default_domain translationDomain %}
 
 {% set transOptions = {
-    '%client%': report.client.firstname | e,
+    '%client%': report.client.firstname | striptags,
 } %}
 
 <div class="section break-before" id="client-benefits-check-section">

--- a/client/app/templates/Report/Formatted/_prof_deputy_costs.html.twig
+++ b/client/app/templates/Report/Formatted/_prof_deputy_costs.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = "report-prof-deputy-costs" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 <div class="section break-before" id="prof-deputy-costs-section">
     <h2 class="section-heading">{{ 'startPage.pageTitle'|trans(transOptions) }}</h2>

--- a/client/app/templates/Report/Formatted/_prof_deputy_costs.html.twig
+++ b/client/app/templates/Report/Formatted/_prof_deputy_costs.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = "report-prof-deputy-costs" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 <div class="section break-before" id="prof-deputy-costs-section">
     <h2 class="section-heading">{{ 'startPage.pageTitle'|trans(transOptions) }}</h2>

--- a/client/app/templates/Report/Formatted/_prof_deputy_costs_estimate.html.twig
+++ b/client/app/templates/Report/Formatted/_prof_deputy_costs_estimate.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = "report-prof-deputy-costs-estimate" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 <div class="section break-before" id="prof-deputy-costs-estimate-section">
     <h2 class="section-heading">{{ 'startPage.pageTitle'|trans }}</h2>
     <div class="dont-break">

--- a/client/app/templates/Report/Formatted/_prof_deputy_costs_estimate.html.twig
+++ b/client/app/templates/Report/Formatted/_prof_deputy_costs_estimate.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = "report-prof-deputy-costs-estimate" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 <div class="section break-before" id="prof-deputy-costs-estimate-section">
     <h2 class="section-heading">{{ 'startPage.pageTitle'|trans }}</h2>
     <div class="dont-break">

--- a/client/app/templates/Report/Formatted/formatted_body.html.twig
+++ b/client/app/templates/Report/Formatted/formatted_body.html.twig
@@ -7,7 +7,7 @@
 {% set isEmailAttachment = true %}
 {% set transfers = report.getMoneyTransfers %}
 {% set mentalCapacity = report.getMentalCapacity %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 {% set reportTypeHeading = ('-4' == report.get104TransSuffix) ? 'property and financial, and health and welfare' : ('104' in report.type) ? 'health and welfare' : 'property and financial'  %}
 
 {# "default(app.user)" is left only to avoid breaking the page before the migration (that adds user.submittedBy) is executed  #}

--- a/client/app/templates/Report/Formatted/formatted_body.html.twig
+++ b/client/app/templates/Report/Formatted/formatted_body.html.twig
@@ -7,7 +7,7 @@
 {% set isEmailAttachment = true %}
 {% set transfers = report.getMoneyTransfers %}
 {% set mentalCapacity = report.getMentalCapacity %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 {% set reportTypeHeading = ('-4' == report.get104TransSuffix) ? 'property and financial, and health and welfare' : ('104' in report.type) ? 'health and welfare' : 'property and financial'  %}
 
 {# "default(app.user)" is left only to avoid breaking the page before the migration (that adds user.submittedBy) is executed  #}

--- a/client/app/templates/Report/Gift/add.html.twig
+++ b/client/app/templates/Report/Gift/add.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-gifts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'addPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/Gift/edit.html.twig
+++ b/client/app/templates/Report/Gift/edit.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-gifts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'editPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'editPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/Gift/exist.html.twig
+++ b/client/app/templates/Report/Gift/exist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-gifts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'existPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/Gift/start.html.twig
+++ b/client/app/templates/Report/Gift/start.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-gifts" %}
 {% trans_default_domain translationDomain %}
 {% set transOptions = {
-    '%client%': report.client.firstname | e,
+    '%client%': report.client.firstname | striptags,
     '%accountsPath%': path('bank_accounts', {reportId: report.id})
 } %}
 

--- a/client/app/templates/Report/Gift/summary.html.twig
+++ b/client/app/templates/Report/Gift/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-gifts" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/Lifestyle/_answers.html.twig
+++ b/client/app/templates/Report/Lifestyle/_answers.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-lifestyle" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/Lifestyle/_answers.html.twig
+++ b/client/app/templates/Report/Lifestyle/_answers.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-lifestyle" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/Lifestyle/start.html.twig
+++ b/client/app/templates/Report/Lifestyle/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-lifestyle" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/Lifestyle/start.html.twig
+++ b/client/app/templates/Report/Lifestyle/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-lifestyle" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/Lifestyle/step.html.twig
+++ b/client/app/templates/Report/Lifestyle/step.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-lifestyle" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/Lifestyle/step.html.twig
+++ b/client/app/templates/Report/Lifestyle/step.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-lifestyle" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/Lifestyle/summary.html.twig
+++ b/client/app/templates/Report/Lifestyle/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-lifestyle" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/Lifestyle/summary.html.twig
+++ b/client/app/templates/Report/Lifestyle/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-lifestyle" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyIn/_list.html.twig
+++ b/client/app/templates/Report/MoneyIn/_list.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/MoneyIn/addAnother.html.twig
+++ b/client/app/templates/Report/MoneyIn/addAnother.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'addAnotherPage.moneyIn.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.moneyIn.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyIn/addAnother.html.twig
+++ b/client/app/templates/Report/MoneyIn/addAnother.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'addAnotherPage.moneyIn.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.moneyIn.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyIn/exist.html.twig
+++ b/client/app/templates/Report/MoneyIn/exist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-in" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'existPage.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/MoneyIn/noMoneyInToReport.html.twig
+++ b/client/app/templates/Report/MoneyIn/noMoneyInToReport.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-in" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'noMoneyIn.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/MoneyIn/start.html.twig
+++ b/client/app/templates/Report/MoneyIn/start.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
 {% set transOptions = {
-    '%client%': report.client.firstname | e,
+    '%client%': report.client.firstname | striptags,
     '%startDate%': report.startDate | date("j M Y"),
     '%endDate%': report.endDate | date("j M Y"),
     '%moneyTransfersPath%': path('money_transfers', {reportId: report.id}),

--- a/client/app/templates/Report/MoneyIn/step.html.twig
+++ b/client/app/templates/Report/MoneyIn/step.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
 
-{% set clientTransOptions = {'%client%': report.client.firstname | e } %}
+{% set clientTransOptions = {'%client%': report.client.firstname | striptags %}
 {% set category = transaction.category %}
 {% set transOptions = clientTransOptions | merge({
     '%moneyTransfersPath%': path('money_transfers', {reportId: report.id})

--- a/client/app/templates/Report/MoneyIn/step.html.twig
+++ b/client/app/templates/Report/MoneyIn/step.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
 
-{% set clientTransOptions = {'%client%': report.client.firstname | striptags %}
+{% set clientTransOptions = {'%client%': report.client.firstname | striptags } %}
 {% set category = transaction.category %}
 {% set transOptions = clientTransOptions | merge({
     '%moneyTransfersPath%': path('money_transfers', {reportId: report.id})

--- a/client/app/templates/Report/MoneyIn/summary.html.twig
+++ b/client/app/templates/Report/MoneyIn/summary.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
 {% set transOptions = {
-    '%client%': report.client.firstname | e,
+    '%client%': report.client.firstname | striptags,
     '%startDate%': report.startDate | date("j F Y"),
     '%endDate%': report.endDate | date("j F Y"),
     '%moneyTransfersPath%': path('money_transfers', {reportId: report.id})

--- a/client/app/templates/Report/MoneyInShort/_answers.html.twig
+++ b/client/app/templates/Report/MoneyInShort/_answers.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/MoneyInShort/_answers.html.twig
+++ b/client/app/templates/Report/MoneyInShort/_answers.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/MoneyInShort/_checkboxes_list.html.twig
+++ b/client/app/templates/Report/MoneyInShort/_checkboxes_list.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 <div class="govuk-form-group">
 {% for sbSingleForm in elements %}

--- a/client/app/templates/Report/MoneyInShort/_checkboxes_list.html.twig
+++ b/client/app/templates/Report/MoneyInShort/_checkboxes_list.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 <div class="govuk-form-group">
 {% for sbSingleForm in elements %}

--- a/client/app/templates/Report/MoneyInShort/addAnother.html.twig
+++ b/client/app/templates/Report/MoneyInShort/addAnother.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'addAnotherPage.moneyIn.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.moneyIn.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyInShort/addAnother.html.twig
+++ b/client/app/templates/Report/MoneyInShort/addAnother.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'addAnotherPage.moneyIn.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.moneyIn.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyInShort/category.html.twig
+++ b/client/app/templates/Report/MoneyInShort/category.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ ('categoryPage.moneyIn.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ 'form.categoriesIn.label' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/MoneyInShort/category.html.twig
+++ b/client/app/templates/Report/MoneyInShort/category.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ ('categoryPage.moneyIn.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ 'form.categoriesIn.label' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/MoneyInShort/edit.html.twig
+++ b/client/app/templates/Report/MoneyInShort/edit.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'editPage.moneyIn.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'editPage.moneyIn.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyInShort/edit.html.twig
+++ b/client/app/templates/Report/MoneyInShort/edit.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'editPage.moneyIn.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'editPage.moneyIn.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyInShort/exist.html.twig
+++ b/client/app/templates/Report/MoneyInShort/exist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'existPage.moneyIn.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/MoneyInShort/exist.html.twig
+++ b/client/app/templates/Report/MoneyInShort/exist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'existPage.moneyIn.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/MoneyInShort/noMoneyInShortToReport.html.twig
+++ b/client/app/templates/Report/MoneyInShort/noMoneyInShortToReport.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'noMoneyIn.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/MoneyInShort/oneOffPaymentsExist.html.twig
+++ b/client/app/templates/Report/MoneyInShort/oneOffPaymentsExist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'oneOffPaymentExistPage.moneyIn.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/MoneyInShort/start.html.twig
+++ b/client/app/templates/Report/MoneyInShort/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'startPage.moneyIn.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.moneyIn.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyInShort/start.html.twig
+++ b/client/app/templates/Report/MoneyInShort/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'startPage.moneyIn.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.moneyIn.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyInShort/summary.html.twig
+++ b/client/app/templates/Report/MoneyInShort/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.moneyIn.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyInShort/summary.html.twig
+++ b/client/app/templates/Report/MoneyInShort/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.moneyIn.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyOut/_list.html.twig
+++ b/client/app/templates/Report/MoneyOut/_list.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/MoneyOut/_list.html.twig
+++ b/client/app/templates/Report/MoneyOut/_list.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/MoneyOut/addAnother.html.twig
+++ b/client/app/templates/Report/MoneyOut/addAnother.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'addAnotherPage.moneyOut.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.moneyOut.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyOut/addAnother.html.twig
+++ b/client/app/templates/Report/MoneyOut/addAnother.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'addAnotherPage.moneyOut.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.moneyOut.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyOut/exist.html.twig
+++ b/client/app/templates/Report/MoneyOut/exist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-out" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'existPage.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/MoneyOut/noMoneyOutToReport.html.twig
+++ b/client/app/templates/Report/MoneyOut/noMoneyOutToReport.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-out" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'noMoneyOut.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/MoneyOut/start.html.twig
+++ b/client/app/templates/Report/MoneyOut/start.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
 {% set transOptions = {
-    '%client%': report.client.firstname | e,
+    '%client%': report.client.firstname | striptags,
     '%startDate%': report.startDate | date("j F Y"),
     '%endDate%': report.endDate | date("j F Y"),
     '%moneyTransfersPath%': path('money_transfers', {reportId: report.id}),

--- a/client/app/templates/Report/MoneyOut/step.html.twig
+++ b/client/app/templates/Report/MoneyOut/step.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
 
-{% set clientTransOptions = {'%client%': report.client.firstname | e } %}
+{% set clientTransOptions = {'%client%': report.client.firstname | striptags %}
 {% set transOptions = clientTransOptions | merge({
     '%moneyTransfersPath%': path('money_transfers', {reportId: report.id}),
     '%deputyExpensesPath%': path('deputy_expenses', {reportId: report.id}),

--- a/client/app/templates/Report/MoneyOut/step.html.twig
+++ b/client/app/templates/Report/MoneyOut/step.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
 
-{% set clientTransOptions = {'%client%': report.client.firstname | striptags %}
+{% set clientTransOptions = {'%client%': report.client.firstname | striptags } %}
 {% set transOptions = clientTransOptions | merge({
     '%moneyTransfersPath%': path('money_transfers', {reportId: report.id}),
     '%deputyExpensesPath%': path('deputy_expenses', {reportId: report.id}),

--- a/client/app/templates/Report/MoneyOut/summary.html.twig
+++ b/client/app/templates/Report/MoneyOut/summary.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-money-transaction" %}
 {% trans_default_domain translationDomain %}
 {% set transOptions = {
-    '%client%': report.client.firstname | e,
+    '%client%': report.client.firstname | striptags,
     '%startDate%': report.startDate | date("j F Y"),
     '%endDate%': report.endDate | date("j F Y"),
     '%moneyTransfersPath%': path('money_transfers', {reportId: report.id}),

--- a/client/app/templates/Report/MoneyOutShort/_answers.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/_answers.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/MoneyOutShort/_answers.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/_answers.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/MoneyOutShort/_checkboxes_list.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/_checkboxes_list.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 <div class="govuk-form-group">
 {% for sbSingleForm in elements %}

--- a/client/app/templates/Report/MoneyOutShort/_checkboxes_list.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/_checkboxes_list.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 <div class="govuk-form-group">
 {% for sbSingleForm in elements %}

--- a/client/app/templates/Report/MoneyOutShort/add.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/add.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'addPage.moneyOut.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addPage.moneyOut.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyOutShort/add.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/add.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'addPage.moneyOut.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addPage.moneyOut.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyOutShort/addAnother.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/addAnother.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'addAnotherPage.moneyOut.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.moneyOut.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyOutShort/addAnother.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/addAnother.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'addAnotherPage.moneyOut.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.moneyOut.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyOutShort/category.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/category.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ ('categoryPage.moneyOut.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ 'form.categoriesOut.label' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/MoneyOutShort/category.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/category.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ ('categoryPage.moneyOut.htmlTitle') | trans }}{% endblock %}
 {% block pageTitle %}{{ 'form.categoriesOut.label' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/MoneyOutShort/edit.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/edit.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'editPage.moneyOut.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'editPage.moneyOut.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyOutShort/edit.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/edit.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'editPage.moneyOut.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'editPage.moneyOut.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyOutShort/exist.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/exist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'existPage.moneyOut.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/MoneyOutShort/exist.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/exist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'existPage.moneyOut.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/MoneyOutShort/noMoneyOutShortToReport.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/noMoneyOutShortToReport.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'noMoneyOut.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/MoneyOutShort/oneOffPaymentsExist.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/oneOffPaymentsExist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'oneOffPaymentExistPage.moneyOut.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/MoneyOutShort/start.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'startPage.moneyOut.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.moneyOut.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyOutShort/start.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'startPage.moneyOut.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.moneyOut.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyOutShort/summary.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.moneyOut.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyOutShort/summary.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-short" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.moneyOut.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyTransfer/addAnother.html.twig
+++ b/client/app/templates/Report/MoneyTransfer/addAnother.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-transfer" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'addAnotherPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyTransfer/addAnother.html.twig
+++ b/client/app/templates/Report/MoneyTransfer/addAnother.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-transfer" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'addAnotherPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'addAnotherPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyTransfer/error.html.twig
+++ b/client/app/templates/Report/MoneyTransfer/error.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-transfer" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'errorPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'errorPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyTransfer/error.html.twig
+++ b/client/app/templates/Report/MoneyTransfer/error.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-transfer" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'errorPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'errorPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyTransfer/exist.html.twig
+++ b/client/app/templates/Report/MoneyTransfer/exist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-transfer" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'existPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/MoneyTransfer/exist.html.twig
+++ b/client/app/templates/Report/MoneyTransfer/exist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-transfer" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'existPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/MoneyTransfer/start.html.twig
+++ b/client/app/templates/Report/MoneyTransfer/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-transfer" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyTransfer/start.html.twig
+++ b/client/app/templates/Report/MoneyTransfer/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-transfer" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyTransfer/step.html.twig
+++ b/client/app/templates/Report/MoneyTransfer/step.html.twig
@@ -13,7 +13,7 @@
 
 {% set translationDomain = "report-money-transfer" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 
 {% block linkBack %}

--- a/client/app/templates/Report/MoneyTransfer/step.html.twig
+++ b/client/app/templates/Report/MoneyTransfer/step.html.twig
@@ -13,7 +13,7 @@
 
 {% set translationDomain = "report-money-transfer" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 
 {% block linkBack %}

--- a/client/app/templates/Report/MoneyTransfer/summary.html.twig
+++ b/client/app/templates/Report/MoneyTransfer/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-transfer" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/MoneyTransfer/summary.html.twig
+++ b/client/app/templates/Report/MoneyTransfer/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-money-transfer" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/OtherInfo/_answers.html.twig
+++ b/client/app/templates/Report/OtherInfo/_answers.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-more-info" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/OtherInfo/_answers.html.twig
+++ b/client/app/templates/Report/OtherInfo/_answers.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-more-info" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/OtherInfo/start.html.twig
+++ b/client/app/templates/Report/OtherInfo/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-more-info" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 {% set append104 = report.get104TransSuffix %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/OtherInfo/start.html.twig
+++ b/client/app/templates/Report/OtherInfo/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-more-info" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 {% set append104 = report.get104TransSuffix %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/OtherInfo/step.html.twig
+++ b/client/app/templates/Report/OtherInfo/step.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-more-info" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/OtherInfo/step.html.twig
+++ b/client/app/templates/Report/OtherInfo/step.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-more-info" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/OtherInfo/summary.html.twig
+++ b/client/app/templates/Report/OtherInfo/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-more-info" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/OtherInfo/summary.html.twig
+++ b/client/app/templates/Report/OtherInfo/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-more-info" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/PaFeeExpense/feeEdit.html.twig
+++ b/client/app/templates/Report/PaFeeExpense/feeEdit.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-pa-fee-expense" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'editPage.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageTitle %}{{ 'editPage.pageTitle' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/PaFeeExpense/feeEdit.html.twig
+++ b/client/app/templates/Report/PaFeeExpense/feeEdit.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-pa-fee-expense" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'editPage.htmlTitle' | trans(transOptions) }}{% endblock %}
 {% block pageTitle %}{{ 'editPage.pageTitle' | trans(transOptions) }}{% endblock %}

--- a/client/app/templates/Report/PaFeeExpense/feeExist.html.twig
+++ b/client/app/templates/Report/PaFeeExpense/feeExist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-pa-fee-expense" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'feeExistPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/PaFeeExpense/feeExist.html.twig
+++ b/client/app/templates/Report/PaFeeExpense/feeExist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-pa-fee-expense" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'feeExistPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/PaFeeExpense/otherAdd.html.twig
+++ b/client/app/templates/Report/PaFeeExpense/otherAdd.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-pa-fee-expense" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'otherAddPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'otherAddPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/PaFeeExpense/otherAdd.html.twig
+++ b/client/app/templates/Report/PaFeeExpense/otherAdd.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-pa-fee-expense" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'otherAddPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'otherAddPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/PaFeeExpense/otherAddAnother.html.twig
+++ b/client/app/templates/Report/PaFeeExpense/otherAddAnother.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-pa-fee-expense" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'otherAddAnotherPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'otherAddAnotherPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/PaFeeExpense/otherAddAnother.html.twig
+++ b/client/app/templates/Report/PaFeeExpense/otherAddAnother.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-pa-fee-expense" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'otherAddAnotherPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'otherAddAnotherPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/PaFeeExpense/otherEdit.html.twig
+++ b/client/app/templates/Report/PaFeeExpense/otherEdit.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-pa-fee-expense" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'otherEditPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'otherEditPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/PaFeeExpense/otherEdit.html.twig
+++ b/client/app/templates/Report/PaFeeExpense/otherEdit.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-pa-fee-expense" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'otherEditPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'otherEditPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/PaFeeExpense/otherExist.html.twig
+++ b/client/app/templates/Report/PaFeeExpense/otherExist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-pa-fee-expense" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'otherExistPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/PaFeeExpense/otherExist.html.twig
+++ b/client/app/templates/Report/PaFeeExpense/otherExist.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-pa-fee-expense" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'otherExistPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/PaFeeExpense/start.html.twig
+++ b/client/app/templates/Report/PaFeeExpense/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-pa-fee-expense" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/PaFeeExpense/start.html.twig
+++ b/client/app/templates/Report/PaFeeExpense/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-pa-fee-expense" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/PaFeeExpense/summary.html.twig
+++ b/client/app/templates/Report/PaFeeExpense/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-pa-fee-expense" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 {% set hideEditLink = hideEditLink | default(false) %}
 
 {# Page Titles #}

--- a/client/app/templates/Report/PaFeeExpense/summary.html.twig
+++ b/client/app/templates/Report/PaFeeExpense/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-pa-fee-expense" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 {% set hideEditLink = hideEditLink | default(false) %}
 
 {# Page Titles #}

--- a/client/app/templates/Report/ProfDeputyCosts/_all_cost_total_answers.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/_all_cost_total_answers.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = transDomain %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {# Set page to summary page to allow correct translations to be pulled in#}
 {% set page = 'summaryPage' %}

--- a/client/app/templates/Report/ProfDeputyCosts/_all_cost_total_answers.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/_all_cost_total_answers.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = transDomain %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {# Set page to summary page to allow correct translations to be pulled in#}
 {% set page = 'summaryPage' %}

--- a/client/app/templates/Report/ProfDeputyCosts/_answers.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/_answers.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-prof-deputy-costs" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 {% set append104 = report.get104TransSuffix %}
 
 {# Set page to summary page to allow correct translations to be pulled in#}

--- a/client/app/templates/Report/ProfDeputyCosts/_answers.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/_answers.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-prof-deputy-costs" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 {% set append104 = report.get104TransSuffix %}
 
 {# Set page to summary page to allow correct translations to be pulled in#}

--- a/client/app/templates/Report/ProfDeputyCosts/_breakdown_costs_answers.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/_breakdown_costs_answers.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = transDomain %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 {% set page = 'summaryPage' %}
 
 <div class="govuk-summary-list__row">

--- a/client/app/templates/Report/ProfDeputyCosts/_breakdown_costs_answers.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/_breakdown_costs_answers.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = transDomain %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 {% set page = 'summaryPage' %}
 
 <div class="govuk-summary-list__row">

--- a/client/app/templates/Report/ProfDeputyCosts/_how_charged_answers.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/_how_charged_answers.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = transDomain %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {# Set page to summary page to allow correct translations to be pulled in#}
 {% set page = 'summaryPage' %}

--- a/client/app/templates/Report/ProfDeputyCosts/_how_charged_answers.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/_how_charged_answers.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = transDomain %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {# Set page to summary page to allow correct translations to be pulled in#}
 {% set page = 'summaryPage' %}

--- a/client/app/templates/Report/ProfDeputyCosts/_total_final_answers.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/_total_final_answers.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = transDomain %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {# Set page to summary page to allow correct translations to be pulled in#}
 {% set page = 'summaryPage' %}

--- a/client/app/templates/Report/ProfDeputyCosts/_total_final_answers.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/_total_final_answers.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = transDomain %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {# Set page to summary page to allow correct translations to be pulled in#}
 {% set page = 'summaryPage' %}

--- a/client/app/templates/Report/ProfDeputyCosts/_total_taken_from_client_answers.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/_total_taken_from_client_answers.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = transDomain %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {# Set page to summary page to allow correct translations to be pulled in#}
 {% set page = 'summaryPage' %}

--- a/client/app/templates/Report/ProfDeputyCosts/_total_taken_from_client_answers.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/_total_taken_from_client_answers.html.twig
@@ -1,6 +1,6 @@
 {% set translationDomain = transDomain %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {# Set page to summary page to allow correct translations to be pulled in#}
 {% set page = 'summaryPage' %}

--- a/client/app/templates/Report/ProfDeputyCosts/amountToScco.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/amountToScco.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCosts/amountToScco.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/amountToScco.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCosts/breakdown.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/breakdown.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCosts/breakdown.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/breakdown.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCosts/fixedCost.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/fixedCost.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCosts/fixedCost.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/fixedCost.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCosts/howCharged.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/howCharged.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCosts/howCharged.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/howCharged.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCosts/interim.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/interim.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCosts/interim.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/interim.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCosts/interimExists.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/interimExists.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCosts/interimExists.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/interimExists.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCosts/previousReceived.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/previousReceived.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCosts/previousReceived.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/previousReceived.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCosts/previousReceivedExists.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/previousReceivedExists.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCosts/previousReceivedExists.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/previousReceivedExists.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCosts/start.html.twig
+++ b/client/app/templates/Report/ProfDeputyCosts/start.html.twig
@@ -1,6 +1,6 @@
 {% extends '@App/Layouts/application.html.twig'%}
 {% set transOptions = {
-    '%client%': report.client.firstname | e,
+    '%client%': report.client.firstname | striptags,
     '%periodStartDate%': report.startDate | date("j F Y"),
     '%periodEndDate%': report.endDate | date("j F Y")
 } %}

--- a/client/app/templates/Report/ProfDeputyCostsEstimate/_answers.html.twig
+++ b/client/app/templates/Report/ProfDeputyCostsEstimate/_answers.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-prof-deputy-costs-estimate" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/ProfDeputyCostsEstimate/_answers.html.twig
+++ b/client/app/templates/Report/ProfDeputyCostsEstimate/_answers.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-prof-deputy-costs-estimate" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/ProfDeputyCostsEstimate/breakdown.html.twig
+++ b/client/app/templates/Report/ProfDeputyCostsEstimate/breakdown.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCostsEstimate/breakdown.html.twig
+++ b/client/app/templates/Report/ProfDeputyCostsEstimate/breakdown.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCostsEstimate/howCharged.html.twig
+++ b/client/app/templates/Report/ProfDeputyCostsEstimate/howCharged.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCostsEstimate/howCharged.html.twig
+++ b/client/app/templates/Report/ProfDeputyCostsEstimate/howCharged.html.twig
@@ -1,5 +1,5 @@
 {% extends '@App/Layouts/application.html.twig' %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% import '@App/Macros/macros.html.twig' as macros %}
 

--- a/client/app/templates/Report/ProfDeputyCostsEstimate/start.html.twig
+++ b/client/app/templates/Report/ProfDeputyCostsEstimate/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-prof-deputy-costs-estimate" %}
 {% set transOptions = {
-'%client%': report.client.firstname | e,
+'%client%': report.client.firstname | striptags,
 '%nextStartDate%': report.nextStartDate | date("j F Y"),
 '%nextEndDate%': report.nextEndDate | date("j F Y")
 } %}

--- a/client/app/templates/Report/Report/_subsection.html.twig
+++ b/client/app/templates/Report/Report/_subsection.html.twig
@@ -2,7 +2,7 @@
 {# @param client App\Entity\Client #}
 {% set translationDomain = "report-overview" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': client.firstname | e } %}
+{% set transOptions = {'%client%': client.firstname | striptags } %}
 {% set sectionId = sectionId | default(null) %}
 {% set sectionNeedsAttention = report.isSectionFlaggedForAttention(sectionId) %}
 
@@ -21,7 +21,7 @@
         {%  if description | default(false) %}
             <div class="opg-overview-section__description">
                 {% if descriptionLeft | default(false)  %}
-                    {{ descriptionLeft }}{{ report.client.firstname | e }}{{ descriptionRight }}
+                    {{ descriptionLeft }}{{ report.client.firstname | striptags }}{{ descriptionRight }}
                 {% else %}
                     {{ (subSection ~ '.subSectionDescription') | trans(transOptions) }}
                 {% endif %}

--- a/client/app/templates/Report/Report/overview.html.twig
+++ b/client/app/templates/Report/Report/overview.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-overview" %}
 {% trans_default_domain translationDomain %}
 {% set transOptions = {
-    '%client%': report.client.firstname | e
+    '%client%': report.client.firstname | striptags
 } %}
 {% set reportStatus = report.status %}
 

--- a/client/app/templates/Report/Report/submitConfirmation.html.twig
+++ b/client/app/templates/Report/Report/submitConfirmation.html.twig
@@ -5,7 +5,7 @@
 {% set translationDomain = "report-submitted" %}
 {% trans_default_domain translationDomain %}
 {% set transOptions = {
-    '%client%': report.client.firstname | e,
+    '%client%': report.client.firstname | striptags,
     '%reportName%' : report.getPeriod()
 } %}
 {% block htmlTitle %}{{ 'page.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/VisitsCare/_answers.html.twig
+++ b/client/app/templates/Report/VisitsCare/_answers.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-visits-care" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/VisitsCare/_answers.html.twig
+++ b/client/app/templates/Report/VisitsCare/_answers.html.twig
@@ -2,7 +2,7 @@
 
 {% set translationDomain = "report-visits-care" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% set hideEditLink = hideEditLink | default(false) %}
 

--- a/client/app/templates/Report/VisitsCare/start.html.twig
+++ b/client/app/templates/Report/VisitsCare/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-visits-care" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/VisitsCare/start.html.twig
+++ b/client/app/templates/Report/VisitsCare/start.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-visits-care" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'startPage.htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/VisitsCare/step.html.twig
+++ b/client/app/templates/Report/VisitsCare/step.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-visits-care" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/VisitsCare/step.html.twig
+++ b/client/app/templates/Report/VisitsCare/step.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-visits-care" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans }}{% endblock %}
 {% block pageHeader %}{% endblock %}

--- a/client/app/templates/Report/VisitsCare/summary.html.twig
+++ b/client/app/templates/Report/VisitsCare/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-visits-care" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | striptags %}
+{% set transOptions = {'%client%': report.client.firstname | striptags } %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans }}{% endblock %}

--- a/client/app/templates/Report/VisitsCare/summary.html.twig
+++ b/client/app/templates/Report/VisitsCare/summary.html.twig
@@ -4,7 +4,7 @@
 
 {% set translationDomain = "report-visits-care" %}
 {% trans_default_domain translationDomain %}
-{% set transOptions = {'%client%': report.client.firstname | e } %}
+{% set transOptions = {'%client%': report.client.firstname | striptags %}
 
 {# Page Titles #}
 {% block htmlTitle %}{{ 'summaryPage.htmlTitle' | trans }}{% endblock %}


### PR DESCRIPTION
## Purpose
In certain parts of the app, when displaying the clients first name that contains special characters (in most cases an apostrophe), the html escaped characters are shown instead.

Fixes DDLS-156

## Approach
By default, twig enables auto-escaping of html characters. Updated the twig config to make this explicit to that anyone looking without any knowledge of how twig works should be able to tell what's going on.

Updated the escaping of client first names in all templates to instead just strip any tags that might have tried to be included by a malicious user. The default twig auto-escaping would escape these characters so that they were not parsed, but as an additional level of security it was decided to strip any tags that may be parsed like `<script>`

## Learning
Twig sets the default of autoescape to be true.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
