### PR TITLE
DDLS-203: Admin users who invited users to the app can't be deleted

### DIFF
--- a/api/app/src/Migrations/Version273.php
+++ b/api/app/src/Migrations/Version273.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version273 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Recreate created_by constraint on dd_user to set to null on deletion of referenced user.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE dd_user DROP CONSTRAINT FK_6764AB8BB03A8386');
+        $this->addSql('ALTER TABLE dd_user ADD CONSTRAINT DD_USER_CREATED_BY_FK FOREIGN KEY (created_by_id) REFERENCES dd_user (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE dd_user DROP CONSTRAINT DD_USER_CREATED_BY_FK');
+        $this->addSql('ALTER TABLE dd_user ADD CONSTRAINT FK_6764AB8BB03A8386 FOREIGN KEY (created_by_id) REFERENCES dd_user (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+}


### PR DESCRIPTION
## Purpose
When an admin user invites a user to the app, a link is created between admin user and the invited user.
This is used purely for investigatory purposes and is not used for any other purposes currently.

This link (referred to a constraint in sql) was set up without the permission to be deleted when the admin user is deleted.
This PR fixes this by recreating the constraint with new configuration to allow for deletion.

Fixes DDLS-203

## Approach
We cannot change or alter a constraint after is it has been created. Therefore we have to drop the constraint and create it again with the new configuration needed.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
