### PR TITLE
DDLS-204 : Satisfaction data mismatch

### DIFF
--- a/api/app/src/Command/SatisfactionPerformanceStatsCommand.php
+++ b/api/app/src/Command/SatisfactionPerformanceStatsCommand.php
@@ -45,8 +45,7 @@ class SatisfactionPerformanceStatsCommand extends Command
                         count(CASE WHEN score = 4 THEN 1 END) AS satisfied,
                         count(CASE WHEN score = 5 THEN 1 END) AS very_satisfied
                     FROM satisfaction
-                    WHERE (report_id IS NOT NULL OR ndr_id IS NOT NULL)
-                    AND created_at >= date_trunc('month', CURRENT_DATE - INTERVAL '1' month)
+                    WHERE created_at >= date_trunc('month', CURRENT_DATE - INTERVAL '1' month)
                     AND created_at <= date_trunc('month', CURRENT_DATE) - INTERVAL '1' second
             ";
 

--- a/api/app/src/Command/SatisfactionPerformanceStatsCommand.php
+++ b/api/app/src/Command/SatisfactionPerformanceStatsCommand.php
@@ -65,7 +65,7 @@ class SatisfactionPerformanceStatsCommand extends Command
                     '_timestamp' => $statsStartDate.'T00:00:00+00:00',
                     'service' => 'deputy-reporting',
                     'channel' => 'digital',
-                    'count' => $satisfactionScoreRow,
+                    'count' => intval($satisfactionScoreRow),
                     'dataType' => str_replace('-', '_', $satisfactionScoreKey),
                     'period' => 'month',
                 ];

--- a/api/app/src/Repository/SatisfactionRepository.php
+++ b/api/app/src/Repository/SatisfactionRepository.php
@@ -17,15 +17,14 @@ class SatisfactionRepository extends ServiceEntityRepository
      * @return array
      */
     public function findAllSatisfactionSubmissions(
-        \DateTime $fromDate = null,
-        \DateTime $toDate = null
+        ?\DateTime $fromDate = null,
+        ?\DateTime $toDate = null
     ) {
         $entityManager = $this->getEntityManager();
         $query = $entityManager->createQuery(
             'SELECT s.id, s.score, s.comments, s.deputyrole, s.reporttype, s.created
              FROM App:Satisfaction s
-             WHERE (s.report IS NOT NULL OR s.ndr IS NOT NULL)
-             AND s.created > :fromDate
+             WHERE s.created > :fromDate
              AND s.created < :toDate'
         )
             ->setParameters(['fromDate' => $fromDate, 'toDate' => $toDate]);


### PR DESCRIPTION
## Purpose
Fixes DDLS-204

The satisfaction data in the Admin Analytics Dashboard vs the CSV report download & performance stats on the OPG Services Performance Data site is different when entering the same dates. The reason being that the CSV report & performance stats excludes satisfaction feedback which are not linked to a report or NDR. The dashboard includes them and so is the difference in the number of responses.

## Approach
This change now includes the satisfaction feedback which are not linked to a report or NDR, into the CSV report & performance stats on the OPG Services Performance Data site. The code also fixes a minor issue with the formatting of the user satisfaction percentage value in OPS Service performance stats by changing it from a string to int so that it can uploaded without any errors.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
