### PR TITLE
DDLS-213 make nginx 403 certain files

### DIFF
--- a/client/docker/web/confd/templates/app.conf.tmpl
+++ b/client/docker/web/confd/templates/app.conf.tmpl
@@ -17,9 +17,13 @@ server {
     client_max_body_size 0;
     client_body_timeout 240s;
 
-    location / {
-        root    /public;
+    # block potentially sensitive files in case they were accidentally added to web root
+    # using a 403 to match status returned by WAF for bad filenames
+    location ~ "^/.*\.(zip|gz|lzh|tar|rar|7z|swp|bak|git|ht|exe|dll|py|msi|bin|sh|bat|xml|apk|jar|log|sql|conf|cfg|ini|tmp|doc|xls|rtf)" {
+        return 403;
+    }
 
+    location / {
         # cache static assets for 90 days
         location ~* \.(css|jpg|js|png|ico|jpeg|woff2|woff)$ {
             expires    90d;


### PR DESCRIPTION
## Purpose
Will 403 for many file types used in scripts that shouldn't be in public instead of doing the 404 and logging an error to nginx logs. This will keep our alarms a bit more clear of spam
 
Fixes DDLS-213

## Approach
Added a list of extensions to 403 for. 

## Learning
NA

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
