### PR TITLE
DDLS-214 : Updated court order uid column to bigint

### DIFF
--- a/api/app/src/Entity/CourtOrder.php
+++ b/api/app/src/Entity/CourtOrder.php
@@ -39,7 +39,7 @@ class CourtOrder
      *
      * @JMS\Type("integer")
      *
-     * @ORM\Column(name="court_order_uid", type="integer", nullable=false, unique=true)
+     * @ORM\Column(name="court_order_uid", type="bigint", nullable=false, unique=true)
      */
     private $courtOrderUid;
 

--- a/api/app/src/Migrations/Version275.php
+++ b/api/app/src/Migrations/Version275.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version275 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE court_order ALTER court_order_uid TYPE BIGINT');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE court_order ALTER court_order_uid TYPE INT');
+    }
+}


### PR DESCRIPTION
## Purpose

Fixes [DDLS-214](https://opgtransform.atlassian.net/browse/DDLS-214)

The court order UID column in the Court Order database table was set to the data type 'integer'. But the court order UIDs from Sirius exceed the number range of an integer in PostgreSQL (2147483648 to +2147483647). So the column has been changed to the data type 'bigint' to support large UID numbers.

## Approach
The court order UID attribute in the Court Order entity in the API has been updated to the datatype 'bigint'. This has resulted in a new migration file to apply the changes to the database. There is no data in the table yet - so no impact.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values


[DDLS-214]: https://opgtransform.atlassian.net/browse/DDLS-214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ