### PR TITLE
DDLS-224 : Add a check for submitted reports in report review page

### DIFF
--- a/client/app/src/Controller/Report/ReportController.php
+++ b/client/app/src/Controller/Report/ReportController.php
@@ -464,11 +464,13 @@ class ReportController extends AbstractController
             $backLink = $this->generateUrl('lay_home');
         }
 
-        // Redirect deputy to doc re-upload page if docs do not exist in S3
-        $documentsNotInS3 = $this->checkIfDocumentsExistInS3($report);
+        if (!$report->isSubmitted()) {
+            // Redirect deputy to doc re-upload page if docs do not exist in S3
+            $documentsNotInS3 = $this->checkIfDocumentsExistInS3($report);
 
-        if (!empty($documentsNotInS3)) {
-            return $this->redirectToRoute('report_documents_reupload', ['reportId' => $reportId]);
+            if (!empty($documentsNotInS3)) {
+                return $this->redirectToRoute('report_documents_reupload', ['reportId' => $reportId]);
+            }
         }
 
         return [


### PR DESCRIPTION
## Purpose

Fixes [DDLS-224](https://opgtransform.atlassian.net/browse/DDLS-224)

## Approach
The review page of a report checks if there are documents attached to the report which are quite old and not available in S3 anymore. In such a scenario, the system asks the user to reupload the documents. The logic did not filter submitted reports. This fix adds a check to see if the report is submitted and if it is, then the logic is ignored.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values


[DDLS-224]: https://opgtransform.atlassian.net/browse/DDLS-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ