### PR TITLE
DDLS-233 : Filter out satisfaction scores not related to a report or a NDR

### DIFF
--- a/api/app/src/Command/SatisfactionPerformanceStatsCommand.php
+++ b/api/app/src/Command/SatisfactionPerformanceStatsCommand.php
@@ -45,7 +45,8 @@ class SatisfactionPerformanceStatsCommand extends Command
                         count(CASE WHEN score = 4 THEN 1 END) AS satisfied,
                         count(CASE WHEN score = 5 THEN 1 END) AS very_satisfied
                     FROM satisfaction
-                    WHERE created_at >= date_trunc('month', CURRENT_DATE - INTERVAL '1' month)
+                    WHERE (report_id IS NOT NULL OR ndr_id IS NOT NULL)
+                    AND created_at >= date_trunc('month', CURRENT_DATE - INTERVAL '1' month)
                     AND created_at <= date_trunc('month', CURRENT_DATE) - INTERVAL '1' second
             ";
 

--- a/api/app/src/Repository/SatisfactionRepository.php
+++ b/api/app/src/Repository/SatisfactionRepository.php
@@ -24,7 +24,8 @@ class SatisfactionRepository extends ServiceEntityRepository
         $query = $entityManager->createQuery(
             'SELECT s.id, s.score, s.comments, s.deputyrole, s.reporttype, s.created
              FROM App:Satisfaction s
-             WHERE s.created > :fromDate
+             WHERE (s.report IS NOT NULL OR s.ndr IS NOT NULL)
+             AND s.created > :fromDate
              AND s.created < :toDate'
         )
             ->setParameters(['fromDate' => $fromDate, 'toDate' => $toDate]);

--- a/api/app/src/Service/Stats/Query/RespondentsQuery.php
+++ b/api/app/src/Service/Stats/Query/RespondentsQuery.php
@@ -18,6 +18,7 @@ class RespondentsQuery extends Query
     {
         return 'SELECT
             s.created_at date
-        FROM satisfaction s';
+        FROM satisfaction s
+        WHERE (s.report_id IS NOT NULL OR s.ndr_id IS NOT NULL)';
     }
 }

--- a/api/app/src/Service/Stats/Query/SatisfactionQuery.php
+++ b/api/app/src/Service/Stats/Query/SatisfactionQuery.php
@@ -27,6 +27,7 @@ class SatisfactionQuery extends Query
             END deputyType,
             COALESCE(report_type, 'none') reportType,
             s.score val
-        FROM satisfaction s";
+        FROM satisfaction s
+        WHERE (s.report_id IS NOT NULL OR s.ndr_id IS NOT NULL)";
     }
 }

--- a/api/app/tests/Unit/Stats/Query/RespondentsQueryTest.php
+++ b/api/app/tests/Unit/Stats/Query/RespondentsQueryTest.php
@@ -2,6 +2,8 @@
 
 namespace App\Tests\Unit\Service\Stats\Query;
 
+use App\Entity\Client;
+use App\Entity\Report\Report;
 use App\Entity\Satisfaction;
 use App\Service\Stats\Query\RespondentsQuery;
 use App\Service\Stats\StatsQueryParameters;
@@ -33,8 +35,8 @@ class RespondentsQueryTest extends WebTestCase
         static::givenSatisfactionScoreForReportOfTypeAndRole(1);
         static::givenSatisfactionScoreForReportOfTypeAndRole(2);
         static::givenSatisfactionScoreForReportOfTypeAndRole(3);
-        static::givenSatisfactionScoreForReportOfTypeAndRole(4);
-        static::givenSatisfactionScoreForReportOfTypeAndRole(5);
+        static::givenSatisfactionScoreForReportOfTypeAndRole(4, '102', 'LAY');
+        static::givenSatisfactionScoreForReportOfTypeAndRole(5, '104', 'LAY');
 
         self::$em->flush();
     }
@@ -48,7 +50,7 @@ class RespondentsQueryTest extends WebTestCase
         ]));
 
         $this->assertCount(1, $result);
-        $this->assertEquals(5, $result[0]['amount']);
+        $this->assertEquals(2, $result[0]['amount']);
     }
 
     private static function givenSatisfactionScoreForReportOfTypeAndRole($score, $reportType = null, $deputyType = null)
@@ -57,7 +59,19 @@ class RespondentsQueryTest extends WebTestCase
             ->setScore($score);
 
         if (isset($reportType)) {
+            $client = new Client();
+
+            $report = new Report(
+                $client,
+                $reportType,
+                new \DateTime('2019-08-01'),
+                new \DateTime('2020-08-01')
+            );
+            self::$em->persist($client);
+            self::$em->persist($report);
+
             $satisfaction->setReportType($reportType);
+            $satisfaction->setReport($report);
         }
 
         if (isset($deputyType)) {

--- a/api/app/tests/Unit/Stats/Query/SatisfactionQueryTest.php
+++ b/api/app/tests/Unit/Stats/Query/SatisfactionQueryTest.php
@@ -2,6 +2,8 @@
 
 namespace App\Tests\Unit\Service\Stats\Query;
 
+use App\Entity\Client;
+use App\Entity\Report\Report;
 use App\Entity\Satisfaction;
 use App\Service\Stats\Query\SatisfactionQuery;
 use App\Service\Stats\StatsQueryParameters;
@@ -59,7 +61,7 @@ class SatisfactionQueryTest extends WebTestCase
         ]));
 
         $this->assertCount(1, $result);
-        $this->assertEquals(53, $result[0]['amount']);
+        $this->assertEquals(63, $result[0]['amount']);
     }
 
     public function testReturnsSatisfactionAverageByDeputyType()
@@ -72,7 +74,7 @@ class SatisfactionQueryTest extends WebTestCase
         ]));
 
         // Assert an array result for each deputy type submitted.
-        $this->assertCount(4, $result);
+        $this->assertCount(3, $result);
 
         // Assert correct amount is returned for each deputy type.
         foreach ($result as $metric) {
@@ -85,9 +87,6 @@ class SatisfactionQueryTest extends WebTestCase
                     break;
                 case 'prof':
                     $this->assertEquals(63, $metric['amount']);
-                    break;
-                case 'none':
-                    $this->assertEquals(17, $metric['amount']);
                     break;
             }
         }
@@ -103,7 +102,7 @@ class SatisfactionQueryTest extends WebTestCase
         ]));
 
         // Assert an array result for each report type submitted
-        $this->assertCount(7, $result);
+        $this->assertCount(6, $result);
 
         // Assert correct amount is returned for each report type
         foreach ($result as $metric) {
@@ -126,9 +125,6 @@ class SatisfactionQueryTest extends WebTestCase
                 case '103-5':
                     $this->assertEquals(50, $metric['amount']);
                     break;
-                case 'none':
-                    $this->assertEquals(17, $metric['amount']);
-                    break;
             }
         }
     }
@@ -139,7 +135,19 @@ class SatisfactionQueryTest extends WebTestCase
             ->setScore($score);
 
         if (isset($reportType)) {
+            $client = new Client();
+
+            $report = new Report(
+                $client,
+                $reportType,
+                new \DateTime('2019-08-01'),
+                new \DateTime('2020-08-01')
+            );
+            self::$em->persist($client);
+            self::$em->persist($report);
+
             $satisfaction->setReportType($reportType);
+            $satisfaction->setReport($report);
         }
 
         if (isset($deputyType)) {


### PR DESCRIPTION


## Purpose
Fixes [DDLS-233](https://opgtransform.atlassian.net/browse/DDLS-233)

## Approach
The satisfaction feedback scores and details are displayed on OPG Service Performance Data site and on the Digideps Admin Analytics dashboard and report. The scores currently consider standalone feedback i.e. feedback that are not associated with a report or a NDR. But a lot of bots are getting past our honey pot traps, selecting dissatisfied scores and putting junk in our feedback forms. This results in the scores getting corrupted. 

This change excludes the standalone feedback from the scores and details across the Satisfaction Scores command job  and the Digideps Admin Analytics dashboard and report so that we can get an accurate reflection of the user feedback about our product.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values


[DDLS-233]: https://opgtransform.atlassian.net/browse/DDLS-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ