### PR TITLE
DDLS-241 : Making Deputy UID optional in the User entity

### DIFF
--- a/api/app/src/Entity/User.php
+++ b/api/app/src/Entity/User.php
@@ -927,12 +927,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this;
     }
 
-    public function getDeputyUid(): int
+    public function getDeputyUid(): ?int
     {
         return $this->deputyUid;
     }
 
-    public function setDeputyUid(int $deputyUid): User
+    public function setDeputyUid(?int $deputyUid): User
     {
         $this->deputyUid = $deputyUid;
 

--- a/client/app/src/Entity/User.php
+++ b/client/app/src/Entity/User.php
@@ -921,12 +921,12 @@ class User implements UserInterface, DeputyInterface, PasswordAuthenticatedUserI
         return $this;
     }
 
-    public function getDeputyUid(): int
+    public function getDeputyUid(): ?int
     {
         return $this->deputyUid;
     }
 
-    public function setDeputyUid(int $deputyUid): User
+    public function setDeputyUid(?int $deputyUid): User
     {
         $this->deputyUid = $deputyUid;
 


### PR DESCRIPTION
## Purpose

Fixes DDLS-241

## Approach
The Deputy UID has been made optional to cater for scenarios where there is no deputy no for a user in the old data prior to DDLS-144 release.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
