### PR TITLE
DDLS-245 pause overnight notifications

### DIFF
--- a/lambdas/functions/slack_lambda/app/slack.py
+++ b/lambdas/functions/slack_lambda/app/slack.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 import time
 import urllib
@@ -606,6 +607,10 @@ def send_message(payload):
 
 def lambda_handler(event, context):
     payload = generate_message(event)
-    response = send_message(payload)
 
+    pause_notifications = os.getenv("PAUSE_NOTIFICATIONS", "0")
+    if pause_notifications == "1":
+        return 0
+
+    response = send_message(payload)
     return response

--- a/orchestration/sleep_mode/main.go
+++ b/orchestration/sleep_mode/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/rds"
 )
 
@@ -97,6 +98,19 @@ func turnOff(sess *session.Session, rdsClusterID string, ecsClusterName string) 
 		}
 		fmt.Printf("Set desired count to 0 for service: %s\n", *serviceArn)
 	}
+
+	lambdaSvc := lambda.New(sess)
+	_, err = lambdaSvc.UpdateFunctionConfiguration(&lambda.UpdateFunctionConfigurationInput{
+		FunctionName: aws.String("slack-notifier"),
+		Environment: &lambda.Environment{
+			Variables: map[string]*string{
+				"PAUSE_NOTIFICATIONS": aws.String("1"),
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
 }
 
 func turnOn(sess *session.Session, rdsClusterID string, ecsClusterName string) {
@@ -152,5 +166,18 @@ func turnOn(sess *session.Session, rdsClusterID string, ecsClusterName string) {
 				fmt.Printf("Skipping service: %s\n", *service.ServiceName)
 			}
 		}
+	}
+
+	lambdaSvc := lambda.New(sess)
+	_, err = lambdaSvc.UpdateFunctionConfiguration(&lambda.UpdateFunctionConfigurationInput{
+		FunctionName: aws.String("slack-notifier"),
+		Environment: &lambda.Environment{
+			Variables: map[string]*string{
+				"PAUSE_NOTIFICATIONS": aws.String("0"),
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
 	}
 }

--- a/terraform/account/region/lambda_slack.tf
+++ b/terraform/account/region/lambda_slack.tf
@@ -12,6 +12,11 @@ resource "aws_lambda_function" "slack_lambda" {
   layers        = [aws_lambda_layer_version.lambda_layer.arn]
   depends_on    = [aws_cloudwatch_log_group.slack_lambda]
   timeout       = 300
+  environment {
+    variables = {
+      PAUSE_NOTIFICATIONS = "0"
+    }
+  }
   tracing_config {
     mode = "Active"
   }

--- a/terraform/environment/region/ecs_iam_sleep_mode.tf
+++ b/terraform/environment/region/ecs_iam_sleep_mode.tf
@@ -30,6 +30,17 @@ data "aws_iam_policy_document" "sleep_mode" {
       "arn:aws:ecs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:service/${local.environment}/*"
     ]
   }
+
+  statement {
+    sid    = "UpdateLambdaConfig"
+    effect = "Allow"
+    actions = [
+      "lambda:UpdateFunctionConfiguration"
+    ]
+    resources = [
+      data.aws_lambda_function.slack_lambda.arn
+    ]
+  }
 }
 
 resource "aws_iam_role_policy" "sleep_mode" {


### PR DESCRIPTION
## Purpose
Getting annoying spam in dev channel when we take the preprod envs down overnight.
Fixes DDLS-245

## Approach
Easier than working our which jobs need turning off and reactivating... it's easier to just update an env on the lambda and not send out the notifications when it's set to pause_notifications.

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
