### PR TITLE
Ddls 281 - cache bust assets but avoid stale connections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,158 +34,158 @@ create-app: build-app up-app reset-database reset-fixtures ##@application Brings
 
 build-app: down-app build-js ##@application Brings up app with a full no-cache build
 	docker container prune --force
-	docker-compose build --no-cache
+	docker compose build --no-cache
 
 up-app: ##@application Brings the app up and mounts local folders
-	COMPOSE_HTTP_TIMEOUT=90 docker-compose up -d --remove-orphans load-balancer
+	COMPOSE_HTTP_TIMEOUT=90 docker compose up -d --remove-orphans load-balancer
 
 up-app-rebuild: ##@application Brings up app with a basic rebuild
-	docker-compose down
+	docker compose down
 	docker container prune --force
-	COMPOSE_HTTP_TIMEOUT=90 docker-compose up -d --remove-orphans --build load-balancer
+	COMPOSE_HTTP_TIMEOUT=90 docker compose up -d --remove-orphans --build load-balancer
 
 up-app-xdebug: ##@application Brings the app up, rebuilds containers and enabled xdebug in api and client (see DEBUGGING.md for config and setup)
-	REQUIRE_XDEBUG_CLIENT=1 REQUIRE_XDEBUG_API=1 XDEBUG_IDEKEY_API=PHPSTORM-API XDEBUG_IDEKEY_CLIENT=PHPSTORM-CLIENT docker-compose up -d --build --remove-orphans load-balancer
+	REQUIRE_XDEBUG_CLIENT=1 REQUIRE_XDEBUG_API=1 XDEBUG_IDEKEY_API=PHPSTORM-API XDEBUG_IDEKEY_CLIENT=PHPSTORM-CLIENT docker compose up -d --build --remove-orphans load-balancer
 
 up-app-xdebug-client: ##@application Brings the app up, rebuilds containers and enabled xdebug in client
-	REQUIRE_XDEBUG_CLIENT=1 XDEBUG_IDEKEY_CLIENT=PHPSTORM docker-compose up -d --build --remove-orphans load-balancer
+	REQUIRE_XDEBUG_CLIENT=1 XDEBUG_IDEKEY_CLIENT=PHPSTORM docker compose up -d --build --remove-orphans load-balancer
 
 up-app-xdebug-client-cachegrind: ##@application Brings the app up, rebuilds containers and enabled xdebug in client with cachegrind being captured
- 	REQUIRE_XDEBUG_CLIENT=1 XDEBUG_IDEKEY_CLIENT=PHPSTORM docker-compose -f docker-compose.yml -f docker-compose.cachegrind.yml up -d --build --remove-orphans load-balancer
+ 	REQUIRE_XDEBUG_CLIENT=1 XDEBUG_IDEKEY_CLIENT=PHPSTORM docker compose -f docker-compose.yml -f docker-compose.cachegrind.yml up -d --build --remove-orphans load-balancer
 
 up-app-xdebug-api: ##@application Brings the app up, rebuilds containers and enabled xdebug in client
-	REQUIRE_XDEBUG_API=1 XDEBUG_IDEKEY_API=PHPSTORM docker-compose up -d --build --remove-orphans load-balancer
+	REQUIRE_XDEBUG_API=1 XDEBUG_IDEKEY_API=PHPSTORM docker compose up -d --build --remove-orphans load-balancer
 
 up-app-xdebug-api-cachegrind: ##@application Brings the app up, rebuilds containers and enabled xdebug in client with cachegrind
-	REQUIRE_XDEBUG_API=1 XDEBUG_IDEKEY_API=PHPSTORM docker-compose -f docker-compose.yml -f docker-compose.cachegrind.yml up -d --build --remove-orphans load-balancer
+	REQUIRE_XDEBUG_API=1 XDEBUG_IDEKEY_API=PHPSTORM docker compose -f docker-compose.yml -f docker-compose.cachegrind.yml up -d --build --remove-orphans load-balancer
 
 down-app: ##@application Tears down the app
-	docker-compose down -v --remove-orphans
+	docker compose down -v --remove-orphans
 
 integration-tests: up-app reset-database reset-fixtures ##@integration-tests Brings the app up using test env vars (see test.env)
-	REQUIRE_XDEBUG_CLIENT=0 REQUIRE_XDEBUG_API=0 docker-compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml build frontend-app frontend-webserver admin-app admin-webserver api-app integration-tests
-	REQUIRE_XDEBUG_CLIENT=0 REQUIRE_XDEBUG_API=0 docker-compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml up -d load-balancer
-	APP_DEBUG=0 docker-compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml run --remove-orphans integration-tests sh ./tests/Behat/run-tests.sh --tags @v2
+	REQUIRE_XDEBUG_CLIENT=0 REQUIRE_XDEBUG_API=0 docker compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml build frontend-app frontend-webserver admin-app admin-webserver api-app integration-tests
+	REQUIRE_XDEBUG_CLIENT=0 REQUIRE_XDEBUG_API=0 docker compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml up -d load-balancer
+	APP_DEBUG=0 docker compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml run --remove-orphans integration-tests sh ./tests/Behat/run-tests.sh --tags @v2
 
 integration-tests-rerun: reset-fixtures ##@integration-tests Rerun integration tests (requires you to have run integration-tests previously), argument in format: tag=your_tag
-	APP_DEBUG=0 docker-compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml run --remove-orphans integration-tests sh ./tests/Behat/run-tests.sh --tags @v2
+	APP_DEBUG=0 docker compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml run --remove-orphans integration-tests sh ./tests/Behat/run-tests.sh --tags @v2
 
 integration-tests-tag: reset-fixtures ##@integration-tests Rerun integration tests with a tag (requires you to have run integration-tests previously)
-	APP_DEBUG=0 docker-compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml run --remove-orphans integration-tests sh ./tests/Behat/run-tests.sh --tags @$(tag)
+	APP_DEBUG=0 docker compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml run --remove-orphans integration-tests sh ./tests/Behat/run-tests.sh --tags @$(tag)
 
 integration-tests-parallel: reset-fixtures ##@integration-tests Rerun the integration tests in parallel (requires you to have run integration-tests previously)
-	APP_DEBUG=0 docker-compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml run --remove-orphans integration-tests sh ./tests/Behat/run-tests.sh --tags @v2_sequential
-	APP_DEBUG=0 docker-compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml run --remove-orphans integration-tests sh ./tests/Behat/run-tests-parallel.sh --tags "@v2&&~@v2_sequential"
+	APP_DEBUG=0 docker compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml run --remove-orphans integration-tests sh ./tests/Behat/run-tests.sh --tags @v2_sequential
+	APP_DEBUG=0 docker compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml run --remove-orphans integration-tests sh ./tests/Behat/run-tests-parallel.sh --tags "@v2&&~@v2_sequential"
 
 integration-tests-browserkit: reset-fixtures ##@integration-tests Pass in suite name as arg e.g. make behat-tests-v2-browserkit suite=<SUITE NAME>
 
 ifdef suite
-	APP_DEBUG=0 docker-compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml run --remove-orphans integration-tests sh ./tests/Behat/run-tests.sh --profile v2-tests-browserkit --tags @v2 --suite $(suite)
+	APP_DEBUG=0 docker compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml run --remove-orphans integration-tests sh ./tests/Behat/run-tests.sh --profile v2-tests-browserkit --tags @v2 --suite $(suite)
 else
-	APP_DEBUG=0 docker-compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml run --remove-orphans integration-tests sh ./tests/Behat/run-tests.sh --profile v2-tests-browserkit --tags @v2
+	APP_DEBUG=0 docker compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml run --remove-orphans integration-tests sh ./tests/Behat/run-tests.sh --profile v2-tests-browserkit --tags @v2
 endif
 
 client-unit-tests: ##@unit-tests Run the client unit tests
-	REQUIRE_XDEBUG_CLIENT=0 REQUIRE_XDEBUG_API=0 docker-compose -f docker-compose.yml -f docker-compose.unit-tests-client.yml build client-unit-tests
-	docker-compose -f docker-compose.yml -f docker-compose.unit-tests-client.yml up -d pact-mock
+	REQUIRE_XDEBUG_CLIENT=0 REQUIRE_XDEBUG_API=0 docker compose -f docker-compose.yml -f docker-compose.unit-tests-client.yml build client-unit-tests
+	docker compose -f docker-compose.yml -f docker-compose.unit-tests-client.yml up -d pact-mock
 	sleep 5
-	docker-compose -f docker-compose.yml -f docker-compose.unit-tests-client.yml run -e APP_ENV=dev -e APP_DEBUG=0 --rm client-unit-tests vendor/bin/phpunit -c tests/phpunit
+	docker compose -f docker-compose.yml -f docker-compose.unit-tests-client.yml run -e APP_ENV=dev -e APP_DEBUG=0 --rm client-unit-tests vendor/bin/phpunit -c tests/phpunit
 
 api-unit-tests: reset-database-unit-tests reset-fixtures-unit-tests ##@unit-tests Run the api unit tests
-	REQUIRE_XDEBUG_FRONTEND=0 REQUIRE_XDEBUG_API=0 docker-compose -f docker-compose.yml -f docker-compose.unit-tests-api.yml build api-unit-tests
-	docker-compose -f docker-compose.yml -f docker-compose.unit-tests-api.yml run -e APP_ENV=test -e APP_DEBUG=0 --rm api-unit-tests sh scripts/api_unit_test.sh selection-all
+	REQUIRE_XDEBUG_FRONTEND=0 REQUIRE_XDEBUG_API=0 docker compose -f docker-compose.yml -f docker-compose.unit-tests-api.yml build api-unit-tests
+	docker compose -f docker-compose.yml -f docker-compose.unit-tests-api.yml run -e APP_ENV=test -e APP_DEBUG=0 --rm api-unit-tests sh scripts/api_unit_test.sh selection-all
 
 reset-database-unit-tests: ##@database Resets the DB schema and runs migrations
-	docker-compose -f docker-compose.yml -f docker-compose.unit-tests-api.yml run --rm api-unit-tests sh scripts/reset_db_structure_local.sh
+	docker compose -f docker-compose.yml -f docker-compose.unit-tests-api.yml run --rm api-unit-tests sh scripts/reset_db_structure_local.sh
 
 reset-fixtures-unit-tests: ##@database Resets the DB schema and runs migrations
-	docker-compose -f docker-compose.yml -f docker-compose.unit-tests-api.yml run --rm api-unit-tests sh scripts/reset_db_fixtures_local.sh
+	docker compose -f docker-compose.yml -f docker-compose.unit-tests-api.yml run --rm api-unit-tests sh scripts/reset_db_fixtures_local.sh
 
 reset-database: ##@database Resets the DB schema and runs migrations
-	docker-compose run --rm api-app sh scripts/reset_db_structure_local.sh
+	docker compose run --rm api-app sh scripts/reset_db_structure_local.sh
 
 reset-fixtures: ##@database Resets the DB contents and reloads fixtures
-	docker-compose run --rm api-app sh scripts/reset_db_fixtures_local.sh
+	docker compose run --rm api-app sh scripts/reset_db_fixtures_local.sh
 
 db-terminal: ##@database Login to the database via the terminal
-	docker-compose exec -it postgres sh -c "psql -U api"
+	docker compose exec -it postgres sh -c "psql -U api"
 
 api-logs: ##@logs Follow the API logs
-	docker-compose logs api-webserver api-app --follow
+	docker compose logs api-webserver api-app --follow
 
 front-logs: ##@logs Follow the frontend logs
-	docker-compose logs frontend-webserver frontend-app --follow
+	docker compose logs frontend-webserver frontend-app --follow
 
 admin-logs: ##@logs Follow the admin logs
-	docker-compose logs admin-webserver admin-app --follow
+	docker compose logs admin-webserver admin-app --follow
 
 redis-clear: ##@database Clears out all the data from redis (session related tokens)
 	for c in ${REDIS_CONTAINERS} ; do \
-	  docker-compose exec $$c redis-cli flushall; \
+	  docker compose exec $$c redis-cli flushall; \
 	  echo "$$c: redis cleared." ; \
 	done
 
 cache-clear: ##@application Clear the cache of the application
-	docker-compose exec api-app sh -c "rm -rf var/cache/*" && \
-	docker-compose -f docker-compose.yml -f docker-compose.behat.yml exec api-app sh -c "rm -rf var/cache/*" && \
-	docker-compose exec frontend-app sh -c "rm -rf var/cache/*" && \
-	docker-compose -f docker-compose.yml -f docker-compose.behat.yml exec frontend-app sh -c "rm -rf var/cache/*" && \
-	docker-compose exec admin-app sh -c "rm -rf var/cache/*" && \
-	docker-compose -f docker-compose.yml -f docker-compose.behat.yml exec admin-app sh -c "rm -rf var/cache/*" && \
+	docker compose exec api-app sh -c "rm -rf var/cache/*" && \
+	docker compose -f docker-compose.yml -f docker-compose.behat.yml exec api-app sh -c "rm -rf var/cache/*" && \
+	docker compose exec frontend-app sh -c "rm -rf var/cache/*" && \
+	docker compose -f docker-compose.yml -f docker-compose.behat.yml exec frontend-app sh -c "rm -rf var/cache/*" && \
+	docker compose exec admin-app sh -c "rm -rf var/cache/*" && \
+	docker compose -f docker-compose.yml -f docker-compose.behat.yml exec admin-app sh -c "rm -rf var/cache/*" && \
 	echo "Cache reset"
 
 enable-debug: ##@application Puts app in dev mode and enables debug (so the app has toolbar/profiling)
 	for c in ${APP_CONTAINERS} ; do \
-	  APP_ENV=dev APP_DEBUG=1 docker-compose up -d --no-deps $$c; \
+	  APP_ENV=dev APP_DEBUG=1 docker compose up -d --no-deps $$c; \
 	  echo "$$c: debug enabled." ; \
 	done
 
 disable-debug: ##@application Puts app in dev mode and disables debug (so the app runs faster, but no toolbar/profiling)
 	for c in ${APP_CONTAINERS} ; do \
-	  APP_ENV=dev APP_DEBUG=0 docker-compose up -d --no-deps $$c; \
+	  APP_ENV=dev APP_DEBUG=0 docker compose up -d --no-deps $$c; \
 	  echo "$$c: debug disabled." ; \
 	done
 
 phpstan-api: ##@static-analysis Runs PHPStan against API. Defaults to max level but supports passing level as an arg e.g. level=1
 ifdef level
-	docker-compose run --rm api-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=$(level)
+	docker compose run --rm api-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=$(level)
 else
-	docker-compose run --rm api-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=max
+	docker compose run --rm api-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=max
 endif
 
 phpstan-client: ##@static-analysis Runs PHPStan against client. Defaults to max level but supports passing level as an arg e.g. level=1
 ifdef level
-	docker-compose run --rm frontend-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=$(level)
+	docker compose run --rm frontend-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=$(level)
 else
-	docker-compose run --rm frontend-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=max
+	docker compose run --rm frontend-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=max
 endif
 
 get-audit-logs: ##@localstack Get audit log groups by passing event name e.g. get-audit-logs event_name=ROLE_CHANGED (see client/Audit/src/service/Audit/AuditEvents)
-	docker-compose exec localstack awslocal logs get-log-events --log-group-name audit-local --log-stream-name $(event_name)
+	docker compose exec localstack awslocal logs get-log-events --log-group-name audit-local --log-stream-name $(event_name)
 
 composer-api: ##@application Drops you into the API container with composer installed
-	docker-compose run --rm --volume ~/.composer:/tmp --volume ${PWD}/api/app:/app composer ${COMPOSER_ARGS}
+	docker compose run --rm --volume ~/.composer:/tmp --volume ${PWD}/api/app:/app composer ${COMPOSER_ARGS}
 
 composer-client: ##@application Drops you into the frontend container with composer installed
-	docker-compose run --rm --volume ~/.composer:/tmp --volume ${PWD}/client/app:/app composer ${COMPOSER_ARGS}
+	docker compose run --rm --volume ~/.composer:/tmp --volume ${PWD}/client/app:/app composer ${COMPOSER_ARGS}
 
 test-js: ##@javascript Run JS tests
-	docker-compose -f docker-compose.yml -f docker-compose.behat.yml run node-js --build --rm run test
+	docker compose -f docker-compose.yml -f docker-compose.behat.yml run node-js --build --rm run test
 
 TEST:='all'
 test-js-single: ##@javascript Allows you to do make test-js-single TEST='Currency Formatting' to run tests whose describe matches the string
-	docker-compose -f docker-compose.yml -f docker-compose.behat.yml run node-js --build --rm run test -- -t ${TEST}
+	docker compose -f docker-compose.yml -f docker-compose.behat.yml run node-js --build --rm run test -- -t ${TEST}
 
 build-js: ##@javascript Build JS resources
-	docker-compose run resources --build --rm
+	docker compose run resources --build --rm
 
 lint-js: ##@javascript Lint JS resources
-	docker-compose -f docker-compose.yml -f docker-compose.behat.yml run node-js --build --rm run fix
+	docker compose -f docker-compose.yml -f docker-compose.behat.yml run node-js --build --rm run fix
 
 smoke-tests: ##@smoke-tests Run smoke tests (requires app to be up)
-	docker-compose build orchestration
-	docker-compose run --remove-orphans orchestration sh tests/run-smoke-tests.sh
+	docker compose build orchestration
+	docker compose run --remove-orphans orchestration sh tests/run-smoke-tests.sh
 
 resilience-tests: ##@resilience-tests Run resilience tests (requires app to be up)
-	docker-compose build orchestration
-	docker-compose run -e LOG_AND_CONTINUE=true --remove-orphans orchestration sh tests/run-resilience-tests.sh
+	docker compose build orchestration
+	docker compose run -e LOG_AND_CONTINUE=true --remove-orphans orchestration sh tests/run-resilience-tests.sh

--- a/client/docker/web/confd/templates/app.conf.tmpl
+++ b/client/docker/web/confd/templates/app.conf.tmpl
@@ -32,6 +32,9 @@ server {
         location ~* \.(css|jpg|png|ico|jpeg|woff2|woff)$ {
             expires    24h;
             access_log off;
+
+            # Support static assets having a version ID in the path.
+            # rewrite ^/assets/([0-9]+)/(.*) /assets/$2  break;
         }
 
         try_files $uri /index.php$is_args$args;

--- a/client/resources/webpack.config.js
+++ b/client/resources/webpack.config.js
@@ -6,6 +6,9 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
 const tag = (new Date()).getTime()
 
+const outputDirWithTimestamp = path.resolve(__dirname, 'public/assets/' + tag)
+const baseOutputDir = path.resolve(__dirname, 'public/assets')
+
 module.exports = {
   entry: {
     application: './assets/scss/application.scss',
@@ -61,7 +64,7 @@ module.exports = {
   },
   output: {
     filename: 'javascripts/[name].js',
-    path: path.resolve(__dirname, 'public/assets/' + tag)
+    path: outputDirWithTimestamp
   },
   plugins: [
     {
@@ -92,12 +95,23 @@ module.exports = {
     }),
     {
       apply: function (compiler) {
-        // Copy CSS file into main assets folder
-        compiler.hooks.afterEmit.tap('CopyOutputPlugin', () => {
-          fs.copyFileSync(
-            path.resolve(__dirname, 'public/assets/' + tag + '/stylesheets/application.css'),
-            path.resolve(__dirname, 'public/images/application.css')
-          )
+        compiler.hooks.afterEmit.tapAsync('CopyOutputPlugin', (compilation, callback) => {
+          const files = Object.keys(compilation.assets)
+
+          files.forEach(file => {
+            // Remove query strings from file names
+            const cleanFileName = file.split('?')[0]
+
+            const sourcePath = path.join(outputDirWithTimestamp, cleanFileName)
+            const destPath = path.join(baseOutputDir, cleanFileName)
+
+            // Ensure the directory exists
+            fs.mkdirSync(path.dirname(destPath), { recursive: true })
+
+            fs.copyFileSync(sourcePath, destPath)
+          })
+
+          callback()
         })
       }
     }

--- a/file-scanner/Dockerfile
+++ b/file-scanner/Dockerfile
@@ -35,7 +35,7 @@ RUN sed -i 's/^#Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf \
     && sed -i 's/^#TCPSocket .*$/TCPSocket 3310/g' /etc/clamav/clamd.conf \
     && sed -i 's/^#Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
 
-RUN freshclam --quiet
+RUN freshclam
 
 COPY file-scanner/entrypoint.sh /usr/bin/
 COPY scripts/hardening/harden.sh /harden.sh


### PR DESCRIPTION
## Purpose
Fix some log issues we're seeing where users are getting file not found

Fixes DDLS-281

## Approach
For some reason, some users access previous versions of the static assets folder sometimes. This causes an error on the webserver that causes us alerts.

If we create a fallback folder and do a rewrite with break then it silently rewrites to the fallback folder. 

This is good as it still enables cache busting. What this means is that for the user the file path will change and it will bust their local cache of the resource but in the background it will always pull from the fallback folder.

To do this, I added a fallback folder as part of the webpack build process and did the rewrite in the correct places in the nginx config.

I tested it by changing the file contents and checking it was pulling the css from fallback folder even though to the user it looks like it's pulling it from the tagged folder.

## Learning
Would be nice to do sharing session on how the tags work as I was a bit confused by this for a while.

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
