### PR TITLE
DDLS-277 add build output

### DIFF
--- a/.github/workflows/workflow-path-to-live.yml
+++ b/.github/workflows/workflow-path-to-live.yml
@@ -35,6 +35,13 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # pin@v3
 
+      - name: Generate build output using Markdown
+        run: |
+          echo "### Build Variables" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Branch: main" >> $GITHUB_STEP_SUMMARY
+          echo "- Build Identifier: main" >> $GITHUB_STEP_SUMMARY
+
       - name: generate semver tag and release
         id: semver_tag
         uses: ministryofjustice/opg-github-actions/.github/actions/semver-tag@v3.0.6

--- a/.github/workflows/workflow-pull-request-path.yml
+++ b/.github/workflows/workflow-pull-request-path.yml
@@ -44,6 +44,15 @@ jobs:
           echo "branch_formatted=$(echo ${BRANCH})" >> $GITHUB_OUTPUT
           echo "build_identifier=$(echo ${BRANCH}${PR_NUMBER})" >> $GITHUB_OUTPUT
           echo ${build_identifier}
+      - name: Generate build output using Markdown
+        env:
+          PARSED_BRANCH: ${{ steps.variables.outputs.branch_formatted }}
+          BUILD_IDENTIFIER: ${{ steps.variables.outputs.build_identifier }}
+        run: |
+          echo "### Build Variables" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Branch: ${PARSED_BRANCH}" >> $GITHUB_STEP_SUMMARY
+          echo "- Build Identifier: ${BUILD_IDENTIFIER}" >> $GITHUB_STEP_SUMMARY
       - name: generate semver tag and release
         id: semver_tag
         uses: ministryofjustice/opg-github-actions/.github/actions/semver-tag@v3.0.6
@@ -347,9 +356,22 @@ jobs:
     steps:
       - name: workflow ended successfully
         run: |
+          export PUBLIC_URL="https://${{ needs.workflow_variables.outputs.build_identifier }}.complete-deputy-report.service.gov.uk"
+          export SERVICE_FRONTEND_URL="https://${{ needs.workflow_variables.outputs.build_identifier }}.digideps.opg.service.justice.gov.uk"
+          export SERVICE_ADMIN_URL="https://${{ needs.workflow_variables.outputs.build_identifier }}.admin.digideps.opg.service.justice.gov.uk"
+
           echo "${{ needs.workflow_variables.outputs.build_identifier }} PR environment tested, built and deployed"
+          echo "Public Frontend URL: ${FRONTEND_URL}"
+          echo "Service Frontend URL: ${SERVICE_FRONTEND_URL}"
+          echo "Service Admin URL: ${SERVICE_ADMIN_URL}"
           echo "Tag Used: ${{ needs.workflow_variables.outputs.version_tag }}"
-          echo "URL: https://${{ needs.workflow_variables.outputs.build_identifier }}.complete-deputy-report.service.gov.uk"
+
+          echo "### Environment Details" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Public Frontend URL: ${FRONTEND_URL}" >> $GITHUB_STEP_SUMMARY
+          echo "- Service Frontend URL: ${SERVICE_FRONTEND_URL}" >> $GITHUB_STEP_SUMMARY
+          echo "- Service Admin URL: ${SERVICE_ADMIN_URL}" >> $GITHUB_STEP_SUMMARY
+          echo "- Tag Used: ${{ needs.workflow_variables.outputs.version_tag }}" >> $GITHUB_STEP_SUMMARY
 
   slack_notify_success:
     name: notify of success


### PR DESCRIPTION
## Purpose
add useful information in build output
Fixes DDLS-277

## Approach
Originally I was looking to implement the docker build github action but actually I like the control we have over the caching  with the current approach. I noticed that it does some nice summary outputting though which I took for our pipeline. 

As such this is just a small one to give us a bit of useful env info in our pipeline summary.

EDIT: also added map to the assets nginx writes as it was logging them out and we don't need them and it interferes with our ip blocking pattern

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
