### PR TITLE
DDLS-262 Middle name in the user name is not considered during User search in Admin

### DIFF
--- a/api/app/src/Repository/UserRepository.php
+++ b/api/app/src/Repository/UserRepository.php
@@ -119,7 +119,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
             if (1 === count($searchTerms)) {
                 $this->addBroadMatchFilter($searchTerm, $includeClients);
             } else {
-                $this->addFullNameExactMatchFilter($searchTerms[0], $searchTerms[1], $includeClients);
+                $this->addFullNameBestMatchFilter($searchTerms[0], $searchTerms[1], $includeClients);
             }
         }
 
@@ -144,16 +144,16 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
     /**
      * @return string
      */
-    public function addFullNameExactMatchFilter(string $firstName, string $lastname, bool $includeClients)
+    public function addFullNameBestMatchFilter(string $firstName, string $otherName, bool $includeClients)
     {
-        $nameBasedQuery = '(lower(u.firstname) = :firstname AND lower(u.lastname) = :lastname)';
+        $nameBasedQuery = '(lower(u.firstname) LIKE :firstname AND (lower(u.firstname) LIKE :othername OR lower(u.lastname) LIKE :othername))';
 
         if ($includeClients) {
-            $nameBasedQuery .= ' OR (lower(c.firstname) = :firstname AND lower(c.lastname) = :lastname)';
+            $nameBasedQuery .= ' OR (lower(c.firstname) LIKE :firstname AND (lower(c.firstname) LIKE :othername OR lower(c.lastname) LIKE :othername))';
         }
 
-        $this->qb->setParameter('firstname', strtolower($firstName));
-        $this->qb->setParameter('lastname', strtolower($lastname));
+        $this->qb->setParameter('firstname', '%'.strtolower($firstName.'%'));
+        $this->qb->setParameter('othername', '%'.strtolower($otherName.'%'));
 
         $this->qb->andWhere($nameBasedQuery);
     }


### PR DESCRIPTION
## Purpose
If a user has a middle name and if you search for the full name in the Admin User search, the user does not come up in the search.

Fixes DDLS-262

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
