### PR TITLE
DDLS-261: Deleting a user with user research response data gives an error

### DIFF
--- a/api/app/src/Command/UserResearchCleanupCommand.php
+++ b/api/app/src/Command/UserResearchCleanupCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\UserResearch\UserResearchResponse;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class UserResearchCleanupCommand extends Command
+{
+    protected static $defaultName = 'digideps:delete-null-user-research-ids';
+
+    /** @var EntityManagerInterface */
+    private $em;
+
+    public function __construct(EntityManagerInterface $em)
+    {
+        $this->em = $em;
+
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        try {
+            $deleteCount = $this->deleteNullIdUsers();
+            $output->writeln("delete-null-user-research-ids - success - Deleted $deleteCount lay user(s) from user research who have had their user account deleted");
+
+            return Command::SUCCESS;
+        } catch (Exception $e) {
+            $output->writeln('delete-null-user-research-ids - failure - Failed to delete lay user(s) from user research who have had their user account deleted');
+            $output->writeln($e);
+
+            return Command::FAILURE;
+        }
+    }
+
+    private function deleteNullIdUsers(): int
+    {
+        $deleteQb = $this->em->createQueryBuilder()
+            ->delete()
+            ->from(UserResearchResponse::class, 'ur')
+            ->where('ur.user is null');
+
+        $deleteCount = $deleteQb->getQuery()->execute();
+
+        return $deleteCount;
+    }
+}

--- a/api/app/src/Controller/UserResearchController.php
+++ b/api/app/src/Controller/UserResearchController.php
@@ -92,14 +92,4 @@ class UserResearchController extends RestController
     {
         $this->userResearchResponseRepository->findByUserId($id);
     }
-
-    /**
-     * @Route("/user-research/delete", name="delete_user_research", methods={"DELETE"})
-     *
-     * @Security("is_granted('ROLE_SUPER_ADMIN')")
-     */
-    public function deleteNullifiedUserId(): void
-    {
-        $this->userResearchResponseRepository->deleteByNullUserId();
-    }
 }

--- a/api/app/src/Controller/UserResearchController.php
+++ b/api/app/src/Controller/UserResearchController.php
@@ -35,7 +35,6 @@ class UserResearchController extends RestController
 
     /**
      * @Route("/user-research", name="create_user_research", methods={"POST"})
-     *
      * @Security("is_granted('ROLE_DEPUTY') or is_granted('ROLE_ORG')")
      */
     public function create(Request $request)
@@ -60,7 +59,6 @@ class UserResearchController extends RestController
 
     /**
      * @Route("/user-research", name="get_user_research", methods={"GET"})
-     *
      * @Security("is_granted('ROLE_SUPER_ADMIN')")
      */
     public function getAll(Request $request)
@@ -81,5 +79,14 @@ class UserResearchController extends RestController
         } catch (\Throwable $e) {
             throw new \RuntimeException(sprintf('There was a problem getting user research responses: %s', $e->getMessage()), Response::HTTP_BAD_REQUEST);
         }
+    }
+
+    /**
+     * @Route("/user-research/{id}", name="user_research_find_by_id", methods={"PUT"})
+     * @Security("is_granted('ROLE_SUPER_ADMIN')")
+     */
+    public function findByUserIdAndNullify(int $id): void
+    {
+        $this->userResearchResponseRepository->findByUserId($id);
     }
 }

--- a/api/app/src/Controller/UserResearchController.php
+++ b/api/app/src/Controller/UserResearchController.php
@@ -35,6 +35,7 @@ class UserResearchController extends RestController
 
     /**
      * @Route("/user-research", name="create_user_research", methods={"POST"})
+     *
      * @Security("is_granted('ROLE_DEPUTY') or is_granted('ROLE_ORG')")
      */
     public function create(Request $request)
@@ -59,6 +60,7 @@ class UserResearchController extends RestController
 
     /**
      * @Route("/user-research", name="get_user_research", methods={"GET"})
+     *
      * @Security("is_granted('ROLE_SUPER_ADMIN')")
      */
     public function getAll(Request $request)
@@ -83,10 +85,21 @@ class UserResearchController extends RestController
 
     /**
      * @Route("/user-research/{id}", name="user_research_find_by_id", methods={"PUT"})
+     *
      * @Security("is_granted('ROLE_SUPER_ADMIN')")
      */
     public function findByUserIdAndNullify(int $id): void
     {
         $this->userResearchResponseRepository->findByUserId($id);
+    }
+
+    /**
+     * @Route("/user-research/delete", name="delete_user_research", methods={"DELETE"})
+     *
+     * @Security("is_granted('ROLE_SUPER_ADMIN')")
+     */
+    public function deleteNullifiedUserId(): void
+    {
+        $this->userResearchResponseRepository->deleteByNullUserId();
     }
 }

--- a/api/app/src/Repository/UserResearchResponseRepository.php
+++ b/api/app/src/Repository/UserResearchResponseRepository.php
@@ -49,15 +49,22 @@ class UserResearchResponseRepository extends ServiceEntityRepository
         return $qb->getQuery()->getArrayResult();
     }
 
-    public function findByUserId(int $id): array
+    public function findByUserId(int $id)
     {
         // this needs work as it assumes the user has completed the user research form
         $qb = $this->createQueryBuilder('ur')
             ->update(UserResearchResponse::class, 'ur')
-            ->set('ur.user', ':null')
-            ->where('ur.user = :id')
-            ->setParameter(':null', null)
-            ->setParameter(':id', $id);
+            ->set('ur.user', ':null')->setParameter('null', null)
+            ->where('ur.user = :id')->setParameter('id', $id);
+
+        return $qb->getQuery()->execute();
+    }
+
+    public function deleteByNullUserId()
+    {
+        $qb = $this->createQueryBuilder('ur')
+            ->delete(UserResearchResponse::class, 'ur')
+            ->where('ur.user = :null')->setParameter('null', null);
 
         return $qb->getQuery()->execute();
     }

--- a/api/app/src/Repository/UserResearchResponseRepository.php
+++ b/api/app/src/Repository/UserResearchResponseRepository.php
@@ -48,4 +48,17 @@ class UserResearchResponseRepository extends ServiceEntityRepository
 
         return $qb->getQuery()->getArrayResult();
     }
+
+    public function findByUserId(int $id): array
+    {
+        // this needs work as it assumes the user has completed the user research form
+        $qb = $this->createQueryBuilder('ur')
+            ->update(UserResearchResponse::class, 'ur')
+            ->set('ur.user', ':null')
+            ->where('ur.user = :id')
+            ->setParameter(':null', null)
+            ->setParameter(':id', $id);
+
+        return $qb->getQuery()->execute();
+    }
 }

--- a/api/app/src/Repository/UserResearchResponseRepository.php
+++ b/api/app/src/Repository/UserResearchResponseRepository.php
@@ -51,7 +51,6 @@ class UserResearchResponseRepository extends ServiceEntityRepository
 
     public function findByUserId(int $id)
     {
-        // this needs work as it assumes the user has completed the user research form
         $qb = $this->createQueryBuilder('ur')
             ->update(UserResearchResponse::class, 'ur')
             ->set('ur.user', ':null')->setParameter('null', null)

--- a/api/app/src/Repository/UserResearchResponseRepository.php
+++ b/api/app/src/Repository/UserResearchResponseRepository.php
@@ -64,7 +64,7 @@ class UserResearchResponseRepository extends ServiceEntityRepository
     {
         $qb = $this->createQueryBuilder('ur')
             ->delete(UserResearchResponse::class, 'ur')
-            ->where('ur.user = :null')->setParameter('null', null);
+            ->where('ur.user is null');
 
         return $qb->getQuery()->execute();
     }

--- a/api/app/src/Repository/UserResearchResponseRepository.php
+++ b/api/app/src/Repository/UserResearchResponseRepository.php
@@ -58,13 +58,4 @@ class UserResearchResponseRepository extends ServiceEntityRepository
 
         return $qb->getQuery()->execute();
     }
-
-    public function deleteByNullUserId()
-    {
-        $qb = $this->createQueryBuilder('ur')
-            ->delete(UserResearchResponse::class, 'ur')
-            ->where('ur.user is null');
-
-        return $qb->getQuery()->execute();
-    }
 }

--- a/api/app/tests/Unit/Command/UserResearchCleanupCommandTest.php
+++ b/api/app/tests/Unit/Command/UserResearchCleanupCommandTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Tests\Unit\Entity\Command;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class UserResearchCleanupCommandTest extends KernelTestCase
+{
+    public function testExecute()
+    {
+        $kernel = static::createKernel();
+        $application = new Application($kernel);
+
+        $command = $application->find('digideps:delete-null-user-research-ids');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $output = $commandTester->getDisplay();
+        self::assertStringContainsString('delete-null-user-research-ids - success - Deleted 0 lay user(s) from user research who have had their user account deleted', $output);
+    }
+}

--- a/api/app/tests/Unit/Controller/UserResearchControllerTest.php
+++ b/api/app/tests/Unit/Controller/UserResearchControllerTest.php
@@ -171,4 +171,25 @@ class UserResearchControllerTest extends AbstractTestController
             ],
         ];
     }
+
+    public function testDeletePermittedForSuperAdmin()
+    {
+        $url = '/user-research/delete';
+
+        $this->assertJsonRequest('DELETE', $url, [
+            'mustSucceed' => true,
+            'AuthToken' => self::$tokenSuperAdmin,
+        ]);
+    }
+
+    public function testDeleteNotPermittedForAdmin()
+    {
+        $url = '/user-research/delete';
+
+        $this->assertJsonRequest('DELETE', $url, [
+            'mustFail' => true,
+            'assertResponseCode' => 403,
+            'AuthToken' => self::$tokenAdmin,
+        ]);
+    }
 }

--- a/api/app/tests/Unit/Controller/UserResearchControllerTest.php
+++ b/api/app/tests/Unit/Controller/UserResearchControllerTest.php
@@ -172,21 +172,21 @@ class UserResearchControllerTest extends AbstractTestController
         ];
     }
 
-    public function testDeletePermittedForSuperAdmin()
+    public function testPutPermittedForSuperAdmin()
     {
-        $url = '/user-research/delete';
+        $url = '/user-research/1';
 
-        $this->assertJsonRequest('DELETE', $url, [
+        $this->assertJsonRequest('PUT', $url, [
             'mustSucceed' => true,
             'AuthToken' => self::$tokenSuperAdmin,
         ]);
     }
 
-    public function testDeleteNotPermittedForAdmin()
+    public function testPutNotPermittedForAdmin()
     {
-        $url = '/user-research/delete';
+        $url = '/user-research/1';
 
-        $this->assertJsonRequest('DELETE', $url, [
+        $this->assertJsonRequest('PUT', $url, [
             'mustFail' => true,
             'assertResponseCode' => 403,
             'AuthToken' => self::$tokenAdmin,

--- a/client/app/src/Controller/Admin/IndexController.php
+++ b/client/app/src/Controller/Admin/IndexController.php
@@ -60,15 +60,13 @@ class IndexController extends AbstractController
         private readonly S3Client $s3,
         private readonly LayDeputyshipApi $layDeputyshipApi,
         private readonly OrgService $orgService,
-        private readonly string $workspace
+        private readonly string $workspace,
     ) {
     }
 
     /**
      * @Route("/", name="admin_homepage")
-     *
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
-     *
      * @Template("@App/Admin/Index/index.html.twig")
      */
     public function indexAction(Request $request): array
@@ -107,9 +105,7 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/user-add", name="admin_add_user")
-     *
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
-     *
      * @Template("@App/Admin/Index/addUser.html.twig")
      */
     public function addUserAction(Request $request): array|RedirectResponse
@@ -144,9 +140,7 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/user/{id}", name="admin_user_view", requirements={"id":"\d+"})
-     *
      * @Security("is_granted('ROLE_ADMIN')")
-     *
      * @Template("@App/Admin/Index/viewUser.html.twig")
      *
      * @return User[]|Response
@@ -162,9 +156,7 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/edit-user", name="admin_editUser", methods={"GET", "POST"})
-     *
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
-     *
      * @Template("@App/Admin/Index/editUser.html.twig")
      *
      * @throws \Throwable
@@ -252,7 +244,6 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/edit-ndr/{id}", name="admin_editNdr", methods={"POST"})
-     *
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
      *
      * @param string $id
@@ -279,15 +270,17 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/delete-confirm/{id}", name="admin_delete_confirm", methods={"GET"})
-     *
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
-     *
      * @Template("@App/Admin/Index/deleteConfirm.html.twig")
      *
      * @param int $id
      */
     public function deleteConfirmAction($id): array
     {
+        // check if deputy completed user research form, if yes null user_id on user research form
+        $this->restClient->put('/user-research/'.$id, intval($id));
+        // delete user research response entry if present
+
         /** @var User $userToDelete */
         $userToDelete = $this->restClient->get("user/{$id}", 'User');
 
@@ -298,7 +291,6 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/delete/{id}", name="admin_delete", methods={"GET"})
-     *
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
      *
      * @param int $id
@@ -329,9 +321,7 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/upload", name="admin_upload")
-     *
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
-     *
      * @Template("@App/Admin/Index/upload.html.twig")
      */
     public function uploadAction(Request $request, RouterInterface $router): array|RedirectResponse
@@ -365,9 +355,7 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/pre-registration-upload", name="pre_registration_upload")
-     *
      * @Security("is_granted('ROLE_SUPER_ADMIN')")
-     *
      * @Template("@App/Admin/Index/uploadUsers.html.twig")
      *
      * @throws \Exception
@@ -445,9 +433,7 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/org-csv-upload", name="admin_org_upload")
-     *
      * @Security("is_granted('ROLE_SUPER_ADMIN')")
-     *
      * @Template("@App/Admin/Index/uploadOrgUsers.html.twig")
      *
      * @throws \Exception
@@ -517,7 +503,6 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/send-activation-link/{email}", name="admin_send_activation_link")
-     *
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
      **/
     public function sendUserActivationLinkAction(string $email, LoggerInterface $logger): Response

--- a/client/app/src/Controller/Admin/IndexController.php
+++ b/client/app/src/Controller/Admin/IndexController.php
@@ -66,7 +66,9 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/", name="admin_homepage")
+     *
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
+     *
      * @Template("@App/Admin/Index/index.html.twig")
      */
     public function indexAction(Request $request): array
@@ -105,7 +107,9 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/user-add", name="admin_add_user")
+     *
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
+     *
      * @Template("@App/Admin/Index/addUser.html.twig")
      */
     public function addUserAction(Request $request): array|RedirectResponse
@@ -140,7 +144,9 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/user/{id}", name="admin_user_view", requirements={"id":"\d+"})
+     *
      * @Security("is_granted('ROLE_ADMIN')")
+     *
      * @Template("@App/Admin/Index/viewUser.html.twig")
      *
      * @return User[]|Response
@@ -156,7 +162,9 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/edit-user", name="admin_editUser", methods={"GET", "POST"})
+     *
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
+     *
      * @Template("@App/Admin/Index/editUser.html.twig")
      *
      * @throws \Throwable
@@ -244,6 +252,7 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/edit-ndr/{id}", name="admin_editNdr", methods={"POST"})
+     *
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
      *
      * @param string $id
@@ -270,7 +279,9 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/delete-confirm/{id}", name="admin_delete_confirm", methods={"GET"})
+     *
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
+     *
      * @Template("@App/Admin/Index/deleteConfirm.html.twig")
      *
      * @param int $id
@@ -280,6 +291,7 @@ class IndexController extends AbstractController
         // check if deputy completed user research form, if yes null user_id on user research form
         $this->restClient->put('/user-research/'.$id, intval($id));
         // delete user research response entry if present
+        $this->restClient->delete('/user-research/delete');
 
         /** @var User $userToDelete */
         $userToDelete = $this->restClient->get("user/{$id}", 'User');
@@ -291,6 +303,7 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/delete/{id}", name="admin_delete", methods={"GET"})
+     *
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
      *
      * @param int $id
@@ -321,7 +334,9 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/upload", name="admin_upload")
+     *
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
+     *
      * @Template("@App/Admin/Index/upload.html.twig")
      */
     public function uploadAction(Request $request, RouterInterface $router): array|RedirectResponse
@@ -355,7 +370,9 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/pre-registration-upload", name="pre_registration_upload")
+     *
      * @Security("is_granted('ROLE_SUPER_ADMIN')")
+     *
      * @Template("@App/Admin/Index/uploadUsers.html.twig")
      *
      * @throws \Exception
@@ -433,7 +450,9 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/org-csv-upload", name="admin_org_upload")
+     *
      * @Security("is_granted('ROLE_SUPER_ADMIN')")
+     *
      * @Template("@App/Admin/Index/uploadOrgUsers.html.twig")
      *
      * @throws \Exception
@@ -503,6 +522,7 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/send-activation-link/{email}", name="admin_send_activation_link")
+     *
      * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
      **/
     public function sendUserActivationLinkAction(string $email, LoggerInterface $logger): Response

--- a/client/app/src/Controller/Admin/IndexController.php
+++ b/client/app/src/Controller/Admin/IndexController.php
@@ -289,7 +289,6 @@ class IndexController extends AbstractController
     public function deleteConfirmAction($id): array
     {
         $this->restClient->put('/user-research/'.$id, intval($id));
-        $this->restClient->delete('/user-research/delete');
 
         /** @var User $userToDelete */
         $userToDelete = $this->restClient->get("user/{$id}", 'User');

--- a/client/app/src/Controller/Admin/IndexController.php
+++ b/client/app/src/Controller/Admin/IndexController.php
@@ -288,9 +288,7 @@ class IndexController extends AbstractController
      */
     public function deleteConfirmAction($id): array
     {
-        // check if deputy completed user research form, if yes null user_id on user research form
         $this->restClient->put('/user-research/'.$id, intval($id));
-        // delete user research response entry if present
         $this->restClient->delete('/user-research/delete');
 
         /** @var User $userToDelete */

--- a/terraform/environment/region/cloudwatch_scheduled_events.tf
+++ b/terraform/environment/region/cloudwatch_scheduled_events.tf
@@ -390,7 +390,7 @@ resource "aws_cloudwatch_event_target" "sleep_mode_off" {
 resource "aws_cloudwatch_event_rule" "delete_null_user_research_ids" {
   name                = "delete-null-user-research-ids-${local.environment}"
   description         = "Delete null user research ids in ${terraform.workspace}"
-  schedule_expression = "cron(0 1 * * *)"
+  schedule_expression = "cron(0 1 ? * * *)"
   tags                = var.default_tags
 }
 

--- a/terraform/environment/region/cloudwatch_scheduled_events.tf
+++ b/terraform/environment/region/cloudwatch_scheduled_events.tf
@@ -384,3 +384,42 @@ resource "aws_cloudwatch_event_target" "sleep_mode_off" {
 #  arn       = data.aws_lambda_function.block_ips_lambda.arn
 #  rule      = aws_cloudwatch_event_rule.block_ips.name
 #}
+
+# Delete null user ids in user research
+
+resource "aws_cloudwatch_event_rule" "delete_null_user_research_ids" {
+  name                = "delete-null-user-research-ids-${local.environment}"
+  description         = "Delete null user research ids in ${terraform.workspace}"
+  schedule_expression = "cron(0 1 * * *)"
+  tags                = var.default_tags
+}
+
+resource "aws_cloudwatch_event_target" "delete_null_user_research_ids" {
+  rule     = aws_cloudwatch_event_rule.delete_null_user_research_ids.name
+  arn      = aws_ecs_cluster.main.arn
+  role_arn = aws_iam_role.events_task_runner.arn
+
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.api.arn
+    launch_type         = "FARGATE"
+    platform_version    = "1.4.0"
+
+    network_configuration {
+      security_groups  = [module.api_service_security_group.id]
+      subnets          = data.aws_subnet.private[*].id
+      assign_public_ip = false
+    }
+  }
+
+  input = jsonencode(
+    {
+      "containerOverrides" : [
+        {
+          "name" : "api_app",
+          "command" : ["sh", "scripts/task_run_console_command.sh", "digideps:delete-null-user-research-ids"]
+        }
+      ]
+    }
+  )
+}

--- a/terraform/environment/region/cloudwatch_scheduled_events.tf
+++ b/terraform/environment/region/cloudwatch_scheduled_events.tf
@@ -390,7 +390,8 @@ resource "aws_cloudwatch_event_target" "sleep_mode_off" {
 resource "aws_cloudwatch_event_rule" "delete_null_user_research_ids" {
   name                = "delete-null-user-research-ids-${local.environment}"
   description         = "Delete null user research ids in ${terraform.workspace}"
-  schedule_expression = "cron(0 1 ? * * *)"
+  schedule_expression = "cron(30 6 ? * * *)"
+  is_enabled          = var.account.is_production == 1 ? false : true
   tags                = var.default_tags
 }
 

--- a/terraform/environment/region/cloudwatch_scheduled_events.tf
+++ b/terraform/environment/region/cloudwatch_scheduled_events.tf
@@ -391,7 +391,6 @@ resource "aws_cloudwatch_event_rule" "delete_null_user_research_ids" {
   name                = "delete-null-user-research-ids-${local.environment}"
   description         = "Delete null user research ids in ${terraform.workspace}"
   schedule_expression = "cron(30 6 ? * * *)"
-  is_enabled          = var.account.is_production == 1 ? false : true
   tags                = var.default_tags
 }
 

--- a/terraform/environment/region/cloudwatch_scheduled_events_checks.tf
+++ b/terraform/environment/region/cloudwatch_scheduled_events_checks.tf
@@ -305,8 +305,8 @@ resource "aws_cloudwatch_event_target" "org_csv_processing_check" {
 resource "aws_cloudwatch_event_rule" "delete_null_user_research_ids_check" {
   name                = "check-delete-null-user-research-ids-${terraform.workspace}"
   description         = "Delete null user research ids in ${terraform.workspace}"
-  schedule_expression = local.sync_service_cron_schedule
-  is_enabled          = var.account.is_production == 1 ? true : false
+  schedule_expression = "cron(30 6 ? * * *)"
+  is_enabled          = var.account.is_production == 1 ? false : true
 }
 
 resource "aws_cloudwatch_event_target" "delete_null_user_research_ids_check" {

--- a/terraform/environment/region/cloudwatch_scheduled_events_checks.tf
+++ b/terraform/environment/region/cloudwatch_scheduled_events_checks.tf
@@ -306,7 +306,6 @@ resource "aws_cloudwatch_event_rule" "delete_null_user_research_ids_check" {
   name                = "check-delete-null-user-research-ids-${terraform.workspace}"
   description         = "Delete null user research ids in ${terraform.workspace}"
   schedule_expression = "cron(30 6 ? * * *)"
-  is_enabled          = var.account.is_production == 1 ? false : true
 }
 
 resource "aws_cloudwatch_event_target" "delete_null_user_research_ids_check" {


### PR DESCRIPTION
## Purpose
If a user has been discharged from a client but if the user has previously submitted a satisfaction score and then a user research form (which appears after the satisfaction survey form), then the system throws an error while deleting the user.

Fixes DDLS-261

## Approach
1. Change the user id to null for any rows in the user research table that equals the user id that is to be deleted.
2. Delete these rows in the user response table that have the user id set to NULL, setup as daily job.
3. This does not affect the satisfaction table and therefore the satisfaction scores are unchanged.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
