### PR TITLE
DDLS-290 add forbidden errors to the document sync overnight job

### DIFF
--- a/.github/workflows/scheduled-update-training-environment.yml
+++ b/.github/workflows/scheduled-update-training-environment.yml
@@ -2,8 +2,8 @@ name: "[Scheduled] Update Training Environment"
 
 on:
   schedule:
-    # 8pm on Friday
-    - cron: "0 20 * * 5"
+    # 18.30pm on Friday
+    - cron: "30 18 * * 5"
 
 permissions:
   id-token: write

--- a/api/app/src/Repository/DocumentRepository.php
+++ b/api/app/src/Repository/DocumentRepository.php
@@ -156,6 +156,8 @@ WHERE
                 d.synchronisation_error LIKE 'Report PDF failed to sync%'
                 OR
                 d.synchronisation_error LIKE 'Document failed to sync after%'
+                OR
+                d.synchronisation_error LIKE '%OPGDATA-API-FORBIDDEN%'
             )
     ) OR
     (
@@ -247,7 +249,7 @@ AND d.synchronisation_status IN ('{$queuedStatus}', '{$permanentErrorStatus}', '
         return $failedCounts[0];
     }
 
-    public function updateSupportingDocumentStatusByReportSubmissionIds(array $reportSubmissionIds, string $syncErrorMessage = null)
+    public function updateSupportingDocumentStatusByReportSubmissionIds(array $reportSubmissionIds, ?string $syncErrorMessage = null)
     {
         $idsString = implode(',', $reportSubmissionIds);
         $status = Document::SYNC_STATUS_PERMANENT_ERROR;

--- a/terraform/environment/region/cloudwatch_scheduled_events.tf
+++ b/terraform/environment/region/cloudwatch_scheduled_events.tf
@@ -331,7 +331,7 @@ resource "aws_cloudwatch_event_target" "sleep_mode_on" {
 resource "aws_cloudwatch_event_rule" "sleep_mode_off" {
   name                = "sleep-mode-off-${local.environment}"
   description         = "Sleep mode - turn off environment ${terraform.workspace}"
-  schedule_expression = "cron(0 02,20 * * ? *)"
+  schedule_expression = "cron(15 02,20 * * ? *)"
   tags                = var.default_tags
   is_enabled          = var.account.sleep_mode_enabled ? true : false
 }


### PR DESCRIPTION
## Purpose
Overnight job can resubmit these without issue.

Fixes DDLS-290

## Approach
We have a overnight job that sets error status document submissions back to 'queued' if the errors are of a temporary nature. 

This PR simply adds the forbidden error message syntax to that query as any permissions issues from our containers should be temporary.

I have also changed a couple of timings on jobs that were occasionally bumping into each other.

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
