### PR TITLE
DDLS-302 Pre work to add the secret that we need to populate

### DIFF
--- a/terraform/account/region/secrets.tf
+++ b/terraform/account/region/secrets.tf
@@ -14,7 +14,8 @@ module "environment_secrets" {
     "synchronisation-jwt-token",
     "public-jwt-key-base64",
     "private-jwt-key-base64",
-    "smoke-test-variables"
+    "smoke-test-variables",
+    "custom-sql-db-password"
   ]
   tags = var.default_tags
 }


### PR DESCRIPTION
## Purpose
Add the secret that we need to populate
Fixes DDLS-302

## Approach
Have to add the secret to account first and run it through all the envs or it will complain in the main PR that the secret doesn't exist. We use default as namespace for ephemeral envs so that secrets are populated properly rather than doing it as a per workspace namespace.

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
