### PR TITLE
DDLS-353 use pull through cache from our ecr for trivy

### DIFF
--- a/.github/workflows/_build-and-push.yml
+++ b/.github/workflows/_build-and-push.yml
@@ -136,6 +136,12 @@ jobs:
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
+      - name: ecr login
+        id: login_ecr
+        uses: aws-actions/amazon-ecr-login@00e8074ea5f4936907c7b26611e2b9b4691c2784 # pin@v1.5.1
+        with:
+          registries: 311462405659
+
       - name: trivy image scanning
         id: trivy_scan
         uses: aquasecurity/trivy-action@2b6a709cf9c4025c5438138008beaddbb02086f0 # pin@v0.7.1
@@ -146,18 +152,15 @@ jobs:
           scanners: "vuln"
           output: "trivy-results.sarif"
           timeout: 15m
+        env:
+          TRIVY_DB_REPOSITORY: ${{ steps.login_ecr.outputs.registry }}/trivy-db-public-ecr/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: ${{ steps.login_ecr.outputs.registry }}/trivy-db-public-ecr/aquasecurity/trivy-java-db
 
       - name: upload trivy scan results to security tab
         id: trivy_upload_sarif
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: "trivy-results.sarif"
-
-      - name: ecr login
-        id: login_ecr
-        uses: aws-actions/amazon-ecr-login@00e8074ea5f4936907c7b26611e2b9b4691c2784 # pin@v1.5.1
-        with:
-          registries: 311462405659
 
       - name: show build tag
         env:


### PR DESCRIPTION
## Purpose
Trivy was constantly breaking due to rate limiting

Fixes DDLS-353

## Approach
This is one suggested approach by trivy to fix this issue

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
