### PR TITLE
DDLS-356b re-add sirius api permissions to front container

### DIFF
--- a/terraform/environment/region/ecs_iam_front.tf
+++ b/terraform/environment/region/ecs_iam_front.tf
@@ -100,3 +100,22 @@ resource "aws_iam_role_policy" "front_ssm" {
   policy = data.aws_iam_policy_document.front_ssm.json
   role   = aws_iam_role.front.id
 }
+
+# ======= INVOKE API GATEWAY PERMISSIONS =====
+resource "aws_iam_role_policy" "front_invoke_api_gateway" {
+  name   = "front-api-gw.${local.environment}"
+  policy = data.aws_iam_policy_document.front_invoke_api_gateway.json
+  role   = aws_iam_role.front.id
+}
+
+data "aws_iam_policy_document" "front_invoke_api_gateway" {
+  statement {
+    sid    = "AllowInvokeOnDeputyReportingGateway"
+    effect = "Allow"
+    actions = [
+      "execute-api:Invoke",
+      "execute-api:ManageConnections"
+    ]
+    resources = ["arn:aws:execute-api:eu-west-1:${var.account.sirius_api_account}:*"]
+  }
+}


### PR DESCRIPTION
Permissions were removed due to not thinking they were needed ages ago but turns out they are now we have reactivated dependency endpoint polling