### PR TITLE
DDLS-357 make anon emails unique

### DIFF
--- a/orchestration/anonymisation/main.go
+++ b/orchestration/anonymisation/main.go
@@ -83,7 +83,11 @@ func main() {
 	err = processing.GenerateAsyncFakeData(db, tableDetails, ChunkSize)
 	common.CheckError(err)
 
-	// ===== Processing - Additional Complex Updates =====
+	// ===== Processing - Additional Complex Script Updates =====
+	err = processing.CustomSQLScriptUpdates(db, fmt.Sprintf("%sprocessing/sql", path))
+	common.CheckError(err)
+
+	// ===== Processing - Additional Programmatic Updates =====
 	err = processing.UpdateAllToPassedInValue(db, "dd_user", "password", defaultUserPassword)
 	common.CheckError(err)
 
@@ -93,11 +97,7 @@ func main() {
 	err = processing.UpdateSelectedColumnsFromPublic(db, "dd_user", "id", "password", "email", EmailSuffixToIgnore)
 	common.CheckError(err)
 
-	// ===== Processing - Additional Complex Updates =====
-	err = processing.CustomSQLScriptUpdates(db, fmt.Sprintf("%sprocessing/sql", path))
-	common.CheckError(err)
-
-	// ===== Processing - Additional Complex Updates =====
+	// ===== Processing - Update Public from Anon =====
 	err = processing.UpdateAsyncOriginalTables(db, tableDetails, ChunkSize, leftJoins)
 	common.CheckError(err)
 

--- a/orchestration/anonymisation/processing/sql/2_email_name.sql
+++ b/orchestration/anonymisation/processing/sql/2_email_name.sql
@@ -5,7 +5,7 @@ SET email = LOWER(
 		'.',
 		COALESCE(lastname, 'none'),
         '.',
-        FLOOR(RANDOM()* (99999-0 + 1) + 0)::int,
+		ppk_id,
 		'@',
 		SUBSTRING(email FROM POSITION('@' IN email) + 1)
 	)

--- a/orchestration/anonymisation/processing/sql/3_org_email_identifers.sql
+++ b/orchestration/anonymisation/processing/sql/3_org_email_identifers.sql
@@ -1,5 +1,5 @@
 UPDATE anon.dd_user ad
-SET email = LOWER(CONCAT(SUBSTRING(orguser.email FROM 1 FOR POSITION('@' IN orguser.email)), orguser.email_identifier))
+SET email = LOWER(CONCAT(SUBSTRING(orguser.email FROM 1 FOR POSITION('@' IN orguser.email)), replace(orguser.email_identifier, '@', '')))
 FROM (
 	SELECT dd.id, dd.email, o.email_identifier
 	FROM public.organisation o


### PR DESCRIPTION
## Purpose
Make emails unique as it's a unique field in the DB

Fixes DDLS-357

## Approach
use ppk_id as this should make them unique

## Learning
NA

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
