### PR TITLE
DDLS-358: Persist primary account when deputy is discharged from court order related to that account

### DIFF
--- a/api/app/tests/Behat/bootstrap/v2/Common/AuthTrait.php
+++ b/api/app/tests/Behat/bootstrap/v2/Common/AuthTrait.php
@@ -469,4 +469,18 @@ trait AuthTrait
         $this->assertPageContainsText($clientFirstName);
         $this->assertPageContainsText($clientLastName);
     }
+
+    /**
+     * @Then /^they should arrive on the client dashboard of their only active "(primary|non-primary)" client$/
+     */
+    public function theyShouldArriveOnTheClientDashboardOfTheirOnlyActiveClient($isPrimary)
+    {
+        if ('non-primary' == $isPrimary) {
+            $clientId = $this->layPfaHighNotStartedMultiClientDeputySecondNonPrimaryUser->getClientId();
+        } else {
+            $clientId = $this->layPfaHighNotStartedMultiClientDeputyPrimaryUser->getClientId();
+        }
+
+        $this->iAmOnPage(sprintf('/client\/%d$/', $clientId));
+    }
 }

--- a/api/app/tests/Behat/bootstrap/v2/Common/AuthTrait.php
+++ b/api/app/tests/Behat/bootstrap/v2/Common/AuthTrait.php
@@ -425,6 +425,32 @@ trait AuthTrait
     }
 
     /**
+     * @Given /^have access to all "(primary|non-primary)" Client dashboards$/
+     */
+    public function haveAccessToAllClientDashboards($isPrimary)
+    {
+        $clientIds = [];
+
+        if ('non-primary' == $isPrimary) {
+            $clientIds[] = $this->layPfaHighNotStartedMultiClientDeputyNonPrimaryUser->getClientId();
+            $clientIds[] = $this->layPfaHighNotStartedMultiClientDeputySecondNonPrimaryUser->getClientId();
+        } else {
+            $clientIds[] = $this->layPfaHighNotStartedMultiClientDeputyPrimaryUser->getClientId();
+        }
+
+        if (count($clientIds) > 1) {
+            foreach ($clientIds as $clientId) {
+                $urlRegex = sprintf('/client\/%d$/', $clientId);
+                $this->iClickOnNthElementBasedOnRegex($urlRegex, 0);
+                $this->clickLink('Your reports');
+            }
+        } else {
+            $urlRegex = sprintf('/client\/%d$/', $clientIds);
+            $this->iClickOnNthElementBasedOnRegex($urlRegex, 0);
+        }
+    }
+
+    /**
      * @Then /^they should be on the "(primary|non-primary)" Client's dashboard$/
      */
     public function theyShouldBeOnThatClientSDashboard($isPrimary)

--- a/api/app/tests/Behat/bootstrap/v2/Common/BaseFeatureContext.php
+++ b/api/app/tests/Behat/bootstrap/v2/Common/BaseFeatureContext.php
@@ -666,4 +666,73 @@ class BaseFeatureContext extends MinkContext
         $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputyNonPrimaryUser = $nonPrimaryUserDetailsOne;
         $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputySecondNonPrimaryUser = $nonPrimaryUserDetailsTwo;
     }
+
+    /**
+     * @BeforeScenario @lay-pfa-high-not-started-multi-client-deputy-one-active-client
+     */
+    public function createLayPfaHighNotStartedMultiClientDeputyWithOneActiveClient()
+    {
+        $deputyUid = 123456789000 + rand(1, 999);
+
+        // generate a second test run id for second non-primary user
+        $testRunId = (string) (time() + rand());
+
+        $primaryUserDetails = new UserDetails($this->fixtureHelper->createLayPfaHighAssetsNotStarted($this->testRunId, null, $deputyUid));
+        $nonPrimaryUserDetailsOne = new UserDetails($this->fixtureHelper->createLayPfaHighAssetsNonPrimaryUser($this->testRunId, null, $deputyUid));
+        $nonPrimaryUserDetailsTwo = new UserDetails($this->fixtureHelper->createLayPfaHighAssetsNonPrimaryUser($testRunId, null, $deputyUid));
+
+        // Discharge client linked to primary account and one of the non-primary accounts
+        $primaryDischargedClientId = $primaryUserDetails->getClientId();
+        $client = $this->em->getRepository(Client::class)->find($primaryDischargedClientId);
+        $client->setDeletedAt(new \DateTime('now'));
+
+        $nonPrimaryDischargedClientId = $nonPrimaryUserDetailsOne->getClientId();
+        $client2 = $this->em->getRepository(Client::class)->find($nonPrimaryDischargedClientId);
+        $client2->setDeletedAt(new \DateTime('now'));
+
+        $this->em->persist($client);
+        $this->em->persist($client2);
+        $this->em->flush();
+
+        $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputyPrimaryUser = $primaryUserDetails;
+        $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputyNonPrimaryUser = $nonPrimaryUserDetailsOne;
+        $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputySecondNonPrimaryUser = $nonPrimaryUserDetailsTwo;
+    }
+
+    /**
+     * @BeforeScenario @lay-pfa-high-not-started-multi-client-deputy-no-active-clients
+     */
+    public function createLayPfaHighNotStartedMultiClientDeputyWithNoActiveClients()
+    {
+        $deputyUid = 123456789000 + rand(1, 999);
+
+        // generate a second test run id for second non-primary user
+        $testRunId = (string) (time() + rand());
+
+        $primaryUserDetails = new UserDetails($this->fixtureHelper->createLayPfaHighAssetsNotStarted($this->testRunId, null, $deputyUid));
+        $nonPrimaryUserDetailsOne = new UserDetails($this->fixtureHelper->createLayPfaHighAssetsNonPrimaryUser($this->testRunId, null, $deputyUid));
+        $nonPrimaryUserDetailsTwo = new UserDetails($this->fixtureHelper->createLayPfaHighAssetsNonPrimaryUser($testRunId, null, $deputyUid));
+
+        // Discharge client linked to primary account and one of the non-primary accounts
+        $primaryDischargedClientId = $primaryUserDetails->getClientId();
+        $client = $this->em->getRepository(Client::class)->find($primaryDischargedClientId);
+        $client->setDeletedAt(new \DateTime('now'));
+
+        $nonPrimaryDischargedClientIdOne = $nonPrimaryUserDetailsOne->getClientId();
+        $client2 = $this->em->getRepository(Client::class)->find($nonPrimaryDischargedClientIdOne);
+        $client2->setDeletedAt(new \DateTime('now'));
+
+        $nonPrimaryDischargedClientIdOne = $nonPrimaryUserDetailsTwo->getClientId();
+        $client3 = $this->em->getRepository(Client::class)->find($nonPrimaryDischargedClientIdOne);
+        $client3->setDeletedAt(new \DateTime('now'));
+
+        $this->em->persist($client);
+        $this->em->persist($client2);
+        $this->em->persist($client3);
+        $this->em->flush();
+
+        $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputyPrimaryUser = $primaryUserDetails;
+        $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputyNonPrimaryUser = $nonPrimaryUserDetailsOne;
+        $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputySecondNonPrimaryUser = $nonPrimaryUserDetailsTwo;
+    }
 }

--- a/api/app/tests/Behat/bootstrap/v2/Common/BaseFeatureContext.php
+++ b/api/app/tests/Behat/bootstrap/v2/Common/BaseFeatureContext.php
@@ -124,6 +124,7 @@ class BaseFeatureContext extends MinkContext
 
     protected Application $application;
     public BufferedOutput $output;
+    private array $activeClientIds;
 
     public function __construct(
         protected readonly FixtureHelper $fixtureHelper,
@@ -642,7 +643,7 @@ class BaseFeatureContext extends MinkContext
     }
 
     /**
-     * @BeforeScenario @lay-pfa-high-started-multi-client-deputy-one-discharged-two-active-clients
+     * @BeforeScenario @lay-pfa-high-started-multi-client-deputy-primary-client-discharged-two-active-clients
      */
     public function createLayPfaHighNotStartedMultiClientDeputyWithActiveAndDischargedClients()
     {
@@ -660,75 +661,6 @@ class BaseFeatureContext extends MinkContext
         $client = $this->em->getRepository(Client::class)->find($primaryDischargedClientId);
         $client->setDeletedAt(new \DateTime('now'));
         $this->em->persist($client);
-        $this->em->flush();
-
-        $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputyPrimaryUser = $primaryUserDetails;
-        $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputyNonPrimaryUser = $nonPrimaryUserDetailsOne;
-        $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputySecondNonPrimaryUser = $nonPrimaryUserDetailsTwo;
-    }
-
-    /**
-     * @BeforeScenario @lay-pfa-high-not-started-multi-client-deputy-one-active-client
-     */
-    public function createLayPfaHighNotStartedMultiClientDeputyWithOneActiveClient()
-    {
-        $deputyUid = 123456789000 + rand(1, 999);
-
-        // generate a second test run id for second non-primary user
-        $testRunId = (string) (time() + rand());
-
-        $primaryUserDetails = new UserDetails($this->fixtureHelper->createLayPfaHighAssetsNotStarted($this->testRunId, null, $deputyUid));
-        $nonPrimaryUserDetailsOne = new UserDetails($this->fixtureHelper->createLayPfaHighAssetsNonPrimaryUser($this->testRunId, null, $deputyUid));
-        $nonPrimaryUserDetailsTwo = new UserDetails($this->fixtureHelper->createLayPfaHighAssetsNonPrimaryUser($testRunId, null, $deputyUid));
-
-        // Discharge client linked to primary account and one of the non-primary accounts
-        $primaryDischargedClientId = $primaryUserDetails->getClientId();
-        $client = $this->em->getRepository(Client::class)->find($primaryDischargedClientId);
-        $client->setDeletedAt(new \DateTime('now'));
-
-        $nonPrimaryDischargedClientId = $nonPrimaryUserDetailsOne->getClientId();
-        $client2 = $this->em->getRepository(Client::class)->find($nonPrimaryDischargedClientId);
-        $client2->setDeletedAt(new \DateTime('now'));
-
-        $this->em->persist($client);
-        $this->em->persist($client2);
-        $this->em->flush();
-
-        $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputyPrimaryUser = $primaryUserDetails;
-        $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputyNonPrimaryUser = $nonPrimaryUserDetailsOne;
-        $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputySecondNonPrimaryUser = $nonPrimaryUserDetailsTwo;
-    }
-
-    /**
-     * @BeforeScenario @lay-pfa-high-not-started-multi-client-deputy-no-active-clients
-     */
-    public function createLayPfaHighNotStartedMultiClientDeputyWithNoActiveClients()
-    {
-        $deputyUid = 123456789000 + rand(1, 999);
-
-        // generate a second test run id for second non-primary user
-        $testRunId = (string) (time() + rand());
-
-        $primaryUserDetails = new UserDetails($this->fixtureHelper->createLayPfaHighAssetsNotStarted($this->testRunId, null, $deputyUid));
-        $nonPrimaryUserDetailsOne = new UserDetails($this->fixtureHelper->createLayPfaHighAssetsNonPrimaryUser($this->testRunId, null, $deputyUid));
-        $nonPrimaryUserDetailsTwo = new UserDetails($this->fixtureHelper->createLayPfaHighAssetsNonPrimaryUser($testRunId, null, $deputyUid));
-
-        // Discharge client linked to primary account and one of the non-primary accounts
-        $primaryDischargedClientId = $primaryUserDetails->getClientId();
-        $client = $this->em->getRepository(Client::class)->find($primaryDischargedClientId);
-        $client->setDeletedAt(new \DateTime('now'));
-
-        $nonPrimaryDischargedClientIdOne = $nonPrimaryUserDetailsOne->getClientId();
-        $client2 = $this->em->getRepository(Client::class)->find($nonPrimaryDischargedClientIdOne);
-        $client2->setDeletedAt(new \DateTime('now'));
-
-        $nonPrimaryDischargedClientIdOne = $nonPrimaryUserDetailsTwo->getClientId();
-        $client3 = $this->em->getRepository(Client::class)->find($nonPrimaryDischargedClientIdOne);
-        $client3->setDeletedAt(new \DateTime('now'));
-
-        $this->em->persist($client);
-        $this->em->persist($client2);
-        $this->em->persist($client3);
         $this->em->flush();
 
         $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputyPrimaryUser = $primaryUserDetails;

--- a/api/app/tests/Behat/bootstrap/v2/Common/BaseFeatureContext.php
+++ b/api/app/tests/Behat/bootstrap/v2/Common/BaseFeatureContext.php
@@ -653,6 +653,7 @@ class BaseFeatureContext extends MinkContext
 
         $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputyPrimaryUser = $primaryUserDetails;
         $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputyNonPrimaryUser = $nonPrimaryUserDetails;
+    }
 
     /**
      * @BeforeScenario @lay-pfa-high-started-multi-client-deputy-primary-client-discharged-two-active-clients

--- a/api/app/tests/Behat/bootstrap/v2/Common/IShouldBeOnFrontendTrait.php
+++ b/api/app/tests/Behat/bootstrap/v2/Common/IShouldBeOnFrontendTrait.php
@@ -850,4 +850,12 @@ trait IShouldBeOnFrontendTrait
 
         return $this->iAmOnPage('/choose-a-client$/');
     }
+
+    /**
+     * @Then /^they should be on the add your client page$/
+     */
+    public function theyShouldBeOnTheAddYourClientPage()
+    {
+        return $this->iAmOnPage('#client/add$#');
+    }
 }

--- a/api/app/tests/Behat/bootstrap/v2/Common/IVisitAdminTrait.php
+++ b/api/app/tests/Behat/bootstrap/v2/Common/IVisitAdminTrait.php
@@ -299,4 +299,11 @@ trait IVisitAdminTrait
 
         $this->visitFrontendPath($this->getOrgAddUserUrl($organisation->getId()));
     }
+
+    public function iVisitClientDetailsUrl($clientId)
+    {
+        $clientDetailsUrl = $this->getAdminClientDetailsUrl($clientId);
+
+        $this->visitAdminPath($clientDetailsUrl);
+    }
 }

--- a/api/app/tests/Behat/features-v2/acl/login/login.feature
+++ b/api/app/tests/Behat/features-v2/acl/login/login.feature
@@ -56,3 +56,9 @@ Feature: Users logging into the service
         When they choose their "non-primary" Client
         Then they should be on the "non-primary" Client's dashboard
         And when they log out they shouldn't see a flash message for non primary accounts
+
+    @multi-feature-flag-enabled @lay-pfa-high-started-multi-client-deputy-one-discharged-two-active-clients
+    Scenario: A user logs into the service with their primary account given they're active clients are linked to their non-primary account
+        Given a Lay Deputy tries to login with their "primary" email address
+        Then they should be on the Choose a Client homepage
+        And have access to all "non-primary" Client dashboards

--- a/api/app/tests/Behat/features-v2/acl/login/login.feature
+++ b/api/app/tests/Behat/features-v2/acl/login/login.feature
@@ -94,18 +94,22 @@ Feature: Users logging into the service
         And the Lay Deputy navigates back to the Client dashboard using the breadcrumb
         Then they should be on the "primary" Client's dashboard
 
-    @multi-feature-flag-enabled @lay-pfa-high-started-multi-client-deputy-one-discharged-two-active-clients
-    Scenario: A user logs into the service with their primary account given they're active clients are linked to their non-primary account
+    @multi-feature-flag-enabled @lay-pfa-high-started-multi-client-deputy-primary-client-discharged-two-active-clients
+    Scenario: A user logs into the service with their primary account given they're active clients are linked to their secondary accounts
         Given a Lay Deputy tries to login with their "primary" email address
         Then they should be on the Choose a Client homepage
-        And have access to all "non-primary" Client dashboards
+        And have access to all active client dashboards
 
-    @multi-feature-flag-enabled @lay-pfa-high-not-started-multi-client-deputy-one-active-client
-    Scenario: A user logs into the service with their primary account given they're remaining active client is linked to their non-primary account
-        Given a Lay Deputy tries to login with their "primary" email address
-        Then they should arrive on the client dashboard of their only active "non-primary" client
+    @multi-feature-flag-enabled @super-admin @lay-pfa-high-started-multi-client-deputy-primary-client-discharged-two-active-clients
+    Scenario: A user logs into the service with their primary account given they're remaining active client is linked to their secondary account
+        Given a super admin user accesses the admin app
+        And they discharge the deputy from "1" secondary client(s)
+        Then a Lay Deputy tries to login with their "primary" email address
+        And should arrive on the client dashboard of their only active client
 
-    @multi-feature-flag-enabled @lay-pfa-high-not-started-multi-client-deputy-no-active-clients
+    @multi-feature-flag-enabled @super-admin @lay-pfa-high-started-multi-client-deputy-primary-client-discharged-two-active-clients
     Scenario: A user logs into the service with their primary account given all of their clients are discharged
-        Given a Lay Deputy tries to login with their "primary" email address
+        Given a super admin user accesses the admin app
+        And they discharge the deputy from "2" secondary client(s)
+        Then a Lay Deputy tries to login with their "primary" email address
         Then they should be on the add your client page

--- a/api/app/tests/Behat/features-v2/acl/login/login.feature
+++ b/api/app/tests/Behat/features-v2/acl/login/login.feature
@@ -62,3 +62,13 @@ Feature: Users logging into the service
         Given a Lay Deputy tries to login with their "primary" email address
         Then they should be on the Choose a Client homepage
         And have access to all "non-primary" Client dashboards
+
+    @multi-feature-flag-enabled @lay-pfa-high-not-started-multi-client-deputy-one-active-client
+    Scenario: A user logs into the service with their primary account given they're remaining active client is linked to their non-primary account
+        Given a Lay Deputy tries to login with their "primary" email address
+        Then they should arrive on the client dashboard of their only active "non-primary" client
+
+    @multi-feature-flag-enabled @lay-pfa-high-not-started-multi-client-deputy-no-active-clients
+    Scenario: A user logs into the service with their primary account given all of their clients are discharged
+        Given a Lay Deputy tries to login with their "primary" email address
+        Then they should be on the add your client page

--- a/api/app/tests/Behat/features-v2/registration/self-register.feature
+++ b/api/app/tests/Behat/features-v2/registration/self-register.feature
@@ -46,7 +46,7 @@ Feature: Lay Deputy Self Registration
         And I should be on the Lay homepage
 
     @admin
-    Scenario: A Co-deputy can register for the service and is searchable in admin - fix
+    Scenario: A Co-deputy can register for the service and is searchable in admin
         Given a csv has been uploaded to the sirius bucket with the file 'lay-2-rows-co-deputy.csv'
         When I run the lay CSV command the file contains 2 new pre-registration entities for the same case
         And one of the Lay Deputies registers to deputise for a client with valid details

--- a/api/app/tests/Behat/features-v2/registration/self-register.feature
+++ b/api/app/tests/Behat/features-v2/registration/self-register.feature
@@ -46,7 +46,7 @@ Feature: Lay Deputy Self Registration
         And I should be on the Lay homepage
 
     @admin
-    Scenario: A Co-deputy can register for the service and is searchable in admin
+    Scenario: A Co-deputy can register for the service and is searchable in admin - fix
         Given a csv has been uploaded to the sirius bucket with the file 'lay-2-rows-co-deputy.csv'
         When I run the lay CSV command the file contains 2 new pre-registration entities for the same case
         And one of the Lay Deputies registers to deputise for a client with valid details

--- a/client/app/src/Controller/Report/ReportController.php
+++ b/client/app/src/Controller/Report/ReportController.php
@@ -167,11 +167,6 @@ class ReportController extends AbstractController
             return $this->redirectToRoute($route);
         }
 
-        $clients = $user->getClients();
-        if (empty($clients)) {
-            throw $this->createNotFoundException('Client not added');
-        }
-
         $clientWithCoDeputies = $this->clientApi->getWithUsersV2($clientId);
         $coDeputies = $clientWithCoDeputies->getCoDeputies();
 
@@ -222,7 +217,8 @@ class ReportController extends AbstractController
             return $this->redirectToRoute($route);
         }
 
-        $clients = $this->clientApi->getAllClientsByDeputyUid($user->getDeputyUid());
+        $groups = ['client', 'client-name', 'client-case-number', 'client-reports', 'client-ndr', 'ndr', 'report', 'status'];
+        $clients = $this->clientApi->getAllClientsByDeputyUid($user->getDeputyUid(), $groups);
 
         if (empty($clients)) {
             throw $this->createNotFoundException('Client not added');

--- a/client/app/src/Entity/Client.php
+++ b/client/app/src/Entity/Client.php
@@ -1036,4 +1036,20 @@ class Client
 
         return null;
     }
+
+    /**
+     * @return array $reportIds
+     */
+    public function getReportIds()
+    {
+        $reportIds = [];
+
+        if (!empty($this->reports)) {
+            foreach ($this->reports as $report) {
+                $reportIds[] = $report->getId();
+            }
+        }
+
+        return $reportIds;
+    }
 }

--- a/client/app/src/Service/Client/Internal/ClientApi.php
+++ b/client/app/src/Service/Client/Internal/ClientApi.php
@@ -242,21 +242,11 @@ class ClientApi
     /**
      * @return Client[]
      */
-    public function getAllClientsByDeputyUid(int $deputyUid)
+    public function getAllClientsByDeputyUid(int $deputyUid, $groups = [])
     {
         return $this->restClient->get(
             sprintf(self::GET_ALL_CLIENTS_BY_DEPUTY_UID, $deputyUid),
-            'Client[]',
-            [
-                'client',
-                'client-name',
-                'client-case-number',
-                'client-reports',
-                'client-ndr',
-                'ndr',
-                'report',
-                'status',
-            ]
+            'Client[]', $groups
         );
     }
 }

--- a/client/app/src/Service/Redirector.php
+++ b/client/app/src/Service/Redirector.php
@@ -163,12 +163,14 @@ class Redirector
         }
 
         // redirect to create report if report is not created
-        if (0 == $user->getNumberOfReports()) {
-            $allActiveClients = $this->clientApi->getAllClientsByDeputyUid($user->getDeputyUid());
+        $allActiveClients = $this->clientApi->getAllClientsByDeputyUid($user->getDeputyUid(), ['client-reports', 'report']);
 
-            if (0 == count($allActiveClients)) {
-                return $this->router->generate('report_create', ['clientId' => $user->getIdOfClientWithDetails()]);
+        foreach ($allActiveClients as $activeClient) {
+            if (count($activeClient->getReportIds()) >= 1) {
+                break;
             }
+
+            return $this->router->generate('report_create', ['clientId' => $user->getIdOfClientWithDetails()]);
         }
 
         // check if last remaining active client is linked to non-primary account if so retrieve id

--- a/client/app/src/Service/Redirector.php
+++ b/client/app/src/Service/Redirector.php
@@ -101,7 +101,7 @@ class Redirector
         $isMultiClientFeatureEnabled = $this->parameterStoreService->getFeatureFlag(ParameterStoreService::FLAG_MULTI_ACCOUNTS);
 
         // Check if user has multiple clients
-        $clients = !is_null($user->getDeputyUid()) ? $this->clientApi->getAllClientsByDeputyUid($user->getDeputyUid()) : null;
+        $clients = !is_null($user->getDeputyUid()) ? $this->clientApi->getAllClientsByDeputyUid($user->getDeputyUid()) : [];
         $multiClientDeputy = !is_null($clients) && count($clients) > 1;
 
         // Redirect to appropriate homepage

--- a/client/app/src/Service/Redirector.php
+++ b/client/app/src/Service/Redirector.php
@@ -99,7 +99,7 @@ class Redirector
     public function getCorrectRouteIfDifferent(User $user, $currentRoute)
     {
         // Check if user has multiple clients
-        $clients = !is_null($user->getDeputyUid()) ? $this->clientApi->getAllClientsByDeputyUid($user->getDeputyUid()) : null;
+        $clients = !is_null($user->getDeputyUid()) ? $this->clientApi->getAllClientsByDeputyUid($user->getDeputyUid()) : [];
         $multiClientDeputy = count($clients) > 1;
 
         // Redirect to appropriate homepage
@@ -262,7 +262,7 @@ class Redirector
         $isMultiClientFeatureEnabled = $this->parameterStoreService->getFeatureFlag(ParameterStoreService::FLAG_MULTI_ACCOUNTS);
         $user = $this->getLoggedUser();
 
-        $clients = !is_null($user->getDeputyUid()) ? $this->clientApi->getAllClientsByDeputyUid($user->getDeputyUid()) : null;
+        $clients = !is_null($user->getDeputyUid()) ? $this->clientApi->getAllClientsByDeputyUid($user->getDeputyUid()) : [];
         $activeClientId = count($clients) > 0 ? array_values($clients)[0]->getId() : null;
 
         if ('1' == $isMultiClientFeatureEnabled) {


### PR DESCRIPTION
## Purpose
As a user with multiple deputies, I want to be able to use my primary login to view my remaining deputies when I am discharged from the court order linked to my primary account.

Fixes DDLS-358

## Approach
- Update Redirector class to track number of active client(s) and redirect to the correct route
- Redirect deputy to 'client_add' page if they no longer have active clients
- Add behat tests to cover various journey's dependent on single or multi-client deputy with secondary clients
- Update redirector class to ensure deputy is only redirected to 'report-create' page if they have no active reports

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
