### PR TITLE
DDLS-380: Fix for org users trying to access reports

### DIFF
--- a/api/app/src/TestHelpers/UserTestHelper.php
+++ b/api/app/src/TestHelpers/UserTestHelper.php
@@ -60,7 +60,7 @@ class UserTestHelper extends TestCase
             ->setAgreeTermsUse(true)
             ->setIsPrimary($isPrimary);
 
-        if (str_contains($roleNaqme, 'LAY')) {
+        if (str_contains($roleName, 'LAY')) {
             $user->setDeputyUid($deputyUid ?: intval('7'.str_pad((string) mt_rand(1, 99999999), 11, '0', STR_PAD_LEFT)));
         }
 

--- a/api/app/src/TestHelpers/UserTestHelper.php
+++ b/api/app/src/TestHelpers/UserTestHelper.php
@@ -58,8 +58,11 @@ class UserTestHelper extends TestCase
             ->setAddressCountry('GB')
             ->setAddressPostcode($faker->postcode())
             ->setAgreeTermsUse(true)
-            ->setIsPrimary($isPrimary)
-            ->setDeputyUid($deputyUid ?: intval('7'.str_pad((string) mt_rand(1, 99999999), 11, '0', STR_PAD_LEFT)));
+            ->setIsPrimary($isPrimary);
+
+        if (str_contains($roleNaqme, 'LAY')) {
+            $user->setDeputyUid($deputyUid ?: intval('7'.str_pad((string) mt_rand(1, 99999999), 11, '0', STR_PAD_LEFT)));
+        }
 
         if (!is_null($client)) {
             $user->addClient($client);

--- a/client/app/src/Controller/Report/ReportController.php
+++ b/client/app/src/Controller/Report/ReportController.php
@@ -381,7 +381,7 @@ class ReportController extends AbstractController
 
         $deputyHasMultiClients = false;
 
-        if ('1' == $isMultiClientFeatureEnabled) {
+        if ('1' == $isMultiClientFeatureEnabled && !$user->isDeputyOrg()) {
             $deputyHasMultiClients = $this->clientApi->checkDeputyHasMultiClients($user->getDeputyUid());
         }
 


### PR DESCRIPTION
## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes DDLS-380

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
