### PR TITLE
DDLS-391 add encryption to SNS

### DIFF
--- a/terraform/account/region/kms_service_sns.tf
+++ b/terraform/account/region/kms_service_sns.tf
@@ -1,0 +1,71 @@
+##### Shared KMS key for SNS #####
+
+# Account logs encryption
+module "sns_kms" {
+  source                  = "./modules/kms_key"
+  encrypted_resource      = "SNS"
+  kms_key_alias_name      = "digideps_sns_encryption_key"
+  enable_key_rotation     = true
+  enable_multi_region     = false
+  deletion_window_in_days = 10
+  kms_key_policy          = var.account.name == "development" ? data.aws_iam_policy_document.kms_sns_merged_for_development.json : data.aws_iam_policy_document.kms_sns_merged.json
+  providers = {
+    aws.eu_west_1 = aws.eu_west_1
+    aws.eu_west_2 = aws.eu_west_2
+  }
+}
+
+# Policies
+data "aws_iam_policy_document" "kms_sns_merged_for_development" {
+  provider = aws.global
+  source_policy_documents = [
+    data.aws_iam_policy_document.kms_sns.json,
+    data.aws_iam_policy_document.kms_base_permissions.json,
+    data.aws_iam_policy_document.kms_development_account_operator_admin.json
+  ]
+}
+
+data "aws_iam_policy_document" "kms_sns_merged" {
+  provider = aws.global
+  source_policy_documents = [
+    data.aws_iam_policy_document.kms_sns.json,
+    data.aws_iam_policy_document.kms_base_permissions.json
+  ]
+}
+
+data "aws_iam_policy_document" "kms_sns" {
+  statement {
+    sid       = "Allow Key to be used for Encryption by SNS"
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "events.amazonaws.com",
+        "cloudwatch.amazonaws.com"
+      ]
+    }
+  }
+
+  statement {
+    sid       = "Allow Key to be decrypted by lambda"
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["kms:Decrypt"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        aws_iam_role.lambda_monitor_notify.arn
+      ]
+    }
+  }
+}

--- a/terraform/account/region/lambda_monitor_notify.tf
+++ b/terraform/account/region/lambda_monitor_notify.tf
@@ -103,6 +103,17 @@ data "aws_iam_policy_document" "lambda_monitor_notify" {
   }
 
   statement {
+    sid    = "SnsDecryptKms"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt"
+    ]
+    resources = [
+      module.sns_kms.eu_west_1_target_key_arn
+    ]
+  }
+
+  statement {
     sid    = "ReadSecret"
     effect = "Allow"
     actions = [

--- a/terraform/account/region/sns.tf
+++ b/terraform/account/region/sns.tf
@@ -1,11 +1,13 @@
 resource "aws_sns_topic" "alerts" {
-  name = "alerts"
+  name              = "alerts"
+  kms_master_key_id = module.sns_kms.eu_west_1_target_key_arn
   tags = merge(
     var.default_tags,
     { Name = "alerts-${var.account.name}" },
   )
 }
 
+# Can't do cross region SNS encryption
 resource "aws_sns_topic" "availability-alert" {
   provider     = aws.global
   name         = "availability-alert-${local.current_main_region}"


### PR DESCRIPTION
## Purpose
Encrypt SNS queues

Fixes DDLS-391

## Approach
Tried to encrypt both SNS queues but cross region encryption not possible so just did the one. Tested that alerts still come through.

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
