### PR TITLE
Renovate Update dependency weasyprint to v63

### DIFF
--- a/client/app/src/Service/HtmlToPdfGenerator.php
+++ b/client/app/src/Service/HtmlToPdfGenerator.php
@@ -34,7 +34,13 @@ class HtmlToPdfGenerator
     {
         $pdf = $this->getPdfFromHtml('test');
 
-        return strlen($pdf) > 800 && preg_match('/PDF-\d/', $pdf);
+        //        file_put_contents('php://stderr', print_r(strlen($pdf), TRUE));
+        //        file_put_contents('php://stderr', print_r(' JIMMY1 ', TRUE));
+        //        file_put_contents('php://stderr', print_r(preg_match('/PDF-\d/', $pdf), TRUE));
+        //        file_put_contents('php://stderr', print_r(' JIMMY2 ', TRUE));
+        //        file_put_contents('php://stderr', print_r(strlen($pdf) > 700, TRUE));
+        //        file_put_contents('php://stderr', print_r(' JIMMY3 ', TRUE));
+        return strlen($pdf) > 700 && preg_match('/PDF-\d/', $pdf);
     }
 
     /**

--- a/htmltopdf/Dockerfile
+++ b/htmltopdf/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.10-alpine3.18
+FROM python:3.12-alpine3.19
 
 ENV PYTHONUNBUFFERED 1
 
 RUN addgroup -S htmltopdf && adduser -S htmltopdf -G htmltopdf
 RUN apk --update --upgrade --no-cache add \
-    cairo-dev pango-dev gdk-pixbuf bash jpeg-dev curl libwebp tiff libcrypto1.1 libssl1.1 ncurses-libs ncurses-terminfo-base libwebp
+    cairo-dev pango-dev gdk-pixbuf bash jpeg-dev curl libwebp tiff libcrypto3 libssl3 ncurses-libs ncurses-terminfo-base libwebp
 
 
 RUN apk --update --upgrade --no-cache add fontconfig ttf-freefont font-noto terminus-font \

--- a/htmltopdf/requirements.txt
+++ b/htmltopdf/requirements.txt
@@ -1,6 +1,6 @@
 executor==23.2
 gunicorn==22.0.0
 setuptools==70.0.0
-weasyprint==52.5
+weasyprint==63.0
 werkzeug==3.0.6
 wheel==0.38.4


### PR DESCRIPTION
## Purpose
Update htmltopdf service generally

## Approach
This was failing with just the weasyprint major update so had to do a bit of mucking around. 

Did the following.

- Upgraded python to a feature supported version. 
- Upgraded alpine to later version
- Alpine upgrade required me to replace two apk packages as they have been replaced in alpine distro
- Newer pdfs generated are slightly smaller in size so had to amend healthcheck to account for that

Checked that PDFs still generated fine and looked the same. They looked find to my eye. 

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
