### PR TITLE
DDLS-408 add encryption to remaining dynamo table

### DIFF
--- a/terraform/account/region/dynamodb.tf
+++ b/terraform/account/region/dynamodb.tf
@@ -76,10 +76,10 @@ resource "aws_dynamodb_table" "blocked_ips_table" {
     enabled        = true
   }
 
-  #  server_side_encryption {
-  #    enabled              = true
-  #    kms_key_arn      = module.dynamodb_kms.eu_west_1_target_key_arn
-  #  }
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = module.dynamodb_kms.eu_west_1_target_key_arn
+  }
 
   lifecycle {
     prevent_destroy = false

--- a/terraform/account/region/lambda_ip_blocker.tf
+++ b/terraform/account/region/lambda_ip_blocker.tf
@@ -119,6 +119,20 @@ data "aws_iam_policy_document" "lambda_block_ips" {
     resources = ["*"]
   }
 
+  statement {
+    sid    = "UseDynamodbKMSKey"
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+    resources = [
+      module.dynamodb_kms.eu_west_1_target_key_arn
+    ]
+  }
 }
 
 data "archive_file" "block_ips_zip" {


### PR DESCRIPTION
## Purpose
This adds the encrypting to the ramaining dynamodb resource.

Fixes DDLS-408

## Approach
Added the encryption. Additionally, I have created two new security groups instead of just amending the current ones. I'm doing it this way to avoid any down time. In subsequent PRs I will duplicate the settings for the cache sg for all the env services then in another PR remove the original. This will result in zero downtime. It's a bit more of a faff but I'll just add it to other PRs that I do.

## Learning
NA

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
