### PR TITLE
Add primsa vpn range to the default allow list

### DIFF
--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -61,7 +61,7 @@ data "aws_ip_ranges" "route53_healthchecks_ips" {
 }
 
 locals {
-  default_allow_list = concat(module.allow_list.moj_sites, formatlist("%s/32", data.aws_nat_gateway.nat[*].public_ip))
+  default_allow_list = concat(module.allow_list.palo_alto_prisma_access, module.allow_list.moj_sites, formatlist("%s/32", data.aws_nat_gateway.nat[*].public_ip))
   admin_allow_list   = length(var.account["admin_allow_list"]) > 0 ? var.account["admin_allow_list"] : local.default_allow_list
   front_allow_list   = length(var.account["front_allow_list"]) > 0 ? var.account["front_allow_list"] : local.default_allow_list
 


### PR DESCRIPTION
Had a request (https://mojdt.slack.com/archives/C7YH87C3A/p1732884764266839) around vpn access for prisma uses - turns out the prisma ip range is not in the `moj_sites` list, so this adds it directly