### PR TITLE
Switch clientFirstName to nullable

### DIFF
--- a/api/app/src/Entity/PreRegistration.php
+++ b/api/app/src/Entity/PreRegistration.php
@@ -33,7 +33,7 @@ class PreRegistration
     public function __construct(array $row)
     {
         $this->caseNumber = $row['Case'] ?? '';
-        $this->clientFirstname = $row['ClientFirstname'] ?? '';
+        $this->clientFirstname = $row['ClientFirstname'] ?? null;
         $this->clientLastname = $row['ClientSurname'] ?? '';
         $this->clientAddress1 = $row['ClientAddress1'] ?? null;
         $this->clientAddress2 = $row['ClientAddress2'] ?? null;
@@ -83,11 +83,9 @@ class PreRegistration
     /**
      * @JMS\Type("string")
      *
-     * @Assert\NotBlank()
-     *
-     * @ORM\Column(name="client_firstname", type="string", length=50, nullable=false)
+     * @ORM\Column(name="client_firstname", type="string", nullable=true)
      */
-    private string $clientFirstname;
+    private ?string $clientFirstname;
 
     /**
      * @JMS\Type("string")
@@ -292,12 +290,12 @@ class PreRegistration
         return $this->clientLastname;
     }
 
-    public function getClientFirstname(): string
+    public function getClientFirstname(): ?string
     {
         return $this->clientFirstname;
     }
 
-    public function setClientFirstname(string $clientFirstname): self
+    public function setClientFirstname(?string $clientFirstname): self
     {
         $this->clientFirstname = $clientFirstname;
 

--- a/api/app/src/Migrations/Version285.php
+++ b/api/app/src/Migrations/Version285.php
@@ -20,7 +20,7 @@ final class Version285 extends AbstractMigration
     public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('ALTER TABLE pre_registration ADD client_firstname VARCHAR(50) NOT NULL');
+        $this->addSql('ALTER TABLE pre_registration ADD client_firstname VARCHAR(50) DEFAULT NULL');
         $this->addSql('ALTER TABLE pre_registration ADD client_address_1 VARCHAR(255) DEFAULT NULL');
         $this->addSql('ALTER TABLE pre_registration ADD client_address_2 VARCHAR(255) DEFAULT NULL');
         $this->addSql('ALTER TABLE pre_registration ADD client_address_3 VARCHAR(255) DEFAULT NULL');

--- a/api/app/src/v2/Registration/Assembler/SiriusToLayDeputyshipDtoAssembler.php
+++ b/api/app/src/v2/Registration/Assembler/SiriusToLayDeputyshipDtoAssembler.php
@@ -8,7 +8,6 @@ class SiriusToLayDeputyshipDtoAssembler implements LayDeputyshipDtoAssemblerInte
 {
     private array $requiredData = [
         'Case',
-        'ClientFirstname',
         'ClientSurname',
         'DeputyUid',
         'DeputyFirstname',
@@ -47,7 +46,7 @@ class SiriusToLayDeputyshipDtoAssembler implements LayDeputyshipDtoAssemblerInte
         return
             (new LayDeputyshipDto())
                 ->setCaseNumber($data['Case'])
-                ->setClientFirstname($data['ClientFirstname'])
+                ->setClientFirstname($data['ClientFirstname'] ?: null)
                 ->setClientSurname($data['ClientSurname'])
                 ->setClientAddress1($data['ClientAddress1'] ?: null)
                 ->setClientAddress2($data['ClientAddress2'] ?: null)

--- a/api/app/tests/Unit/Controller/SelfRegisterControllerTest.php
+++ b/api/app/tests/Unit/Controller/SelfRegisterControllerTest.php
@@ -34,7 +34,7 @@ class SelfRegisterControllerTest extends AbstractTestController
                 'firstname' => 'Zac',
                 'lastname' => 'Tolley',
                 'email' => 'behat-dontsaveme@example.org',
-                'client_firstname' => '',
+                'client_firstname' => null,
                 'client_lastname' => '',
                 'case_number' => '12345678',
             ],
@@ -217,7 +217,7 @@ class SelfRegisterControllerTest extends AbstractTestController
                 [
                     'id' => 1,
                     'case_number' => '97643164',
-                    'client_firstname' => '',
+                    'client_firstname' => null,
                     'client_lastname' => 'Douglas',
                     'client_address1' => null,
                     'client_address2' => null,
@@ -296,7 +296,7 @@ class SelfRegisterControllerTest extends AbstractTestController
                 [
                     'id' => 1,
                     'case_number' => '97643164',
-                    'client_firstname' => '',
+                    'client_firstname' => null,
                     'client_lastname' => 'Douglas',
                     'client_address1' => null,
                     'client_address2' => null,
@@ -375,7 +375,7 @@ class SelfRegisterControllerTest extends AbstractTestController
                 [
                     'id' => 1,
                     'case_number' => '97643164',
-                    'client_firstname' => '',
+                    'client_firstname' => null,
                     'client_lastname' => 'Douglas',
                     'client_address1' => null,
                     'client_address2' => null,
@@ -454,7 +454,7 @@ class SelfRegisterControllerTest extends AbstractTestController
                 [
                     'id' => 1,
                     'case_number' => '97643164',
-                    'client_firstname' => '',
+                    'client_firstname' => null,
                     'client_lastname' => 'Douglas',
                     'client_address1' => null,
                     'client_address2' => null,


### PR DESCRIPTION
We weren't aware but it is in fact possible that the source data may contain null values here.

It was possible to edit the same doctrine migration script, 285, as it hasn't yet run on prod and all the other envs rebuild schema.

## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes DDLS-####

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
