### PR TITLE
DDLS-402 - Migrate existing data from dd_user table to deputy table

### DIFF
--- a/api/app/api.env
+++ b/api/app/api.env
@@ -56,3 +56,5 @@ SECRETS_MANAGER_LOCALSTACK=true
 
 JWT_HOST=http://frontend-webserver
 WORKSPACE=local
+
+RUN_ONE_OFF_MIGRATIONS=true

--- a/api/app/src/Entity/Deputy.php
+++ b/api/app/src/Entity/Deputy.php
@@ -57,7 +57,7 @@ class Deputy
      *
      * @JMS\Groups({"report-submitted-by", "deputy"})
      *
-     * @ORM\Column(name="deputy_uid", type="string", length=20, nullable=false, unique=true)
+     * @ORM\Column(name="deputy_uid", type="bigint", length=20, nullable=false, unique=true)
      */
     private $deputyUid;
 
@@ -253,7 +253,7 @@ class Deputy
     }
 
     /**
-     * @return string
+     * @return int
      */
     public function getDeputyUid()
     {
@@ -261,7 +261,7 @@ class Deputy
     }
 
     /**
-     * @param string $deputyUid
+     * @param int $deputyUid
      *
      * @return $this
      */

--- a/api/app/src/Migrations/Version286.php
+++ b/api/app/src/Migrations/Version286.php
@@ -11,7 +11,7 @@ final class Version286 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return 'Adjusts fk constraint so cleanup job can correctly execute';
+        return 'Alters column & adds missing deputies to deputy table';
     }
 
     public function up(Schema $schema): void

--- a/api/app/src/Migrations/Version286.php
+++ b/api/app/src/Migrations/Version286.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version286 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adjusts fk constraint so cleanup job can correctly execute';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE deputy ALTER COLUMN deputy_uid TYPE BIGINT;');
+        if (getenv('RUN_ONE_OFF_MIGRATIONS')) {
+            $sql = <<<SQL
+            INSERT INTO deputy 
+            (user_id, deputy_uid, firstname, lastname, email1, address1, address2, 
+            address3, address4, address5, address_postcode, address_country, phone_main, phone_alternative)
+
+            SELECT id, deputy_uid, firstname, lastname, email, address1, address2, address3, 
+            address4, address5, address_postcode, address_country, phone_main, phone_alternative
+            FROM dd_user
+            WHERE id IN (
+                SELECT u.id
+                FROM client c
+                LEFT JOIN deputy_case dc ON c.id = dc.client_id
+                LEFT JOIN dd_user u ON dc.user_id = u.id
+                WHERE dc.user_id IN (
+                    SELECT id
+                    FROM dd_user 
+                    WHERE is_primary = TRUE
+                    AND deputy_uid NOT IN (
+                        SELECT deputy_uid 
+                        FROM deputy
+                        )
+                )
+            )
+            SQL;
+
+            $this->addSql($sql);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE deputy ALTER COLUMN deputy_uid TYPE VARCHAR(20);');
+    }
+}

--- a/terraform/environment/region/ecs_cluster.tf
+++ b/terraform/environment/region/ecs_cluster.tf
@@ -120,6 +120,10 @@ locals {
       name  = "LAY_REPORT_CSV_FILENAME",
       value = local.lay_report_csv_file
     },
+    {
+      name  = "RUN_ONE_OFF_MIGRATIONS",
+      value = true
+    },
   ]
 
   api_integration_test_variables = [


### PR DESCRIPTION
## Purpose
Allows us to separate account information from deputy entity and move one step closer to aligning Lay deputy data to Prof and PA. 


Fixes DDLS-402

## Approach
Creates migration script to copy all users who are missing from deputy table.
Also adjusts datatype on deputy table to align `deputy_uid` with the data stored elsewhere in the database.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
