### PR TITLE
DDLS-402 - Migrate existing data from dd_user table to deputy table

### DIFF
--- a/api/app/src/Entity/Deputy.php
+++ b/api/app/src/Entity/Deputy.php
@@ -57,7 +57,7 @@ class Deputy
      *
      * @JMS\Groups({"report-submitted-by", "deputy"})
      *
-     * @ORM\Column(name="deputy_uid", type="string", length=20, nullable=false, unique=true)
+     * @ORM\Column(name="deputy_uid", type="bigint", length=20, nullable=false, unique=true)
      */
     private $deputyUid;
 
@@ -253,7 +253,7 @@ class Deputy
     }
 
     /**
-     * @return string
+     * @return int
      */
     public function getDeputyUid()
     {
@@ -261,7 +261,7 @@ class Deputy
     }
 
     /**
-     * @param string $deputyUid
+     * @param int $deputyUid
      *
      * @return $this
      */

--- a/api/app/src/Migrations/Version286.php
+++ b/api/app/src/Migrations/Version286.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version286 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adjusts column on deputy table to match data elsewhere in database';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE deputy ALTER COLUMN deputy_uid TYPE BIGINT;');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE deputy ALTER COLUMN deputy_uid TYPE VARCHAR(20);');
+    }
+}


### PR DESCRIPTION
## Purpose
Allows us to separate account information from deputy entity and move one step closer to aligning Lay deputy data to Prof and PA.

Fixes DDLS-402

## Approach
This PR changes data type, required before migration script can be committed.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
