### PR TITLE
DDLS-402 - Migrate existing data from dd_user table to deputy table

### DIFF
--- a/api/app/api.env
+++ b/api/app/api.env
@@ -56,3 +56,5 @@ SECRETS_MANAGER_LOCALSTACK=true
 
 JWT_HOST=http://frontend-webserver
 WORKSPACE=local
+
+RUN_ONE_OFF_MIGRATIONS=true

--- a/api/app/src/Migrations/Version286.php
+++ b/api/app/src/Migrations/Version286.php
@@ -19,7 +19,7 @@ final class Version286 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        if (getenv('RUN_ONE_OFF_MIGRATIONS')) {
+        if (!!getenv('RUN_ONE_OFF_MIGRATIONS')) {
             $sql = <<<SQL
             INSERT INTO deputy 
             (user_id, deputy_uid, firstname, lastname, email1, address1, address2, 

--- a/api/app/src/Migrations/Version286.php
+++ b/api/app/src/Migrations/Version286.php
@@ -10,7 +10,7 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version287 extends AbstractMigration
+final class Version286 extends AbstractMigration
 {
     public function getDescription(): string
     {
@@ -24,7 +24,7 @@ final class Version287 extends AbstractMigration
             INSERT INTO deputy 
             (user_id, deputy_uid, firstname, lastname, email1, address1, address2, 
             address3, address4, address5, address_postcode, address_country, phone_main, phone_alternative)
-            SELECT id, deputy_uid, firstname, lastname, email, address1, address2, address3, 
+            SELECT id, CAST(deputy_uid AS VARCHAR), firstname, lastname, email, address1, address2, address3, 
             address4, address5, address_postcode, address_country, phone_main, phone_alternative
             FROM dd_user
             WHERE id IN (
@@ -36,7 +36,7 @@ final class Version287 extends AbstractMigration
                     SELECT id
                     FROM dd_user 
                     WHERE is_primary = TRUE
-                    AND deputy_uid NOT IN (
+                    AND CAST(deputy_uid AS VARCHAR) NOT IN (
                         SELECT deputy_uid 
                         FROM deputy
                         )

--- a/api/app/src/Migrations/Version287.php
+++ b/api/app/src/Migrations/Version287.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version287 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adds mirgration script';
+    }
+
+    public function up(Schema $schema): void
+    {
+        if (getenv('RUN_ONE_OFF_MIGRATIONS')) {
+            $sql = <<<SQL
+            INSERT INTO deputy 
+            (user_id, deputy_uid, firstname, lastname, email1, address1, address2, 
+            address3, address4, address5, address_postcode, address_country, phone_main, phone_alternative)
+            SELECT id, deputy_uid, firstname, lastname, email, address1, address2, address3, 
+            address4, address5, address_postcode, address_country, phone_main, phone_alternative
+            FROM dd_user
+            WHERE id IN (
+                SELECT u.id
+                FROM client c
+                LEFT JOIN deputy_case dc ON c.id = dc.client_id
+                LEFT JOIN dd_user u ON dc.user_id = u.id
+                WHERE dc.user_id IN (
+                    SELECT id
+                    FROM dd_user 
+                    WHERE is_primary = TRUE
+                    AND deputy_uid NOT IN (
+                        SELECT deputy_uid 
+                        FROM deputy
+                        )
+                )
+            )
+            SQL;
+
+            $this->addSql($sql);
+        }
+    }
+}

--- a/terraform/environment/region/ecs_cluster.tf
+++ b/terraform/environment/region/ecs_cluster.tf
@@ -122,7 +122,7 @@ locals {
     },
     {
       name  = "RUN_ONE_OFF_MIGRATIONS",
-      value = "true"
+      value = var.account.run_one_off_migrations
     },
   ]
 

--- a/terraform/environment/region/ecs_cluster.tf
+++ b/terraform/environment/region/ecs_cluster.tf
@@ -120,6 +120,10 @@ locals {
       name  = "LAY_REPORT_CSV_FILENAME",
       value = local.lay_report_csv_file
     },
+    {
+      name  = "RUN_ONE_OFF_MIGRATIONS",
+      value = true
+    },
   ]
 
   api_integration_test_variables = [

--- a/terraform/environment/region/ecs_cluster.tf
+++ b/terraform/environment/region/ecs_cluster.tf
@@ -122,7 +122,7 @@ locals {
     },
     {
       name  = "RUN_ONE_OFF_MIGRATIONS",
-      value = true
+      value = "true"
     },
   ]
 

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -42,7 +42,8 @@
       "secondary_region_enabled": false,
       "fault_injection_experiments_enabled": false,
       "sleep_mode_enabled": false,
-      "waf_ip_blocking_enabled": true
+      "waf_ip_blocking_enabled": true,
+      "run_one_off_migrations": ""
     },
     "preproduction": {
       "name": "preproduction",
@@ -131,7 +132,8 @@
       "secondary_region_enabled": false,
       "fault_injection_experiments_enabled": false,
       "sleep_mode_enabled": true,
-      "waf_ip_blocking_enabled": false
+      "waf_ip_blocking_enabled": false,
+      "run_one_off_migrations": ""
     },
     "integration": {
       "name": "preproduction",
@@ -175,7 +177,8 @@
       "secondary_region_enabled": false,
       "fault_injection_experiments_enabled": true,
       "sleep_mode_enabled": true,
-      "waf_ip_blocking_enabled": false
+      "waf_ip_blocking_enabled": false,
+      "run_one_off_migrations": ""
     },
     "development": {
       "name": "development",
@@ -220,7 +223,8 @@
       "secondary_region_enabled": false,
       "fault_injection_experiments_enabled": false,
       "sleep_mode_enabled": false,
-      "waf_ip_blocking_enabled": false
+      "waf_ip_blocking_enabled": false,
+      "run_one_off_migrations": ""
     },
     "default": {
       "name": "development",
@@ -265,7 +269,8 @@
       "secondary_region_enabled": false,
       "fault_injection_experiments_enabled": false,
       "sleep_mode_enabled": false,
-      "waf_ip_blocking_enabled": false
+      "waf_ip_blocking_enabled": false,
+      "run_one_off_migrations": ""
     }
   }
 }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -86,7 +86,8 @@
       "secondary_region_enabled": false,
       "fault_injection_experiments_enabled": false,
       "sleep_mode_enabled": true,
-      "waf_ip_blocking_enabled": true
+      "waf_ip_blocking_enabled": true,
+      "run_one_off_migrations": "true"
     },
     "training": {
       "name": "preproduction",

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -53,6 +53,7 @@ variable "accounts" {
       fault_injection_experiments_enabled    = bool
       sleep_mode_enabled                     = bool
       waf_ip_blocking_enabled                = bool
+      run_one_off_migrations                 = string
     })
   )
 }


### PR DESCRIPTION
## Purpose
Allows us to separate account information from deputy entity and move one step closer to aligning Lay deputy data to Prof and PA.

Fixes DDLS-402

## Approach
Adds migration script to add missing deputies to deputies table from user table. 

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [x] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
