### PR TITLE
DDLS-426 : Prevent user from inputting invalid year during registration

### DIFF
--- a/client/app/src/Form/ClientType.php
+++ b/client/app/src/Form/ClientType.php
@@ -5,6 +5,7 @@ namespace App\Form;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type as FormTypes;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -30,19 +31,25 @@ class ClientType extends AbstractType
                 ->add('address5', FormTypes\TextType::class)
                 ->add('postcode', FormTypes\TextType::class)
                 ->add('country', FormTypes\CountryType::class, [
-                      'preferred_choices' => ['GB'],
-                      'placeholder' => 'country.defaultOption',
+                    'preferred_choices' => ['GB'],
+                    'placeholder' => 'country.defaultOption',
                 ])
                 ->add('phone', FormTypes\TextType::class)
                 ->add('id', FormTypes\HiddenType::class)
                 ->add('save', FormTypes\SubmitType::class);
 
         // strip tags to prevent XSS as the name is often displayed around mixed with translation with the twig "raw" filter
+        // only allow user to enter a four digit year
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $data = $event->getData();
             $data['firstname'] = strip_tags($data['firstname']);
             $data['lastname'] = strip_tags($data['lastname']);
             $event->setData($data);
+
+            if (!preg_match('/^\d{4}$/', $data['courtDate']['year'])) {
+                $form = $event->getForm();
+                $form->addError(new FormError('Please enter a valid four-digit year.'));
+            }
         });
     }
 

--- a/client/app/src/Form/Report/ReportType.php
+++ b/client/app/src/Form/Report/ReportType.php
@@ -5,6 +5,9 @@ namespace App\Form\Report;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type as FormTypes;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ReportType extends AbstractType
@@ -12,19 +15,26 @@ class ReportType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-                ->add('id', FormTypes\HiddenType::class)
-                ->add('startDate', FormTypes\DateType::class, ['widget' => 'text',
-                                              'input' => 'datetime',
-                                              'format' => 'yyyy-MM-dd',
-                                              'invalid_message' => 'report.startDate.invalidMessage', ])
+            ->add('id', FormTypes\HiddenType::class)
+            ->add('startDate', FormTypes\DateType::class, ['widget' => 'text',
+                'input' => 'datetime',
+                'format' => 'yyyy-MM-dd',
+                'invalid_message' => 'report.startDate.invalidMessage', ])
+            ->add('endDate', FormTypes\DateType::class, ['widget' => 'text',
+                'input' => 'datetime',
+                'format' => 'yyyy-MM-dd',
+                'invalid_message' => 'report.endDate.invalidMessage',
+            ])
+            ->add('save', FormTypes\SubmitType::class);
 
-                ->add('endDate', FormTypes\DateType::class, ['widget' => 'text',
-                                            'input' => 'datetime',
-                                            'format' => 'yyyy-MM-dd',
-                                            'invalid_message' => 'report.endDate.invalidMessage',
-                                          ])
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
+            $data = $event->getData();
 
-                ->add('save', FormTypes\SubmitType::class);
+            if (!preg_match('/^\d{4}$/', $data['startDate']['year']) || !preg_match('/^\d{4}$/', $data['endDate']['year'])) {
+                $form = $event->getForm();
+                $form->addError(new FormError('Please enter a valid four-digit year.'));
+            }
+        });
     }
 
     public function configureOptions(OptionsResolver $resolver)


### PR DESCRIPTION
## Purpose
Following investigation into a bug that prevented a document from syncing to Sirius, it appears that a user can enter an invalid year when entering the court date and reporting period during the registration process.

It looks like Symony's form component attempts to transform an invalid date into a valid DateTime object based on the configured format of 'yyyy-MM-dd'. For example, a user's input of 13-12-25 transforms into '0013-12-25' and is stored in the database.

This only seems to affect the year as validation is thrown when inputting invalid dates and months.

Fixes DDLS-426

## Approach
- Use the PRE_SUBMIT event in the form builder to capture the user's input (specifically the year) and throw an error to the user to input a valid four digit year
- This has been applied to the court date and reporting period fields

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
