### PR TITLE
DDLS-434f swap back to digideps-ci with retricted access

### DIFF
--- a/terraform/account/.envrc
+++ b/terraform/account/.envrc
@@ -1,5 +1,5 @@
 source ../../scripts/pipeline/terraform/switch-terraform-version.sh
 export TF_WORKSPACE=development
 export TF_VAR_DEFAULT_ROLE=operator
-export TF_VAR_DEFAULT_ROLE_MGMT=operator
+export TF_VAR_DEFAULT_ROLE=operator
 export TF_CLI_ARGS_init="-backend-config=\"assume_role={role_arn=\\\"arn:aws:iam::311462405659:role/operator\\\"}\""

--- a/terraform/account/provider.tf
+++ b/terraform/account/provider.tf
@@ -30,7 +30,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::311462405659:role/${var.DEFAULT_ROLE_MGMT}"
+    role_arn     = "arn:aws:iam::311462405659:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
 }
@@ -54,7 +54,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::311462405659:role/${var.DEFAULT_ROLE_MGMT}"
+    role_arn     = "arn:aws:iam::311462405659:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
 }

--- a/terraform/account/variables.tf
+++ b/terraform/account/variables.tf
@@ -4,12 +4,6 @@ variable "DEFAULT_ROLE" {
   default     = "digideps-ci"
 }
 
-variable "DEFAULT_ROLE_MGMT" {
-  type        = string
-  description = "Default role to use for management providers"
-  default     = "digideps-custom-ci"
-}
-
 variable "accounts" {
   type = map(
     object({

--- a/terraform/environment/.envrc
+++ b/terraform/environment/.envrc
@@ -1,5 +1,5 @@
 source ../../scripts/pipeline/terraform/switch-terraform-version.sh
 export TF_WORKSPACE=development
 export TF_VAR_DEFAULT_ROLE=operator
-export TF_VAR_DEFAULT_ROLE_MGMT=operator
+export TF_VAR_DEFAULT_ROLE=operator
 export TF_CLI_ARGS_init="-backend-config=\"assume_role={role_arn=\\\"arn:aws:iam::311462405659:role/operator\\\"}\""

--- a/terraform/environment/provider.tf
+++ b/terraform/environment/provider.tf
@@ -29,7 +29,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::311462405659:role/${var.DEFAULT_ROLE_MGMT}"
+    role_arn     = "arn:aws:iam::311462405659:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
 }
@@ -54,7 +54,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::311462405659:role/${var.DEFAULT_ROLE_MGMT}"
+    role_arn     = "arn:aws:iam::311462405659:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
 }
@@ -78,7 +78,7 @@ provider "aws" {
     tags = local.default_tags
   }
   assume_role {
-    role_arn     = "arn:aws:iam::311462405659:role/${var.DEFAULT_ROLE_MGMT}"
+    role_arn     = "arn:aws:iam::311462405659:role/${var.DEFAULT_ROLE}"
     session_name = "terraform-session"
   }
 }

--- a/terraform/environment/region.tf
+++ b/terraform/environment/region.tf
@@ -7,7 +7,6 @@ module "eu_west_1" {
 
   account                           = local.account
   default_tags                      = local.default_tags
-  default_role                      = var.DEFAULT_ROLE
   secrets_prefix                    = local.secrets_prefix
   shared_environment_variables      = local.shared_environment_variables
   docker_tag                        = var.OPG_DOCKER_TAG
@@ -31,7 +30,6 @@ module "eu_west_2" {
 
   account                           = local.account
   default_tags                      = local.default_tags
-  default_role                      = var.DEFAULT_ROLE
   secrets_prefix                    = local.secrets_prefix
   shared_environment_variables      = local.shared_environment_variables
   docker_tag                        = var.OPG_DOCKER_TAG

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -8,11 +8,6 @@ variable "account" {
   description = "The account map"
 }
 
-variable "default_role" {
-  type        = string
-  description = "The default role to use"
-}
-
 variable "docker_tag" {
   type        = string
   description = "The docker_tag"
@@ -85,10 +80,10 @@ data "terraform_remote_state" "shared" {
   workspace = var.account.state_source
   config = {
     bucket = "opg.terraform.state"
-    key    = "digideps-infrastructure-shared/terraform.tfstate"
+    key    = "opg-digideps-account/terraform.tfstate"
     region = "eu-west-1"
     assume_role = {
-      role_arn = "arn:aws:iam::311462405659:role/${var.default_role}"
+      role_arn = "arn:aws:iam::311462405659:role/digideps-state-write"
     }
   }
 }

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -4,12 +4,6 @@ variable "DEFAULT_ROLE" {
   default     = "digideps-ci"
 }
 
-variable "DEFAULT_ROLE_MGMT" {
-  type        = string
-  description = "Default role to use for management providers"
-  default     = "digideps-custom-ci"
-}
-
 variable "OPG_DOCKER_TAG" {
   description = "docker tag to deploy"
   type        = string


### PR DESCRIPTION
Now that everything works with the digideps-custom-ci role I have switched the access to be the same as this on old digideps-ci role and this PR switches us back to using that name so we don't need two vars for digideps-ci