### PR TITLE
DDLS-370 Non primary accounts should get redirect message instead of add client

### DIFF
--- a/api/app/tests/Behat/bootstrap/v2/Common/BaseFeatureContext.php
+++ b/api/app/tests/Behat/bootstrap/v2/Common/BaseFeatureContext.php
@@ -664,4 +664,24 @@ class BaseFeatureContext extends MinkContext
         $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputyNonPrimaryUser = $nonPrimaryUserDetailsOne;
         $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputySecondNonPrimaryUser = $nonPrimaryUserDetailsTwo;
     }
+
+    /**
+     * @BeforeScenario @lay-pfa-high-not-started-multi-client-deputy-secondary-client-discharged-one-active-client
+     */
+    public function createLayPfaHighNotStartedMultiClientDeputyWithOneActiveClientAndSecondaryDischargedClient()
+    {
+        $deputyUid = 123456789000 + rand(1, 999);
+        $primaryUserDetails = new UserDetails($this->fixtureHelper->createLayPfaHighAssetsNotStarted($this->testRunId, null, $deputyUid));
+        $nonPrimaryUserDetails = new UserDetails($this->fixtureHelper->createLayPfaHighAssetsNonPrimaryUser($this->testRunId, null, $deputyUid));
+
+        // Discharge client linked to secondary account
+        $nonPrimaryDischargedClientId = $nonPrimaryUserDetails->getClientId();
+        $client = $this->em->getRepository(Client::class)->find($nonPrimaryDischargedClientId);
+        $client->setDeletedAt(new \DateTime('now'));
+        $this->em->persist($client);
+        $this->em->flush();
+
+        $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputyPrimaryUser = $primaryUserDetails;
+        $this->fixtureUsers[] = $this->layPfaHighNotStartedMultiClientDeputyNonPrimaryUser = $nonPrimaryUserDetails;
+    }
 }

--- a/api/app/tests/Behat/features-v2/acl/login/login.feature
+++ b/api/app/tests/Behat/features-v2/acl/login/login.feature
@@ -146,3 +146,11 @@ Feature: Users logging into the service
         When they choose their "primary" Client
         Then they should be on the "primary" Client's dashboard
         And I should not see the NDR report on the reports page
+
+    @lay-pfa-high-not-started-multi-client-deputy-secondary-client-discharged-one-active-client
+    Scenario: A user tries to login to the service with their secondary account that has no active clients attached to it
+        Given a Lay Deputy tries to login with their "non-primary" email address
+        Then they get redirected back to the log in page
+        And a flash message should be displayed to the user with their primary email address
+        When the user tries to access their clients report overview page
+        Then they get redirected back to the log in page


### PR DESCRIPTION
## Purpose
Non primary accounts that have no active clients associated with them are taken to the add client screen instead of the ‘use your other account’ screen.

Fixes DDLS-370

## Approach
Added in test to cover the scenario where secondary account with discharged client tries to login and is logged out and flash message appears with primary email address to login with.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [X] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
