### PR TITLE
DDLS-447 Fix waitforit ref to point at new repo

### DIFF
--- a/api/docker/app/Dockerfile
+++ b/api/docker/app/Dockerfile
@@ -52,7 +52,7 @@ RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/re
     && chmod +x /usr/local/bin/confd
 # Add Waitforit to wait on db starting
 ENV WAITFORIT_VERSION="v2.4.1"
-RUN wget -q -O /usr/local/bin/waitforit https://github.com/maxcnunes/waitforit/releases/download/$WAITFORIT_VERSION/waitforit-linux_amd64 \
+RUN wget -q -O /usr/local/bin/waitforit https://github.com/maxclaus/waitforit/releases/download/$WAITFORIT_VERSION/waitforit-linux_amd64 \
     && chmod +x /usr/local/bin/waitforit
 
 # Create var directories

--- a/api/docker/web/Dockerfile
+++ b/api/docker/web/Dockerfile
@@ -10,7 +10,7 @@ RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/re
 
 # Add Waitforit to wait on app starting
 ENV WAITFORIT_VERSION="v2.4.1"
-RUN wget -q -O /usr/local/bin/waitforit https://github.com/maxcnunes/waitforit/releases/download/$WAITFORIT_VERSION/waitforit-linux_amd64 \
+RUN wget -q -O /usr/local/bin/waitforit https://github.com/maxclaus/waitforit/releases/download/$WAITFORIT_VERSION/waitforit-linux_amd64 \
   && chmod +x /usr/local/bin/waitforit
 
 COPY --chown=nginx api/docker/web/confd /etc/confd

--- a/client/docker/app/Dockerfile
+++ b/client/docker/app/Dockerfile
@@ -56,7 +56,7 @@ RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/re
     && chmod +x /usr/local/bin/confd
 # Add Waitforit to wait on API starting
 ENV WAITFORIT_VERSION="v2.4.1"
-RUN wget -q -O /usr/local/bin/waitforit https://github.com/maxcnunes/waitforit/releases/download/$WAITFORIT_VERSION/waitforit-linux_amd64 \
+RUN wget -q -O /usr/local/bin/waitforit https://github.com/maxclaus/waitforit/releases/download/$WAITFORIT_VERSION/waitforit-linux_amd64 \
     && chmod +x /usr/local/bin/waitforit
 
 # Create var directories

--- a/client/docker/web/Dockerfile
+++ b/client/docker/web/Dockerfile
@@ -11,7 +11,7 @@ RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/re
 
 # Add Waitforit to wait on app starting
 ENV WAITFORIT_VERSION="v2.4.1"
-RUN wget -q -O /usr/local/bin/waitforit https://github.com/maxcnunes/waitforit/releases/download/$WAITFORIT_VERSION/waitforit-linux_amd64 \
+RUN wget -q -O /usr/local/bin/waitforit https://github.com/maxclaus/waitforit/releases/download/$WAITFORIT_VERSION/waitforit-linux_amd64 \
   && chmod +x /usr/local/bin/waitforit
 
 COPY --chown=nginx client/docker/web/confd /etc/confd

--- a/wait-for-it/Dockerfile
+++ b/wait-for-it/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.20
 ENV WAITFORIT_VERSION="v2.4.1"
-RUN wget -q -O /usr/local/bin/waitforit https://github.com/maxcnunes/waitforit/releases/download/${WAITFORIT_VERSION:?}/waitforit-linux_amd64 \
+RUN wget -q -O /usr/local/bin/waitforit https://github.com/maxclaus/waitforit/releases/download/${WAITFORIT_VERSION:?}/waitforit-linux_amd64 \
   && chmod +x /usr/local/bin/waitforit
 ENTRYPOINT ["/usr/local/bin/waitforit"]


### PR DESCRIPTION
## Purpose

Fix reference to waitforit so that build can succeed. I looked at the new repo to ensure it looks legitimate (the release we are referencing has a timestamp of 6 years ago and there are 173 followers on the new project).

Fixes DDLS-447

## Approach

Change a URL

## Learning

n/a

## Checklist
- [X] I have performed a self-review of my own code
- [X] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [X] I have added tests to prove my work
- [] The product team have approved these changes
- [X] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend

n/a

- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
