### PR TITLE
DDLS-450 Associate clients with court orders (database changes)

### DIFF
--- a/api/app/src/Entity/Client.php
+++ b/api/app/src/Entity/Client.php
@@ -1054,4 +1054,19 @@ class Client implements ClientInterface
 
         return false;
     }
+
+    public function getCourtOrders(): ArrayCollection
+    {
+        return $this->courtOrders;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setCourtOrders(ArrayCollection $courtOrders)
+    {
+        $this->courtOrders = $courtOrders;
+
+        return $this;
+    }
 }

--- a/api/app/src/Entity/Client.php
+++ b/api/app/src/Entity/Client.php
@@ -282,7 +282,7 @@ class Client implements ClientInterface
      *
      * @ORM\OneToMany(targetEntity="App\Entity\CourtOrder", mappedBy="client", cascade={"persist", "remove"})
      *
-     * @ORM\OrderBy({"created_at"="DESC"})
+     * @ORM\OrderBy({"created"="DESC"})
      */
     private $courtOrders;
 

--- a/api/app/src/Entity/Client.php
+++ b/api/app/src/Entity/Client.php
@@ -282,7 +282,7 @@ class Client implements ClientInterface
      *
      * @ORM\OneToMany(targetEntity="App\Entity\CourtOrder", mappedBy="client", cascade={"persist", "remove"})
      *
-     * @ORM\OrderBy({"created"="DESC"})
+     * @ORM\OrderBy({"createdAt"="DESC"})
      */
     private $courtOrders;
 

--- a/api/app/src/Entity/Client.php
+++ b/api/app/src/Entity/Client.php
@@ -276,6 +276,17 @@ class Client implements ClientInterface
     private $deputy;
 
     /**
+     * @var ArrayCollection
+     *
+     * @JMS\Type("ArrayCollection<App\Entity\CourtOrder>")
+     *
+     * @ORM\OneToMany(targetEntity="App\Entity\CourtOrder", mappedBy="client", cascade={"persist", "remove"})
+     *
+     * @ORM\OrderBy({"created_at"="DESC"})
+     */
+    private $courtOrders;
+
+    /**
      * @var \DateTime|null
      *
      * @JMS\Type("DateTime<'Y-m-d H:i:s'>")

--- a/api/app/src/Entity/CourtOrder.php
+++ b/api/app/src/Entity/CourtOrder.php
@@ -61,6 +61,17 @@ class CourtOrder
      */
     private $active;
 
+    /**
+     * @var Client
+     *
+     * @JMS\Type("App\Entity\Client")
+     *
+     * @ORM\ManyToOne(targetEntity="App\Entity\Client", inversedBy="courtOrders", fetch="EAGER")
+     *
+     * @ORM\JoinColumn(name="client_id", referencedColumnName="id")
+     */
+    private $client;
+
     public function getId(): int
     {
         return $this->id;

--- a/api/app/src/Entity/CourtOrder.php
+++ b/api/app/src/Entity/CourtOrder.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use App\Entity\Traits\CreateUpdateTimestamps;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
 use JMS\Serializer\Annotation as JMS;
 
 /**
@@ -60,6 +61,24 @@ class CourtOrder
      * @ORM\Column(name="active", type="boolean", options = { "default": true })
      */
     private $active;
+
+    /**
+     * @ORM\Column(name="created_at", type="datetime",nullable=true)
+     *
+     * @Gedmo\Timestampable(on="create")
+     *
+     * @JMS\Type("DateTime<'Y-m-d'>")
+     */
+    private \DateTime $created;
+
+    /**
+     * @ORM\Column(name="updated_at", type="datetime",nullable=true)
+     *
+     * @Gedmo\Timestampable(on="update")
+     *
+     * @JMS\Type("DateTime<'Y-m-d'>")
+     */
+    private \DateTime $updated;
 
     /**
      * @var Client
@@ -125,12 +144,21 @@ class CourtOrder
         return $this->client;
     }
 
-    /**
-     * @return CourtOrder
-     */
-    public function setClient(Client $client)
+    public function setClient(Client $client): CourtOrder
     {
         $this->client = $client;
+
+        return $this;
+    }
+
+    public function getCreated(): \DateTime
+    {
+        return $this->created;
+    }
+
+    public function setCreated(\DateTime $created): CourtOrder
+    {
+        $this->created = $created;
 
         return $this;
     }

--- a/api/app/src/Entity/CourtOrder.php
+++ b/api/app/src/Entity/CourtOrder.php
@@ -4,7 +4,6 @@ namespace App\Entity;
 
 use App\Entity\Traits\CreateUpdateTimestamps;
 use Doctrine\ORM\Mapping as ORM;
-use Gedmo\Mapping\Annotation as Gedmo;
 use JMS\Serializer\Annotation as JMS;
 
 /**
@@ -61,24 +60,6 @@ class CourtOrder
      * @ORM\Column(name="active", type="boolean", options = { "default": true })
      */
     private $active;
-
-    /**
-     * @ORM\Column(name="created_at", type="datetime",nullable=true)
-     *
-     * @Gedmo\Timestampable(on="create")
-     *
-     * @JMS\Type("DateTime<'Y-m-d'>")
-     */
-    private \DateTime $created;
-
-    /**
-     * @ORM\Column(name="updated_at", type="datetime",nullable=true)
-     *
-     * @Gedmo\Timestampable(on="update")
-     *
-     * @JMS\Type("DateTime<'Y-m-d'>")
-     */
-    private \DateTime $updated;
 
     /**
      * @var Client
@@ -147,18 +128,6 @@ class CourtOrder
     public function setClient(Client $client): CourtOrder
     {
         $this->client = $client;
-
-        return $this;
-    }
-
-    public function getCreated(): \DateTime
-    {
-        return $this->created;
-    }
-
-    public function setCreated(\DateTime $created): CourtOrder
-    {
-        $this->created = $created;
 
         return $this;
     }

--- a/api/app/src/Entity/CourtOrder.php
+++ b/api/app/src/Entity/CourtOrder.php
@@ -119,4 +119,19 @@ class CourtOrder
 
         return $this;
     }
+
+    public function getClient(): Client
+    {
+        return $this->client;
+    }
+
+    /**
+     * @return CourtOrder
+     */
+    public function setClient(Client $client)
+    {
+        $this->client = $client;
+
+        return $this;
+    }
 }

--- a/api/app/src/Migrations/Version287.php
+++ b/api/app/src/Migrations/Version287.php
@@ -14,7 +14,7 @@ final class Version287 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return '';
+        return 'Add migration script for relationship between Client and Court Order';
     }
 
     public function up(Schema $schema): void

--- a/api/app/src/Migrations/Version287.php
+++ b/api/app/src/Migrations/Version287.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version287 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE court_order ADD client_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE court_order ADD CONSTRAINT FK_E824C019EB6921 FOREIGN KEY (client_id) REFERENCES client (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_E824C019EB6921 ON court_order (client_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE court_order DROP CONSTRAINT FK_E824C019EB6921');
+        $this->addSql('DROP INDEX IDX_E824C019EB6921');
+        $this->addSql('ALTER TABLE court_order DROP client_id');
+    }
+}


### PR DESCRIPTION
## Purpose
Create a 1 to many association between clients and court orders (one client can have 1 or more court orders, but each court order belongs to a single client).

Fixes DDLS-450

## Approach
Add client property to Court Order entity
Add court orders property of type array (as more than one needs to be stored) to Client entity
Create new migration for this relationship with client id being added as a foreign key to Court Order table

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
