### PR TITLE
DDLS-451: Associate deputies with court orders (database changes)

### DIFF
--- a/api/app/src/Entity/CourtOrder.php
+++ b/api/app/src/Entity/CourtOrder.php
@@ -73,7 +73,7 @@ class CourtOrder
     private $client;
 
     /**
-     * @ORM\OneToMany(targetEntity="CourtOrderDeputy", mappedBy="deputy")
+     * @ORM\OneToMany(targetEntity="App\Entity\CourtOrderDeputy", mappedBy="deputy")
      */
     private $deputyCourtOrderRelationship;
 
@@ -135,19 +135,5 @@ class CourtOrder
         $this->client = $client;
 
         return $this;
-    }
-
-    public function getDeputiesWithStatus(): array
-    {
-        $result = [];
-
-        foreach ($this->deputyCourtOrderRelationship as $element) {
-            $result[] = [
-                'deputy' => $element->getDeputy(),
-                'discharged' => $element->isDischarged(),
-            ];
-        }
-
-        return $result;
     }
 }

--- a/api/app/src/Entity/CourtOrder.php
+++ b/api/app/src/Entity/CourtOrder.php
@@ -61,6 +61,11 @@ class CourtOrder
      */
     private $active;
 
+    /**
+     * @ORM\OneToMany(targetEntity="CourtOrderDeputy", mappedBy="deputy")
+     */
+    private $deputyCourtOrderRelationship;
+
     public function getId(): int
     {
         return $this->id;
@@ -107,5 +112,19 @@ class CourtOrder
         $this->active = $active;
 
         return $this;
+    }
+
+    public function getDeputiesWithStatus(): array
+    {
+        $result = [];
+
+        foreach ($this->deputyCourtOrderRelationship as $element) {
+            $result[] = [
+                'deputy' => $element->getDeputy(),
+                'discharged' => $element->isDischarged(),
+            ];
+        }
+
+        return $result;
     }
 }

--- a/api/app/src/Entity/CourtOrder.php
+++ b/api/app/src/Entity/CourtOrder.php
@@ -74,6 +74,7 @@ class CourtOrder
      */
     private $client;
 
+    /**
      * @JMS\Type("ArrayCollection<App\Entity\Report\Report>")
      *
      * @ORM\ManyToMany(targetEntity="App\Entity\Report\Report", inversedBy="courtOrders", fetch="EXTRA_LAZY")
@@ -84,8 +85,8 @@ class CourtOrder
      *     )
      */
     private $reports;
-    
-      /**
+
+    /**
      * @ORM\OneToMany(targetEntity="App\Entity\CourtOrderDeputy", mappedBy="courtOrder", cascade={"persist"})
      *
      * @ORM\JoinColumn(name="id", referencedColumnName="court_order_id")

--- a/api/app/src/Entity/CourtOrder.php
+++ b/api/app/src/Entity/CourtOrder.php
@@ -3,6 +3,8 @@
 namespace App\Entity;
 
 use App\Entity\Traits\CreateUpdateTimestamps;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as JMS;
 
@@ -66,16 +68,23 @@ class CourtOrder
      *
      * @JMS\Type("App\Entity\Client")
      *
-     * @ORM\ManyToOne(targetEntity="App\Entity\Client", inversedBy="courtOrders", fetch="EAGER")
+     * @ORM\ManyToOne(targetEntity="App\Entity\Client", inversedBy="courtOrders")
      *
      * @ORM\JoinColumn(name="client_id", referencedColumnName="id")
      */
     private $client;
 
     /**
-     * @ORM\OneToMany(targetEntity="App\Entity\CourtOrderDeputy", mappedBy="deputy")
+     * @ORM\OneToMany(targetEntity="App\Entity\CourtOrderDeputy", mappedBy="courtOrder", cascade={"persist"})
+     *
+     * @ORM\JoinColumn(name="id", referencedColumnName="court_order_id")
      */
-    private $deputyCourtOrderRelationship;
+    private Collection $courtOrderDeputyRelationships;
+
+    public function __construct()
+    {
+        $this->courtOrderDeputyRelationships = new ArrayCollection();
+    }
 
     public function getId(): int
     {

--- a/api/app/src/Entity/CourtOrder.php
+++ b/api/app/src/Entity/CourtOrder.php
@@ -72,6 +72,11 @@ class CourtOrder
      */
     private $client;
 
+    /**
+     * @ORM\OneToMany(targetEntity="CourtOrderDeputy", mappedBy="deputy")
+     */
+    private $deputyCourtOrderRelationship;
+
     public function getId(): int
     {
         return $this->id;
@@ -130,5 +135,19 @@ class CourtOrder
         $this->client = $client;
 
         return $this;
+    }
+
+    public function getDeputiesWithStatus(): array
+    {
+        $result = [];
+
+        foreach ($this->deputyCourtOrderRelationship as $element) {
+            $result[] = [
+                'deputy' => $element->getDeputy(),
+                'discharged' => $element->isDischarged(),
+            ];
+        }
+
+        return $result;
     }
 }

--- a/api/app/src/Entity/CourtOrderDeputy.php
+++ b/api/app/src/Entity/CourtOrderDeputy.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Link table between court orders and deputies.
+ *
+ * @ORM\Table(name="court_order_deputy")
+ *
+ * @ORM\Entity()
+ *
+ * @ORM\HasLifecycleCallbacks()
+ */
+class CourtOrderDeputy
+{
+    /**
+     * @ORM\Id
+     *
+     * @ORM\ManyToOne(targetEntity="App\Entity\CourtOrder")
+     *
+     * @ORM\JoinColumn(name="court_order_id", referencedColumnName="id", nullable=false)
+     */
+    private $courtOrder;
+
+    /**
+     * @ORM\Id
+     *
+     * @ORM\ManyToOne(targetEntity="App\Entity\Deputy")
+     *
+     * @ORM\JoinColumn(name="deputy_id", referencedColumnName="id", nullable=false)
+     */
+    private $deputy;
+
+    /**
+     * @ORM\Column(name="discharged", type="boolean", nullable=false)
+     */
+    private bool $discharged;
+
+    public function getDeputy(): Deputy
+    {
+        return $this->deputy;
+    }
+
+    public function getCourtOrder(): CourtOrder
+    {
+        return $this->courtOrder;
+    }
+
+    public function isDischarged(): bool
+    {
+        return $this->discharged;
+    }
+
+    public function setDischarged(bool $discharged)
+    {
+        $this->discharged = $discharged;
+
+        return $this;
+    }
+}

--- a/api/app/src/Entity/CourtOrderDeputy.php
+++ b/api/app/src/Entity/CourtOrderDeputy.php
@@ -18,20 +18,20 @@ class CourtOrderDeputy
     /**
      * @ORM\Id
      *
-     * @ORM\ManyToOne(targetEntity="App\Entity\CourtOrder")
+     * @ORM\ManyToOne(targetEntity="App\Entity\CourtOrder", cascade={"persist"}, fetch="EAGER")
      *
      * @ORM\JoinColumn(name="court_order_id", referencedColumnName="id", nullable=false)
      */
-    private $courtOrder;
+    private CourtOrder $courtOrder;
 
     /**
      * @ORM\Id
      *
-     * @ORM\ManyToOne(targetEntity="App\Entity\Deputy")
+     * @ORM\ManyToOne(targetEntity="App\Entity\Deputy", cascade={"persist"}, fetch="EAGER")
      *
      * @ORM\JoinColumn(name="deputy_id", referencedColumnName="id", nullable=false)
      */
-    private $deputy;
+    private Deputy $deputy;
 
     /**
      * @ORM\Column(name="discharged", type="boolean", nullable=false)
@@ -43,9 +43,23 @@ class CourtOrderDeputy
         return $this->deputy;
     }
 
+    public function setDeputy(Deputy $deputy): CourtOrderDeputy
+    {
+        $this->deputy = $deputy;
+
+        return $this;
+    }
+
     public function getCourtOrder(): CourtOrder
     {
         return $this->courtOrder;
+    }
+
+    public function setCourtOrder(CourtOrder $courtOrder): CourtOrderDeputy
+    {
+        $this->courtOrder = $courtOrder;
+
+        return $this;
     }
 
     public function isDischarged(): bool
@@ -53,7 +67,7 @@ class CourtOrderDeputy
         return $this->discharged;
     }
 
-    public function setDischarged(bool $discharged)
+    public function setDischarged(bool $discharged): CourtOrderDeputy
     {
         $this->discharged = $discharged;
 

--- a/api/app/src/Entity/CourtOrderDeputy.php
+++ b/api/app/src/Entity/CourtOrderDeputy.php
@@ -18,18 +18,18 @@ class CourtOrderDeputy
     /**
      * @ORM\Id
      *
-     * @ORM\ManyToOne(targetEntity="App\Entity\CourtOrder", cascade={"persist"}, fetch="EAGER")
+     * @ORM\ManyToOne(targetEntity="App\Entity\CourtOrder", inversedBy="courtOrderDeputyRelationships", cascade={"persist"})
      *
-     * @ORM\JoinColumn(name="court_order_id", referencedColumnName="id", nullable=false)
+     * @ORM\JoinColumn(name="court_order_id", referencedColumnName="id")
      */
     private CourtOrder $courtOrder;
 
     /**
      * @ORM\Id
      *
-     * @ORM\ManyToOne(targetEntity="App\Entity\Deputy", cascade={"persist"}, fetch="EAGER")
+     * @ORM\ManyToOne(targetEntity="App\Entity\Deputy", inversedBy="courtOrderDeputyRelationships", cascade={"persist"})
      *
-     * @ORM\JoinColumn(name="deputy_id", referencedColumnName="id", nullable=false)
+     * @ORM\JoinColumn(name="deputy_id", referencedColumnName="id")
      */
     private Deputy $deputy;
 

--- a/api/app/src/Entity/CourtOrderDeputy.php
+++ b/api/app/src/Entity/CourtOrderDeputy.php
@@ -20,7 +20,7 @@ class CourtOrderDeputy
      *
      * @ORM\ManyToOne(targetEntity="App\Entity\CourtOrder", inversedBy="courtOrderDeputyRelationships", cascade={"persist"})
      *
-     * @ORM\JoinColumn(name="court_order_id", referencedColumnName="id")
+     * @ORM\JoinColumn(name="court_order_id", referencedColumnName="id", nullable=false)
      */
     private CourtOrder $courtOrder;
 
@@ -29,7 +29,7 @@ class CourtOrderDeputy
      *
      * @ORM\ManyToOne(targetEntity="App\Entity\Deputy", inversedBy="courtOrderDeputyRelationships", cascade={"persist"})
      *
-     * @ORM\JoinColumn(name="deputy_id", referencedColumnName="id")
+     * @ORM\JoinColumn(name="deputy_id", referencedColumnName="id", nullable=false)
      */
     private Deputy $deputy;
 
@@ -37,6 +37,11 @@ class CourtOrderDeputy
      * @ORM\Column(name="discharged", type="boolean", nullable=false)
      */
     private bool $discharged;
+
+    public function __construct()
+    {
+        $this->discharged = false;
+    }
 
     public function getDeputy(): Deputy
     {

--- a/api/app/src/Entity/Deputy.php
+++ b/api/app/src/Entity/Deputy.php
@@ -222,7 +222,12 @@ class Deputy
      *
      * @ORM\JoinColumn(name="user_id", referencedColumnName="id")
      */
-    private User|null $user;
+    private ?User $user;
+
+    /**
+     * @ORM\OneToMany(targetEntity="CourtOrderDeputy", mappedBy="courtOrder")
+     */
+    private $courtOrderDeputyRelationship;
 
     /**
      * @return int
@@ -595,5 +600,19 @@ class Deputy
     {
         return $this->email1 !== $dto->getDeputyEmail()
             && null !== $dto->getDeputyEmail();
+    }
+
+    public function getCourtOrdersWithStatus(): array
+    {
+        $result = [];
+
+        foreach ($this->courtOrderDeputyRelationship as $element) {
+            $result[] = [
+                'courtOrder' => $element->getCourtOrder(),
+                'discharged' => $element->isDischarged(),
+            ];
+        }
+
+        return $result;
     }
 }

--- a/api/app/src/Entity/Deputy.php
+++ b/api/app/src/Entity/Deputy.php
@@ -225,9 +225,9 @@ class Deputy
     private ?User $user;
 
     /**
-     * @ORM\OneToMany(targetEntity="CourtOrderDeputy", mappedBy="courtOrder")
+     * @ORM\OneToMany(targetEntity="App\Entity\CourtOrderDeputy", mappedBy="courtOrder", cascade={"persist"})
      */
-    private $courtOrderDeputyRelationship;
+    private $courtOrderDeputyRelationship = [];
 
     /**
      * @return int

--- a/api/app/src/Migrations/Version288.php
+++ b/api/app/src/Migrations/Version288.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version288 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Creates link table between court orders and deputies';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE court_order_deputy (court_order_id INT NOT NULL, deputy_id INT NOT NULL, discharged BOOLEAN NOT NULL, PRIMARY KEY(court_order_id, deputy_id))');
+        $this->addSql('CREATE INDEX IDX_994DD8A9A8D7D89C ON court_order_deputy (court_order_id)');
+        $this->addSql('CREATE INDEX IDX_994DD8A94B6F93BB ON court_order_deputy (deputy_id)');
+        $this->addSql('ALTER TABLE court_order_deputy ADD CONSTRAINT FK_994DD8A9A8D7D89C FOREIGN KEY (court_order_id) REFERENCES court_order (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE court_order_deputy ADD CONSTRAINT FK_994DD8A94B6F93BB FOREIGN KEY (deputy_id) REFERENCES deputy (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE court_order_deputy DROP CONSTRAINT FK_994DD8A9A8D7D89C');
+        $this->addSql('ALTER TABLE court_order_deputy DROP CONSTRAINT FK_994DD8A94B6F93BB');
+        $this->addSql('DROP TABLE court_order_deputy');
+    }
+}

--- a/api/app/src/Migrations/Version289.php
+++ b/api/app/src/Migrations/Version289.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version289 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Creates link table between court orders and deputies';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE court_order_deputy (court_order_id INT NOT NULL, deputy_id INT NOT NULL, discharged BOOLEAN NOT NULL, PRIMARY KEY(court_order_id, deputy_id))');
+        $this->addSql('CREATE INDEX IDX_994DD8A9A8D7D89C ON court_order_deputy (court_order_id)');
+        $this->addSql('CREATE INDEX IDX_994DD8A94B6F93BB ON court_order_deputy (deputy_id)');
+        $this->addSql('ALTER TABLE court_order_deputy ADD CONSTRAINT FK_994DD8A9A8D7D89C FOREIGN KEY (court_order_id) REFERENCES court_order (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE court_order_deputy ADD CONSTRAINT FK_994DD8A94B6F93BB FOREIGN KEY (deputy_id) REFERENCES deputy (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE court_order_deputy DROP CONSTRAINT FK_994DD8A9A8D7D89C');
+        $this->addSql('ALTER TABLE court_order_deputy DROP CONSTRAINT FK_994DD8A94B6F93BB');
+        $this->addSql('DROP TABLE court_order_deputy');
+    }
+}

--- a/api/app/tests/Unit/Entity/DeputyIntegrationTest.php
+++ b/api/app/tests/Unit/Entity/DeputyIntegrationTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\CourtOrder;
+use App\Entity\Deputy;
+use App\TestHelpers\DeputyTestHelper;
+use Doctrine\ORM\EntityManagerInterface;
+use Faker\Factory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class DeputyIntegrationTest extends KernelTestCase
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    private $em;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->em = $kernel->getContainer()->get('doctrine')->getManager();
+    }
+
+    public function testGetCourtOrdersWithStatus()
+    {
+        $faker = Factory::create();
+        $fakeUid = $faker->unique()->randomNumber(8);
+
+        $deputyHelper = new DeputyTestHelper();
+        $deputy = $deputyHelper->generateDeputy();
+        $deputy->setLastname('MONK');
+
+        $courtOrder = new CourtOrder();
+        $courtOrder
+            ->setCourtOrderUid($fakeUid)
+            ->setType('hybrid')
+            ->setActive(true);
+
+        $deputy->associateWithCourtOrder($courtOrder);
+
+        $this->em->persist($courtOrder);
+        $this->em->persist($deputy);
+        $this->em->flush();
+
+        // retrieve the deputy from the db and check the association is populated correctly
+        $repo = $this->em->getRepository(Deputy::class);
+        $retrievedDeputy = $repo->findOneBy(['deputyUid' => $deputy->getDeputyUid()]);
+
+        $actual = $retrievedDeputy->getCourtOrdersWithStatus();
+        $actualDischarged = $actual[0]['discharged'];
+        $actualCourtOrder = $actual[0]['courtOrder'];
+
+        $this->assertEquals(1, count($actual));
+        $this->assertEquals(false, $actualDischarged);
+        $this->assertEquals($fakeUid, $actualCourtOrder->getCourtOrderUid());
+        $this->assertEquals('hybrid', $actualCourtOrder->getType());
+    }
+}

--- a/api/app/tests/Unit/Entity/DeputyTest.php
+++ b/api/app/tests/Unit/Entity/DeputyTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\CourtOrder;
+use App\Entity\CourtOrderDeputy;
+use App\TestHelpers\DeputyTestHelper;
+use Doctrine\ORM\EntityManagerInterface;
+use Faker\Factory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class DeputyTest extends KernelTestCase
+{
+    /**
+     * @var EntityManagerInterface
+     */
+    private $em;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->em = $kernel->getContainer()->get('doctrine')->getManager();
+    }
+
+    public function testGetCourtOrdersWithStatus()
+    {
+        $faker = Factory::create();
+
+        $deputyHelper = new DeputyTestHelper();
+        $deputy = $deputyHelper->generateDeputy();
+
+        $courtOrder = new CourtOrder();
+        $courtOrder
+            ->setCourtOrderUid($faker->unique()->randomNumber(8))
+            ->setType('hybrid')
+            ->setActive(true);
+
+        $courtOrderDeputy = new CourtOrderDeputy();
+
+        $courtOrderDeputy
+            ->setDeputy($deputy)
+            ->setCourtOrder($courtOrder)
+            ->setDischarged(false);
+
+        $this->em->persist($deputy);
+
+        $this->em->persist($courtOrder);
+
+        $this->em->persist($courtOrderDeputy);
+        $this->em->flush();
+
+        // one deputy can have many court orders
+        $actual = $deputy->getCourtOrdersWithStatus();
+
+        $expected = ['courtOrder' => $courtOrder, 'discharged' => false];
+
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -25,6 +25,14 @@ $ make api-unit-tests
 
 This will run the api tests and generate test coverage reports in the build/coverage-api directory.
 
+### Populating local databases
+ - Tests that interact with the database will populate the local api database when ran directly from your IDE
+ - Tests that interact with the database will populate the api-unit-test database when ran as part of the make api-unit-tests command
+ - Both databases are ran from the api-app container
+ - The following command allows you to run an individual test from the command line that specifically populates the api-unit-database if preferred
+ `make reset-database-unit-tests reset-fixtures-unit-tests; docker compose -f docker-compose.yml -f docker-compose.unit-tests-api.yml build api-unit-tests; docker compose -f docker-compose.yml -f docker-compose.unit-tests-api.yml run -e APP_ENV=test -e APP_DEBUG=0 api-unit-tests php vendor/bin/phpunit -d memory_limit=512M -c tests/Unit {enter path to file for e.g. tests/Unit/Entity/DeputyTest.php}`
+
+
 ### Client unit tests using CLI
 
 To run the client tests without a docker container (useful for running tests quickly during dev as it avoids having to


### PR DESCRIPTION
## Purpose
As part of the database change work, this PR is to add a link table between court orders and deputies so that one deputy can have many court orders, and one court order can have many deputies.

Fixes DDLS-451

## Approach
- Create CourtOrderDeputy entity class (which acts as the link table) 
- Getter method added to Deputy entity to retrieve court order objects and discharged property
- Define ManytoOne relationship with CourtOrder and Deputy entities
- Generate Doctrine migration 
- Add unit and integration test 

Note: associateWithCourtOrder method has been added to the Deputy entity class temporarily to show how the association would work between the link table and associated entities, this logic would eventually move into a factory class. The integration test would also get replaced with a more suitable test as it's currently in place to test how the new link table is populated. 

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [x] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
