### PR TITLE
DDLS-454 Create a link table (many-to-many) for court-orders & reports

### DIFF
--- a/api/app/src/Entity/CourtOrder.php
+++ b/api/app/src/Entity/CourtOrder.php
@@ -72,6 +72,18 @@ class CourtOrder
      */
     private $client;
 
+    /**
+     * @JMS\Type("ArrayCollection<App\Entity\Report\Report>")
+     *
+     * @ORM\ManyToMany(targetEntity="App\Entity\Report\Report", inversedBy="courtOrders", fetch="EXTRA_LAZY")
+     *
+     * @ORM\JoinTable(name="court_order_report",
+     *         joinColumns={@ORM\JoinColumn(name="court_order_id", referencedColumnName="id", onDelete="CASCADE")},
+     *         inverseJoinColumns={@ORM\JoinColumn(name="report_id", referencedColumnName="id", onDelete="CASCADE")}
+     *     )
+     */
+    private $reports;
+
     public function getId(): int
     {
         return $this->id;

--- a/api/app/src/Entity/Report/Report.php
+++ b/api/app/src/Entity/Report/Report.php
@@ -588,6 +588,15 @@ class Report implements ReportInterface
      **/
     private $reasonForNoMoneyOut;
 
+    /**
+     * @JMS\Groups({"report"})
+     *
+     * @JMS\Type("ArrayCollection<App\Entity\CourtOrder>")
+     *
+     * @ORM\ManyToMany(targetEntity="App\Entity\CourtOrder", mappedBy="reports", cascade={"persist"}, fetch="EXTRA_LAZY")
+     */
+    private $courtOrders;
+
     private array $excludeSections = [];
     private ?\DateTime $benefitsSectionReleaseDate = null;
 
@@ -807,7 +816,7 @@ class Report implements ReportInterface
      *
      * @return Report
      */
-    public function setSubmitDate(\DateTime $submitDate = null)
+    public function setSubmitDate(?\DateTime $submitDate = null)
     {
         $this->submitDate = $submitDate;
 
@@ -888,7 +897,7 @@ class Report implements ReportInterface
      *
      * @return Report
      */
-    public function setClient(Client $client = null)
+    public function setClient(?Client $client = null)
     {
         $this->client = $client;
 
@@ -921,7 +930,7 @@ class Report implements ReportInterface
     /**
      * @return Report
      */
-    public function setVisitsCare(VisitsCare $visitsCare = null)
+    public function setVisitsCare(?VisitsCare $visitsCare = null)
     {
         $this->visitsCare = $visitsCare;
 
@@ -1341,9 +1350,9 @@ class Report implements ReportInterface
         }
 
         return [
-                'report-summary' => $previousReport->getReportSummary(),
-                'financial-summary' => $previousReport->getFinancialSummary(),
-            ];
+            'report-summary' => $previousReport->getReportSummary(),
+            'financial-summary' => $previousReport->getFinancialSummary(),
+        ];
     }
 
     /**

--- a/api/app/src/Migrations/Version288.php
+++ b/api/app/src/Migrations/Version288.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version288 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE court_order_report (court_order_id INT NOT NULL, report_id INT NOT NULL, PRIMARY KEY(court_order_id, report_id))');
+        $this->addSql('CREATE INDEX IDX_7598C4B2A8D7D89C ON court_order_report (court_order_id)');
+        $this->addSql('CREATE INDEX IDX_7598C4B24BD2A4C0 ON court_order_report (report_id)');
+        $this->addSql('ALTER TABLE court_order_report ADD CONSTRAINT FK_7598C4B2A8D7D89C FOREIGN KEY (court_order_id) REFERENCES court_order (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE court_order_report ADD CONSTRAINT FK_7598C4B24BD2A4C0 FOREIGN KEY (report_id) REFERENCES report (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE court_order_report DROP CONSTRAINT FK_7598C4B2A8D7D89C');
+        $this->addSql('ALTER TABLE court_order_report DROP CONSTRAINT FK_7598C4B24BD2A4C0');
+        $this->addSql('DROP TABLE court_order_report');
+    }
+}


### PR DESCRIPTION
## Purpose
Reasoning: due to hybrids & a need to link both court-orders of the hybrid to the report a link table (many-to-many) for court orders and reports is required.

Fixes DDLS-454

## Approach
The approach is similar to the one used for deputy_case table.
ORM\JoinTable within Doctrine has been used to create the many-to-many relationship.
Delete cascade has also been added to the links in the JoinTable so that if the court order or report is deleted then the relationship is also deleted in the court_order_report table.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
