### PR TITLE
DDLS-452 Event tests (in client/app/tests/Event) are not included in suite

### DIFF
--- a/client/app/tests/phpunit/Event/ClientDeletedEventTest.php
+++ b/client/app/tests/phpunit/Event/ClientDeletedEventTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Tests\App\Event;
 
@@ -10,19 +12,17 @@ use PHPUnit\Framework\TestCase;
 class ClientDeletedEventTest extends TestCase
 {
     /** @test */
-    public function event_is_initialised_correctly()
+    public function eventIsInitialisedCorrectly()
     {
         $client = ClientHelpers::createClient();
         $currentUser = UserHelpers::createUser();
-        $deletedDeputy = UserHelpers::createUser();
         $trigger = 'A_TRIGGER';
 
-        $event = new ClientDeletedEvent($client, $currentUser, $deletedDeputy, $trigger);
+        $event = new ClientDeletedEvent($client, $currentUser, $trigger);
 
-        self::assertEquals($client->getCaseNumber(), $event->getCaseNumber());
-        self::assertEquals($client->getCourtDate(), $event->getDeputyshipStartDate());
-        self::assertEquals($currentUser->getEmail(), $event->getDischargedByEmail());
-        self::assertEquals($deletedDeputy->getFullName(), $event->getDischargedDeputyName());
+        self::assertEquals($client->getCaseNumber(), $event->getClientWithUsers()->getCaseNumber());
+        self::assertEquals($client->getCourtDate(), $event->getClientWithUsers()->getCourtDate());
+        self::assertEquals($currentUser->getEmail(), $event->getCurrentUser()->getEmail());
         self::assertEquals($trigger, $event->getTrigger());
     }
 }

--- a/client/app/tests/phpunit/Event/UserUpdatedEventTest.php
+++ b/client/app/tests/phpunit/Event/UserUpdatedEventTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace App\Event;
 
@@ -8,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class UserUpdatedEventTest extends TestCase
 {
     /** @test */
-    public function event_is_initialised_correctly()
+    public function eventIsInitialisedCorrectly()
     {
         $preUpdateUser = UserHelpers::createUser();
         $postUpdateUser = UserHelpers::createUser();
@@ -17,12 +19,12 @@ class UserUpdatedEventTest extends TestCase
 
         $event = new UserUpdatedEvent($preUpdateUser, $postUpdateUser, $currentUser, $trigger);
 
-        self::assertEquals($currentUser->getEmail(), $event->getCurrentUserEmail());
-        self::assertEquals($postUpdateUser->getEmail(), $event->getPostUpdateEmail());
-        self::assertEquals($postUpdateUser->getFullName(), $event->getPostUpdateFullName());
-        self::assertEquals($postUpdateUser->getRoleName(), $event->getPostUpdateRoleName());
-        self::assertEquals($preUpdateUser->getEmail(), $event->getPreUpdateEmail());
-        self::assertEquals($preUpdateUser->getRoleName(), $event->getPreUpdateRoleName());
+        self::assertEquals($currentUser->getEmail(), $event->getCurrentUser()->getEmail());
+        self::assertEquals($postUpdateUser->getEmail(), $event->getPostUpdateUser()->getEmail());
+        self::assertEquals($postUpdateUser->getFullName(), $event->getPostUpdateUser()->getFullName());
+        self::assertEquals($postUpdateUser->getRoleName(), $event->getPostUpdateUser()->getRoleName());
+        self::assertEquals($preUpdateUser->getEmail(), $event->getPreUpdateUser()->getEmail());
+        self::assertEquals($preUpdateUser->getRoleName(), $event->getPreUpdateUser()->getRoleName());
         self::assertEquals($trigger, $event->getTrigger());
     }
 }

--- a/client/app/tests/phpunit/phpunit.xml
+++ b/client/app/tests/phpunit/phpunit.xml
@@ -21,9 +21,21 @@
     </coverage>
     <testsuites>
         <testsuite name="Client unit tests">
-            <directory suffix=".php">./</directory>
-            <exclude>./Pact</exclude>
-            <exclude>./Helpers</exclude>
+            <directory>./Command</directory>
+            <directory>./Entity</directory>
+            <directory>./Event</directory>
+            <directory>./EventListener</directory>
+            <directory>./EventSubscriber</directory>
+            <directory>./Form</directory>
+            <directory>./Logger</directory>
+            <directory>./Mapper</directory>
+            <directory>./Model</directory>
+            <directory>./Resolver</directory>
+            <directory>./Security</directory>
+            <directory>./Service</directory>
+            <directory>./Transformer</directory>
+            <directory>./Twig</directory>
+            <directory>./Validator</directory>
         </testsuite>
         <testsuite name="Pact contract tests">
             <directory>./Pact</directory>

--- a/client/app/tests/phpunit/phpunit.xml
+++ b/client/app/tests/phpunit/phpunit.xml
@@ -23,6 +23,7 @@
         <testsuite name="Client unit tests">
             <directory suffix=".php">./</directory>
             <exclude>./Pact</exclude>
+            <exclude>./Helpers</exclude>
         </testsuite>
         <testsuite name="Pact contract tests">
             <directory>./Pact</directory>

--- a/client/app/tests/phpunit/phpunit.xml
+++ b/client/app/tests/phpunit/phpunit.xml
@@ -21,20 +21,8 @@
     </coverage>
     <testsuites>
         <testsuite name="Client unit tests">
-            <directory>./Command</directory>
-            <directory>./Entity</directory>
-            <directory>./EventListener</directory>
-            <directory>./EventSubscriber</directory>
-            <directory>./Form</directory>
-            <directory>./Logger</directory>
-            <directory>./Mapper</directory>
-            <directory>./Model</directory>
-            <directory>./Resolver</directory>
-            <directory>./Security</directory>
-            <directory>./Service</directory>
-            <directory>./Transformer</directory>
-            <directory>./Twig</directory>
-            <directory>./Validator</directory>
+            <directory suffix=".php">./</directory>
+            <exclude>./Pact</exclude>
         </testsuite>
         <testsuite name="Pact contract tests">
             <directory>./Pact</directory>


### PR DESCRIPTION
## Purpose
The phpunit.xml config for the client unit tests does not include the Event directory mentioned, so these tests are being ignored.

Fixes DDLS-452

## Approach
Added in Event folder to phpunit.xml file for client unit tests.
Fixed failing tests in Event folder now being included.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
