### PR TITLE
DDLS-486 - Create scheduled task within Cloudwatch for new Court Order CSV Job

### DIFF
--- a/terraform/environment/region/cloudwatch_scheduled_events.tf
+++ b/terraform/environment/region/cloudwatch_scheduled_events.tf
@@ -1,40 +1,40 @@
 # Sirius CourtOrder CSV Ingestion
 
-#resource "aws_cloudwatch_event_rule" "csv_automation_court_order_processing" {
-#  name                = "csv-automation-court-order-processing-${local.environment}"
-#  description         = "Process Sirus Court Orders CSV for all Users ${terraform.workspace}"
-#  schedule_expression = "cron(0 2 * * ? *)"
-#  tags                = var.default_tags
-#}
-#
-#resource "aws_cloudwatch_event_target" "csv_automation_court_order_processing" {
-#  rule     = aws_cloudwatch_event_rule.csv_automation_court_order_processing.name
-#  arn      = aws_ecs_cluster.main.arn
-#  role_arn = aws_iam_role.events_task_runner.arn
-#
-#  ecs_target {
-#    task_count          = 1
-#    task_definition_arn = aws_ecs_task_definition.api_high_memory.arn
-#    launch_type         = "FARGATE"
-#    platform_version    = "1.4.0"
-#
-#    network_configuration {
-#      security_groups  = [module.api_service_security_group.id]
-#      subnets          = data.aws_subnet.private[*].id
-#      assign_public_ip = false
-#    }
-#  }
-#  input = jsonencode(
-#    {
-#      "containerOverrides" : [
-#        {
-#          "name" : "api_app",
-#          "command" : ["sh", "scripts/task_run_console_command.sh", "digideps:api:process-court-orders-csv", "--env=prod", "--no-debug", local.court_order_report_csv_file]
-#        }
-#      ]
-#    }
-#  )
-#}
+resource "aws_cloudwatch_event_rule" "csv_automation_court_order_processing" {
+  name                = "csv-automation-court-order-processing-${local.environment}"
+  description         = "Process Sirus Court Orders CSV for all Users ${terraform.workspace}"
+  schedule_expression = "cron(0 2 * * ? *)"
+  tags                = var.default_tags
+}
+
+resource "aws_cloudwatch_event_target" "csv_automation_court_order_processing" {
+  rule     = aws_cloudwatch_event_rule.csv_automation_court_order_processing.name
+  arn      = aws_ecs_cluster.main.arn
+  role_arn = aws_iam_role.events_task_runner.arn
+
+  ecs_target {
+    task_count          = 1
+    task_definition_arn = aws_ecs_task_definition.api_high_memory.arn
+    launch_type         = "FARGATE"
+    platform_version    = "1.4.0"
+
+    network_configuration {
+      security_groups  = [module.api_service_security_group.id]
+      subnets          = data.aws_subnet.private[*].id
+      assign_public_ip = false
+    }
+  }
+  input = jsonencode(
+    {
+      "containerOverrides" : [
+        {
+          "name" : "api_app",
+          "command" : ["sh", "scripts/task_run_console_command.sh", "digideps:api:process-court-orders-csv", "--env=prod", "--no-debug", local.court_order_report_csv_file]
+        }
+      ]
+    }
+  )
+}
 
 # Sirius Lay CSV Ingestion
 

--- a/terraform/environment/region/cloudwatch_scheduled_events.tf
+++ b/terraform/environment/region/cloudwatch_scheduled_events.tf
@@ -1,3 +1,41 @@
+# Sirius CourtOrder CSV Ingestion
+
+#resource "aws_cloudwatch_event_rule" "csv_automation_court_order_processing" {
+#  name                = "csv-automation-court-order-processing-${local.environment}"
+#  description         = "Process Sirus Court Orders CSV for all Users ${terraform.workspace}"
+#  schedule_expression = "cron(0 2 * * ? *)"
+#  tags                = var.default_tags
+#}
+#
+#resource "aws_cloudwatch_event_target" "csv_automation_court_order_processing" {
+#  rule     = aws_cloudwatch_event_rule.csv_automation_court_order_processing.name
+#  arn      = aws_ecs_cluster.main.arn
+#  role_arn = aws_iam_role.events_task_runner.arn
+#
+#  ecs_target {
+#    task_count          = 1
+#    task_definition_arn = aws_ecs_task_definition.api_high_memory.arn
+#    launch_type         = "FARGATE"
+#    platform_version    = "1.4.0"
+#
+#    network_configuration {
+#      security_groups  = [module.api_service_security_group.id]
+#      subnets          = data.aws_subnet.private[*].id
+#      assign_public_ip = false
+#    }
+#  }
+#  input = jsonencode(
+#    {
+#      "containerOverrides" : [
+#        {
+#          "name" : "api_app",
+#          "command" : ["sh", "scripts/task_run_console_command.sh", "digideps:api:process-court-orders-csv", "--env=prod", "--no-debug", local.court_order_report_csv_file]
+#        }
+#      ]
+#    }
+#  )
+#}
+
 # Sirius Lay CSV Ingestion
 
 resource "aws_cloudwatch_event_rule" "csv_automation_lay_processing" {

--- a/terraform/environment/region/cloudwatch_scheduled_events.tf
+++ b/terraform/environment/region/cloudwatch_scheduled_events.tf
@@ -3,7 +3,7 @@
 resource "aws_cloudwatch_event_rule" "csv_automation_court_order_processing" {
   name                = "csv-automation-court-order-processing-${local.environment}"
   description         = "Process Sirus Court Orders CSV for all Users ${terraform.workspace}"
-  schedule_expression = "cron(0 2 * * ? *)"
+  schedule_expression = "cron(59 1 * * ? *)"
   tags                = var.default_tags
 }
 

--- a/terraform/environment/region/cloudwatch_scheduled_events_checks.tf
+++ b/terraform/environment/region/cloudwatch_scheduled_events_checks.tf
@@ -329,3 +329,33 @@ resource "aws_cloudwatch_event_target" "resubmit_error_checklists_check" {
     }
   )
 }
+
+# CourtOrder CSV Processing Check
+
+#resource "aws_cloudwatch_event_rule" "court_order_csv_processing_check" {
+#  name                = "check-court-order-csv-processing-${terraform.workspace}"
+#  description         = "Execute the Court Order CSV user processing check for ${terraform.workspace}"
+#  schedule_expression = "cron(18 09 * * ? *)"
+#  is_enabled          = var.account.is_production == 1 ? true : false
+#}
+#
+#
+#resource "aws_cloudwatch_event_target" "court_order_csv_processing_check" {
+#  target_id = "check-org-csv-processing-${terraform.workspace}"
+#  arn       = data.aws_lambda_function.monitor_notify_lambda.arn
+#  rule      = aws_cloudwatch_event_rule.org_csv_processing_check.name
+#  input = jsonencode(
+#    {
+#      scheduled-event-detail = {
+#        job-name                   = "court_order_csv_processing_check"
+#        log-group                  = terraform.workspace,
+#        log-entries                = ["org_csv_processing"],
+#        search-timespan            = "24 hours",
+#        bank-holidays              = "true",
+#        channel-identifier-absent  = "team",
+#        channel-identifier-success = "scheduled-jobs",
+#        channel-identifier-failure = "team"
+#      }
+#    }
+#  )
+#}

--- a/terraform/environment/region/cloudwatch_scheduled_events_checks.tf
+++ b/terraform/environment/region/cloudwatch_scheduled_events_checks.tf
@@ -332,30 +332,30 @@ resource "aws_cloudwatch_event_target" "resubmit_error_checklists_check" {
 
 # CourtOrder CSV Processing Check
 
-#resource "aws_cloudwatch_event_rule" "court_order_csv_processing_check" {
-#  name                = "check-court-order-csv-processing-${terraform.workspace}"
-#  description         = "Execute the Court Order CSV user processing check for ${terraform.workspace}"
-#  schedule_expression = "cron(18 09 * * ? *)"
-#  is_enabled          = var.account.is_production == 1 ? true : false
-#}
-#
-#
-#resource "aws_cloudwatch_event_target" "court_order_csv_processing_check" {
-#  target_id = "check-org-csv-processing-${terraform.workspace}"
-#  arn       = data.aws_lambda_function.monitor_notify_lambda.arn
-#  rule      = aws_cloudwatch_event_rule.org_csv_processing_check.name
-#  input = jsonencode(
-#    {
-#      scheduled-event-detail = {
-#        job-name                   = "court_order_csv_processing_check"
-#        log-group                  = terraform.workspace,
-#        log-entries                = ["org_csv_processing"],
-#        search-timespan            = "24 hours",
-#        bank-holidays              = "true",
-#        channel-identifier-absent  = "team",
-#        channel-identifier-success = "scheduled-jobs",
-#        channel-identifier-failure = "team"
-#      }
-#    }
-#  )
-#}
+resource "aws_cloudwatch_event_rule" "court_order_csv_processing_check" {
+  name                = "check-court-order-csv-processing-${terraform.workspace}"
+  description         = "Execute the Court Order CSV user processing check for ${terraform.workspace}"
+  schedule_expression = "cron(18 09 * * ? *)"
+  is_enabled          = var.account.is_production == 1 ? true : false
+}
+
+
+resource "aws_cloudwatch_event_target" "court_order_csv_processing_check" {
+  target_id = "check-org-csv-processing-${terraform.workspace}"
+  arn       = data.aws_lambda_function.monitor_notify_lambda.arn
+  rule      = aws_cloudwatch_event_rule.org_csv_processing_check.name
+  input = jsonencode(
+    {
+      scheduled-event-detail = {
+        job-name                   = "court_order_csv_processing_check"
+        log-group                  = terraform.workspace,
+        log-entries                = ["org_csv_processing"],
+        search-timespan            = "24 hours",
+        bank-holidays              = "true",
+        channel-identifier-absent  = "team",
+        channel-identifier-success = "scheduled-jobs",
+        channel-identifier-failure = "team"
+      }
+    }
+  )
+}

--- a/terraform/environment/region/cloudwatch_scheduled_events_checks.tf
+++ b/terraform/environment/region/cloudwatch_scheduled_events_checks.tf
@@ -349,7 +349,7 @@ resource "aws_cloudwatch_event_target" "court_order_csv_processing_check" {
       scheduled-event-detail = {
         job-name                   = "court_order_csv_processing_check"
         log-group                  = terraform.workspace,
-        log-entries                = ["org_csv_processing"],
+        log-entries                = ["court_order_csv_processing"],
         search-timespan            = "24 hours",
         bank-holidays              = "true",
         channel-identifier-absent  = "team",

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -71,8 +71,9 @@ locals {
 
   capacity_provider = var.account.fargate_spot ? "FARGATE_SPOT" : "FARGATE"
 
-  pa_pro_report_csv_filename = "paProDeputyReport.csv"
-  lay_report_csv_file        = "layDeputyReport.csv"
+  pa_pro_report_csv_filename  = "paProDeputyReport.csv"
+  lay_report_csv_file         = "layDeputyReport.csv"
+  court_order_report_csv_file = "courtOrdersReport.csv"
 }
 
 data "terraform_remote_state" "shared" {


### PR DESCRIPTION
## Purpose
We need to create and implement a new job within cloudwatch scheduled events to handle the execution of the nightly Court Order CSV job, ensuring it runs at the designated time each night. 

As this is a DB operation, you will need to make sure that no other tasks are interfering with the DB, you should also consider that this needs to run before the other CSV jobs (Lay, PA & Prof)

You can find examples of other scheduled jobs in the file cloudwatch_scheduled_events.tf

The results of the job will also need to be posted to the slack channel opg-digideps-scheduled-jobs, this will also require a separate cloudwatch task to be created, examples of this can be found within cloudwatch_scheduled_events_checks.tf

Fixes DDLS-486

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
