### PR TITLE
DDLS-485 check submission valid for NDR before submitting

### DIFF
--- a/client/app/src/Entity/Ndr/Ndr.php
+++ b/client/app/src/Entity/Ndr/Ndr.php
@@ -24,6 +24,7 @@ class Ndr implements ReportInterface
 
     /**
      * @JMS\Type("integer")
+     *
      * @JMS\Groups({"ndr", "ndr_id"})
      *
      * @var int
@@ -32,6 +33,7 @@ class Ndr implements ReportInterface
 
     /**
      * @JMS\Type("boolean")
+     *
      * @JMS\Groups({"submit"})
      *
      * @var bool
@@ -39,15 +41,19 @@ class Ndr implements ReportInterface
     private $submitted;
 
     /**
-     * @var DateTime
+     * @var \DateTime
+     *
      * @JMS\Type("DateTime")
+     *
      * @JMS\Groups({"start_date"})
      */
     private $startDate;
 
     /**
-     * @var DateTime
+     * @var \DateTime
+     *
      * @JMS\Type("DateTime")
+     *
      * @JMS\Groups({"submit"})
      */
     private $submitDate;
@@ -75,6 +81,7 @@ class Ndr implements ReportInterface
 
     /**
      * @JMS\Type("array<App\Entity\Ndr\Debt>")
+     *
      * @JMS\Groups({"debt"})
      *
      * @var Debt[]
@@ -83,7 +90,9 @@ class Ndr implements ReportInterface
 
     /**
      * @JMS\Type("string")
+     *
      * @JMS\Groups({"ndr-debt-management"})
+     *
      * @Assert\NotBlank(message="ndr.debt.debts-management.notBlank", groups={"ndr-debt-management"})
      *
      * @var string
@@ -92,6 +101,7 @@ class Ndr implements ReportInterface
 
     /**
      * @JMS\Type("string")
+     *
      * @JMS\Groups({"debt"})
      *
      * @Assert\NotBlank(message="ndr.debt.notBlank", groups={"debts"})
@@ -102,6 +112,7 @@ class Ndr implements ReportInterface
 
     /**
      * @JMS\Type("string")
+     *
      * @JMS\Groups({"debt"})
      *
      * @var float
@@ -117,6 +128,7 @@ class Ndr implements ReportInterface
 
     /**
      * @JMS\Type("boolean")
+     *
      * @JMS\Groups({"noAssetsToAdd"})
      *
      * @var bool
@@ -132,7 +144,9 @@ class Ndr implements ReportInterface
 
     /**
      * @JMS\Type("App\Entity\Ndr\ClientBenefitsCheck")
+     *
      * @Assert\Valid(groups={"client-benefits-check"})
+     *
      * @JMS\Groups({"client-benefits-check"})
      *
      * @var ?ClientBenefitsCheck
@@ -172,8 +186,6 @@ class Ndr implements ReportInterface
 
     /**
      * @param int $id
-     *
-     * @return Ndr
      */
     public function setId($id): self
     {
@@ -183,7 +195,7 @@ class Ndr implements ReportInterface
     }
 
     /**
-     * @return DateTime
+     * @return \DateTime
      */
     public function getStartDate()
     {
@@ -191,9 +203,7 @@ class Ndr implements ReportInterface
     }
 
     /**
-     * @param DateTime $startDate
-     *
-     * @return Ndr
+     * @param \DateTime $startDate
      */
     public function setStartDate($startDate): self
     {
@@ -203,7 +213,7 @@ class Ndr implements ReportInterface
     }
 
     /**
-     * @return DateTime|null
+     * @return \DateTime|null
      */
     public function getSubmitDate()
     {
@@ -211,9 +221,7 @@ class Ndr implements ReportInterface
     }
 
     /**
-     * @param DateTime $submitDate
-     *
-     * @return Ndr
+     * @param \DateTime $submitDate
      */
     public function setSubmitDate($submitDate): self
     {
@@ -230,9 +238,6 @@ class Ndr implements ReportInterface
         return $this->client;
     }
 
-    /**
-     * @param mixed $client
-     */
     public function setClient($client)
     {
         $this->client = $client;
@@ -302,11 +307,11 @@ class Ndr implements ReportInterface
     /**
      * Return the due date (calculated as court order date + 40 days).
      *
-     * @return DateTime|null $dueDate
+     * @return \DateTime|null $dueDate
      */
     public function getDueDate()
     {
-        if (!$this->getStartDate() instanceof DateTime) {
+        if (!$this->getStartDate() instanceof \DateTime) {
             return null;
         }
 
@@ -635,5 +640,35 @@ class Ndr implements ReportInterface
         $this->clientBenefitsCheck = $clientBenefitsCheck;
 
         return $this;
+    }
+
+    /**
+     * Checks if NDR is in submittable state.
+     *
+     * @return array
+     */
+    public function validForSubmission()
+    {
+        $valid = true;
+        $msg = [];
+        if (empty($this->getClient()->getCourtDate())) {
+            $valid = false;
+            $msg[] = 'Missing Court Date on Client';
+        }
+        if (empty($this->getClient()->getCaseNumber())) {
+            $valid = false;
+            $msg[] = 'Missing CaseNumber on Client';
+        }
+        if (empty($this->getClient()->getAddress())) {
+            $msg[] = 'Missing Address on Client';
+        }
+        if (empty($this->getClient()->getPostcode())) {
+            $msg[] = 'Missing Postcode on Client';
+        }
+
+        return [
+            'valid' => $valid,
+            'msg' => $msg,
+        ];
     }
 }

--- a/client/app/src/Service/Client/Internal/NdrApi.php
+++ b/client/app/src/Service/Client/Internal/NdrApi.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace App\Service\Client\Internal;
 
-use App\Entity\Client;
 use App\Entity\Ndr\Ndr;
 use App\Entity\Report\Document;
-use App\Entity\User;
 use App\Event\NdrSubmittedEvent;
 use App\EventDispatcher\ObservableEventDispatcher;
 use App\Exception\RestClientException;
@@ -42,8 +40,6 @@ class NdrApi
             $ndrToSubmit,
             ['submit']
         );
-
-        // Debug here and see what we have with the User -> client -> report getting mailfactory 419 error on cloning non-object
 
         $submittedByWithClientsAndReports = $this->userApi->getUserWithData(['user-clients', 'client', 'client-reports', 'report']);
         $client = $submittedByWithClientsAndReports->getClients()[0];

--- a/client/app/tests/phpunit/Entity/Ndr/NdrTest.php
+++ b/client/app/tests/phpunit/Entity/Ndr/NdrTest.php
@@ -2,12 +2,13 @@
 
 namespace App\Entity\Ndr;
 
+use App\Entity\Client;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
 class NdrTest extends TestCase
 {
-    /** @var Ndr $report */
+    /** @var Ndr */
     private $ndr;
 
     protected function setUp(): void
@@ -15,6 +16,9 @@ class NdrTest extends TestCase
         $this->ndr = new Ndr();
         $this->incomeTicked = new StateBenefit('t1', true);
         $this->incomeUnticked = new StateBenefit('t2', false);
+
+        $this->client = $this->createMock(Client::class);
+        $this->ndr->setClient($this->client);
     }
 
     public function tearDown(): void
@@ -56,10 +60,63 @@ class NdrTest extends TestCase
     public function testGetAssetsTotalValue()
     {
         $this->ndr->setAssets([
-            m::mock(AssetOther::class, ['getValueTotal'=>1]),
-            m::mock(AssetProperty::class, ['getValueTotal'=>2]),
+            m::mock(AssetOther::class, ['getValueTotal' => 1]),
+            m::mock(AssetProperty::class, ['getValueTotal' => 2]),
         ]);
 
         $this->assertEquals(3, $this->ndr->getAssetsTotalValue());
+    }
+
+    public function testValidForSubmissionAllFieldsPresent()
+    {
+        $this->client->method('getCourtDate')->willReturn('2024-01-01');
+        $this->client->method('getCaseNumber')->willReturn('123456');
+        $this->client->method('getAddress')->willReturn('123 Main St');
+        $this->client->method('getPostcode')->willReturn('AB12 3CD');
+
+        $result = $this->ndr->validForSubmission();
+
+        $this->assertTrue($result['valid']);
+        $this->assertEmpty($result['msg']);
+    }
+
+    public function testValidForSubmissionMissingCourtDate()
+    {
+        $this->client->method('getCourtDate')->willReturn(null);
+        $this->client->method('getCaseNumber')->willReturn('123456');
+        $this->client->method('getAddress')->willReturn('123 Main St');
+        $this->client->method('getPostcode')->willReturn('AB12 3CD');
+
+        $result = $this->ndr->validForSubmission();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('Missing Court Date on Client', $result['msg']);
+    }
+
+    public function testValidForSubmissionMissingCaseNumber()
+    {
+        $this->client->method('getCourtDate')->willReturn('2024-01-01');
+        $this->client->method('getCaseNumber')->willReturn(null);
+        $this->client->method('getAddress')->willReturn('123 Main St');
+        $this->client->method('getPostcode')->willReturn('AB12 3CD');
+
+        $result = $this->ndr->validForSubmission();
+
+        $this->assertFalse($result['valid']);
+        $this->assertContains('Missing CaseNumber on Client', $result['msg']);
+    }
+
+    public function testValidForSubmissionMissingOptionalFields()
+    {
+        $this->client->method('getCourtDate')->willReturn('2024-01-01');
+        $this->client->method('getCaseNumber')->willReturn('123456');
+        $this->client->method('getAddress')->willReturn(null);
+        $this->client->method('getPostcode')->willReturn(null);
+
+        $result = $this->ndr->validForSubmission();
+
+        $this->assertTrue($result['valid']);
+        $this->assertContains('Missing Address on Client', $result['msg']);
+        $this->assertContains('Missing Postcode on Client', $result['msg']);
     }
 }


### PR DESCRIPTION
## Purpose
When important data for the submission is missing for whatever reason, create exception before creating the report pdf and doing other updates

Fixes DDLS-485

## Approach
This is the first in a number of submission related bug fixes. This does a check early on for casenumber and court_date and if they're missing it raises an exception that breaks the request early. I'm also logging instances of missing address and postcode as although this would not break the submit (and hence I don't raise exception), it would be useful to see how often we're missing the address and postcode.

## Learning
For the unit tests I'm using createMock as the prophesise was giving deprecation warnings. 

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
