### PR TITLE
DDLS-494 PDF missing sections

### DIFF
--- a/client/app/templates/Report/Formatted/_visits_care.html.twig
+++ b/client/app/templates/Report/Formatted/_visits_care.html.twig
@@ -1,7 +1,7 @@
 {% set translationDomain = "report-visits-care" %}
 {% import '@App/Macros/macros-review.html.twig' as macros %}
 
-<div class="section" id="safeguarding-section">
+<div class="section break-before" id="safeguarding-section">
     <h2 class="section-heading">Visits and care</h2>
 
     {{ macros.answerYesNo({


### PR DESCRIPTION
## Purpose
When creating the annual report pdf for the above case ref, there are several line spaces between the ‘Gifts’ and ‘Deputy expenses’ fields and the ‘Decisions made over the reporting period’ section - This has pushed the Decisions section off the page (see image) - the user is unable to see the 'Reason for no decisions'

Fixes DDLS-494

## Approach
Amended class to section break-before so that breaks before visits and care section

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
