### PR TITLE
DDLS-498 build for graviton architecture (with more testing)

### DIFF
--- a/.github/workflows/_build-and-push.yml
+++ b/.github/workflows/_build-and-push.yml
@@ -32,35 +32,60 @@ jobs:
           - svc_name: "client-webserver"
             sub_folder: "."
             docker_file: "client/docker/web/Dockerfile"
+            platform: "linux/arm64"
+
           - svc_name: "client"
             sub_folder: "."
             docker_file: "client/docker/app/Dockerfile"
+            platform: "linux/arm64"
+
           - svc_name: "api-webserver"
             sub_folder: "."
             docker_file: "api/docker/web/Dockerfile"
+            platform: "linux/arm64"
+
           - svc_name: "api"
             sub_folder: "."
             docker_file: "api/docker/app/Dockerfile"
+            platform: "linux/arm64"
+
           - svc_name: "sync"
             sub_folder: "orchestration"
             docker_file: "Dockerfile"
+            platform: "linux/arm64"
+
           - svc_name: "htmltopdf"
             sub_folder: "."
             docker_file: "htmltopdf/Dockerfile"
+            platform: "linux/arm64"
+
           - svc_name: "file-scanner"
             sub_folder: "."
             docker_file: "file-scanner/Dockerfile"
+            platform: "linux/arm64"
+
           - svc_name: "dr-backup"
             sub_folder: "disaster-recovery/backup"
             docker_file: "Dockerfile"
+            platform: "linux/arm64"
+
           - svc_name: "custom-sql-lambda"
             sub_folder: "lambdas/functions/custom_sql_query"
             docker_file: "Dockerfile"
+            platform: "linux/amd64"
+
     steps:
       - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2 # pin@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.4.0
+
       - name: set up docker buildx
         uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca
+        id: buildx_setup
+        with:
+          version: v0.15.1
+          platforms: linux/amd64,linux/arm64
 
       - name: export dates
         id: cache-dates
@@ -96,11 +121,17 @@ jobs:
           IMAGE_NAME: ${{ matrix.svc_name }}
           DOCKERFILE: ${{ matrix.docker_file }}
           BRANCH_NAME: ${{ inputs.branch_name }}
+          PLATFORM: ${{ matrix.platform }}
+          # We can default to arm64 as this isn't used unless specified in the dockerfile
+          PACKAGE: arm64
         run: |
           if [ "${BRANCH_NAME}" == "main" ]; then
             docker buildx build \
             -f ${DOCKERFILE} \
             --cache-to=type=local,dest=/tmp/.buildx-cache-new \
+            --platform ${PLATFORM} \
+            --load \
+            --build-arg PACKAGE=${PACKAGE} \
             --tag ${IMAGE_NAME}:latest \
             --output type=docker \
             .
@@ -109,7 +140,10 @@ jobs:
             -f ${DOCKERFILE} \
             --cache-from=type=local,src=/tmp/.buildx-cache \
             --cache-to=type=local,dest=/tmp/.buildx-cache-new \
+            --platform ${PLATFORM} \
             --tag ${IMAGE_NAME}:latest \
+            --load \
+            --build-arg PACKAGE=${PACKAGE} \
             --output type=docker \
             .
           fi

--- a/.github/workflows/_build-and-push.yml
+++ b/.github/workflows/_build-and-push.yml
@@ -24,7 +24,6 @@ on:
 
 jobs:
   docker_build_scan_push:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -32,60 +31,67 @@ jobs:
           - svc_name: "client-webserver"
             sub_folder: "."
             docker_file: "client/docker/web/Dockerfile"
-            platform: "linux/arm64"
+            platform: "arm64"
+            runs_on: "ubuntu-24.04-arm"
 
           - svc_name: "client"
             sub_folder: "."
             docker_file: "client/docker/app/Dockerfile"
-            platform: "linux/arm64"
+            platform: "arm64"
+            runs_on: "ubuntu-24.04-arm"
 
           - svc_name: "api-webserver"
             sub_folder: "."
             docker_file: "api/docker/web/Dockerfile"
-            platform: "linux/arm64"
+            platform: "arm64"
+            runs_on: "ubuntu-24.04-arm"
 
           - svc_name: "api"
             sub_folder: "."
             docker_file: "api/docker/app/Dockerfile"
-            platform: "linux/arm64"
+            platform: "arm64"
+            runs_on: "ubuntu-24.04-arm"
 
           - svc_name: "sync"
             sub_folder: "orchestration"
             docker_file: "Dockerfile"
-            platform: "linux/arm64"
+            platform: "arm64"
+            runs_on: "ubuntu-24.04-arm"
 
           - svc_name: "htmltopdf"
             sub_folder: "."
             docker_file: "htmltopdf/Dockerfile"
-            platform: "linux/arm64"
+            platform: "arm64"
+            runs_on: "ubuntu-24.04-arm"
 
           - svc_name: "file-scanner"
             sub_folder: "."
             docker_file: "file-scanner/Dockerfile"
-            platform: "linux/arm64"
+            platform: "arm64"
+            runs_on: "ubuntu-24.04-arm"
 
           - svc_name: "dr-backup"
             sub_folder: "disaster-recovery/backup"
             docker_file: "Dockerfile"
-            platform: "linux/arm64"
+            platform: "arm64"
+            runs_on: "ubuntu-24.04-arm"
 
           - svc_name: "custom-sql-lambda"
             sub_folder: "lambdas/functions/custom_sql_query"
             docker_file: "Dockerfile"
-            platform: "linux/amd64"
+            platform: "amd64"
+            runs_on: "ubuntu-latest"
 
+    runs-on: ${{ matrix.runs_on }}
     steps:
       - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2 # pin@v3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.4.0
 
       - name: set up docker buildx
         uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca
         id: buildx_setup
         with:
           version: v0.15.1
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{ matrix.platform }}
 
       - name: export dates
         id: cache-dates
@@ -122,16 +128,14 @@ jobs:
           DOCKERFILE: ${{ matrix.docker_file }}
           BRANCH_NAME: ${{ inputs.branch_name }}
           PLATFORM: ${{ matrix.platform }}
-          # We can default to arm64 as this isn't used unless specified in the dockerfile
-          PACKAGE: arm64
         run: |
           if [ "${BRANCH_NAME}" == "main" ]; then
             docker buildx build \
             -f ${DOCKERFILE} \
             --cache-to=type=local,dest=/tmp/.buildx-cache-new \
-            --platform ${PLATFORM} \
+            --platform linux/${PLATFORM} \
             --load \
-            --build-arg PACKAGE=${PACKAGE} \
+            --build-arg PLATFORM=${PLATFORM} \
             --tag ${IMAGE_NAME}:latest \
             --output type=docker \
             .
@@ -140,10 +144,10 @@ jobs:
             -f ${DOCKERFILE} \
             --cache-from=type=local,src=/tmp/.buildx-cache \
             --cache-to=type=local,dest=/tmp/.buildx-cache-new \
-            --platform ${PLATFORM} \
+            --platform linux/${PLATFORM} \
             --tag ${IMAGE_NAME}:latest \
             --load \
-            --build-arg PACKAGE=${PACKAGE} \
+            --build-arg PLATFORM=${PLATFORM} \
             --output type=docker \
             .
           fi

--- a/api/app/scripts/wait-for-db.sh
+++ b/api/app/scripts/wait-for-db.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+# Usage function
+usage() {
+    echo "Usage: $0 -h <hostname> -p <port> -t <timeout>"
+    exit 1
+}
+
+# Default timeout value
+TIMEOUT=60
+
+# Parse command-line arguments
+while getopts "h:p:t:" opt; do
+  case "$opt" in
+    h) DATABASE_HOSTNAME=$OPTARG ;;
+    p) DATABASE_PORT=$OPTARG ;;
+    t) TIMEOUT=$OPTARG ;;
+    *) usage ;;
+  esac
+done
+
+# Validate inputs
+if [[ -z "$DATABASE_HOSTNAME" || -z "$DATABASE_PORT" ]]; then
+    echo "Error: Missing required arguments."
+    usage
+fi
+
+# Start timer
+START_TIME=$(date +%s)
+
+# Wait for database to become available
+while ! nc -z "$DATABASE_HOSTNAME" "$DATABASE_PORT"; do
+    echo "Waiting for database at $DATABASE_HOSTNAME:$DATABASE_PORT..."
+    sleep 2
+
+    if [ $(( $(date +%s) - START_TIME )) -ge "$TIMEOUT" ]; then
+        echo "Timeout reached after $TIMEOUT seconds. Database did not respond."
+        exit 1
+    fi
+done
+
+echo "Database is now reachable!"
+exit 0

--- a/api/docker/app/Dockerfile
+++ b/api/docker/app/Dockerfile
@@ -13,7 +13,7 @@ RUN composer run-script post-install-cmd --no-interaction
 RUN composer dump-autoload --optimize
 
 FROM php:8.1.28-fpm-alpine3.19 AS base
-ARG PACKAGE=${PACKAGE:-amd64}
+ARG PLATFORM=${PLATFORM:-amd64}
 WORKDIR /var/www
 EXPOSE 80
 EXPOSE 443
@@ -49,7 +49,7 @@ RUN if [[ $REQUIRE_XDEBUG = 1 ]] ; then \
 
 # Add Confd to configure parameters on start
 ENV CONFD_VERSION="0.16.0"
-RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-${PACKAGE}" \
+RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-${PLATFORM}" \
     && chmod +x /usr/local/bin/confd
 
 # Create var directories

--- a/api/docker/app/Dockerfile
+++ b/api/docker/app/Dockerfile
@@ -13,6 +13,7 @@ RUN composer run-script post-install-cmd --no-interaction
 RUN composer dump-autoload --optimize
 
 FROM php:8.1.28-fpm-alpine3.19 AS base
+ARG PACKAGE=${PACKAGE:-amd64}
 WORKDIR /var/www
 EXPOSE 80
 EXPOSE 443
@@ -48,12 +49,8 @@ RUN if [[ $REQUIRE_XDEBUG = 1 ]] ; then \
 
 # Add Confd to configure parameters on start
 ENV CONFD_VERSION="0.16.0"
-RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64" \
+RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-${PACKAGE}" \
     && chmod +x /usr/local/bin/confd
-# Add Waitforit to wait on db starting
-ENV WAITFORIT_VERSION="v2.4.1"
-RUN wget -q -O /usr/local/bin/waitforit https://github.com/maxclaus/waitforit/releases/download/$WAITFORIT_VERSION/waitforit-linux_amd64 \
-    && chmod +x /usr/local/bin/waitforit
 
 # Create var directories
 RUN mkdir -p var/cache \
@@ -78,6 +75,9 @@ COPY --chown=www-data:www-data api/app/tests tests
 COPY --chown=www-data:www-data api/app/api.env api.env
 COPY --chown=www-data:www-data api/app/postgres.env postgres.env
 COPY --chown=www-data:www-data api/app/phpstan.neon .
+COPY --chown=www-data:www-data api/app/scripts/wait-for-db.sh wait-for-db.sh
+
+RUN chmod 544 /var/www/wait-for-db.sh
 # Behat
 RUN mkdir -p /tmp/html
 RUN mkdir -p /tmp/sql
@@ -96,7 +96,7 @@ RUN mkdir certs && chmod 755 certs && wget -O certs/eu-west-1-bundle.pem https:/
 FROM application AS ci-tests
 # We use this setup for certain commands as part of the CI processing of unit tests
 CMD ["sh", "-c", "confd -onetime -backend env \
-    && waitforit -address=tcp://$DATABASE_HOSTNAME:$DATABASE_PORT -timeout=$TIMEOUT \
+    && /var/www/wait-for-db.sh -h $DATABASE_HOSTNAME -p $DATABASE_PORT -t $TIMEOUT \
     && php app/console doctrine:migrations:migrate --allow-no-migration --no-interaction \
     && php app/console doctrine:migrations:up-to-date \
     && php-fpm"]
@@ -108,7 +108,7 @@ RUN /harden.sh www-data && rm /harden.sh
 USER www-data
 
 CMD ["sh", "-c", "confd -onetime -backend env \
-    && waitforit -address=tcp://$DATABASE_HOSTNAME:$DATABASE_PORT -timeout=$TIMEOUT \
+    && /var/www/wait-for-db.sh -h $DATABASE_HOSTNAME -p $DATABASE_PORT -t $TIMEOUT \
     && php app/console doctrine:migrations:migrate --allow-no-migration --no-interaction \
     && php app/console doctrine:migrations:up-to-date \
     && php-fpm"]

--- a/api/docker/web/Dockerfile
+++ b/api/docker/web/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginxinc/nginx-unprivileged:stable-alpine
-
+ARG PACKAGE=${PACKAGE:-amd64}
 USER root
 
 WORKDIR /www/data
@@ -10,13 +10,8 @@ RUN apk --no-cache add wget libcap
 
 # Add Confd to configure nginx on start
 ENV CONFD_VERSION="0.16.0"
-ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 /usr/local/bin/confd
+ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-${PACKAGE} /usr/local/bin/confd
 RUN chmod +x /usr/local/bin/confd
-
-# Add Waitforit to wait on app starting
-ENV WAITFORIT_VERSION="v2.4.1"
-ADD https://github.com/maxclaus/waitforit/releases/download/${WAITFORIT_VERSION}/waitforit-linux_amd64 /usr/local/bin/waitforit
-RUN chmod +x /usr/local/bin/waitforit
 
 COPY --chown=nginx client/docker/web/confd /etc/confd
 COPY --chown=nginx client/resources/public/ /www/data/public/

--- a/api/docker/web/Dockerfile
+++ b/api/docker/web/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginxinc/nginx-unprivileged:stable-alpine
-ARG PACKAGE=${PACKAGE:-amd64}
+ARG PLATFORM=${PLATFORM:-amd64}
 USER root
 
 WORKDIR /www/data
@@ -10,7 +10,7 @@ RUN apk --no-cache add wget libcap
 
 # Add Confd to configure nginx on start
 ENV CONFD_VERSION="0.16.0"
-ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-${PACKAGE} /usr/local/bin/confd
+ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-${PLATFORM} /usr/local/bin/confd
 RUN chmod +x /usr/local/bin/confd
 
 COPY --chown=nginx client/docker/web/confd /etc/confd

--- a/client/docker/app/Dockerfile
+++ b/client/docker/app/Dockerfile
@@ -13,6 +13,7 @@ RUN composer run-script post-install-cmd --no-interaction
 RUN composer dump-autoload --optimize
 
 FROM php:8.1.28-fpm-alpine3.19 as base
+ARG PACKAGE=${PACKAGE:-amd64}
 WORKDIR /var/www
 ENV TIMEOUT=60
 ENV PHP_EXT_DIR=/usr/local/lib/php/extensions/no-debug-non-zts-20210902/
@@ -52,12 +53,8 @@ RUN if [[ $REQUIRE_XDEBUG = 1 ]] ; then \
 
 # Add Confd to configure parameters on start
 ENV CONFD_VERSION="0.16.0"
-RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64" \
+RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-${PACKAGE}" \
     && chmod +x /usr/local/bin/confd
-# Add Waitforit to wait on API starting
-ENV WAITFORIT_VERSION="v2.4.1"
-RUN wget -q -O /usr/local/bin/waitforit https://github.com/maxclaus/waitforit/releases/download/$WAITFORIT_VERSION/waitforit-linux_amd64 \
-    && chmod +x /usr/local/bin/waitforit
 
 # Create var directories
 RUN mkdir -p var/cache \

--- a/client/docker/app/Dockerfile
+++ b/client/docker/app/Dockerfile
@@ -13,7 +13,7 @@ RUN composer run-script post-install-cmd --no-interaction
 RUN composer dump-autoload --optimize
 
 FROM php:8.1.28-fpm-alpine3.19 as base
-ARG PACKAGE=${PACKAGE:-amd64}
+ARG PLATFORM=${PLATFORM:-amd64}
 WORKDIR /var/www
 ENV TIMEOUT=60
 ENV PHP_EXT_DIR=/usr/local/lib/php/extensions/no-debug-non-zts-20210902/
@@ -53,7 +53,7 @@ RUN if [[ $REQUIRE_XDEBUG = 1 ]] ; then \
 
 # Add Confd to configure parameters on start
 ENV CONFD_VERSION="0.16.0"
-RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-${PACKAGE}" \
+RUN wget -q -O /usr/local/bin/confd "https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-${PLATFORM}" \
     && chmod +x /usr/local/bin/confd
 
 # Create var directories

--- a/client/docker/web/Dockerfile
+++ b/client/docker/web/Dockerfile
@@ -1,6 +1,7 @@
 FROM nginxinc/nginx-unprivileged:stable-alpine
 
-ARG PACKAGE=${PACKAGE:-amd64}
+ARG PLATFORM=${PLATFORM:-amd64}
+
 USER root
 
 WORKDIR /www/data
@@ -11,7 +12,7 @@ RUN apk --no-cache add wget libcap
 
 # Add Confd to configure nginx on start
 ENV CONFD_VERSION="0.16.0"
-ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-${PACKAGE} /usr/local/bin/confd
+ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-${PLATFORM} /usr/local/bin/confd
 RUN chmod +x /usr/local/bin/confd
 
 COPY --chown=nginx client/docker/web/confd /etc/confd

--- a/client/docker/web/Dockerfile
+++ b/client/docker/web/Dockerfile
@@ -1,5 +1,6 @@
 FROM nginxinc/nginx-unprivileged:stable-alpine
 
+ARG PACKAGE=${PACKAGE:-amd64}
 USER root
 
 WORKDIR /www/data
@@ -10,13 +11,8 @@ RUN apk --no-cache add wget libcap
 
 # Add Confd to configure nginx on start
 ENV CONFD_VERSION="0.16.0"
-ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 /usr/local/bin/confd
+ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-${PACKAGE} /usr/local/bin/confd
 RUN chmod +x /usr/local/bin/confd
-
-# Add Waitforit to wait on app starting
-ENV WAITFORIT_VERSION="v2.4.1"
-ADD https://github.com/maxclaus/waitforit/releases/download/${WAITFORIT_VERSION}/waitforit-linux_amd64 /usr/local/bin/waitforit
-RUN chmod +x /usr/local/bin/waitforit
 
 COPY --chown=nginx client/docker/web/confd /etc/confd
 COPY --chown=nginx client/resources/public/ /www/data/public/

--- a/file-scanner/Dockerfile
+++ b/file-scanner/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM golang:1.22.9-alpine3.20 AS build
+FROM golang:1.22.12-alpine3.20 AS build
 WORKDIR /go/src/clamav-rest
 
 COPY file-scanner/. .

--- a/terraform/environment/region/ecs_service_admin.tf
+++ b/terraform/environment/region/ecs_service_admin.tf
@@ -7,7 +7,11 @@ resource "aws_ecs_task_definition" "admin" {
   container_definitions    = "[${local.admin_web}, ${local.admin_container}]"
   task_role_arn            = aws_iam_role.admin.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = var.default_tags
+  runtime_platform {
+    cpu_architecture        = "ARM64"
+    operating_system_family = "LINUX"
+  }
+  tags = var.default_tags
 }
 
 resource "aws_ecs_service" "admin" {

--- a/terraform/environment/region/ecs_service_api.tf
+++ b/terraform/environment/region/ecs_service_api.tf
@@ -7,7 +7,11 @@ resource "aws_ecs_task_definition" "api" {
   container_definitions    = "[${local.api_web}, ${local.api_container}]"
   task_role_arn            = aws_iam_role.api.arn
   execution_role_arn       = aws_iam_role.execution_role_db.arn
-  tags                     = var.default_tags
+  runtime_platform {
+    cpu_architecture        = "ARM64"
+    operating_system_family = "LINUX"
+  }
+  tags = var.default_tags
 }
 
 resource "aws_ecs_service" "api" {
@@ -149,5 +153,9 @@ resource "aws_ecs_task_definition" "api_high_memory" {
   container_definitions    = "[${local.api_container}]"
   task_role_arn            = aws_iam_role.api.arn
   execution_role_arn       = aws_iam_role.execution_role_db.arn
-  tags                     = var.default_tags
+  runtime_platform {
+    cpu_architecture        = "ARM64"
+    operating_system_family = "LINUX"
+  }
+  tags = var.default_tags
 }

--- a/terraform/environment/region/ecs_service_front.tf
+++ b/terraform/environment/region/ecs_service_front.tf
@@ -7,7 +7,11 @@ resource "aws_ecs_task_definition" "front" {
   container_definitions    = "[${local.front_web}, ${local.front_container}]"
   task_role_arn            = aws_iam_role.front.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = var.default_tags
+  runtime_platform {
+    cpu_architecture        = "ARM64"
+    operating_system_family = "LINUX"
+  }
+  tags = var.default_tags
 }
 
 resource "aws_ecs_service" "front" {

--- a/terraform/environment/region/ecs_service_htmltopdf.tf
+++ b/terraform/environment/region/ecs_service_htmltopdf.tf
@@ -7,7 +7,11 @@ resource "aws_ecs_task_definition" "htmltopdf" {
   container_definitions    = "[${local.htmltopdf_container}]"
   task_role_arn            = aws_iam_role.htmltopdf.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = var.default_tags
+  runtime_platform {
+    cpu_architecture        = "ARM64"
+    operating_system_family = "LINUX"
+  }
+  tags = var.default_tags
 }
 
 resource "aws_ecs_service" "htmltopdf" {

--- a/terraform/environment/region/ecs_service_scan.tf
+++ b/terraform/environment/region/ecs_service_scan.tf
@@ -7,7 +7,11 @@ resource "aws_ecs_task_definition" "scan" {
   container_definitions    = "[${local.file_scanner_rest_container}]"
   task_role_arn            = aws_iam_role.scan.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = var.default_tags
+  runtime_platform {
+    cpu_architecture        = "ARM64"
+    operating_system_family = "LINUX"
+  }
+  tags = var.default_tags
 }
 
 resource "aws_ecs_service" "scan" {

--- a/terraform/environment/region/ecs_service_sirius_files_sync.tf
+++ b/terraform/environment/region/ecs_service_sirius_files_sync.tf
@@ -7,7 +7,11 @@ resource "aws_ecs_task_definition" "sirius_files_sync" {
   container_definitions    = "[${local.sirius_files_sync_container}]"
   task_role_arn            = aws_iam_role.sirius_files_sync.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = var.default_tags
+  runtime_platform {
+    cpu_architecture        = "ARM64"
+    operating_system_family = "LINUX"
+  }
+  tags = var.default_tags
 }
 
 resource "aws_ecs_service" "sirius_files_sync" {

--- a/terraform/environment/region/ecs_task_analyse.tf
+++ b/terraform/environment/region/ecs_task_analyse.tf
@@ -9,7 +9,8 @@ module "analyse" {
   execution_role_arn    = aws_iam_role.execution_role_db.arn
   subnet_ids            = data.aws_subnet.private[*].id
   task_role_arn         = data.aws_iam_role.sync.arn
-  vpc_id                = data.aws_vpc.vpc.id
+  architecture          = "ARM64"
+  os                    = "LINUX"
   security_group_id     = module.db_access_task_security_group.id
 }
 

--- a/terraform/environment/region/ecs_task_backup.tf
+++ b/terraform/environment/region/ecs_task_backup.tf
@@ -9,7 +9,8 @@ module "backup" {
   execution_role_arn    = aws_iam_role.execution_role_db.arn
   subnet_ids            = data.aws_subnet.private[*].id
   task_role_arn         = data.aws_iam_role.sync.arn
-  vpc_id                = data.aws_vpc.vpc.id
+  architecture          = "ARM64"
+  os                    = "LINUX"
   security_group_id     = module.db_access_task_security_group.id
 }
 

--- a/terraform/environment/region/ecs_task_check_csv_upload.tf
+++ b/terraform/environment/region/ecs_task_check_csv_upload.tf
@@ -45,7 +45,11 @@ resource "aws_ecs_task_definition" "check_csv_uploaded" {
   container_definitions    = "[${local.check_csv_uploaded_container}]"
   task_role_arn            = aws_iam_role.front.arn
   execution_role_arn       = aws_iam_role.execution_role.arn
-  tags                     = var.default_tags
+  runtime_platform {
+    cpu_architecture        = "ARM64"
+    operating_system_family = "LINUX"
+  }
+  tags = var.default_tags
 }
 
 resource "aws_cloudwatch_event_rule" "check_csv_uploaded_cron_rule" {

--- a/terraform/environment/region/ecs_task_integration_tests.tf
+++ b/terraform/environment/region/ecs_task_integration_tests.tf
@@ -9,10 +9,11 @@ module "integration_tests" {
   execution_role_arn    = aws_iam_role.execution_role_db.arn
   subnet_ids            = data.aws_subnet.private[*].id
   task_role_arn         = aws_iam_role.integration_tests.arn
-  vpc_id                = data.aws_vpc.vpc.id
   security_group_id     = module.integration_tests_security_group.id
   cpu                   = 4096
   memory                = 8192
+  architecture          = "ARM64"
+  os                    = "LINUX"
   override              = ["sh", "./tests/Behat/run-tests-parallel.sh"]
   service_name          = "integration-tests"
 }

--- a/terraform/environment/region/ecs_task_performance_data.tf
+++ b/terraform/environment/region/ecs_task_performance_data.tf
@@ -9,7 +9,8 @@ module "performance_data" {
   execution_role_arn    = aws_iam_role.execution_role_db.arn
   subnet_ids            = data.aws_subnet.private[*].id
   task_role_arn         = aws_iam_role.performance_data.arn
-  vpc_id                = data.aws_vpc.vpc.id
+  architecture          = "ARM64"
+  os                    = "LINUX"
   security_group_id     = module.db_access_task_security_group.id
 }
 

--- a/terraform/environment/region/ecs_task_reset_database.tf
+++ b/terraform/environment/region/ecs_task_reset_database.tf
@@ -9,7 +9,8 @@ module "reset_database" {
   execution_role_arn    = aws_iam_role.execution_role_db.arn
   subnet_ids            = data.aws_subnet.private[*].id
   task_role_arn         = aws_iam_role.task_runner.arn
-  vpc_id                = data.aws_vpc.vpc.id
+  architecture          = "ARM64"
+  os                    = "LINUX"
   security_group_id     = module.db_access_task_security_group.id
 }
 

--- a/terraform/environment/region/ecs_task_resilience_tests.tf
+++ b/terraform/environment/region/ecs_task_resilience_tests.tf
@@ -109,7 +109,8 @@ module "resilience_tests" {
   execution_role_arn    = aws_iam_role.execution_role.arn
   subnet_ids            = data.aws_subnet.private[*].id
   task_role_arn         = aws_iam_role.resilience_tests.arn
-  vpc_id                = data.aws_vpc.vpc.id
+  architecture          = "ARM64"
+  os                    = "LINUX"
   security_group_id     = module.resilience_tests_security_group.id
 }
 

--- a/terraform/environment/region/ecs_task_restore.tf
+++ b/terraform/environment/region/ecs_task_restore.tf
@@ -12,7 +12,8 @@ module "restore" {
   execution_role_arn    = aws_iam_role.execution_role_db.arn
   subnet_ids            = data.aws_subnet.private[*].id
   task_role_arn         = data.aws_iam_role.sync.arn
-  vpc_id                = data.aws_vpc.vpc.id
+  architecture          = "ARM64"
+  os                    = "LINUX"
   security_group_id     = module.db_access_task_security_group.id
 }
 

--- a/terraform/environment/region/ecs_task_restore_from_production.tf
+++ b/terraform/environment/region/ecs_task_restore_from_production.tf
@@ -11,7 +11,8 @@ module "restore_from_production" {
   execution_role_arn    = aws_iam_role.execution_role_db.arn
   subnet_ids            = data.aws_subnet.private[*].id
   task_role_arn         = data.aws_iam_role.sync.arn
-  vpc_id                = data.aws_vpc.vpc.id
+  architecture          = "ARM64"
+  os                    = "LINUX"
   security_group_id     = module.db_access_task_security_group.id
 }
 

--- a/terraform/environment/region/ecs_task_sleep_mode.tf
+++ b/terraform/environment/region/ecs_task_sleep_mode.tf
@@ -9,7 +9,8 @@ module "sleep_mode" {
   execution_role_arn    = aws_iam_role.execution_role.arn
   subnet_ids            = data.aws_subnet.private[*].id
   task_role_arn         = aws_iam_role.sleep_mode.arn
-  vpc_id                = data.aws_vpc.vpc.id
+  architecture          = "ARM64"
+  os                    = "LINUX"
   security_group_id     = module.sleep_mode_security_group.id
 }
 

--- a/terraform/environment/region/ecs_task_smoke_tests.tf
+++ b/terraform/environment/region/ecs_task_smoke_tests.tf
@@ -77,7 +77,8 @@ module "smoke_tests" {
   execution_role_arn    = aws_iam_role.execution_role.arn
   subnet_ids            = data.aws_subnet.private[*].id
   task_role_arn         = aws_iam_role.smoke_tests.arn
-  vpc_id                = data.aws_vpc.vpc.id
+  architecture          = "ARM64"
+  os                    = "LINUX"
   security_group_id     = module.smoke_tests_security_group.id
 }
 

--- a/terraform/environment/region/modules/disaster_recovery/ecs.tf
+++ b/terraform/environment/region/modules/disaster_recovery/ecs.tf
@@ -7,6 +7,10 @@ resource "aws_ecs_task_definition" "dr_backup" {
   container_definitions    = "[${local.dr_backup}]"
   task_role_arn            = aws_iam_role.dr_backup.arn
   execution_role_arn       = var.execution_role_arn
+  runtime_platform {
+    cpu_architecture        = "ARM64"
+    operating_system_family = "LINUX"
+  }
   tags = merge(var.default_tags,
     { "Role" = "backup-cross-account-${var.environment}" },
   )

--- a/terraform/environment/region/modules/task/main.tf
+++ b/terraform/environment/region/modules/task/main.tf
@@ -7,5 +7,9 @@ resource "aws_ecs_task_definition" "task" {
   container_definitions    = var.container_definitions
   task_role_arn            = var.task_role_arn
   execution_role_arn       = var.execution_role_arn
-  tags                     = var.tags
+  runtime_platform {
+    cpu_architecture        = var.architecture
+    operating_system_family = var.os
+  }
+  tags = var.tags
 }

--- a/terraform/environment/region/modules/task/variables.tf
+++ b/terraform/environment/region/modules/task/variables.tf
@@ -1,8 +1,3 @@
-variable "vpc_id" {
-  description = "The ID of the VPC where the ECS task will be deployed."
-  type        = string
-}
-
 variable "tags" {
   description = "A map of tags to be applied to the ECS resources."
   type        = map(string)
@@ -70,4 +65,16 @@ variable "cpu" {
   description = "The CPU units to allocate to the containers."
   type        = number
   default     = 256
+}
+
+variable "architecture" {
+  description = "Architecture for the task."
+  type        = string
+  default     = "X86_64"
+}
+
+variable "os" {
+  description = "Operating system for the task."
+  type        = string
+  default     = "LINUX"
 }

--- a/terraform/environment/region/modules/task/versions.tf
+++ b/terraform/environment/region/modules/task/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+  required_version = ">= 1.0.0"
+}


### PR DESCRIPTION
Tested building the images without the cache and they build much more respectable time now. I've used native runners instead of QEMU and that seems to help nicely as it doesn't emulate anymore and just builds for the environment that we want. 