### PR TITLE
Improve compatibility with Symfony 6

### DIFF
--- a/api/app/src/Entity/User.php
+++ b/api/app/src/Entity/User.php
@@ -825,7 +825,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this->password;
     }
 
-    public function getRoles()
+    public function getRoles(): array
     {
         return [$this->roleName];
     }
@@ -1494,7 +1494,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      *
      * @see UserInterface
      */
-    public function getUserIdentifier(): ?string
+    public function getUserIdentifier(): string
     {
         return $this->email;
     }

--- a/api/app/src/Repository/UserRepository.php
+++ b/api/app/src/Repository/UserRepository.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Query\ResultSetMappingBuilder;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -311,7 +312,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         return $query->getResult();
     }
 
-    public function upgradePassword(UserInterface $user, string $newEncodedPassword): void
+    public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newEncodedPassword): void
     {
         // set the new encoded password on the User object
         $user->setPassword($newEncodedPassword);

--- a/api/app/src/Security/ClientVoter.php
+++ b/api/app/src/Security/ClientVoter.php
@@ -28,24 +28,15 @@ class ClientVoter extends Voter
         $this->security = $security;
     }
 
-    /**
-     * @param string $attribute
-     * @param mixed  $subject
-     *
-     * @return bool
-     */
-    protected function supports($attribute, $subject)
+    protected function supports(string $attribute, mixed $subject): bool
     {
         return in_array($attribute, [self::VIEW, self::EDIT, self::DELETE]) && $subject instanceof Client;
     }
 
     /**
-     * @param string $attribute
-     * @param Client $client
-     *
-     * @return bool
+     * @param Client $subject
      */
-    protected function voteOnAttribute($attribute, $client, TokenInterface $token)
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
     {
         $user = $token->getUser();
 
@@ -57,7 +48,7 @@ class ClientVoter extends Voter
         switch ($attribute) {
             case self::VIEW:
             case self::EDIT:
-                return $this->canManage($client, $user);
+                return $this->canManage($subject, $user);
             case self::DELETE:
                 return $this->canDelete($user);
 

--- a/api/app/src/Security/OrganisationVoter.php
+++ b/api/app/src/Security/OrganisationVoter.php
@@ -24,24 +24,15 @@ class OrganisationVoter extends Voter
         $this->security = $security;
     }
 
-    /**
-     * @param string $attribute
-     * @param mixed  $subject
-     *
-     * @return bool
-     */
-    protected function supports($attribute, $subject)
+    protected function supports(string $attribute, mixed $subject): bool
     {
         return in_array($attribute, [self::VIEW, self::EDIT]) && $subject instanceof Organisation;
     }
 
     /**
-     * @param string       $attribute
-     * @param Organisation $organisation
-     *
-     * @return bool
+     * @param Organisation $subject
      */
-    protected function voteOnAttribute($attribute, $organisation, TokenInterface $token)
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
     {
         $user = $token->getUser();
 
@@ -53,7 +44,7 @@ class OrganisationVoter extends Voter
         switch ($attribute) {
             case self::VIEW:
             case self::EDIT:
-                return $this->canManage($organisation, $user);
+                return $this->canManage($subject, $user);
 
             default:
                 throw new \LogicException('This code should not be reached!');

--- a/api/app/src/Security/UserVoter.php
+++ b/api/app/src/Security/UserVoter.php
@@ -16,12 +16,8 @@ class UserVoter extends Voter
 
     /**
      * Does this voter support the attribute?
-     *
-     * @param string $attribute
-     *
-     * @return bool
      */
-    protected function supports($attribute, $subject)
+    protected function supports(string $attribute, mixed $subject): bool
     {
         if (!$subject instanceof User) {
             return false;
@@ -39,12 +35,8 @@ class UserVoter extends Voter
 
     /**
      * Vote on whether to grant attribute permission on subject.
-     *
-     * @param string $attribute
-     *
-     * @return bool
      */
-    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
     {
         $loggedInUser = $token->getUser();
         if (!$loggedInUser instanceof User) {

--- a/api/app/tests/Unit/Service/Auth/AuthServiceTest.php
+++ b/api/app/tests/Unit/Service/Auth/AuthServiceTest.php
@@ -146,9 +146,6 @@ class AuthServiceTest extends TestCase
         ]);
         $this->userRepo->shouldReceive('findOneBy')->with(['email' => 'email@example.org'])->andReturn($user);
 
-        $encoder = m::stub('Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface', [
-                'encodePassword(plainPassword,salt)' => 'encodedPassword',
-        ]);
         $this->passwordHasher->shouldReceive('isPasswordValid')->with($user, 'plainPassword')->andReturn(true);
 
         $this->assertEquals($user, $this->authService->getUserByEmailAndPassword('email@example.org', 'plainPassword'));

--- a/api/app/tests/Unit/Service/OrganisationRestHandlerTest.php
+++ b/api/app/tests/Unit/Service/OrganisationRestHandlerTest.php
@@ -14,6 +14,8 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class OrganisationRestHandlerTest extends TestCase
@@ -79,7 +81,7 @@ class OrganisationRestHandlerTest extends TestCase
     public function createValidOrgDetails()
     {
         $this->orgRepository->findOneBy(Argument::any())->willReturn(null);
-        $this->validator->validate(Argument::any())->willReturn([]);
+        $this->validator->validate(Argument::any())->willReturn(new ConstraintViolationList());
         $this->orgFactory->createFromEmailIdentifier(Argument::any(), Argument::any(), Argument::any())->willReturn(new Organisation());
 
         $this->em->persist(Argument::type(Organisation::class))->shouldBeCalled();
@@ -147,7 +149,9 @@ class OrganisationRestHandlerTest extends TestCase
     public function createOrgValidationFails()
     {
         $this->orgRepository->findOneBy(Argument::any())->willReturn(null);
-        $this->validator->validate(Argument::any())->willReturn(['an error']);
+        $this->validator->validate(Argument::any())->willReturn(new ConstraintViolationList([
+            new ConstraintViolation('an error', null, [], null, null, null)
+        ]));
         $this->orgFactory->createFromEmailIdentifier(Argument::any(), Argument::any(), Argument::any())->willReturn(new Organisation());
 
         self::expectException(OrganisationCreationException::class);
@@ -166,7 +170,7 @@ class OrganisationRestHandlerTest extends TestCase
 
         $this->orgRepository->find(Argument::any())->willReturn($originalOrg);
         $this->orgRepository->findOneBy(Argument::any())->willReturn(null);
-        $this->validator->validate(Argument::any())->willReturn([]);
+        $this->validator->validate(Argument::any())->willReturn(new ConstraintViolationList());
 
         $this->em->persist(Argument::type(Organisation::class))->shouldBeCalled();
         $this->em->flush()->shouldBeCalled();
@@ -230,7 +234,9 @@ class OrganisationRestHandlerTest extends TestCase
 
         $this->orgRepository->find(Argument::any())->willReturn($originalOrg);
         $this->orgRepository->findOneBy(Argument::any())->willReturn(null);
-        $this->validator->validate(Argument::any())->willReturn(['an error']);
+        $this->validator->validate(Argument::any())->willReturn(new ConstraintViolationList([
+            new ConstraintViolation('an error', null, [], null, null, null)
+        ]));
 
         self::expectException(OrganisationCreationException::class);
 

--- a/client/app/src/Security/ClientContactVoter.php
+++ b/client/app/src/Security/ClientContactVoter.php
@@ -29,12 +29,8 @@ class ClientContactVoter extends Voter
 
     /**
      * Does this voter support the attribute?
-     *
-     * @param string $attribute
-     *
-     * @return bool
      */
-    protected function supports($attribute, $subject)
+    protected function supports(string $attribute, mixed $subject): bool
     {
         switch ($attribute) {
             case self::ADD_CLIENT_CONTACT:


### PR DESCRIPTION
## Purpose
Update some method signatures to be compatible with Symfony v6

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
