### PR TITLE
DDLS-520 use versions helper for renovate

### DIFF
--- a/.github/workflows/_cycle-secrets.yml
+++ b/.github/workflows/_cycle-secrets.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
 
-      - uses: actions/setup-python@8039c45ed9a312fba91f3399cd0605ba2ebfe93c
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # 5.4.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/_ecr-scanning.yml
+++ b/.github/workflows/_ecr-scanning.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2 # pin@v3
 
       - name: install python
-        uses: actions/setup-python@8039c45ed9a312fba91f3399cd0605ba2ebfe93c # pin@v4.2.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # 5.4.0
         with:
           python-version: "3.10"
           cache: "pip"

--- a/.github/workflows/_run-terraform.yml
+++ b/.github/workflows/_run-terraform.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: unfor19/install-aws-cli-action@27d6061dae5d39e89be4d2246824f15e111a7e06 # pin@v1.0.3
 
-      - uses: actions/setup-python@8039c45ed9a312fba91f3399cd0605ba2ebfe93c
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # 5.4.0
         if: inputs.terraform_path == 'shared'
         with:
           python-version: "3.11"

--- a/.github/workflows/_slack-notification.yml
+++ b/.github/workflows/_slack-notification.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2 # pin@v3
 
       - name: install python
-        uses: actions/setup-python@8039c45ed9a312fba91f3399cd0605ba2ebfe93c # pin@v4.2.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # 5.4.0
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/_tests-miscellaneous.yml
+++ b/.github/workflows/_tests-miscellaneous.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2 # pin@v3
 
-      - uses: actions/setup-python@8039c45ed9a312fba91f3399cd0605ba2ebfe93c
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # 5.4.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/scheduled-disaster-recovery-test.yml
+++ b/.github/workflows/scheduled-disaster-recovery-test.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2 # pin@v3
 
       - name: install python
-        uses: actions/setup-python@8039c45ed9a312fba91f3399cd0605ba2ebfe93c # pin@v4.2.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # 5.4.0
         with:
           python-version: "3.11"
           cache: "pip"
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2 # pin@v3
 
       - name: install python
-        uses: actions/setup-python@8039c45ed9a312fba91f3399cd0605ba2ebfe93c # pin@v4.2.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # 5.4.0
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/scheduled-workspace-cleanup.yml
+++ b/.github/workflows/scheduled-workspace-cleanup.yml
@@ -42,7 +42,7 @@ jobs:
           sudo chmod +x /usr/local/bin/terraform-workspace-manager
 
       - name: install python
-        uses: actions/setup-python@8039c45ed9a312fba91f3399cd0605ba2ebfe93c # pin@v4.2.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # 5.4.0
         with:
           python-version: "3.10"
           cache: "pip"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "schedule:earlyMondays"],
+  "extends": [
+    "config:base",
+    "schedule:earlyMondays",
+    "helpers:pinGitHubActionDigests"
+  ],
   "branchPrefix": "renovate-",
   "commitMessageAction": "Renovate Update",
   "labels": ["Dependencies", "Renovate"],

--- a/terraform/environment/region/cloudwatch_scheduled_events_checks.tf
+++ b/terraform/environment/region/cloudwatch_scheduled_events_checks.tf
@@ -343,7 +343,7 @@ resource "aws_cloudwatch_event_rule" "court_order_csv_processing_check" {
 resource "aws_cloudwatch_event_target" "court_order_csv_processing_check" {
   target_id = "check-org-csv-processing-${terraform.workspace}"
   arn       = data.aws_lambda_function.monitor_notify_lambda.arn
-  rule      = aws_cloudwatch_event_rule.org_csv_processing_check.name
+  rule      = aws_cloudwatch_event_rule.court_order_csv_processing_check.name
   input = jsonencode(
     {
       scheduled-event-detail = {


### PR DESCRIPTION
## Purpose
only use shas that have attached release rather than just commit to main in renovate.

Fixes DDLS-520

## Approach
Add helper and manually do the python helper.

## Learning
[_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_
](https://docs.renovatebot.com/presets-helpers/)

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
