### PR TITLE
DDLS-524 make logout eventlistener

### DIFF
--- a/.github/workflows/_cycle-secrets.yml
+++ b/.github/workflows/_cycle-secrets.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # 5.4.0
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/_ecr-scanning.yml
+++ b/.github/workflows/_ecr-scanning.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: install python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # 5.4.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.10"
           cache: "pip"

--- a/.github/workflows/_run-terraform.yml
+++ b/.github/workflows/_run-terraform.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: unfor19/install-aws-cli-action@e8b481e524a99f37fbd39fdc1dcb3341ab091367 # v1
 
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # 5.4.0
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         if: inputs.terraform_path == 'shared'
         with:
           python-version: "3.11"

--- a/.github/workflows/_slack-notification.yml
+++ b/.github/workflows/_slack-notification.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: install python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # 5.4.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/_tests-miscellaneous.yml
+++ b/.github/workflows/_tests-miscellaneous.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # 5.4.0
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/scheduled-disaster-recovery-test.yml
+++ b/.github/workflows/scheduled-disaster-recovery-test.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: install python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # 5.4.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.11"
           cache: "pip"
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: install python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # 5.4.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.11"
           cache: "pip"

--- a/.github/workflows/scheduled-workspace-cleanup.yml
+++ b/.github/workflows/scheduled-workspace-cleanup.yml
@@ -42,7 +42,7 @@ jobs:
           sudo chmod +x /usr/local/bin/terraform-workspace-manager
 
       - name: install python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # 5.4.0
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.10"
           cache: "pip"

--- a/client/app/config/packages/security.yml
+++ b/client/app/config/packages/security.yml
@@ -86,10 +86,6 @@ security:
         - App\Security\SessionAuthenticator
       logout:
         path: app_logout
-        target: /
-        success_handler: logout_listener
-        # needed to save custom login params
-        invalidate_session: false
 
   access_control:
     # /admin accessible only from ADMIN, super users and AD users

--- a/client/app/config/services.yml
+++ b/client/app/config/services.yml
@@ -290,9 +290,22 @@ services:
           method: onKernelRequest,
         }
 
-  logout_listener:
-    class: App\EventListener\LogoutListener
+  App\EventListener\AuthenticationHandler:
+    tags:
+      - {
+          name: kernel.event_listener,
+          event: security.authentication.failure,
+          method: onAuthenticationFailure,
+        }
+
+  App\EventListener\LogoutListener:
     arguments: ["@security.token_storage", "@rest_client", "@router"]
+    tags:
+      - {
+          name: kernel.event_listener,
+          event: security.logout,
+          method: onLogout,
+        }
 
   App\EventListener\ResponseNoCacheListener:
     tags:

--- a/client/app/src/Controller/IndexController.php
+++ b/client/app/src/Controller/IndexController.php
@@ -203,7 +203,7 @@ class IndexController extends AbstractController
     /**
      * @Route("/logout", name="app_logout")
      */
-    public function logoutAction(Request $request)
+    public function logout()
     {
         // Handled as automatically as part of Symfony security component
     }

--- a/client/app/src/EventListener/AuthenticationHandler.php
+++ b/client/app/src/EventListener/AuthenticationHandler.php
@@ -2,25 +2,18 @@
 
 namespace App\EventListener;
 
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
-use Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface;
 
-class AuthenticationHandler implements AuthenticationFailureHandlerInterface, LogoutSuccessHandlerInterface
+class AuthenticationHandler implements AuthenticationFailureHandlerInterface
 {
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
         $referer = $request->headers->get('referer');
-        $request->getSession()->setFlash('error', $exception->getMessage());
+        $request->getSession()->getFlashBag()->add('error', $exception->getMessage());
 
         return new RedirectResponse($referer);
-    }
-
-    public function onLogoutSuccess(Request $request)
-    {
-        $request->getSession()->set('fromLogoutPage', 1);
-
-        return new RedirectResponse('/login');
     }
 }

--- a/client/app/src/EventListener/LogoutListener.php
+++ b/client/app/src/EventListener/LogoutListener.php
@@ -4,28 +4,16 @@ namespace App\EventListener;
 
 use App\Service\Client\RestClientInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
-use Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
 
-class LogoutListener implements LogoutSuccessHandlerInterface
+class LogoutListener
 {
-    /**
-     * @var TokenStorageInterface
-     */
-    private $tokenStorage;
-
-    /**
-     * @var RouterInterface
-     */
-    private $router;
-
-    /**
-     * @var RestClientInterface
-     */
-    private $restClient;
+    private TokenStorageInterface $tokenStorage;
+    private RestClientInterface $restClient;
+    private RouterInterface $router;
 
     public function __construct(TokenStorageInterface $tokenStorage, RestClientInterface $restClient, RouterInterface $router)
     {
@@ -34,22 +22,24 @@ class LogoutListener implements LogoutSuccessHandlerInterface
         $this->router = $router;
     }
 
-    public function onLogoutSuccess(Request $request)
+    public function onLogout(LogoutEvent $event): void
     {
+        $request = $event->getRequest();
+
+        // Handle token-based logout
         if ($this->tokenStorage->getToken() instanceof UsernamePasswordToken) {
             $this->restClient->logout();
         }
 
+        // Handle session value setting (merged from AuthenticationHandler)
         $notPrimaryAccount = $request->query->get('notPrimaryAccount');
 
         if (!$notPrimaryAccount) {
             $request->getSession()->set('loggedOutFrom', 'logoutPage');
         }
 
-        return new RedirectResponse(
-            $this->router->generate(
-                'login'
-            )
-        );
+        // Set the redirect response
+        $response = new RedirectResponse($this->router->generate('login'));
+        $event->setResponse($response);
     }
 }

--- a/client/app/tests/phpunit/phpunit.xml
+++ b/client/app/tests/phpunit/phpunit.xml
@@ -49,7 +49,7 @@
         <env name="PACT_CONSUMER_NAME" value="Complete the deputy report"/>
         <env name="PACT_PROVIDER_NAME" value="OPG Data"/>
         <env name="KERNEL_CLASS" value="App\Kernel"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
     </php>
     <listeners>
         <listener class="App\Pact\Listener\PactTestListener" file="./Pact/Listener/PactTestListener.php">


### PR DESCRIPTION
## Purpose
Part of symfony upgrade
Fixes DDLS-524

## Approach
So there was a logout method in here: AuthenticationHandler which I don't think was being used. I made this listener explicit in services.yml as the other listeners are and removed the logout bit from it.

Now we basically have a logout controller that has nothing in it and an event listener that does all the gubbins it did before. The security.yml wires it up by just having app_logout in it as per the docs.  In the docs it also used a subscriber but it says listener or subscriber are fine so I just kept it as listener.

Also not part of this PR but something I overlooked before was the actions versions for python have the v prefix so adding that in here too.

## Learning
[_symfony
](https://symfony.com/doc/6.0/security.html)

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
