### PR TITLE
Constructor property promotion Api remaining

### DIFF
--- a/api/app/phpstan-baseline.neon
+++ b/api/app/phpstan-baseline.neon
@@ -61,11 +61,6 @@ parameters:
 			path: src/Command/ReportStatusUpdaterCommand.php
 
 		-
-			message: "#^Property App\\\\Command\\\\ReportStatusUpdaterCommand\\:\\:\\$entityManager has no type specified\\.$#"
-			count: 1
-			path: src/Command/ReportStatusUpdaterCommand.php
-
-		-
 			message: "#^Right side of && is always true\\.$#"
 			count: 1
 			path: src/Command/ReportStatusUpdaterCommand.php
@@ -8776,16 +8771,6 @@ parameters:
 			path: src/EventListener/FixDefaultSchemaListener.php
 
 		-
-			message: "#^Method App\\\\EventListener\\\\RestInputOuputFormatter\\:\\:__construct\\(\\) has parameter \\$debug with no type specified\\.$#"
-			count: 1
-			path: src/EventListener/RestInputOuputFormatter.php
-
-		-
-			message: "#^Method App\\\\EventListener\\\\RestInputOuputFormatter\\:\\:__construct\\(\\) has parameter \\$defaultFormat with no type specified\\.$#"
-			count: 1
-			path: src/EventListener/RestInputOuputFormatter.php
-
-		-
 			message: "#^Method App\\\\EventListener\\\\RestInputOuputFormatter\\:\\:addContextModifier\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/EventListener/RestInputOuputFormatter.php
@@ -9034,16 +9019,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$subject of function preg_match expects string, mixed given\\.$#"
 			count: 1
 			path: src/Logger/OpgLineFormatter.php
-
-		-
-			message: "#^Property App\\\\Migrations\\\\Factory\\\\MigrationFactoryDecorator\\:\\:\\$container has no type specified\\.$#"
-			count: 1
-			path: src/Migrations/Factory/MigrationFactoryDecorator.php
-
-		-
-			message: "#^Property App\\\\Migrations\\\\Factory\\\\MigrationFactoryDecorator\\:\\:\\$migrationFactory has no type specified\\.$#"
-			count: 1
-			path: src/Migrations/Factory/MigrationFactoryDecorator.php
 
 		-
 			message: "#^Cannot call method get\\(\\) on Symfony\\\\Component\\\\DependencyInjection\\\\ContainerInterface\\|null\\.$#"
@@ -9726,11 +9701,6 @@ parameters:
 			path: src/Repository/UserRepository.php
 
 		-
-			message: "#^Property App\\\\Repository\\\\UserRepository\\:\\:\\$serializer is never read, only written\\.$#"
-			count: 1
-			path: src/Repository/UserRepository.php
-
-		-
 			message: "#^Class App\\\\Repository\\\\UserResearchResponseRepository extends generic class Doctrine\\\\Bundle\\\\DoctrineBundle\\\\Repository\\\\ServiceEntityRepository but does not specify its types\\: T$#"
 			count: 1
 			path: src/Repository/UserResearchResponseRepository.php
@@ -9807,11 +9777,6 @@ parameters:
 
 		-
 			message: "#^Property App\\\\Security\\\\RedisUserProvider\\:\\:\\$em is never read, only written\\.$#"
-			count: 1
-			path: src/Security/RedisUserProvider.php
-
-		-
-			message: "#^Property App\\\\Security\\\\RedisUserProvider\\:\\:\\$options is never read, only written\\.$#"
 			count: 1
 			path: src/Security/RedisUserProvider.php
 

--- a/api/app/src/Command/ProcessOrgCSVCommand.php
+++ b/api/app/src/Command/ProcessOrgCSVCommand.php
@@ -80,10 +80,10 @@ class ProcessOrgCSVCommand extends Command
     private OutputInterface $cliOutput;
 
     public function __construct(
-        private S3Client $s3,
-        private ParameterBagInterface $params,
-        private LoggerInterface $verboseLogger,
-        private CSVDeputyshipProcessing $csvProcessing,
+        private readonly S3Client $s3,
+        private readonly ParameterBagInterface $params,
+        private readonly LoggerInterface $verboseLogger,
+        private readonly CSVDeputyshipProcessing $csvProcessing,
     ) {
         parent::__construct();
     }

--- a/api/app/src/Command/ReportStatusUpdaterCommand.php
+++ b/api/app/src/Command/ReportStatusUpdaterCommand.php
@@ -19,12 +19,8 @@ class ReportStatusUpdaterCommand extends Command
 {
     use ContainerAwareTrait;
 
-    private $entityManager;
-
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(private EntityManagerInterface $entityManager)
     {
-        $this->entityManager = $entityManager;
-
         parent::__construct();
     }
 
@@ -39,13 +35,13 @@ class ReportStatusUpdaterCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $limit = $input->getOption('limit');
-        $em = $this->entityManager; /* @var $em EntityManager */
+        $em = $this->entityManager;
 
         $chunkSize = 10;
 
         $output->write("Updating report status for next $limit reports: ");
         for ($i = 0, $continue = true; $i < $limit && $continue; $i += $chunkSize) {
-            /* @var $reports Report[] */
+            /** @var Report[] $reports */
             $reports = $em->getRepository(Report::class)
                 ->createQueryBuilder('r')
                 ->select('r')
@@ -61,7 +57,6 @@ class ReportStatusUpdaterCommand extends Command
             }
             foreach ($reports as $report) {
                 $report->setSectionStatusesCached([]);
-                /* @var $report Report */
                 $report->updateSectionsStatusCache($report->getAvailableSections());
             }
 

--- a/api/app/src/Command/ResyncResubmittableErrorChecklists.php
+++ b/api/app/src/Command/ResyncResubmittableErrorChecklists.php
@@ -11,13 +11,8 @@ class ResyncResubmittableErrorChecklists extends Command
 {
     protected static $defaultName = 'digideps:resync-resubmittable-error-checklists';
 
-    /** @var ChecklistRepository */
-    private $checklistRepository;
-
-    public function __construct(ChecklistRepository $checklistRepository)
+    public function __construct(private readonly ChecklistRepository $checklistRepository)
     {
-        $this->checklistRepository = $checklistRepository;
-
         parent::__construct();
     }
 

--- a/api/app/src/Command/ResyncResubmittableErrorDocuments.php
+++ b/api/app/src/Command/ResyncResubmittableErrorDocuments.php
@@ -11,13 +11,8 @@ class ResyncResubmittableErrorDocuments extends Command
 {
     protected static $defaultName = 'digideps:resync-resubmittable-error-documents';
 
-    /** @var DocumentRepository */
-    private $documentRepository;
-
-    public function __construct(DocumentRepository $documentRepository)
+    public function __construct(private readonly DocumentRepository $documentRepository)
     {
-        $this->documentRepository = $documentRepository;
-
         parent::__construct();
     }
 

--- a/api/app/src/Command/SatisfactionPerformanceStatsCommand.php
+++ b/api/app/src/Command/SatisfactionPerformanceStatsCommand.php
@@ -12,17 +12,10 @@ class SatisfactionPerformanceStatsCommand extends Command
 {
     public static $defaultName = 'digideps:satisfaction-performance-stats';
 
-    /** @var EntityManagerInterface */
-    private $em;
-
-    /** @var S3SatisfactionDataStorage */
-    private $s3SatisfactionDataStorage;
-
-    public function __construct(EntityManagerInterface $em, S3SatisfactionDataStorage $s3SatisfactionDataStorage)
-    {
-        $this->em = $em;
-        $this->s3SatisfactionDataStorage = $s3SatisfactionDataStorage;
-
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly S3SatisfactionDataStorage $s3SatisfactionDataStorage
+    ) {
         parent::__construct();
     }
 

--- a/api/app/src/Command/UserCleanupCommand.php
+++ b/api/app/src/Command/UserCleanupCommand.php
@@ -13,17 +13,10 @@ class UserCleanupCommand extends Command
 {
     protected static $defaultName = 'digideps:delete-zero-activity-users';
 
-    /** @var EntityManagerInterface */
-    private $em;
-
-    /** @var UserRepository */
-    private $userRepository;
-
-    public function __construct(EntityManagerInterface $em, UserRepository $userRepository)
-    {
-        $this->em = $em;
-        $this->userRepository = $userRepository;
-
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly UserRepository $userRepository
+    ) {
         parent::__construct();
     }
 

--- a/api/app/src/DBAL/ConnectionWrapper.php
+++ b/api/app/src/DBAL/ConnectionWrapper.php
@@ -25,7 +25,7 @@ class ConnectionWrapper extends Connection
      * @var array|mixed[]
      */
     private array $params;
-    private bool $autoCommit;
+    private readonly bool $autoCommit;
     private SecretsManagerClient $secretClient;
 
     public function __construct(

--- a/api/app/src/DataFixtures/PAUserFixtures.php
+++ b/api/app/src/DataFixtures/PAUserFixtures.php
@@ -143,9 +143,9 @@ class PAUserFixtures extends AbstractDataFixture
     ];
 
     public function __construct(
-        private OrganisationRepository $orgRepository,
-        private OrganisationFactory $orgFactory,
-        private DeputyRepository $deputyRepository
+        private readonly OrganisationRepository $orgRepository,
+        private readonly OrganisationFactory $orgFactory,
+        private readonly DeputyRepository $deputyRepository
     ) {
     }
 

--- a/api/app/src/DataFixtures/ProfUserFixtures.php
+++ b/api/app/src/DataFixtures/ProfUserFixtures.php
@@ -143,9 +143,9 @@ class ProfUserFixtures extends AbstractDataFixture
     ];
 
     public function __construct(
-        private OrganisationRepository $orgRepository,
-        private OrganisationFactory $orgFactory,
-        private DeputyRepository $deputyRepository
+        private readonly OrganisationRepository $orgRepository,
+        private readonly OrganisationFactory $orgFactory,
+        private readonly DeputyRepository $deputyRepository
     ) {
     }
 

--- a/api/app/src/DataFixtures/UserPasswordFixtures.php
+++ b/api/app/src/DataFixtures/UserPasswordFixtures.php
@@ -9,7 +9,7 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 class UserPasswordFixtures extends AbstractDataFixture implements OrderedFixtureInterface
 {
-    public function __construct(private UserPasswordHasherInterface $passwordHasher)
+    public function __construct(private readonly UserPasswordHasherInterface $passwordHasher)
     {
     }
 

--- a/api/app/src/EventDispatcher/ObservableEventDispatcher.php
+++ b/api/app/src/EventDispatcher/ObservableEventDispatcher.php
@@ -9,17 +9,11 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class ObservableEventDispatcher
 {
-    /**
-     * @var EventDispatcherInterface
-     */
-    private $dispatcher;
-
     /** @var array */
     private $dispatchedEvents = [];
 
-    public function __construct(EventDispatcherInterface $dispatcher)
+    public function __construct(private readonly EventDispatcherInterface $dispatcher)
     {
-        $this->dispatcher = $dispatcher;
     }
 
     public function dispatch(Event $event, string $eventName)

--- a/api/app/src/EventListener/RestInputOuputFormatter.php
+++ b/api/app/src/EventListener/RestInputOuputFormatter.php
@@ -18,29 +18,9 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class RestInputOuputFormatter
 {
     /**
-     * @var SerializerInterface
-     */
-    private $serializer;
-
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
-     * @var string
-     */
-    private $defaultFormat;
-
-    /**
      * @var array
      */
     private $supportedFormats;
-
-    /**
-     * @var bool
-     */
-    private $debug;
 
     /**
      * @var \Closure[]
@@ -52,13 +32,14 @@ class RestInputOuputFormatter
      */
     private $contextModifiers = [];
 
-    public function __construct(SerializerInterface $serializer, LoggerInterface $logger, array $supportedFormats, $defaultFormat, $debug)
-    {
-        $this->serializer = $serializer;
-        $this->logger = $logger;
+    public function __construct(
+        private readonly SerializerInterface $serializer,
+        private readonly LoggerInterface $logger,
+        array $supportedFormats,
+        private readonly string $defaultFormat,
+        private readonly bool $debug
+    ) {
         $this->supportedFormats = array_values($supportedFormats);
-        $this->defaultFormat = $defaultFormat;
-        $this->debug = $debug;
     }
 
     /**
@@ -214,7 +195,7 @@ class RestInputOuputFormatter
             xdebug_disable();
         }
 
-        register_shutdown_function(function () {
+        register_shutdown_function(function (): void {
             $lastError = error_get_last();
             if (!$lastError) {
                 return;

--- a/api/app/src/EventSubscriber/ClientArchivedSubscriber.php
+++ b/api/app/src/EventSubscriber/ClientArchivedSubscriber.php
@@ -12,16 +12,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ClientArchivedSubscriber implements EventSubscriberInterface
 {
-    /** @var LoggerInterface */
-    private $logger;
-
-    /** @var DateTimeProvider */
-    private $dateTimeProvider;
-
-    public function __construct(LoggerInterface $logger, DateTimeProvider $dateTimeProvider)
-    {
-        $this->logger = $logger;
-        $this->dateTimeProvider = $dateTimeProvider;
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly DateTimeProvider $dateTimeProvider
+    ) {
     }
 
     public static function getSubscribedEvents()

--- a/api/app/src/EventSubscriber/UserRetentionPolicyCommandSubscriber.php
+++ b/api/app/src/EventSubscriber/UserRetentionPolicyCommandSubscriber.php
@@ -13,8 +13,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class UserRetentionPolicyCommandSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private LoggerInterface $logger,
-        private DateTimeProvider $dateTimeProvider
+        private readonly LoggerInterface $logger,
+        private readonly DateTimeProvider $dateTimeProvider
     ) {
     }
 

--- a/api/app/src/Factory/ClientBenefitsCheckFactory.php
+++ b/api/app/src/Factory/ClientBenefitsCheckFactory.php
@@ -17,15 +17,11 @@ use Ramsey\Uuid\Uuid;
 
 class ClientBenefitsCheckFactory
 {
-    private ReportRepository $reportRepository;
-    private NdrRepository $ndrRepository;
-    private EntityManagerInterface $em;
-
-    public function __construct(ReportRepository $reportRepository, NdrRepository $ndrRepository, EntityManagerInterface $em)
-    {
-        $this->reportRepository = $reportRepository;
-        $this->ndrRepository = $ndrRepository;
-        $this->em = $em;
+    public function __construct(
+        private readonly ReportRepository $reportRepository,
+        private readonly NdrRepository $ndrRepository,
+        private readonly EntityManagerInterface $em
+    ) {
     }
 
     public function createFromFormData(array $formData, string $reportOrNdr, ClientBenefitsCheckInterface $existingEntity = null)

--- a/api/app/src/Factory/OrganisationFactory.php
+++ b/api/app/src/Factory/OrganisationFactory.php
@@ -8,12 +8,8 @@ use App\Entity\Organisation;
 
 class OrganisationFactory
 {
-    /** @var array */
-    private $sharedDomains = [];
-
-    public function __construct(array $sharedDomains)
+    public function __construct(private readonly array $sharedDomains)
     {
-        $this->sharedDomains = $sharedDomains;
     }
 
     public function createFromFullEmail(string $name, string $email, bool $isActivated = false): Organisation

--- a/api/app/src/FixtureFactory/LoadTestFactory.php
+++ b/api/app/src/FixtureFactory/LoadTestFactory.php
@@ -11,11 +11,8 @@ use Doctrine\ORM\EntityManagerInterface;
 
 class LoadTestFactory
 {
-    private EntityManagerInterface $em;
-
-    public function __construct(EntityManagerInterface $em)
+    public function __construct(private readonly EntityManagerInterface $em)
     {
-        $this->em = $em;
     }
 
     /**

--- a/api/app/src/FixtureFactory/PreRegistrationFactory.php
+++ b/api/app/src/FixtureFactory/PreRegistrationFactory.php
@@ -10,7 +10,7 @@ use App\v2\Registration\SelfRegistration\Factory\PreRegistrationFactory as PreRe
 
 class PreRegistrationFactory
 {
-    public function __construct(private PreRegistrationDTOFactory $preRegistrationFactory)
+    public function __construct(private readonly PreRegistrationDTOFactory $preRegistrationFactory)
     {
     }
 

--- a/api/app/src/FixtureFactory/ReportFactory.php
+++ b/api/app/src/FixtureFactory/ReportFactory.php
@@ -9,12 +9,8 @@ use App\v2\Fixture\ReportSection;
 
 class ReportFactory
 {
-    /** @var ReportSection */
-    private $reportSection;
-
-    public function __construct(ReportSection $reportSection)
+    public function __construct(private readonly ReportSection $reportSection)
     {
-        $this->reportSection = $reportSection;
     }
 
     /**

--- a/api/app/src/FixtureFactory/UserFactory.php
+++ b/api/app/src/FixtureFactory/UserFactory.php
@@ -10,7 +10,7 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 class UserFactory
 {
-    public function __construct(private UserPasswordHasherInterface $passwordHasher)
+    public function __construct(private readonly UserPasswordHasherInterface $passwordHasher)
     {
     }
 

--- a/api/app/src/Migrations/Factory/MigrationFactoryDecorator.php
+++ b/api/app/src/Migrations/Factory/MigrationFactoryDecorator.php
@@ -9,13 +9,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class MigrationFactoryDecorator implements MigrationFactory
 {
-    private $migrationFactory;
-    private $container;
-
-    public function __construct(MigrationFactory $migrationFactory, ContainerInterface $container)
+    public function __construct(private readonly MigrationFactory $migrationFactory, private readonly ContainerInterface $container)
     {
-        $this->migrationFactory = $migrationFactory;
-        $this->container = $container;
     }
 
     public function createVersion(string $migrationClassName): AbstractMigration

--- a/api/app/src/Repository/ClientRepository.php
+++ b/api/app/src/Repository/ClientRepository.php
@@ -11,13 +11,9 @@ use Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter;
 
 class ClientRepository extends ServiceEntityRepository
 {
-    /** @var ClientSearchFilter */
-    private $filter;
-
-    public function __construct(ManagerRegistry $registry, ClientSearchFilter $filter)
+    public function __construct(ManagerRegistry $registry, private readonly ClientSearchFilter $filter)
     {
         parent::__construct($registry, Client::class);
-        $this->filter = $filter;
     }
 
     /**

--- a/api/app/src/Repository/ReportRepository.php
+++ b/api/app/src/Repository/ReportRepository.php
@@ -22,16 +22,12 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 
 class ReportRepository extends ServiceEntityRepository
 {
-    /** @var ClientSearchFilter */
-    private $filter;
-
     public const USER_DETERMINANT = 1;
     public const ORG_DETERMINANT = 2;
 
-    public function __construct(ManagerRegistry $registry, ClientSearchFilter $filter)
+    public function __construct(ManagerRegistry $registry, private readonly ClientSearchFilter $filter)
     {
         parent::__construct($registry, Report::class);
-        $this->filter = $filter;
     }
 
     /**

--- a/api/app/src/Repository/UserRepository.php
+++ b/api/app/src/Repository/UserRepository.php
@@ -12,15 +12,13 @@ use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
-use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Serializer\SerializerInterface;
 
 class UserRepository extends ServiceEntityRepository implements PasswordUpgraderInterface
 {
     /** @var QueryBuilder */
     private $qb;
 
-    public function __construct(ManagerRegistry $registry, private SerializerInterface $serializer)
+    public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, User::class);
     }

--- a/api/app/src/Security/ClientVoter.php
+++ b/api/app/src/Security/ClientVoter.php
@@ -20,12 +20,8 @@ class ClientVoter extends Voter
     /** @var string */
     public const DELETE = 'delete';
 
-    /** @var Security */
-    private $security;
-
-    public function __construct(Security $security)
+    public function __construct(private readonly Security $security)
     {
-        $this->security = $security;
     }
 
     protected function supports(string $attribute, mixed $subject): bool

--- a/api/app/src/Security/HeaderTokenAuthenticator.php
+++ b/api/app/src/Security/HeaderTokenAuthenticator.php
@@ -26,9 +26,9 @@ class HeaderTokenAuthenticator extends AbstractAuthenticator
     public const HEADER_NAME = 'AuthToken';
 
     public function __construct(
-        private Client $redis,
-        private UserRepository $userRepository,
-        private LoggerInterface $logger
+        private readonly Client $redis,
+        private readonly UserRepository $userRepository,
+        private readonly LoggerInterface $logger
     ) {
     }
 

--- a/api/app/src/Security/LoginRequestAuthenticator.php
+++ b/api/app/src/Security/LoginRequestAuthenticator.php
@@ -28,13 +28,13 @@ class LoginRequestAuthenticator extends AbstractAuthenticator
     private string $bruteForceKey = '';
 
     public function __construct(
-        private UserRepository $userRepository,
-        private AttemptsInTimeChecker $attemptsInTimechecker,
-        private AttemptsIncrementalWaitingChecker $incrementalWaitingTimechecker,
-        private AuthService $authService,
-        private TokenStorageInterface $tokenStorage,
-        private LoggerInterface $logger,
-        private DateTimeProvider $dateTimeProvider
+        private readonly UserRepository $userRepository,
+        private readonly AttemptsInTimeChecker $attemptsInTimechecker,
+        private readonly AttemptsIncrementalWaitingChecker $incrementalWaitingTimechecker,
+        private readonly AuthService $authService,
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly LoggerInterface $logger,
+        private readonly DateTimeProvider $dateTimeProvider
     ) {
     }
 

--- a/api/app/src/Security/OrganisationVoter.php
+++ b/api/app/src/Security/OrganisationVoter.php
@@ -16,12 +16,8 @@ class OrganisationVoter extends Voter
     /** @var string */
     public const EDIT = 'edit';
 
-    /** @var Security */
-    private $security;
-
-    public function __construct(Security $security)
+    public function __construct(private readonly Security $security)
     {
-        $this->security = $security;
     }
 
     protected function supports(string $attribute, mixed $subject): bool

--- a/api/app/src/Security/RedisUserProvider.php
+++ b/api/app/src/Security/RedisUserProvider.php
@@ -17,15 +17,15 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
  */
 class RedisUserProvider implements UserProviderInterface, PasswordUpgraderInterface
 {
-    private mixed $timeoutSeconds;
+    private readonly mixed $timeoutSeconds;
 
     public function __construct(
-        private EntityManagerInterface $em,
-        private Client $redis,
-        private LoggerInterface $logger,
-        private array $options,
-        private UserRepository $userRepository,
-        private string $workspace
+        private readonly EntityManagerInterface $em,
+        private readonly Client $redis,
+        private readonly LoggerInterface $logger,
+        readonly array $options,
+        private readonly UserRepository $userRepository,
+        private readonly string $workspace
     ) {
         $this->timeoutSeconds = $options['timeout_seconds'];
     }

--- a/api/app/src/Security/RegistrationTokenAuthenticator.php
+++ b/api/app/src/Security/RegistrationTokenAuthenticator.php
@@ -27,11 +27,11 @@ class RegistrationTokenAuthenticator extends AbstractAuthenticator
     private string $bruteForceKey = '';
 
     public function __construct(
-        private UserRepository $userRepository,
-        private TokenStorageInterface $tokenStorage,
-        private AuthService $authService,
-        private AttemptsInTimeChecker $attemptsInTimeChecker,
-        private AttemptsIncrementalWaitingChecker $incrementalWaitingTimeChecker,
+        private readonly UserRepository $userRepository,
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly AuthService $authService,
+        private readonly AttemptsInTimeChecker $attemptsInTimeChecker,
+        private readonly AttemptsIncrementalWaitingChecker $incrementalWaitingTimeChecker,
     ) {
     }
 

--- a/api/app/src/Transformer/ReportSubmission/ReportSubmissionSummaryTransformer.php
+++ b/api/app/src/Transformer/ReportSubmission/ReportSubmissionSummaryTransformer.php
@@ -8,12 +8,8 @@ use App\Service\DateTimeProvider;
 
 class ReportSubmissionSummaryTransformer
 {
-    /** @var DateTimeProvider */
-    private $dateTimeProvider;
-
-    public function __construct(DateTimeProvider $dateTimeProvider)
+    public function __construct(private readonly DateTimeProvider $dateTimeProvider)
     {
-        $this->dateTimeProvider = $dateTimeProvider;
     }
 
     /**


### PR DESCRIPTION
Apply Rector ClassPropertyAssignToConstructorPromotionRector and ReadOnlyPropertyRector rules on App\;
- Command
- DataFixtures
- DBAL
- EventDispatcher
- EventListener
- EventSubscriber
- Factory
- FixtureFactory
- Migrations\Factory
- Repository
- Security
- Transformer

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
