### PR TITLE
Remove calls to deprecated AbstractController->getRepository

### DIFF
--- a/api/app/phpstan-baseline.neon
+++ b/api/app/phpstan-baseline.neon
@@ -121,16 +121,6 @@ parameters:
 			path: src/Controller/AuthController.php
 
 		-
-			message: "#^Call to an undefined method object\\:\\:getClient\\(\\)\\.$#"
-			count: 3
-			path: src/Controller/ClientContactController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/ClientContactController.php
-
-		-
 			message: "#^Method App\\\\Controller\\\\ClientContactController\\:\\:add\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Controller/ClientContactController.php
@@ -176,16 +166,6 @@ parameters:
 			path: src/Controller/ClientContactController.php
 
 		-
-			message: "#^Parameter \\#1 \\$client of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfClientDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\Client, object given\\.$#"
-			count: 1
-			path: src/Controller/ClientContactController.php
-
-		-
-			message: "#^Parameter \\#1 \\$client of method App\\\\Entity\\\\ClientContact\\:\\:setClient\\(\\) expects App\\\\Entity\\\\Client, object given\\.$#"
-			count: 1
-			path: src/Controller/ClientContactController.php
-
-		-
 			message: "#^Parameter \\#1 \\$createdBy of method App\\\\Entity\\\\ClientContact\\:\\:setCreatedBy\\(\\) expects App\\\\Entity\\\\User, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
 			count: 1
 			path: src/Controller/ClientContactController.php
@@ -194,46 +174,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$data of method App\\\\Controller\\\\RestController\\:\\:hydrateEntityWithArrayData\\(\\) expects array, array\\|null given\\.$#"
 			count: 2
 			path: src/Controller/ClientContactController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getArchivedAt\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/ClientController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 6
-			path: src/Controller/ClientController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getNdr\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/ClientController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setArchivedAt\\(\\)\\.$#"
-			count: 2
-			path: src/Controller/ClientController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setCourtDate\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/ClientController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setDateOfBirth\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/ClientController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setDeletedAt\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/ClientController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setDeputy\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/ClientController.php
 
 		-
 			message: "#^Cannot call method getUser\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\TokenInterface\\|null\\.$#"
@@ -286,18 +226,13 @@ parameters:
 			path: src/Controller/ClientController.php
 
 		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: src/Controller/ClientController.php
+
+		-
 			message: "#^Offset 'case_number' does not exist on array\\|null\\.$#"
 			count: 3
-			path: src/Controller/ClientController.php
-
-		-
-			message: "#^Parameter \\#1 \\$client of class App\\\\Entity\\\\Ndr\\\\Ndr constructor expects App\\\\Entity\\\\Client, object given\\.$#"
-			count: 1
-			path: src/Controller/ClientController.php
-
-		-
-			message: "#^Parameter \\#1 \\$client of class App\\\\Event\\\\ClientArchivedEvent constructor expects App\\\\Entity\\\\Client, object given\\.$#"
-			count: 1
 			path: src/Controller/ClientController.php
 
 		-
@@ -331,37 +266,12 @@ parameters:
 			path: src/Controller/ClientController.php
 
 		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: src/Controller/ClientController.php
+
+		-
 			message: "#^Argument of an invalid type array\\|string supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: src/Controller/CoDeputyController.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:createQueryBuilder\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/CoDeputyController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getIdOfClientWithDetails\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/CoDeputyController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:isCoDeputy\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/CoDeputyController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setEmail\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/CoDeputyController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setFirstname\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/CoDeputyController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setLastname\\(\\)\\.$#"
 			count: 1
 			path: src/Controller/CoDeputyController.php
 
@@ -416,17 +326,7 @@ parameters:
 			path: src/Controller/CoDeputyController.php
 
 		-
-			message: "#^Parameter \\#1 \\$originalUser of method App\\\\Service\\\\UserService\\:\\:editUser\\(\\) expects App\\\\Entity\\\\User, object given\\.$#"
-			count: 1
-			path: src/Controller/CoDeputyController.php
-
-		-
 			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\|string given\\.$#"
-			count: 1
-			path: src/Controller/CoDeputyController.php
-
-		-
-			message: "#^Parameter \\#2 \\$updatedUser of method App\\\\Service\\\\UserService\\:\\:editUser\\(\\) expects App\\\\Entity\\\\User, object given\\.$#"
 			count: 1
 			path: src/Controller/CoDeputyController.php
 
@@ -451,17 +351,7 @@ parameters:
 			path: src/Controller/DeputyController.php
 
 		-
-			message: "#^Call to an undefined method object\\:\\:query\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/HealthController.php
-
-		-
 			message: "#^Method App\\\\Controller\\\\HealthController\\:\\:containerHealthAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/HealthController.php
-
-		-
-			message: "#^Property App\\\\Controller\\\\HealthController\\:\\:\\$restFormatter is never read, only written\\.$#"
 			count: 1
 			path: src/Controller/HealthController.php
 
@@ -469,16 +359,6 @@ parameters:
 			message: "#^Property App\\\\Controller\\\\JWTController\\:\\:\\$authService is never read, only written\\.$#"
 			count: 1
 			path: src/Controller/JWTController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AccountController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getNdr\\(\\)\\.$#"
-			count: 3
-			path: src/Controller/Ndr/AccountController.php
 
 		-
 			message: "#^Method App\\\\Controller\\\\Ndr\\\\AccountController\\:\\:accountDelete\\(\\) has no return type specified\\.$#"
@@ -526,22 +406,7 @@ parameters:
 			path: src/Controller/Ndr/AccountController.php
 
 		-
-			message: "#^Parameter \\#1 \\$account of method App\\\\Controller\\\\Ndr\\\\AccountController\\:\\:fillAccountData\\(\\) expects App\\\\Entity\\\\Ndr\\\\BankAccount, object given\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AccountController.php
-
-		-
 			message: "#^Parameter \\#1 \\$bank of method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:setBank\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AccountController.php
-
-		-
-			message: "#^Parameter \\#1 \\$ndr of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfNdrDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\Ndr\\\\Ndr, object given\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AccountController.php
-
-		-
-			message: "#^Parameter \\#1 \\$ndr of method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:setNdr\\(\\) expects App\\\\Entity\\\\Ndr\\\\Ndr, object given\\.$#"
 			count: 1
 			path: src/Controller/Ndr/AccountController.php
 
@@ -556,22 +421,7 @@ parameters:
 			path: src/Controller/Ndr/AccountController.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectRepository\\:\\:findByNdr\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AssetController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AssetController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getNdr\\(\\)\\.$#"
-			count: 3
-			path: src/Controller/Ndr/AssetController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setNoAssetToAdd\\(\\)\\.$#"
+			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\Ndr\\\\Asset\\>\\:\\:findByNdr\\(\\)\\.$#"
 			count: 1
 			path: src/Controller/Ndr/AssetController.php
 
@@ -656,39 +506,9 @@ parameters:
 			path: src/Controller/Ndr/AssetController.php
 
 		-
-			message: "#^Parameter \\#1 \\$asset of method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:updateEntityWithData\\(\\) expects App\\\\Entity\\\\Ndr\\\\Asset, object given\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AssetController.php
-
-		-
-			message: "#^Parameter \\#1 \\$ndr of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfNdrDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\Ndr\\\\Ndr, object given\\.$#"
-			count: 5
-			path: src/Controller/Ndr/AssetController.php
-
-		-
-			message: "#^Parameter \\#1 \\$ndr of method App\\\\Entity\\\\Ndr\\\\Asset\\:\\:setNdr\\(\\) expects App\\\\Entity\\\\Ndr\\\\Ndr\\|null, object given\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AssetController.php
-
-		-
 			message: "#^Parameter \\#2 \\$data of method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:updateEntityWithData\\(\\) expects array, array\\|null given\\.$#"
 			count: 2
 			path: src/Controller/Ndr/AssetController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/ExpenseController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getNdr\\(\\)\\.$#"
-			count: 3
-			path: src/Controller/Ndr/ExpenseController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setPaidForAnything\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/ExpenseController.php
 
 		-
 			message: "#^Method App\\\\Controller\\\\Ndr\\\\ExpenseController\\:\\:add\\(\\) has no return type specified\\.$#"
@@ -756,173 +576,28 @@ parameters:
 			path: src/Controller/Ndr/ExpenseController.php
 
 		-
-			message: "#^Parameter \\#1 \\$expense of method App\\\\Controller\\\\Ndr\\\\ExpenseController\\:\\:updateEntityWithData\\(\\) expects App\\\\Entity\\\\Ndr\\\\Expense, object given\\.$#"
-			count: 1
-			path: src/Controller/Ndr/ExpenseController.php
-
-		-
-			message: "#^Parameter \\#1 \\$ndr of class App\\\\Entity\\\\Ndr\\\\Expense constructor expects App\\\\Entity\\\\Ndr\\\\Ndr, object given\\.$#"
-			count: 1
-			path: src/Controller/Ndr/ExpenseController.php
-
-		-
-			message: "#^Parameter \\#1 \\$ndr of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfNdrDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\Ndr\\\\Ndr, object given\\.$#"
-			count: 4
-			path: src/Controller/Ndr/ExpenseController.php
-
-		-
 			message: "#^Parameter \\#2 \\$data of method App\\\\Controller\\\\Ndr\\\\ExpenseController\\:\\:updateEntityWithData\\(\\) expects array, array\\|null given\\.$#"
 			count: 2
 			path: src/Controller/Ndr/ExpenseController.php
 
 		-
-			message: "#^Call to an undefined method object\\:\\:getAssets\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getDebtByTypeId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getDebts\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getExpenses\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getNoAssetToAdd\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getOneOffByTypeId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getStateBenefitByTypeId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setActionGiveGiftsToClient\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setActionGiveGiftsToClientDetails\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setActionMoreInfo\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setActionMoreInfoDetails\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setActionPropertyBuy\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setActionPropertyMaintenance\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setActionPropertySellingRent\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setAgreedBehalfDeputy\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setAgreedBehalfDeputyExplanation\\(\\)\\.$#"
-			count: 2
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setDebtManagement\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setExpectCompensationDamages\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setExpectCompensationDamagesDetails\\(\\)\\.$#"
-			count: 2
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setHasDebts\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setNoAssetToAdd\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setPaidForAnything\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setReceiveOtherIncome\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setReceiveOtherIncomeDetails\\(\\)\\.$#"
-			count: 2
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setReceiveStatePension\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setStartDate\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setSubmitDate\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setSubmitted\\(\\)\\.$#"
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: src/Controller/Ndr/NdrController.php
 
 		-
 			message: "#^Call to method setMoreDetails\\(\\) on an unknown class App\\\\Entity\\\\Ndr\\\\IncomeBenefit\\.$#"
 			count: 2
+			path: src/Controller/Ndr/NdrController.php
+
+		-
+			message: "#^Cannot call method setAmount\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/NdrController.php
+
+		-
+			message: "#^Cannot call method setMoreDetails\\(\\) on mixed\\.$#"
+			count: 1
 			path: src/Controller/Ndr/NdrController.php
 
 		-
@@ -956,13 +631,18 @@ parameters:
 			path: src/Controller/Ndr/NdrController.php
 
 		-
-			message: "#^Parameter \\#1 \\$currentReport of method App\\\\Service\\\\ReportService\\:\\:submit\\(\\) expects App\\\\Entity\\\\ReportInterface, object given\\.$#"
+			message: "#^Parameter \\#1 \\$agreedBehalfDeputyExplanation of method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setAgreedBehalfDeputyExplanation\\(\\) expects string, null given\\.$#"
 			count: 1
 			path: src/Controller/Ndr/NdrController.php
 
 		-
-			message: "#^Parameter \\#1 \\$ndr of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfNdrDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\Ndr\\\\Ndr, object given\\.$#"
-			count: 3
+			message: "#^Parameter \\#1 \\$expectCompensationDamagesDetails of method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setExpectCompensationDamagesDetails\\(\\) expects string, null given\\.$#"
+			count: 1
+			path: src/Controller/Ndr/NdrController.php
+
+		-
+			message: "#^Parameter \\#1 \\$receiveOtherIncomeDetails of method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setReceiveOtherIncomeDetails\\(\\) expects string, null given\\.$#"
+			count: 1
 			path: src/Controller/Ndr/NdrController.php
 
 		-
@@ -986,18 +666,8 @@ parameters:
 			path: src/Controller/Ndr/NdrController.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectRepository\\:\\:findByReport\\(\\)\\.$#"
+			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\Ndr\\\\Ndr\\>\\:\\:findByReport\\(\\)\\.$#"
 			count: 1
-			path: src/Controller/Ndr/VisitsCareController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/VisitsCareController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getNdr\\(\\)\\.$#"
-			count: 3
 			path: src/Controller/Ndr/VisitsCareController.php
 
 		-
@@ -1051,13 +721,8 @@ parameters:
 			path: src/Controller/Ndr/VisitsCareController.php
 
 		-
-			message: "#^Parameter \\#1 \\$ndr of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfNdrDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\Ndr\\\\Ndr, object given\\.$#"
-			count: 2
-			path: src/Controller/Ndr/VisitsCareController.php
-
-		-
-			message: "#^Parameter \\#1 \\$ndr of method App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:setNdr\\(\\) expects App\\\\Entity\\\\Ndr\\\\Ndr, object given\\.$#"
-			count: 1
+			message: "#^Parameter \\#1 \\$ndr of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfNdrDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\Ndr\\\\Ndr, mixed given\\.$#"
+			count: 3
 			path: src/Controller/Ndr/VisitsCareController.php
 
 		-
@@ -1069,26 +734,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$whenWasCarePlanLastReviewed of method App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:setWhenWasCarePlanLastReviewed\\(\\) expects App\\\\Entity\\\\Ndr\\\\date, null given\\.$#"
 			count: 1
 			path: src/Controller/Ndr/VisitsCareController.php
-
-		-
-			message: "#^Parameter \\#2 \\$visitsCare of method App\\\\Controller\\\\Ndr\\\\VisitsCareController\\:\\:updateEntity\\(\\) expects App\\\\Entity\\\\Ndr\\\\VisitsCare, object given\\.$#"
-			count: 1
-			path: src/Controller/Ndr/VisitsCareController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getClient\\(\\)\\.$#"
-			count: 3
-			path: src/Controller/NoteController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/NoteController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setLastModifiedBy\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/NoteController.php
 
 		-
 			message: "#^Method App\\\\Controller\\\\NoteController\\:\\:add\\(\\) has no return type specified\\.$#"
@@ -1146,17 +791,12 @@ parameters:
 			path: src/Controller/NoteController.php
 
 		-
-			message: "#^Parameter \\#1 \\$client of class App\\\\Entity\\\\Note constructor expects App\\\\Entity\\\\Client, object given\\.$#"
-			count: 1
-			path: src/Controller/NoteController.php
-
-		-
-			message: "#^Parameter \\#1 \\$client of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfClientDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\Client, object given\\.$#"
-			count: 1
-			path: src/Controller/NoteController.php
-
-		-
 			message: "#^Parameter \\#1 \\$createdBy of method App\\\\Entity\\\\Note\\:\\:setCreatedBy\\(\\) expects App\\\\Entity\\\\User, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Controller/NoteController.php
+
+		-
+			message: "#^Parameter \\#1 \\$lastModifiedBy of method App\\\\Entity\\\\Note\\:\\:setLastModifiedBy\\(\\) expects App\\\\Entity\\\\User, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
 			count: 1
 			path: src/Controller/NoteController.php
 
@@ -1167,11 +807,6 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\Client\\>\\:\\:findByCaseNumber\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/PreRegistrationController.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:createQueryBuilder\\(\\)\\.$#"
 			count: 1
 			path: src/Controller/PreRegistrationController.php
 
@@ -1201,13 +836,18 @@ parameters:
 			path: src/Controller/PreRegistrationController.php
 
 		-
-			message: "#^Call to an undefined method object\\:\\:getReport\\(\\)\\.$#"
-			count: 6
+			message: "#^Cannot call method filter\\(\\) on array\\<App\\\\Entity\\\\Report\\\\Expense\\>\\.$#"
+			count: 1
 			path: src/Controller/Report/AccountController.php
 
 		-
-			message: "#^Call to an undefined method object\\:\\:updateSectionsStatusCache\\(\\)\\.$#"
+			message: "#^Cannot call method filter\\(\\) on array\\<App\\\\Entity\\\\Report\\\\Gift\\>\\.$#"
 			count: 1
+			path: src/Controller/Report/AccountController.php
+
+		-
+			message: "#^Cannot call method filter\\(\\) on array\\<App\\\\Entity\\\\Report\\\\MoneyTransaction\\>\\.$#"
+			count: 2
 			path: src/Controller/Report/AccountController.php
 
 		-
@@ -1266,22 +906,7 @@ parameters:
 			path: src/Controller/Report/AccountController.php
 
 		-
-			message: "#^Parameter \\#1 \\$account of method App\\\\Controller\\\\Report\\\\AccountController\\:\\:fillAccountData\\(\\) expects App\\\\Entity\\\\Report\\\\BankAccount, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/AccountController.php
-
-		-
 			message: "#^Parameter \\#1 \\$bank of method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setBank\\(\\) expects string, null given\\.$#"
-			count: 1
-			path: src/Controller/Report/AccountController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfReportDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\ReportInterface, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/AccountController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setReport\\(\\) expects App\\\\Entity\\\\Report\\\\Report\\|null, object given\\.$#"
 			count: 1
 			path: src/Controller/Report/AccountController.php
 
@@ -1299,21 +924,6 @@ parameters:
 			message: "#^Property App\\\\Controller\\\\Report\\\\AccountController\\:\\:\\$sectionIds has no type specified\\.$#"
 			count: 1
 			path: src/Controller/Report/AccountController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getAction\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ActionController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getReport\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ActionController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:updateSectionsStatusCache\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ActionController.php
 
 		-
 			message: "#^Method App\\\\Controller\\\\Report\\\\ActionController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
@@ -1336,39 +946,14 @@ parameters:
 			path: src/Controller/Report/ActionController.php
 
 		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: src/Controller/Report/ActionController.php
+
+		-
 			message: "#^Parameter \\#1 \\$data of method App\\\\Controller\\\\Report\\\\ActionController\\:\\:updateEntity\\(\\) expects array, array\\|null given\\.$#"
 			count: 1
 			path: src/Controller/Report/ActionController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of class App\\\\Entity\\\\Report\\\\Action constructor expects App\\\\Entity\\\\Report\\\\Report, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/ActionController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfReportDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\ReportInterface, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/ActionController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/AssetController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getReport\\(\\)\\.$#"
-			count: 3
-			path: src/Controller/Report/AssetController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setNoAssetToAdd\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/AssetController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:updateSectionsStatusCache\\(\\)\\.$#"
-			count: 3
-			path: src/Controller/Report/AssetController.php
 
 		-
 			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:add\\(\\) has no return type specified\\.$#"
@@ -1436,21 +1021,6 @@ parameters:
 			path: src/Controller/Report/AssetController.php
 
 		-
-			message: "#^Parameter \\#1 \\$asset of method App\\\\Controller\\\\Report\\\\AssetController\\:\\:updateEntityWithData\\(\\) expects App\\\\Entity\\\\Report\\\\Asset, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/AssetController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfReportDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\ReportInterface, object given\\.$#"
-			count: 4
-			path: src/Controller/Report/AssetController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Entity\\\\Report\\\\Asset\\:\\:setReport\\(\\) expects App\\\\Entity\\\\Report\\\\Report\\|null, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/AssetController.php
-
-		-
 			message: "#^Parameter \\#2 \\$data of method App\\\\Controller\\\\Report\\\\AssetController\\:\\:updateEntityWithData\\(\\) expects array, array\\|null given\\.$#"
 			count: 2
 			path: src/Controller/Report/AssetController.php
@@ -1511,22 +1081,7 @@ parameters:
 			path: src/Controller/Report/ClientBenefitsCheckController.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectRepository\\:\\:findByReport\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ContactController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ContactController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getReport\\(\\)\\.$#"
-			count: 5
-			path: src/Controller/Report/ContactController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setContactName\\(\\)\\.$#"
+			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\Report\\\\Contact\\>\\:\\:findByReport\\(\\)\\.$#"
 			count: 1
 			path: src/Controller/Report/ContactController.php
 
@@ -1616,24 +1171,9 @@ parameters:
 			path: src/Controller/Report/ContactController.php
 
 		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfReportDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\ReportInterface, object given\\.$#"
-			count: 2
-			path: src/Controller/Report/ContactController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Entity\\\\Report\\\\Contact\\:\\:setReport\\(\\) expects App\\\\Entity\\\\Report\\\\Report\\|null, object given\\.$#"
+			message: "#^Parameter \\#1 \\$reasonForNoContacts of method App\\\\Entity\\\\Report\\\\Report\\:\\:setReasonForNoContacts\\(\\) expects string, null given\\.$#"
 			count: 1
 			path: src/Controller/Report/ContactController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/DecisionController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getReport\\(\\)\\.$#"
-			count: 5
-			path: src/Controller/Report/DecisionController.php
 
 		-
 			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:deleteDecision\\(\\) has no return type specified\\.$#"
@@ -1666,16 +1206,6 @@ parameters:
 			path: src/Controller/Report/DecisionController.php
 
 		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfReportDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\ReportInterface, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/DecisionController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Entity\\\\Report\\\\Decision\\:\\:setReport\\(\\) expects App\\\\Entity\\\\Report\\\\Report, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/DecisionController.php
-
-		-
 			message: "#^Parameter \\#2 \\$data of method App\\\\Controller\\\\RestController\\:\\:hydrateEntityWithArrayData\\(\\) expects array, array\\|null given\\.$#"
 			count: 1
 			path: src/Controller/Report/DecisionController.php
@@ -1693,11 +1223,6 @@ parameters:
 		-
 			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\Report\\\\Document\\>\\:\\:updateSupportingDocumentStatusByReportSubmissionIds\\(\\)\\.$#"
 			count: 1
-			path: src/Controller/Report/DocumentController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getReport\\(\\)\\.$#"
-			count: 3
 			path: src/Controller/Report/DocumentController.php
 
 		-
@@ -1846,26 +1371,6 @@ parameters:
 			path: src/Controller/Report/DocumentController.php
 
 		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getReport\\(\\)\\.$#"
-			count: 3
-			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setPaidForAnything\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:updateSectionsStatusCache\\(\\)\\.$#"
-			count: 3
-			path: src/Controller/Report/ExpenseController.php
-
-		-
 			message: "#^Method App\\\\Controller\\\\Report\\\\ExpenseController\\:\\:add\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Controller/Report/ExpenseController.php
@@ -1926,54 +1431,9 @@ parameters:
 			path: src/Controller/Report/ExpenseController.php
 
 		-
-			message: "#^Parameter \\#1 \\$report of class App\\\\Entity\\\\Report\\\\Expense constructor expects App\\\\Entity\\\\Report\\\\Report, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Controller\\\\Report\\\\ExpenseController\\:\\:updateEntityWithData\\(\\) expects App\\\\Entity\\\\Report\\\\Report, object given\\.$#"
-			count: 2
-			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfReportDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\ReportInterface, object given\\.$#"
-			count: 4
-			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Parameter \\#2 \\$expense of method App\\\\Controller\\\\Report\\\\ExpenseController\\:\\:updateEntityWithData\\(\\) expects App\\\\Entity\\\\Report\\\\Expense, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/ExpenseController.php
-
-		-
 			message: "#^Parameter \\#3 \\$data of method App\\\\Controller\\\\Report\\\\ExpenseController\\:\\:updateEntityWithData\\(\\) expects array, array\\|null given\\.$#"
 			count: 2
 			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/GiftController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getReport\\(\\)\\.$#"
-			count: 3
-			path: src/Controller/Report/GiftController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setBankAccount\\(\\)\\.$#"
-			count: 2
-			path: src/Controller/Report/GiftController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setGiftsExist\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/GiftController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:updateSectionsStatusCache\\(\\)\\.$#"
-			count: 3
-			path: src/Controller/Report/GiftController.php
 
 		-
 			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:add\\(\\) has no return type specified\\.$#"
@@ -2036,21 +1496,6 @@ parameters:
 			path: src/Controller/Report/GiftController.php
 
 		-
-			message: "#^Parameter \\#1 \\$report of class App\\\\Entity\\\\Report\\\\Gift constructor expects App\\\\Entity\\\\Report\\\\Report, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/GiftController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Controller\\\\Report\\\\GiftController\\:\\:updateEntityWithData\\(\\) expects App\\\\Entity\\\\Report\\\\Report, object given\\.$#"
-			count: 2
-			path: src/Controller/Report/GiftController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfReportDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\ReportInterface, object given\\.$#"
-			count: 4
-			path: src/Controller/Report/GiftController.php
-
-		-
 			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\|null given\\.$#"
 			count: 1
 			path: src/Controller/Report/GiftController.php
@@ -2061,32 +1506,12 @@ parameters:
 			path: src/Controller/Report/GiftController.php
 
 		-
-			message: "#^Parameter \\#2 \\$gift of method App\\\\Controller\\\\Report\\\\GiftController\\:\\:updateEntityWithData\\(\\) expects App\\\\Entity\\\\Report\\\\Gift, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/GiftController.php
-
-		-
 			message: "#^Parameter \\#3 \\$data of method App\\\\Controller\\\\Report\\\\GiftController\\:\\:updateEntityWithData\\(\\) expects array, array\\|null given\\.$#"
 			count: 2
 			path: src/Controller/Report/GiftController.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectRepository\\:\\:findByReport\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/LifestyleController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/LifestyleController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getReport\\(\\)\\.$#"
-			count: 5
-			path: src/Controller/Report/LifestyleController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:updateSectionsStatusCache\\(\\)\\.$#"
+			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\Report\\\\Lifestyle\\>\\:\\:findByReport\\(\\)\\.$#"
 			count: 1
 			path: src/Controller/Report/LifestyleController.php
 
@@ -2141,36 +1566,6 @@ parameters:
 			path: src/Controller/Report/LifestyleController.php
 
 		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfReportDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\ReportInterface, object given\\.$#"
-			count: 2
-			path: src/Controller/Report/LifestyleController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Entity\\\\Report\\\\Lifestyle\\:\\:setReport\\(\\) expects App\\\\Entity\\\\Report\\\\Report\\|null, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/LifestyleController.php
-
-		-
-			message: "#^Parameter \\#2 \\$lifestyle of method App\\\\Controller\\\\Report\\\\LifestyleController\\:\\:updateInfo\\(\\) expects App\\\\Entity\\\\Report\\\\Lifestyle, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/LifestyleController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getMentalCapacity\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/MentalCapacityController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getReport\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/MentalCapacityController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:updateSectionsStatusCache\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/MentalCapacityController.php
-
-		-
 			message: "#^Method App\\\\Controller\\\\Report\\\\MentalCapacityController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Controller/Report/MentalCapacityController.php
@@ -2191,17 +1586,12 @@ parameters:
 			path: src/Controller/Report/MentalCapacityController.php
 
 		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: src/Controller/Report/MentalCapacityController.php
+
+		-
 			message: "#^Parameter \\#1 \\$data of method App\\\\Controller\\\\Report\\\\MentalCapacityController\\:\\:updateEntity\\(\\) expects array, array\\|null given\\.$#"
-			count: 1
-			path: src/Controller/Report/MentalCapacityController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of class App\\\\Entity\\\\Report\\\\MentalCapacity constructor expects App\\\\Entity\\\\Report\\\\Report, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/MentalCapacityController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfReportDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\ReportInterface, object given\\.$#"
 			count: 1
 			path: src/Controller/Report/MentalCapacityController.php
 
@@ -2218,46 +1608,6 @@ parameters:
 		-
 			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\Query\\\\Filter\\\\SQLFilter\\:\\:disableForEntity\\(\\)\\.$#"
 			count: 1
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 2
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getReport\\(\\)\\.$#"
-			count: 3
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:isDeleted\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setAmount\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setBankAccount\\(\\)\\.$#"
-			count: 2
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setDeletedAt\\(\\)\\.$#"
-			count: 2
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setDescription\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:updateSectionsStatusCache\\(\\)\\.$#"
-			count: 3
 			path: src/Controller/Report/MoneyTransactionController.php
 
 		-
@@ -2336,21 +1686,6 @@ parameters:
 			path: src/Controller/Report/MoneyTransactionController.php
 
 		-
-			message: "#^Parameter \\#1 \\$report of class App\\\\Entity\\\\Report\\\\MoneyTransaction constructor expects App\\\\Entity\\\\Report\\\\Report, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfReportDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\ReportInterface, object given\\.$#"
-			count: 3
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:setReport\\(\\) expects App\\\\Entity\\\\Report\\\\Report, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
 			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\|null given\\.$#"
 			count: 3
 			path: src/Controller/Report/MoneyTransactionController.php
@@ -2363,31 +1698,6 @@ parameters:
 		-
 			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\Query\\\\Filter\\\\SQLFilter\\:\\:disableForEntity\\(\\)\\.$#"
 			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getReport\\(\\)\\.$#"
-			count: 4
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:isDeleted\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setDeletedAt\\(\\)\\.$#"
-			count: 3
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:updateSectionsStatusCache\\(\\)\\.$#"
-			count: 3
 			path: src/Controller/Report/MoneyTransactionShortController.php
 
 		-
@@ -2486,54 +1796,14 @@ parameters:
 			path: src/Controller/Report/MoneyTransactionShortController.php
 
 		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfReportDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\ReportInterface, object given\\.$#"
-			count: 4
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Parameter \\#1 \\$t of method App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:fillData\\(\\) expects App\\\\Entity\\\\Report\\\\MoneyTransactionShort, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
 			message: "#^Parameter \\#2 \\$data of method App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:fillData\\(\\) expects array, array\\|null given\\.$#"
 			count: 2
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Parameter \\#2 \\$report of static method App\\\\Entity\\\\Report\\\\MoneyTransactionShort\\:\\:factory\\(\\) expects App\\\\Entity\\\\Report\\\\Report, object given\\.$#"
-			count: 1
 			path: src/Controller/Report/MoneyTransactionShortController.php
 
 		-
 			message: "#^Property App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:\\$sectionIds has no type specified\\.$#"
 			count: 1
 			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransferController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getReport\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransferController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setDescription\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransferController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setNoTransfersToAdd\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransferController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:updateSectionsStatusCache\\(\\)\\.$#"
-			count: 3
-			path: src/Controller/Report/MoneyTransferController.php
 
 		-
 			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:addMoneyTransferAction\\(\\) has no return type specified\\.$#"
@@ -2581,31 +1851,6 @@ parameters:
 			path: src/Controller/Report/MoneyTransferController.php
 
 		-
-			message: "#^Parameter \\#1 \\$from of method App\\\\Entity\\\\Report\\\\MoneyTransfer\\:\\:setFrom\\(\\) expects App\\\\Entity\\\\Report\\\\BankAccount, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransferController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfReportDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\ReportInterface, object given\\.$#"
-			count: 3
-			path: src/Controller/Report/MoneyTransferController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Entity\\\\Report\\\\MoneyTransfer\\:\\:setReport\\(\\) expects App\\\\Entity\\\\Report\\\\Report, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransferController.php
-
-		-
-			message: "#^Parameter \\#1 \\$to of method App\\\\Entity\\\\Report\\\\MoneyTransfer\\:\\:setTo\\(\\) expects App\\\\Entity\\\\Report\\\\BankAccount, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransferController.php
-
-		-
-			message: "#^Parameter \\#1 \\$transfer of method App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:fillEntity\\(\\) expects App\\\\Entity\\\\Report\\\\MoneyTransfer, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransferController.php
-
-		-
 			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\|null given\\.$#"
 			count: 2
 			path: src/Controller/Report/MoneyTransferController.php
@@ -2619,21 +1864,6 @@ parameters:
 			message: "#^Property App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:\\$sectionIds has no type specified\\.$#"
 			count: 1
 			path: src/Controller/Report/MoneyTransferController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getReport\\(\\)\\.$#"
-			count: 3
-			path: src/Controller/Report/ProfDeputyPrevCostController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setProfDeputyCostsHasPrevious\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfDeputyPrevCostController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:updateSectionsStatusCache\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfDeputyPrevCostController.php
 
 		-
 			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyPrevCostController\\:\\:addAction\\(\\) has no return type specified\\.$#"
@@ -2681,12 +1911,12 @@ parameters:
 			path: src/Controller/Report/ProfDeputyPrevCostController.php
 
 		-
-			message: "#^Parameter \\#1 \\$report of class App\\\\Entity\\\\Report\\\\ProfDeputyPreviousCost constructor expects App\\\\Entity\\\\Report\\\\Report, object given\\.$#"
+			message: "#^Parameter \\#1 \\$profDeputyCostsHasPrevious of method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfDeputyCostsHasPrevious\\(\\) expects string, null given\\.$#"
 			count: 1
 			path: src/Controller/Report/ProfDeputyPrevCostController.php
 
 		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfReportDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\ReportInterface, object given\\.$#"
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, mixed given\\.$#"
 			count: 1
 			path: src/Controller/Report/ProfDeputyPrevCostController.php
 
@@ -2694,21 +1924,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\|null given\\.$#"
 			count: 1
 			path: src/Controller/Report/ProfDeputyPrevCostController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getReport\\(\\)\\.$#"
-			count: 3
-			path: src/Controller/Report/ProfServiceFeeController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setCurrentProfPaymentsReceived\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfServiceFeeController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:updateSectionsStatusCache\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfServiceFeeController.php
 
 		-
 			message: "#^Method App\\\\Controller\\\\Report\\\\ProfServiceFeeController\\:\\:addAction\\(\\) has no return type specified\\.$#"
@@ -2761,21 +1976,6 @@ parameters:
 			path: src/Controller/Report/ProfServiceFeeController.php
 
 		-
-			message: "#^Parameter \\#1 \\$report of class App\\\\Entity\\\\Report\\\\ProfServiceFeeCurrent constructor expects App\\\\Entity\\\\Report\\\\Report, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfServiceFeeController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfReportDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\ReportInterface, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfServiceFeeController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Entity\\\\Report\\\\ProfServiceFee\\:\\:setReport\\(\\) expects App\\\\Entity\\\\Report\\\\Report, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfServiceFeeController.php
-
-		-
 			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportController.php
@@ -2783,261 +1983,6 @@ parameters:
 		-
 			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\Query\\\\Filter\\\\SQLFilter\\:\\:disableForEntity\\(\\)\\.$#"
 			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getAssets\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getAvailableSections\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getCurrentProfServiceFees\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getDebtByTypeId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getDebts\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getExpenses\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getFeeByTypeId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getFees\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getGifts\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 2
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getMoneyShortCategoryByTypeId\\(\\)\\.$#"
-			count: 2
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getMoneyTransactionsShortIn\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getMoneyTransactionsShortOut\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getMoneyTransfers\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getNoAssetToAdd\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getProfDeputyOtherCostByTypeId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getProfDeputyOtherCostTypeIds\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setActionMoreInfo\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setActionMoreInfoDetails\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setAgreedBehalfDeputy\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setAgreedBehalfDeputyExplanation\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setBalanceMismatchExplanation\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setCurrentProfPaymentsReceived\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setDebtManagement\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setDueDate\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setEndDate\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setGiftsExist\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setHasDebts\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setMoneyInExists\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setMoneyOutExists\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setMoneyTransactionsShortInExist\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setMoneyTransactionsShortOutExist\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setNoAssetToAdd\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setNoTransfersToAdd\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setPaidForAnything\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setPreviousProfFeesEstimateGiven\\(\\)\\.$#"
-			count: 2
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setProfFeesEstimateSccoReason\\(\\)\\.$#"
-			count: 3
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setReasonForNoContacts\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setReasonForNoDecisions\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setReasonForNoFees\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setReasonForNoMoneyIn\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setReasonForNoMoneyOut\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setReportSeen\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setSignificantDecisionsMade\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setStartDate\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setSubmitted\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setType\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setUnSubmitDate\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setWishToProvideDocumentation\\(\\)\\.$#"
-			count: 2
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:updateDueDateBasedOnEndDate\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:updateSectionsStatusCache\\(\\)\\.$#"
-			count: 26
 			path: src/Controller/Report/ReportController.php
 
 		-
@@ -3056,12 +2001,12 @@ parameters:
 			path: src/Controller/Report/ReportController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:addAction\\(\\) has no return type specified\\.$#"
+			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:getById\\(\\) should return App\\\\Entity\\\\Report\\\\Report but returns object\\.$#"
+			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:addAction\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportController.php
 
@@ -3236,27 +2181,22 @@ parameters:
 			path: src/Controller/Report/ReportController.php
 
 		-
-			message: "#^Parameter \\#1 \\$client of class App\\\\Entity\\\\Report\\\\Report constructor expects App\\\\Entity\\\\Client, object given\\.$#"
+			message: "#^Parameter \\#1 \\$amount of method App\\\\Entity\\\\Report\\\\Debt\\:\\:setAmount\\(\\) expects string, null given\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportController.php
 
 		-
-			message: "#^Parameter \\#1 \\$client of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfClientDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\Client, object given\\.$#"
+			message: "#^Parameter \\#1 \\$amount of method App\\\\Entity\\\\Report\\\\Fee\\:\\:setAmount\\(\\) expects string, null given\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportController.php
 
 		-
-			message: "#^Parameter \\#1 \\$client of method App\\\\Service\\\\ReportService\\:\\:getReportTypeBasedOnSirius\\(\\) expects App\\\\Entity\\\\Client, object given\\.$#"
+			message: "#^Parameter \\#1 \\$moreDetails of method App\\\\Entity\\\\Report\\\\Debt\\:\\:setMoreDetails\\(\\) expects string, null given\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportController.php
 
 		-
-			message: "#^Parameter \\#1 \\$currentReport of method App\\\\Service\\\\ReportService\\:\\:submit\\(\\) expects App\\\\Entity\\\\ReportInterface, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Parameter \\#1 \\$currentReport of method App\\\\Service\\\\ReportService\\:\\:submitAdditionalDocuments\\(\\) expects App\\\\Entity\\\\Report\\\\Report, object given\\.$#"
+			message: "#^Parameter \\#1 \\$moreDetails of method App\\\\Entity\\\\Report\\\\Fee\\:\\:setMoreDetails\\(\\) expects string, null given\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportController.php
 
@@ -3266,17 +2206,27 @@ parameters:
 			path: src/Controller/Report/ReportController.php
 
 		-
-			message: "#^Parameter \\#1 \\$report of class App\\\\Entity\\\\Report\\\\ProfDeputyOtherCost constructor expects App\\\\Entity\\\\Report\\\\Report, object given\\.$#"
+			message: "#^Parameter \\#1 \\$object of method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:remove\\(\\) expects object, mixed given\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportController.php
 
 		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfReportDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\ReportInterface, object given\\.$#"
-			count: 4
+			message: "#^Parameter \\#1 \\$previousProfFeesEstimateGiven of method App\\\\Entity\\\\Report\\\\Report\\:\\:setPreviousProfFeesEstimateGiven\\(\\) expects string, null given\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Parameter \\#1 \\$profFeesEstimateSccoReason of method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfFeesEstimateSccoReason\\(\\) expects string, null given\\.$#"
+			count: 2
 			path: src/Controller/Report/ReportController.php
 
 		-
 			message: "#^Parameter \\#1 \\$reportData of method App\\\\Controller\\\\Report\\\\ReportController\\:\\:transformReports\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Parameter \\#1 \\$unSubmitDate of method App\\\\Entity\\\\Report\\\\Report\\:\\:setUnSubmitDate\\(\\) expects DateTime\\|null, array given\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportController.php
 
@@ -3301,52 +2251,27 @@ parameters:
 			path: src/Controller/Report/ReportController.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectRepository\\:\\:findAllReportSubmissionsRawSql\\(\\)\\.$#"
+			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\Report\\\\ReportSubmission\\>\\:\\:findAllReportSubmissionsRawSql\\(\\)\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportSubmissionController.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectRepository\\:\\:findByFiltersWithCounts\\(\\)\\.$#"
+			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\Report\\\\ReportSubmission\\>\\:\\:findDownloadableOlderThan\\(\\)\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportSubmissionController.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectRepository\\:\\:findDownloadableOlderThan\\(\\)\\.$#"
+			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\Report\\\\ReportSubmission\\>\\:\\:findOneByIdUnfiltered\\(\\)\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportSubmissionController.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectRepository\\:\\:findOneByIdUnfiltered\\(\\)\\.$#"
+			message: "#^Cannot call method getDocuments\\(\\) on App\\\\Entity\\\\Report\\\\ReportSubmission\\|null\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportSubmissionController.php
 
 		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 2
-			path: src/Controller/Report/ReportSubmissionController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setArchived\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportSubmissionController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setArchivedBy\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportSubmissionController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setUuid\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportSubmissionController.php
-
-		-
-			message: "#^Cannot call method getDocuments\\(\\) on object\\|null\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportSubmissionController.php
-
-		-
-			message: "#^Cannot call method setDownloadable\\(\\) on object\\|null\\.$#"
+			message: "#^Cannot call method setDownloadable\\(\\) on App\\\\Entity\\\\Report\\\\ReportSubmission\\|null\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportSubmissionController.php
 
@@ -3416,12 +2341,57 @@ parameters:
 			path: src/Controller/Report/ReportSubmissionController.php
 
 		-
+			message: "#^Parameter \\#1 \\$archivedBy of method App\\\\Entity\\\\Report\\\\ReportSubmission\\:\\:setArchivedBy\\(\\) expects App\\\\Entity\\\\User\\|null, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportSubmissionController.php
+
+		-
 			message: "#^Parameter \\#1 \\$datetime of class DateTime constructor expects string, mixed given\\.$#"
 			count: 2
 			path: src/Controller/Report/ReportSubmissionController.php
 
 		-
+			message: "#^Parameter \\#1 \\$status of method App\\\\Repository\\\\ReportSubmissionRepository\\:\\:findByFiltersWithCounts\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportSubmissionController.php
+
+		-
+			message: "#^Parameter \\#1 \\$storageReference of method App\\\\Entity\\\\Report\\\\Document\\:\\:setStorageReference\\(\\) expects string, null given\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportSubmissionController.php
+
+		-
 			message: "#^Parameter \\#1 \\$user of method App\\\\Entity\\\\Report\\\\Document\\:\\:setSynchronisedBy\\(\\) expects App\\\\Entity\\\\User\\|null, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportSubmissionController.php
+
+		-
+			message: "#^Parameter \\#2 \\$q of method App\\\\Repository\\\\ReportSubmissionRepository\\:\\:findByFiltersWithCounts\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportSubmissionController.php
+
+		-
+			message: "#^Parameter \\#3 \\$createdByRole of method App\\\\Repository\\\\ReportSubmissionRepository\\:\\:findByFiltersWithCounts\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportSubmissionController.php
+
+		-
+			message: "#^Parameter \\#4 \\$offset of method App\\\\Repository\\\\ReportSubmissionRepository\\:\\:findByFiltersWithCounts\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportSubmissionController.php
+
+		-
+			message: "#^Parameter \\#5 \\$limit of method App\\\\Repository\\\\ReportSubmissionRepository\\:\\:findByFiltersWithCounts\\(\\) expects int, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportSubmissionController.php
+
+		-
+			message: "#^Parameter \\#6 \\$orderBy of method App\\\\Repository\\\\ReportSubmissionRepository\\:\\:findByFiltersWithCounts\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportSubmissionController.php
+
+		-
+			message: "#^Parameter \\#7 \\$order of method App\\\\Repository\\\\ReportSubmissionRepository\\:\\:findByFiltersWithCounts\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportSubmissionController.php
 
@@ -3431,22 +2401,7 @@ parameters:
 			path: src/Controller/Report/ReportSubmissionController.php
 
 		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectRepository\\:\\:findByReport\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/VisitsCareController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/VisitsCareController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getReport\\(\\)\\.$#"
-			count: 5
-			path: src/Controller/Report/VisitsCareController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:updateSectionsStatusCache\\(\\)\\.$#"
+			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\Report\\\\VisitsCare\\>\\:\\:findByReport\\(\\)\\.$#"
 			count: 1
 			path: src/Controller/Report/VisitsCareController.php
 
@@ -3501,27 +2456,12 @@ parameters:
 			path: src/Controller/Report/VisitsCareController.php
 
 		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfReportDoesNotBelongToUser\\(\\) expects App\\\\Entity\\\\ReportInterface, object given\\.$#"
-			count: 2
-			path: src/Controller/Report/VisitsCareController.php
-
-		-
-			message: "#^Parameter \\#1 \\$report of method App\\\\Entity\\\\Report\\\\VisitsCare\\:\\:setReport\\(\\) expects App\\\\Entity\\\\Report\\\\Report\\|null, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/VisitsCareController.php
-
-		-
 			message: "#^Parameter \\#1 \\$whenWasCarePlanLastReviewed of method App\\\\Entity\\\\Report\\\\VisitsCare\\:\\:setWhenWasCarePlanLastReviewed\\(\\) expects DateTime, null given\\.$#"
 			count: 1
 			path: src/Controller/Report/VisitsCareController.php
 
 		-
-			message: "#^Parameter \\#2 \\$visitsCare of method App\\\\Controller\\\\Report\\\\VisitsCareController\\:\\:updateInfo\\(\\) expects App\\\\Entity\\\\Report\\\\VisitsCare, object given\\.$#"
-			count: 1
-			path: src/Controller/Report/VisitsCareController.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectRepository\\<App\\\\Entity\\\\User\\>\\:\\:findDeputyUidsForClient\\(\\)\\.$#"
+			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\User\\>\\:\\:findDeputyUidsForClient\\(\\)\\.$#"
 			count: 1
 			path: src/Controller/RestController.php
 
@@ -3556,11 +2496,6 @@ parameters:
 			path: src/Controller/RestController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\RestController\\:\\:getRepository\\(\\) return type with generic interface Doctrine\\\\Persistence\\\\ObjectRepository does not specify its types\\: T$#"
-			count: 1
-			path: src/Controller/RestController.php
-
-		-
 			message: "#^Method App\\\\Controller\\\\RestController\\:\\:hydrateEntityWithArrayData\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Controller/RestController.php
@@ -3581,22 +2516,12 @@ parameters:
 			path: src/Controller/RestController.php
 
 		-
-			message: "#^Parameter \\#1 \\$className of method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getRepository\\(\\) expects class\\-string\\<object\\>, string given\\.$#"
-			count: 1
-			path: src/Controller/RestController.php
-
-		-
 			message: "#^Parameter \\$client of method App\\\\Controller\\\\RestController\\:\\:denyAccessIfClientDoesNotBelongToUser\\(\\) has invalid type App\\\\Controller\\\\Client\\.$#"
 			count: 1
 			path: src/Controller/RestController.php
 
 		-
-			message: "#^Unable to resolve the template type T in call to method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:getRepository\\(\\)$#"
-			count: 1
-			path: src/Controller/RestController.php
-
-		-
-			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectRepository\\:\\:findAllSatisfactionSubmissions\\(\\)\\.$#"
+			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\Satisfaction\\>\\:\\:findAllSatisfactionSubmissions\\(\\)\\.$#"
 			count: 1
 			path: src/Controller/SatisfactionController.php
 
@@ -3756,21 +2681,6 @@ parameters:
 			path: src/Controller/SelfRegisterController.php
 
 		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/SettingController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setContent\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/SettingController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setEnabled\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/SettingController.php
-
-		-
 			message: "#^Method App\\\\Controller\\\\SettingController\\:\\:getSetting\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Controller/SettingController.php
@@ -3856,27 +2766,7 @@ parameters:
 			path: src/Controller/UserController.php
 
 		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 2
-			path: src/Controller/UserController.php
-
-		-
 			message: "#^Call to an undefined method object\\:\\:getIsPrimary\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/UserController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getRoleName\\(\\)\\.$#"
-			count: 6
-			path: src/Controller/UserController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setAgreeTermsUse\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/UserController.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:setRegistrationToken\\(\\)\\.$#"
 			count: 1
 			path: src/Controller/UserController.php
 
@@ -4117,7 +3007,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$registrationToken of method App\\\\Entity\\\\User\\:\\:setRegistrationToken\\(\\) expects string, null given\\.$#"
-			count: 1
+			count: 2
 			path: src/Controller/UserController.php
 
 		-
@@ -11614,11 +10504,6 @@ parameters:
 			message: "#^Method App\\\\v2\\\\Assembler\\\\UserAssembler\\:\\:setPropertiesFromData\\(\\) has parameter \\$dto with no type specified\\.$#"
 			count: 1
 			path: src/v2/Assembler/UserAssembler.php
-
-		-
-			message: "#^Call to an undefined method object\\:\\:getId\\(\\)\\.$#"
-			count: 2
-			path: src/v2/Controller/ClientController.php
 
 		-
 			message: "#^Method App\\\\v2\\\\Controller\\\\DeputyController\\:\\:getByIdAction\\(\\) has parameter \\$id with no type specified\\.$#"

--- a/api/app/src/Controller/AuthController.php
+++ b/api/app/src/Controller/AuthController.php
@@ -25,8 +25,10 @@ class AuthController extends RestController
         private readonly JWTService $JWTService,
         private readonly LoggerInterface $logger,
         private readonly TokenStorageInterface $tokenStorage,
-        private readonly string $workspace
+        private readonly string $workspace,
+        EntityManagerInterface $em,
     ) {
+       parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/ChecklistController.php
+++ b/api/app/src/Controller/ChecklistController.php
@@ -15,8 +15,12 @@ use Symfony\Component\Routing\Annotation\Route;
  */
 class ChecklistController extends RestController
 {
-    public function __construct(private readonly AuthService $authService, private readonly RestFormatter $formatter)
-    {
+    public function __construct(
+        private readonly AuthService $authService,
+        private readonly RestFormatter $formatter,
+        EntityManagerInterface $em
+    ) {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/ClientContactController.php
+++ b/api/app/src/Controller/ClientContactController.php
@@ -17,6 +17,7 @@ class ClientContactController extends RestController
 {
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/ClientController.php
+++ b/api/app/src/Controller/ClientController.php
@@ -26,6 +26,7 @@ class ClientController extends RestController
         private readonly ObservableEventDispatcher $eventDispatcher,
         private readonly TokenStorageInterface $tokenStorage,
     ) {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/CoDeputyController.php
+++ b/api/app/src/Controller/CoDeputyController.php
@@ -18,6 +18,7 @@ class CoDeputyController extends RestController
 {
     public function __construct(private readonly UserService $userService, private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**
@@ -27,7 +28,7 @@ class CoDeputyController extends RestController
      */
     public function countMld(Request $request)
     {
-        $qb = $this->getDoctrine()->getManager()->createQueryBuilder()
+        $qb = $this->em->createQueryBuilder()
             ->select('count(u.id)')
             ->from('App\Entity\User', 'u')
             ->where('u.coDeputyClientConfirmed = ?1')

--- a/api/app/src/Controller/DeputyController.php
+++ b/api/app/src/Controller/DeputyController.php
@@ -6,6 +6,7 @@ use App\Entity\Deputy;
 use App\Entity\User;
 use App\Service\DeputyService;
 use App\Service\Formatter\RestFormatter;
+use Doctrine\ORM\EntityManagerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -21,7 +22,9 @@ class DeputyController extends RestController
     public function __construct(
         private readonly DeputyService $deputyService,
         private readonly RestFormatter $formatter,
+        EntityManagerInterface $em
     ) {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/HealthController.php
+++ b/api/app/src/Controller/HealthController.php
@@ -2,7 +2,7 @@
 
 namespace App\Controller;
 
-use App\Service\Formatter\RestFormatter;
+use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -11,8 +11,12 @@ use Symfony\Component\Routing\Annotation\Route;
  */
 class HealthController extends RestController
 {
-    public function __construct(private readonly string $symfonyEnvironment, private readonly LoggerInterface $logger, private readonly RestFormatter $restFormatter)
-    {
+    public function __construct(
+        private readonly string $symfonyEnvironment,
+        private readonly LoggerInterface $logger,
+        private EntityManagerInterface $em
+    ) {
+        parent::__construct($em);
     }
 
     /**
@@ -45,7 +49,7 @@ class HealthController extends RestController
     private function dbInfo()
     {
         try {
-            $this->getDoctrine()->getConnection()->query('select * from migrations LIMIT 1')->fetchAll();
+            $this->em->getConnection()->query('select * from migrations LIMIT 1')->fetchAll();
 
             return [true, ''];
         } catch (\Throwable $e) {

--- a/api/app/src/Controller/Ndr/AccountController.php
+++ b/api/app/src/Controller/Ndr/AccountController.php
@@ -14,6 +14,7 @@ class AccountController extends RestController
 {
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/Ndr/AssetController.php
+++ b/api/app/src/Controller/Ndr/AssetController.php
@@ -14,6 +14,7 @@ class AssetController extends RestController
 {
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**
@@ -25,8 +26,8 @@ class AssetController extends RestController
     {
         $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $ndrId);
         $this->denyAccessIfNdrDoesNotBelongToUser($ndr);
-
-        $assets = $this->getRepository(EntityDir\Ndr\Asset::class)->findByNdr($ndr);
+        
+        $assets = $this->em->getRepository(EntityDir\Ndr\Asset::class)->findByNdr($ndr);
 
         if (0 == count($assets)) {
             return [];

--- a/api/app/src/Controller/Ndr/ExpenseController.php
+++ b/api/app/src/Controller/Ndr/ExpenseController.php
@@ -14,6 +14,7 @@ class ExpenseController extends RestController
 {
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/Ndr/NdrController.php
+++ b/api/app/src/Controller/Ndr/NdrController.php
@@ -16,6 +16,7 @@ class NdrController extends RestController
 {
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/Ndr/VisitsCareController.php
+++ b/api/app/src/Controller/Ndr/VisitsCareController.php
@@ -14,6 +14,7 @@ class VisitsCareController extends RestController
 {
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**
@@ -69,7 +70,7 @@ class VisitsCareController extends RestController
         $report = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $ndrId);
         $this->denyAccessIfNdrDoesNotBelongToUser($report);
 
-        $ret = $this->getRepository(EntityDir\Ndr\Ndr::class)->findByReport($report);
+        $ret = $this->em->getRepository(EntityDir\Ndr\Ndr::class)->findByReport($report);
 
         return $ret;
     }

--- a/api/app/src/Controller/NoteController.php
+++ b/api/app/src/Controller/NoteController.php
@@ -17,6 +17,7 @@ class NoteController extends RestController
 {
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/PreRegistrationController.php
+++ b/api/app/src/Controller/PreRegistrationController.php
@@ -25,6 +25,7 @@ class PreRegistrationController extends RestController
         private readonly RestFormatter $formatter,
         private readonly EntityManagerInterface $em
     ) {
+        parent::__construct($em);
     }
 
     /**
@@ -107,7 +108,7 @@ class PreRegistrationController extends RestController
      */
     public function userCount()
     {
-        $qb = $this->getDoctrine()->getManager()->createQueryBuilder();
+        $qb = $this->em->createQueryBuilder();
         $qb->select('count(p.id)');
         $qb->from('App\Entity\PreRegistration', 'p');
 

--- a/api/app/src/Controller/Report/AccountController.php
+++ b/api/app/src/Controller/Report/AccountController.php
@@ -17,6 +17,7 @@ class AccountController extends RestController
 
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/Report/ActionController.php
+++ b/api/app/src/Controller/Report/ActionController.php
@@ -16,6 +16,7 @@ class ActionController extends RestController
 
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/Report/AssetController.php
+++ b/api/app/src/Controller/Report/AssetController.php
@@ -16,6 +16,7 @@ class AssetController extends RestController
 
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/Report/ClientBenefitsCheckController.php
+++ b/api/app/src/Controller/Report/ClientBenefitsCheckController.php
@@ -11,14 +11,21 @@ use App\Factory\ClientBenefitsCheckFactory;
 use App\Repository\ClientBenefitsCheckRepository;
 use App\Repository\NdrClientBenefitsCheckRepository;
 use App\Service\Formatter\RestFormatter;
+use Doctrine\ORM\EntityManagerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
 class ClientBenefitsCheckController extends RestController
 {
-    public function __construct(private readonly ClientBenefitsCheckRepository $clientBenefitsCheckRepository, private readonly NdrClientBenefitsCheckRepository $ndrClientBenefitsCheckRepository, private readonly ClientBenefitsCheckFactory $factory, private readonly RestFormatter $formatter)
-    {
+    public function __construct(
+        private readonly ClientBenefitsCheckRepository $clientBenefitsCheckRepository,
+        private readonly NdrClientBenefitsCheckRepository $ndrClientBenefitsCheckRepository,
+        private readonly ClientBenefitsCheckFactory $factory,
+        private readonly RestFormatter $formatter,
+        EntityManagerInterface $em
+    ) {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/Report/ContactController.php
+++ b/api/app/src/Controller/Report/ContactController.php
@@ -19,6 +19,7 @@ class ContactController extends RestController
 
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**
@@ -126,7 +127,7 @@ class ContactController extends RestController
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $id);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
 
-        $contacts = $this->getRepository(EntityDir\Report\Contact::class)->findByReport($report);
+        $contacts = $this->em->getRepository(EntityDir\Report\Contact::class)->findByReport($report);
 
         if (0 == count($contacts)) {
             // throw new AppExceptions\NotFound("No contacts found for report id: $id", 404);

--- a/api/app/src/Controller/Report/DecisionController.php
+++ b/api/app/src/Controller/Report/DecisionController.php
@@ -21,6 +21,7 @@ class DecisionController extends RestController
         private readonly EntityManagerInterface $em,
         private readonly RestFormatter $formatter,
     ) {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/Report/DocumentController.php
+++ b/api/app/src/Controller/Report/DocumentController.php
@@ -23,6 +23,7 @@ class DocumentController extends RestController
 
     public function __construct(private readonly EntityManagerInterface $em, private readonly AuthService $authService, private readonly RestFormatter $formatter, private readonly LoggerInterface $verboseLogger)
     {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/Report/ExpenseController.php
+++ b/api/app/src/Controller/Report/ExpenseController.php
@@ -16,6 +16,7 @@ class ExpenseController extends RestController
 
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**
@@ -125,7 +126,7 @@ class ExpenseController extends RestController
         // update bank account
         $expense->setBankAccount(null);
         if (array_key_exists('bank_account_id', $data) && is_numeric($data['bank_account_id'])) {
-            $bankAccount = $this->getRepository(
+            $bankAccount = $this->em->getRepository(
                 EntityDir\Report\BankAccount::class
             )->findOneBy(
                 [

--- a/api/app/src/Controller/Report/GiftController.php
+++ b/api/app/src/Controller/Report/GiftController.php
@@ -16,6 +16,7 @@ class GiftController extends RestController
 
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**
@@ -132,7 +133,7 @@ class GiftController extends RestController
         // update bank account
         $gift->setBankAccount(null);
         if (array_key_exists('bank_account_id', $data) && is_numeric($data['bank_account_id'])) {
-            $bankAccount = $this->getRepository(
+            $bankAccount = $this->em->getRepository(
                 EntityDir\Report\BankAccount::class
             )->findOneBy(
                 [

--- a/api/app/src/Controller/Report/LifestyleController.php
+++ b/api/app/src/Controller/Report/LifestyleController.php
@@ -19,6 +19,7 @@ class LifestyleController extends RestController
 
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**
@@ -79,7 +80,7 @@ class LifestyleController extends RestController
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
 
-        $ret = $this->getRepository(EntityDir\Report\Lifestyle::class)->findByReport($report);
+        $ret = $this->em->getRepository(EntityDir\Report\Lifestyle::class)->findByReport($report);
 
         return $ret;
     }

--- a/api/app/src/Controller/Report/MentalCapacityController.php
+++ b/api/app/src/Controller/Report/MentalCapacityController.php
@@ -16,6 +16,7 @@ class MentalCapacityController extends RestController
 
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/Report/MoneyReceivedOnClientsBehalfController.php
+++ b/api/app/src/Controller/Report/MoneyReceivedOnClientsBehalfController.php
@@ -8,6 +8,7 @@ use App\Controller\RestController;
 use App\Repository\MoneyReceivedOnClientsBehalfRepository;
 use App\Repository\NdrMoneyReceivedOnClientsBehalfRepository;
 use App\Service\Formatter\RestFormatter;
+use Doctrine\ORM\EntityManagerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -17,8 +18,10 @@ class MoneyReceivedOnClientsBehalfController extends RestController
     public function __construct(
         private readonly MoneyReceivedOnClientsBehalfRepository $reportMoneyRepository,
         private readonly NdrMoneyReceivedOnClientsBehalfRepository $ndrMoneyRepository,
-        private readonly RestFormatter $formatter
+        private readonly RestFormatter $formatter,
+        EntityManagerInterface $em
     ) {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/Report/MoneyTransactionController.php
+++ b/api/app/src/Controller/Report/MoneyTransactionController.php
@@ -23,6 +23,7 @@ class MoneyTransactionController extends RestController
        private readonly RestFormatter $formatter,
        private readonly MoneyTransactionRepository $moneyTransactionRepository
     ) {
+        parent::__construct($em);
     }
 
     /**
@@ -49,7 +50,7 @@ class MoneyTransactionController extends RestController
         // update bank account
         $t->setBankAccount(null);
         if (array_key_exists('bank_account_id', $data) && is_numeric($data['bank_account_id'])) {
-            $bankAccount = $this->getRepository(
+            $bankAccount = $this->em->getRepository(
                 EntityDir\Report\BankAccount::class
             )->findOneBy(
                 [

--- a/api/app/src/Controller/Report/MoneyTransactionShortController.php
+++ b/api/app/src/Controller/Report/MoneyTransactionShortController.php
@@ -23,6 +23,7 @@ class MoneyTransactionShortController extends RestController
         private readonly RestFormatter $formatter,
         private readonly MoneyTransactionShortRepository $moneyTransactionShortRepository
     ) {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/Report/MoneyTransferController.php
+++ b/api/app/src/Controller/Report/MoneyTransferController.php
@@ -16,6 +16,7 @@ class MoneyTransferController extends RestController
 
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/Report/ProfDeputyPrevCostController.php
+++ b/api/app/src/Controller/Report/ProfDeputyPrevCostController.php
@@ -16,6 +16,7 @@ class ProfDeputyPrevCostController extends RestController
 
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/Report/ProfServiceFeeController.php
+++ b/api/app/src/Controller/Report/ProfServiceFeeController.php
@@ -16,6 +16,7 @@ class ProfServiceFeeController extends RestController
 
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/Report/ReportController.php
+++ b/api/app/src/Controller/Report/ReportController.php
@@ -49,6 +49,7 @@ class ReportController extends RestController
 
     public function __construct(private readonly array $updateHandlers, private readonly ReportRepository $repository, private readonly ReportService $reportService, private readonly EntityManagerInterface $em, private readonly AuthService $authService, private readonly RestFormatter $formatter, private readonly ParameterStoreService $parameterStoreService)
     {
+        parent::__construct($em);
     }
 
     /**
@@ -871,7 +872,7 @@ class ReportController extends RestController
     {
         $this->formatter->setJmsSerialiserGroups(['checklist', 'last-modified', 'user']);
 
-        $checklist = $this
+        $checklist = $this->em
             ->getRepository(EntityDir\Report\ReviewChecklist::class)
             ->findOneBy(['report' => $report_id]);
 
@@ -896,7 +897,7 @@ class ReportController extends RestController
         $checklistData = $this->formatter->deserializeBodyContent($request);
 
         /** @var EntityDir\Report\ReviewChecklist|null $checklist */
-        $checklist = $this
+        $checklist = $this->em
             ->getRepository(EntityDir\Report\ReviewChecklist::class)
             ->findOneBy(['report' => $report->getId()]);
 

--- a/api/app/src/Controller/Report/VisitsCareController.php
+++ b/api/app/src/Controller/Report/VisitsCareController.php
@@ -19,6 +19,7 @@ class VisitsCareController extends RestController
 
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**
@@ -81,7 +82,7 @@ class VisitsCareController extends RestController
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
 
-        $ret = $this->getRepository(EntityDir\Report\VisitsCare::class)->findByReport($report);
+        $ret = $this->em->getRepository(EntityDir\Report\VisitsCare::class)->findByReport($report);
 
         return $ret;
     }

--- a/api/app/src/Controller/RestController.php
+++ b/api/app/src/Controller/RestController.php
@@ -4,27 +4,25 @@ namespace App\Controller;
 
 use App\Entity as EntityDir;
 use App\Exception\NotFound;
-use Doctrine\Persistence\ObjectRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
 abstract class RestController extends AbstractController
 {
-    /**
-     * @param $entityClass string
-     */
-    protected function getRepository(string $entityClass): ObjectRepository
+    public function __construct(private readonly EntityManagerInterface $em)
     {
-        return $this->getDoctrine()->getManager()->getRepository($entityClass);
     }
 
     /**
+     * @template T of object
+     * @param class-string<T> $entityClass
      * @param array|int $criteriaOrId
-     *
+     * @return T
      * @throws NotFound
      */
     protected function findEntityBy(string $entityClass, $criteriaOrId, $errorMessage = null): object
     {
-        $repo = $this->getRepository($entityClass);
+        $repo = $this->em->getRepository($entityClass);
         $entity = is_array($criteriaOrId) ? $repo->findOneBy($criteriaOrId) : $repo->find($criteriaOrId);
 
         if (!$entity) {
@@ -92,7 +90,7 @@ abstract class RestController extends AbstractController
         if (in_array('ROLE_LAY_DEPUTY', $this->getUser()->getRoles())) {
             $deputyUid = $this->getUser()->getDeputyUid();
             if ($deputyUid) {
-                $deputyUidArray = $this->getDoctrine()->getManager()->getRepository(EntityDir\User::class)->findDeputyUidsForClient($clientId);
+                $deputyUidArray = $this->em->getRepository(EntityDir\User::class)->findDeputyUidsForClient($clientId);
                 if (in_array($deputyUid, array_column($deputyUidArray, 'deputyUid'))) {
                     $hasAccess = true;
                 }

--- a/api/app/src/Controller/SatisfactionController.php
+++ b/api/app/src/Controller/SatisfactionController.php
@@ -20,6 +20,7 @@ class SatisfactionController extends RestController
 {
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter, private readonly ReportRepository $reportRepository, private readonly NdrRepository $ndrRepository, private readonly SatisfactionRepository $satisfactionRepository)
     {
+        parent::__construct($em);
     }
 
     /**
@@ -101,7 +102,7 @@ class SatisfactionController extends RestController
     public function getSatisfactionData(Request $request)
     {
         /* @var $repo SatisfactionRepository */
-        $repo = $this->getRepository(Satisfaction::class);
+        $repo = $this->em->getRepository(Satisfaction::class);
 
         $fromDate = $this->convertDateStringToDateTime($request->get('fromDate', ''));
         $fromDate instanceof \DateTime ? $fromDate->setTime(0, 0, 1) : null;
@@ -112,8 +113,6 @@ class SatisfactionController extends RestController
         return $repo->findAllSatisfactionSubmissions(
             $fromDate,
             $toDate,
-            $request->get('orderBy', 'createdAt'),
-            $request->get('order', 'ASC')
         );
     }
 

--- a/api/app/src/Controller/SelfRegisterController.php
+++ b/api/app/src/Controller/SelfRegisterController.php
@@ -20,6 +20,7 @@ class SelfRegisterController extends RestController
 {
     public function __construct(private readonly LoggerInterface $logger, private readonly ValidatorInterface $validator, private readonly AuthService $authService, private readonly RestFormatter $formatter, private readonly EntityManagerInterface $em)
     {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/SettingController.php
+++ b/api/app/src/Controller/SettingController.php
@@ -16,6 +16,7 @@ class SettingController extends RestController
 {
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
+        parent::__construct($em);
     }
 
     /**
@@ -23,7 +24,7 @@ class SettingController extends RestController
      */
     public function getSetting(Request $request, $id)
     {
-        $setting = $this->getRepository(EntityDir\Setting::class)->find($id); /* @var $setting EntityDir\Setting */
+        $setting = $this->em->getRepository(EntityDir\Setting::class)->find($id); /* @var $setting EntityDir\Setting */
 
         $this->formatter->setJmsSerialiserGroups(['setting']);
 
@@ -42,7 +43,7 @@ class SettingController extends RestController
             'enabled' => 'mustExist',
         ]);
 
-        $setting = $this->getRepository(EntityDir\Setting::class)->find($id); /* @var $setting EntityDir\Setting */
+        $setting = $this->em->getRepository(EntityDir\Setting::class)->find($id); /* @var $setting EntityDir\Setting */
         if ($setting) { // update
             $setting->setContent($data['content']);
             $setting->setEnabled($data['enabled']);

--- a/api/app/src/Controller/StatsController.php
+++ b/api/app/src/Controller/StatsController.php
@@ -8,7 +8,6 @@ use App\Entity\Ndr\AssetOther as NdrAssetOther;
 use App\Entity\Ndr\AssetProperty as NdrAssetProperty;
 use App\Entity\Report\AssetOther;
 use App\Entity\Report\AssetProperty;
-use App\Entity\Report\Report;
 use App\Exception\UnauthorisedException;
 use App\Repository\AssetRepository;
 use App\Repository\BankAccountRepository;
@@ -20,6 +19,7 @@ use App\Service\Auth\AuthService;
 use App\Service\Formatter\RestFormatter;
 use App\Service\Stats\QueryFactory;
 use App\Service\Stats\StatsQueryParameters;
+use Doctrine\ORM\EntityManagerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -35,8 +35,10 @@ class StatsController extends RestController
         private readonly BankAccountRepository $bankAccountRepository,
         private readonly NdrAssetRepository $ndrAssetRepository,
         private readonly NdrBankAccountRepository $ndrBankAccountRepository,
-        private readonly AuthService $authService
+        private readonly AuthService $authService,
+        EntityManagerInterface $em
     ) {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/UserController.php
+++ b/api/app/src/Controller/UserController.php
@@ -42,6 +42,7 @@ class UserController extends RestController
         private readonly RestFormatter $formatter,
         private readonly PasswordHasherFactoryInterface $hasherFactory,
     ) {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/Controller/UserResearchController.php
+++ b/api/app/src/Controller/UserResearchController.php
@@ -8,6 +8,7 @@ use App\Factory\UserResearchResponseFactory;
 use App\Repository\SatisfactionRepository;
 use App\Repository\UserResearchResponseRepository;
 use App\Service\Formatter\RestFormatter;
+use Doctrine\ORM\EntityManagerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -16,8 +17,14 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class UserResearchController extends RestController
 {
-    public function __construct(private readonly UserResearchResponseFactory $factory, private readonly UserResearchResponseRepository $userResearchResponseRepository, private readonly SatisfactionRepository $satisfactionRepository, private readonly RestFormatter $formatter)
-    {
+    public function __construct(
+        private readonly UserResearchResponseFactory $factory,
+        private readonly UserResearchResponseRepository $userResearchResponseRepository,
+        private readonly SatisfactionRepository $satisfactionRepository,
+        private readonly RestFormatter $formatter,
+        EntityManagerInterface $em
+    ) {
+        parent::__construct($em);
     }
 
     /**

--- a/api/app/src/v2/Controller/ClientController.php
+++ b/api/app/src/v2/Controller/ClientController.php
@@ -9,6 +9,7 @@ use App\v2\Assembler\ClientAssembler;
 use App\v2\Assembler\OrganisationAssembler;
 use App\v2\Transformer\ClientTransformer;
 use App\v2\Transformer\OrganisationTransformer;
+use Doctrine\ORM\EntityManagerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -26,8 +27,10 @@ class ClientController extends RestController
         private readonly ClientAssembler $clientAssembler,
         private readonly OrganisationAssembler $orgAssembler,
         private readonly ClientTransformer $clientTransformer,
-        private readonly OrganisationTransformer $orgTransformer
+        private readonly OrganisationTransformer $orgTransformer,
+        EntityManagerInterface $em
     ) {
+        parent::__construct($em);
     }
 
     /**


### PR DESCRIPTION
Inject EntityManagerInterface into RestController, and update inheriting constructors

## Purpose
Path to upgrade to symfony 6

Fixes DDLS-####

## Learning
phpstan templating in RestController

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
