### PR TITLE
Convert API symfony annotations to attributes

### DIFF
--- a/api/app/src/Controller/AuthController.php
+++ b/api/app/src/Controller/AuthController.php
@@ -15,9 +15,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 
-/**
- * @Route("/auth")
- */
+#[Route(path: '/auth')]
 class AuthController extends RestController
 {
     public function __construct(
@@ -32,12 +30,11 @@ class AuthController extends RestController
     }
 
     /**
-     * @Route("/login", methods={"POST"}, name="api_login")
      *
      * @return User
-     *
      * @throws \Throwable
      */
+    #[Route(path: '/login', methods: ['POST'], name: 'api_login')]
     public function login(
         RestInputOuputFormatter $restInputOutputFormatter,
         EntityManagerInterface $em,
@@ -60,7 +57,7 @@ class AuthController extends RestController
                 $redis->set($authToken, serialize($this->tokenStorage->getToken()));
 
                 // add token into response
-                $restInputOutputFormatter->addResponseModifier(function ($response) use ($authToken) {
+                $restInputOutputFormatter->addResponseModifier(function ($response) use ($authToken): void {
                     $response->headers->set(HeaderTokenAuthenticator::HEADER_NAME, $authToken);
                 });
             } else {
@@ -70,7 +67,7 @@ class AuthController extends RestController
             if (User::ROLE_SUPER_ADMIN === $user->getRoleName()) {
                 $jwt = $this->JWTService->createNewJWT($user);
 
-                $restInputOutputFormatter->addResponseModifier(function ($response) use ($jwt) {
+                $restInputOutputFormatter->addResponseModifier(function ($response) use ($jwt): void {
                     $response->headers->set('JWT', $jwt);
                 });
             }
@@ -85,9 +82,7 @@ class AuthController extends RestController
         }
     }
 
-    /**
-     * @Route("/logout", methods={"POST"})
-     */
+    #[Route(path: '/logout', methods: ['POST'])]
     public function logout(RedisUserProvider $userProvider)
     {
         $authToken = $this->tokenStorage->getToken();
@@ -97,9 +92,8 @@ class AuthController extends RestController
 
     /**
      * Test endpoint used for testing to check auth permissions.
-     *
-     * @Route("/get-logged-user", methods={"GET"})
      */
+    #[Route(path: '/get-logged-user', methods: ['GET'])]
     public function getLoggedUser()
     {
         $this->restFormatter->setJmsSerialiserGroups(['user', 'user-login']);

--- a/api/app/src/Controller/ChecklistController.php
+++ b/api/app/src/Controller/ChecklistController.php
@@ -10,9 +10,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/checklist")
- */
+#[Route(path: '/checklist')]
 class ChecklistController extends RestController
 {
     public function __construct(
@@ -23,9 +21,7 @@ class ChecklistController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/{id}", methods={"PUT"})
-     */
+    #[Route(path: '/{id}', methods: ['PUT'])]
     public function update(Request $request, int $id, EntityManagerInterface $em): Checklist
     {
         if (!$this->authService->isSecretValid($request)) {

--- a/api/app/src/Controller/ClientContactController.php
+++ b/api/app/src/Controller/ClientContactController.php
@@ -10,9 +10,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("")
- */
+#[Route(path: '')]
 class ClientContactController extends RestController
 {
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
@@ -20,11 +18,8 @@ class ClientContactController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/clients/{clientId}/clientcontacts", name="clientcontact_add", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_ORG')")
-     */
+    #[Route(path: '/clients/{clientId}/clientcontacts', name: 'clientcontact_add', methods: ['POST'])]
+    #[Security("is_granted('ROLE_ORG')")]
     public function add(Request $request, $clientId)
     {
         $client = $this->findEntityBy(EntityDir\Client::class, $clientId);
@@ -59,10 +54,10 @@ class ClientContactController extends RestController
      * Update contact
      * Only the creator can update the note.
      *
-     * @Route("/clientcontacts/{id}", methods={"PUT"})
      *
-     * @Security("is_granted('ROLE_ORG')")
      */
+    #[Route(path: '/clientcontacts/{id}', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_ORG')")]
     public function update(Request $request, $id)
     {
         $clientContact = $this->findEntityBy(EntityDir\ClientContact::class, $id);
@@ -87,11 +82,8 @@ class ClientContactController extends RestController
         return $clientContact->getId();
     }
 
-    /**
-     * @Route("/clientcontacts/{id}", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_ORG')")
-     */
+    #[Route(path: '/clientcontacts/{id}', methods: ['GET'])]
+    #[Security("is_granted('ROLE_ORG')")]
     public function getOneById(Request $request, $id)
     {
         $serialisedGroups = $request->query->has('groups')
@@ -109,10 +101,10 @@ class ClientContactController extends RestController
      * Delete contact
      * Only the creator can delete the note.
      *
-     * @Route("/clientcontacts/{id}", methods={"DELETE"})
      *
-     * @Security("is_granted('ROLE_ORG')")
      */
+    #[Route(path: '/clientcontacts/{id}', methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_ORG')")]
     public function delete($id, LoggerInterface $logger)
     {
         try {

--- a/api/app/src/Controller/ClientController.php
+++ b/api/app/src/Controller/ClientController.php
@@ -14,9 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
-/**
- * @Route("/client")
- */
+#[Route(path: '/client')]
 class ClientController extends RestController
 {
     public function __construct(
@@ -33,10 +31,10 @@ class ClientController extends RestController
      * Add/Edit a client.
      * When added, the current logged used will be added.
      *
-     * @Route("/upsert", methods={"POST", "PUT"})
      *
-     * @Security("is_granted('ROLE_DEPUTY')")
      */
+    #[Route(path: '/upsert', methods: ['POST', 'PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function upsertAction(Request $request)
     {
         $data = $this->formatter->deserializeBodyContent($request);
@@ -101,12 +99,12 @@ class ClientController extends RestController
     }
 
     /**
-     * @Route("/{id}", name="client_find_by_id", requirements={"id":"\d+"}, methods={"GET"})
      *
-     * @Security("is_granted('ROLE_DEPUTY') or is_granted('ROLE_ADMIN')")
      *
      * @return object|null
      */
+    #[Route(path: '/{id}', name: 'client_find_by_id', requirements: ['id' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY') or is_granted('ROLE_ADMIN')")]
     public function findByIdAction(Request $request, int $id)
     {
         $serialisedGroups = $request->query->has('groups')
@@ -128,12 +126,12 @@ class ClientController extends RestController
     }
 
     /**
-     * @Route("/{id}/details", name="client_details", requirements={"id":"\d+"}, methods={"GET"})
      *
-     * @Security("is_granted('ROLE_ADMIN')")
      *
      * @return object|null
      */
+    #[Route(path: '/{id}/details', name: 'client_details', requirements: ['id' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function detailsAction(Request $request, int $id)
     {
         if ($request->query->has('groups')) {
@@ -161,12 +159,12 @@ class ClientController extends RestController
     }
 
     /**
-     * @Route("/{id}/archive", name="client_archive", requirements={"id":"\d+"}, methods={"PUT"})
      *
-     * @Security("is_granted('ROLE_ORG')")
      *
      * @param int $id
      */
+    #[Route(path: '/{id}/archive', name: 'client_archive', requirements: ['id' => '\d+'], methods: ['PUT'])]
+    #[Security("is_granted('ROLE_ORG')")]
     public function archiveAction(Request $request, $id)
     {
         /* @var $client EntityDir\Client */
@@ -195,11 +193,8 @@ class ClientController extends RestController
         ];
     }
 
-    /**
-     * @Route("/get-all", defaults={"order_by" = "lastname", "sort_order" = "ASC"}, methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_ADMIN')")
-     */
+    #[Route(path: '/get-all', defaults: ['order_by' => 'lastname', 'sort_order' => 'ASC'], methods: ['GET'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function getAllAction(Request $request)
     {
         $this->formatter->setJmsSerialiserGroups(['client', 'active-period']);
@@ -213,11 +208,8 @@ class ClientController extends RestController
         );
     }
 
-    /**
-     * @Route("/{id}/delete", name="client_delete", requirements={"id":"\d+"}, methods={"DELETE"})
-     *
-     * @Security("is_granted('ROLE_ADMIN_MANAGER')")
-     */
+    #[Route(path: '/{id}/delete', name: 'client_delete', requirements: ['id' => '\d+'], methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_ADMIN_MANAGER')")]
     public function deleteAction(Request $request, $id)
     {
         /* @var $client EntityDir\Client */
@@ -229,11 +221,8 @@ class ClientController extends RestController
         return [];
     }
 
-    /**
-     * @Route("/{id}/unarchive", methods={"PUT"}, requirements={"id":"\d+"})
-     *
-     * @Security("is_granted('ROLE_ADMIN_MANAGER')")
-     */
+    #[Route(path: '/{id}/unarchive', methods: ['PUT'], requirements: ['id' => '\d+'])]
+    #[Security("is_granted('ROLE_ADMIN_MANAGER')")]
     public function unarchiveClientAction(int $id)
     {
         $client = $this->findEntityBy(EntityDir\Client::class, $id);
@@ -246,11 +235,8 @@ class ClientController extends RestController
         ];
     }
 
-    /**
-     * @Route("/{id}/update-deputy/{deputyId}", methods={"PUT"}, requirements={"id":"\d+", "deputyId":"\d+"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY') or is_granted('ROLE_ADMIN')")
-     */
+    #[Route(path: '/{id}/update-deputy/{deputyId}', methods: ['PUT'], requirements: ['id' => '\d+', 'deputyId' => '\d+'])]
+    #[Security("is_granted('ROLE_DEPUTY') or is_granted('ROLE_ADMIN')")]
     public function updateDeputyAction(Request $request, int $id, int $deputyId)
     {
         $client = $this->findEntityBy(EntityDir\Client::class, $id);
@@ -266,10 +252,10 @@ class ClientController extends RestController
     /**
      * Endpoint for getting the clients for a deputy uid.
      *
-     * @Route("/get-all-clients-by-deputy-uid/{deputyUid}", methods={"GET"})
      *
      * @throws \Exception
      */
+    #[Route(path: '/get-all-clients-by-deputy-uid/{deputyUid}', methods: ['GET'])]
     public function getAllClientsByDeputyUid(Request $request, int $deputyUid)
     {
         $serialisedGroups = $request->query->has('groups')

--- a/api/app/src/Controller/CoDeputyController.php
+++ b/api/app/src/Controller/CoDeputyController.php
@@ -11,9 +11,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/codeputy/")
- */
+#[Route(path: '/codeputy/')]
 class CoDeputyController extends RestController
 {
     public function __construct(private readonly UserService $userService, private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
@@ -21,11 +19,8 @@ class CoDeputyController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("{count}", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_ADMIN')")
-     */
+    #[Route(path: '{count}', methods: ['GET'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function countMld(Request $request)
     {
         $qb = $this->em->createQueryBuilder()
@@ -37,11 +32,8 @@ class CoDeputyController extends RestController
         return $qb->getQuery()->getSingleScalarResult();
     }
 
-    /**
-     * @Route("add/{clientId}", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: 'add/{clientId}', methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function add(Request $request, int $clientId)
     {
         $data = $this->formatter->deserializeBodyContent($request, [
@@ -67,11 +59,8 @@ class CoDeputyController extends RestController
         return $newUser;
     }
 
-    /**
-     * @Route("{id}", methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '{id}', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function update(Request $request, $id)
     {
         $user = $this->findEntityBy(User::class, $id, 'User not found'); /* @var $user User */
@@ -101,10 +90,10 @@ class CoDeputyController extends RestController
      * Max 10k otherwise failing (memory reach 128M).
      * Borrows heavily from CasRecController:addBulk.
      *
-     * @Route("{mldupgrade}", methods={"POST"})
      *
-     * @Security("is_granted('ROLE_ADMIN')")
      */
+    #[Route(path: '{mldupgrade}', methods: ['POST'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function upgradeToMld(Request $request)
     {
         $maxRecords = 10000;

--- a/api/app/src/Controller/DeputyController.php
+++ b/api/app/src/Controller/DeputyController.php
@@ -13,10 +13,7 @@ use Symfony\Component\Routing\Annotation\Route;
 
 // TODO
 // http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html
-
-/**
- * @Route("/deputy")
- */
+#[Route(path: '/deputy')]
 class DeputyController extends RestController
 {
     public function __construct(
@@ -27,11 +24,8 @@ class DeputyController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/add", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY') or is_granted('ROLE_ADMIN')")
-     */
+    #[Route(path: '/add', methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY') or is_granted('ROLE_ADMIN')")]
     public function add(Request $request)
     {
         $data = $this->formatter->deserializeBodyContent($request);
@@ -74,12 +68,12 @@ class DeputyController extends RestController
     }
 
     /**
-     * @Route("/{id}", name="deputy_find_by_id", requirements={"id":"\d+"}, methods={"GET"})
      *
-     * @Security("is_granted('ROLE_DEPUTY') or is_granted('ROLE_ADMIN')")
      *
      * @return object|null
      */
+    #[Route(path: '/{id}', name: 'deputy_find_by_id', requirements: ['id' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY') or is_granted('ROLE_ADMIN')")]
     public function findByIdAction(Request $request, int $id)
     {
         $serialisedGroups = $request->query->has('groups')

--- a/api/app/src/Controller/HealthController.php
+++ b/api/app/src/Controller/HealthController.php
@@ -6,9 +6,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/health-check")
- */
+#[Route(path: '/health-check')]
 class HealthController extends RestController
 {
     public function __construct(
@@ -19,19 +17,16 @@ class HealthController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("", name="health-check", methods={"GET"})
-     */
+    #[Route(path: '', name: 'health-check', methods: ['GET'])]
     public function containerHealthAction()
     {
         return 'ok';
     }
 
     /**
-     * @Route("/service", methods={"GET"})
-     *
      * @return array
      */
+    #[Route(path: '/service', methods: ['GET'])]
     public function serviceHealthAction()
     {
         list($dbHealthy, $dbError) = $this->dbInfo();

--- a/api/app/src/Controller/JWTController.php
+++ b/api/app/src/Controller/JWTController.php
@@ -20,9 +20,7 @@ class JWTController extends AbstractController
     ) {
     }
 
-    /**
-     * @Route("/v3/jwk-public-key", methods={"GET"})
-     */
+    #[Route(path: '/v3/jwk-public-key', methods: ['GET'])]
     public function getPublicJwkKey(): JsonResponse
     {
         try {

--- a/api/app/src/Controller/Ndr/AccountController.php
+++ b/api/app/src/Controller/Ndr/AccountController.php
@@ -17,11 +17,8 @@ class AccountController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/ndr/{ndrId}/account", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/ndr/{ndrId}/account', methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function addAccountAction(Request $request, $ndrId)
     {
         $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $ndrId);
@@ -41,11 +38,8 @@ class AccountController extends RestController
         return ['id' => $account->getId()];
     }
 
-    /**
-     * @Route("/ndr/account/{id}", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/ndr/account/{id}', methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getOneById(Request $request, $id)
     {
         if ($request->query->has('groups')) {
@@ -60,11 +54,8 @@ class AccountController extends RestController
         return $account;
     }
 
-    /**
-     * @Route("/ndr/account/{id}", methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/ndr/account/{id}', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function editAccountAction(Request $request, $id)
     {
         $account = $this->findEntityBy(EntityDir\Ndr\BankAccount::class, $id, 'Account not found'); /* @var $account EntityDir\Ndr\BankAccount */
@@ -79,11 +70,8 @@ class AccountController extends RestController
         return $account->getId();
     }
 
-    /**
-     * @Route("/ndr/account/{id}", methods={"DELETE"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/ndr/account/{id}', methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function accountDelete($id)
     {
         $account = $this->findEntityBy(EntityDir\Ndr\BankAccount::class, $id, 'Account not found'); /* @var $account EntityDir\Ndr\BankAccount */

--- a/api/app/src/Controller/Ndr/AssetController.php
+++ b/api/app/src/Controller/Ndr/AssetController.php
@@ -17,11 +17,8 @@ class AssetController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/ndr/{ndrId}/assets", requirements={"ndrId":"\d+"}, methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/ndr/{ndrId}/assets', requirements: ['ndrId' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getAll($ndrId)
     {
         $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $ndrId);
@@ -38,11 +35,8 @@ class AssetController extends RestController
         return $assets;
     }
 
-    /**
-     * @Route("/ndr/{ndrId}/asset/{assetId}", requirements={"ndrId":"\d+", "assetId":"\d+"}, methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/ndr/{ndrId}/asset/{assetId}', requirements: ['ndrId' => '\d+', 'assetId' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getOneById($ndrId, $assetId)
     {
         $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $ndrId);
@@ -56,11 +50,8 @@ class AssetController extends RestController
         return $asset;
     }
 
-    /**
-     * @Route("/ndr/{ndrId}/asset", requirements={"ndrId":"\d+"}, methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/ndr/{ndrId}/asset', requirements: ['ndrId' => '\d+'], methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function add(Request $request, $ndrId)
     {
         $data = $this->formatter->deserializeBodyContent($request);
@@ -82,11 +73,8 @@ class AssetController extends RestController
         return ['id' => $asset->getId()];
     }
 
-    /**
-     * @Route("/ndr/{ndrId}/asset/{assetId}", requirements={"ndrId":"\d+", "assetId":"\d+"}, methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/ndr/{ndrId}/asset/{assetId}', requirements: ['ndrId' => '\d+', 'assetId' => '\d+'], methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function edit(Request $request, $ndrId, $assetId)
     {
         $data = $this->formatter->deserializeBodyContent($request);
@@ -104,11 +92,8 @@ class AssetController extends RestController
         return ['id' => $asset->getId()];
     }
 
-    /**
-     * @Route("/ndr/{ndrId}/asset/{assetId}", requirements={"ndrId":"\d+", "assetId":"\d+"}, methods={"DELETE"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/ndr/{ndrId}/asset/{assetId}', requirements: ['ndrId' => '\d+', 'assetId' => '\d+'], methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function delete($ndrId, $assetId)
     {
         $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $ndrId);

--- a/api/app/src/Controller/Ndr/ExpenseController.php
+++ b/api/app/src/Controller/Ndr/ExpenseController.php
@@ -17,11 +17,8 @@ class ExpenseController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/ndr/{ndrId}/expense/{expenseId}", requirements={"ndrId":"\d+", "expenseId":"\d+"}, methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/ndr/{ndrId}/expense/{expenseId}', requirements: ['ndrId' => '\d+', 'expenseId' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getOneById($ndrId, $expenseId)
     {
         $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $ndrId);
@@ -35,11 +32,8 @@ class ExpenseController extends RestController
         return $expense;
     }
 
-    /**
-     * @Route("/ndr/{ndrId}/expense", requirements={"ndrId":"\d+"}, methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/ndr/{ndrId}/expense', requirements: ['ndrId' => '\d+'], methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function add(Request $request, $ndrId)
     {
         $data = $this->formatter->deserializeBodyContent($request);
@@ -62,11 +56,8 @@ class ExpenseController extends RestController
         return ['id' => $expense->getId()];
     }
 
-    /**
-     * @Route("/ndr/{ndrId}/expense/{expenseId}", requirements={"ndrId":"\d+", "expenseId":"\d+"}, methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/ndr/{ndrId}/expense/{expenseId}', requirements: ['ndrId' => '\d+', 'expenseId' => '\d+'], methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function edit(Request $request, $ndrId, $expenseId)
     {
         $data = $this->formatter->deserializeBodyContent($request);
@@ -84,11 +75,8 @@ class ExpenseController extends RestController
         return ['id' => $expense->getId()];
     }
 
-    /**
-     * @Route("/ndr/{ndrId}/expense/{expenseId}", requirements={"ndrId":"\d+", "expenseId":"\d+"}, methods={"DELETE"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/ndr/{ndrId}/expense/{expenseId}', requirements: ['ndrId' => '\d+', 'expenseId' => '\d+'], methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function delete($ndrId, $expenseId)
     {
         $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $ndrId); /* @var $ndr EntityDir\Ndr\Ndr */

--- a/api/app/src/Controller/Ndr/NdrController.php
+++ b/api/app/src/Controller/Ndr/NdrController.php
@@ -20,10 +20,9 @@ class NdrController extends RestController
     }
 
     /**
-     * @Route("/ndr/{id}", methods={"GET"})
-     *
      * @param int $id
      */
+    #[Route(path: '/ndr/{id}', methods: ['GET'])]
     public function getById(Request $request, $id)
     {
         $groups = $request->query->has('groups') ? (array) $request->query->get('groups') : ['ndr'];
@@ -40,11 +39,8 @@ class NdrController extends RestController
         return $report;
     }
 
-    /**
-     * @Route("/ndr/{id}/submit", methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/ndr/{id}/submit', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function submit(Request $request, $id, ReportService $reportService)
     {
         $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $id, 'Ndr not found');
@@ -87,9 +83,7 @@ class NdrController extends RestController
         return ['id' => $nextYearReport->getId()];
     }
 
-    /**
-     * @Route("/ndr/{id}", methods={"PUT"})
-     */
+    #[Route(path: '/ndr/{id}', methods: ['PUT'])]
     public function update(Request $request, $id)
     {
         /* @var $ndr EntityDir\Ndr\Ndr */

--- a/api/app/src/Controller/Ndr/VisitsCareController.php
+++ b/api/app/src/Controller/Ndr/VisitsCareController.php
@@ -17,11 +17,8 @@ class VisitsCareController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/ndr/visits-care", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/ndr/visits-care', methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function addAction(Request $request)
     {
         $visitsCare = new EntityDir\Ndr\VisitsCare();
@@ -40,11 +37,8 @@ class VisitsCareController extends RestController
         return ['id' => $visitsCare->getId()];
     }
 
-    /**
-     * @Route("/ndr/visits-care/{id}", methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/ndr/visits-care/{id}', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function updateAction(Request $request, $id)
     {
         $visitsCare = $this->findEntityBy(EntityDir\Ndr\VisitsCare::class, $id);
@@ -59,12 +53,12 @@ class VisitsCareController extends RestController
     }
 
     /**
-     * @Route("/ndr/{ndrId}/visits-care", methods={"GET"})
      *
-     * @Security("is_granted('ROLE_DEPUTY')")
      *
      * @param int $ndrId
      */
+    #[Route(path: '/ndr/{ndrId}/visits-care', methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function findByNdrIdAction($ndrId)
     {
         $report = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $ndrId);
@@ -76,12 +70,12 @@ class VisitsCareController extends RestController
     }
 
     /**
-     * @Route("/ndr/visits-care/{id}", methods={"GET"})
      *
-     * @Security("is_granted('ROLE_DEPUTY')")
      *
      * @param int $id
      */
+    #[Route(path: '/ndr/visits-care/{id}', methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getOneById(Request $request, $id)
     {
         $serialiseGroups = $request->query->has('groups') ? (array) $request->query->get('groups') : ['visits-care'];
@@ -93,11 +87,8 @@ class VisitsCareController extends RestController
         return $visitsCare;
     }
 
-    /**
-     * @Route("/ndr/visits-care/{id}", methods={"DELETE"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/ndr/visits-care/{id}', methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function deleteVisitsCare($id)
     {
         $visitsCare = $this->findEntityBy(EntityDir\Ndr\VisitsCare::class, $id, 'VisitsCare not found'); /* @var $visitsCare EntityDir\Ndr\VisitsCare */

--- a/api/app/src/Controller/NoteController.php
+++ b/api/app/src/Controller/NoteController.php
@@ -10,9 +10,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/note/")
- */
+#[Route(path: '/note/')]
 class NoteController extends RestController
 {
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
@@ -20,11 +18,8 @@ class NoteController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("{clientId}", requirements={"clientId":"\d+"}, methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_ORG')")
-     */
+    #[Route(path: '{clientId}', requirements: ['clientId' => '\d+'], methods: ['POST'])]
+    #[Security("is_granted('ROLE_ORG')")]
     public function add(Request $request, $clientId)
     {
         $client = $this->findEntityBy(EntityDir\Client::class, $clientId); /* @var $report EntityDir\Client */
@@ -51,10 +46,10 @@ class NoteController extends RestController
      * User that created the note is not returned as default, as not currently needed from the CLIENT.
      * Add "user" group if needed
      *
-     * @Route("{id}", methods={"GET"})
      *
-     * @Security("is_granted('ROLE_ORG')")
      */
+    #[Route(path: '{id}', methods: ['GET'])]
+    #[Security("is_granted('ROLE_ORG')")]
     public function getOneById(Request $request, $id)
     {
         $serialisedGroups = $request->query->has('groups')
@@ -71,10 +66,10 @@ class NoteController extends RestController
      * Update note
      * Only the creator can update the note.
      *
-     * @Route("{id}", methods={"PUT"})
      *
-     * @Security("is_granted('ROLE_ORG')")
      */
+    #[Route(path: '{id}', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_ORG')")]
     public function updateNote(Request $request, $id)
     {
         $note = $this->findEntityBy(EntityDir\Note::class, $id); /* @var $note EntityDir\Note */
@@ -99,14 +94,14 @@ class NoteController extends RestController
     /**
      * Delete note.
      *
-     * @Route("{id}", methods={"DELETE"})
      *
-     * @Security("is_granted('ROLE_ORG')")
      *
      * @param int $id
      *
      * @return array
      */
+    #[Route(path: '{id}', methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_ORG')")]
     public function delete($id, LoggerInterface $logger)
     {
         try {

--- a/api/app/src/Controller/PreRegistrationController.php
+++ b/api/app/src/Controller/PreRegistrationController.php
@@ -15,9 +15,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/pre-registration")
- */
+#[Route(path: '/pre-registration')]
 class PreRegistrationController extends RestController
 {
     public function __construct(
@@ -29,14 +27,14 @@ class PreRegistrationController extends RestController
     }
 
     /**
-     * @Route("/delete", methods={"DELETE"})
      *
-     * @Security("is_granted('ROLE_ADMIN')")
      *
      * @return array|JsonResponse
      *
      * @throws NonUniqueResultException
      */
+    #[Route(path: '/delete', methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function delete(PreRegistrationRepository $preRegistrationRepository)
     {
         $result = $preRegistrationRepository->deleteAll();
@@ -46,9 +44,8 @@ class PreRegistrationController extends RestController
 
     /**
      * Verify Deputy first and last names, Client last name, Postcode, and Case Number.
-     *
-     * @Route("/verify", methods={"POST"})
      */
+    #[Route(path: '/verify', methods: ['POST'])]
     public function verify(Request $request, PreRegistrationVerificationService $verificationService)
     {
         $clientData = $this->formatter->deserializeBodyContent($request);
@@ -101,11 +98,8 @@ class PreRegistrationController extends RestController
         return ['verified' => $verified];
     }
 
-    /**
-     * @Route("/count", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_ADMIN')")
-     */
+    #[Route(path: '/count', methods: ['GET'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function userCount()
     {
         $qb = $this->em->createQueryBuilder();
@@ -116,10 +110,9 @@ class PreRegistrationController extends RestController
     }
 
     /**
-     * @Route("/clientHasCoDeputies/{caseNumber}", methods={"GET"})
-     *
      * @return array|JsonResponse
      */
+    #[Route(path: '/clientHasCoDeputies/{caseNumber}', methods: ['GET'])]
     public function clientHasCoDeputies(string $caseNumber)
     {
         return $this->preRegistrationVerificationService->isMultiDeputyCase($caseNumber);

--- a/api/app/src/Controller/Report/AccountController.php
+++ b/api/app/src/Controller/Report/AccountController.php
@@ -20,11 +20,8 @@ class AccountController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/report/{reportId}/account", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/account', methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function addAccountAction(Request $request, $reportId)
     {
         $report = $this->findEntityBy(Report::class, $reportId);
@@ -48,11 +45,8 @@ class AccountController extends RestController
         return ['id' => $account->getId()];
     }
 
-    /**
-     * @Route("/report/account/{id}", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/account/{id}', methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getOneById(Request $request, $id)
     {
         $account = $this->findEntityBy(EntityDir\Report\BankAccount::class, $id, 'Account not found');
@@ -65,11 +59,8 @@ class AccountController extends RestController
         return $account;
     }
 
-    /**
-     * @Route("/account/{id}", methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/account/{id}', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function editAccountAction(Request $request, $id)
     {
         $account = $this->findEntityBy(EntityDir\Report\BankAccount::class, $id, 'Account not found'); /* @var $account EntityDir\Report\BankAccount */
@@ -90,11 +81,8 @@ class AccountController extends RestController
         return $account;
     }
 
-    /**
-     * @Route("/account/{id}/dependent-records", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/account/{id}/dependent-records', methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function accountDependentRecords($id)
     {
         $account = $this->findEntityBy(EntityDir\Report\BankAccount::class, $id, 'Account not found'); /* @var $account EntityDir\Report\BankAccount */
@@ -135,11 +123,8 @@ class AccountController extends RestController
         return $ret;
     }
 
-    /**
-     * @Route("/account/{id}", methods={"DELETE"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/account/{id}', methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function accountDelete($id)
     {
         $account = $this->findEntityBy(EntityDir\Report\BankAccount::class, $id, 'Account not found'); /* @var $account EntityDir\Report\BankAccount */

--- a/api/app/src/Controller/Report/ActionController.php
+++ b/api/app/src/Controller/Report/ActionController.php
@@ -19,11 +19,8 @@ class ActionController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/report/{reportId}/action", methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/action', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function updateAction(Request $request, $reportId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
@@ -46,12 +43,12 @@ class ActionController extends RestController
     }
 
     /**
-     * @Route("/report/{reportId}/action", methods={"GET"})
      *
-     * @Security("is_granted('ROLE_DEPUTY')")
      *
      * @param int $id
      */
+    #[Route(path: '/report/{reportId}/action', methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getOneById(Request $request, $id)
     {
         $action = $this->findEntityBy(EntityDir\Report\Action::class, $id, 'Action with id:'.$id.' not found');

--- a/api/app/src/Controller/Report/AssetController.php
+++ b/api/app/src/Controller/Report/AssetController.php
@@ -19,11 +19,8 @@ class AssetController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/report/{reportId}/asset/{assetId}", requirements={"reportId":"\d+", "assetId":"\d+"}, methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/asset/{assetId}', requirements: ['reportId' => '\d+', 'assetId' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getOneById(Request $request, $reportId, $assetId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
@@ -39,11 +36,8 @@ class AssetController extends RestController
         return $asset;
     }
 
-    /**
-     * @Route("/report/{reportId}/asset", requirements={"reportId":"\d+"}, methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/asset', requirements: ['reportId' => '\d+'], methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function add(Request $request, $reportId)
     {
         $data = $this->formatter->deserializeBodyContent($request);
@@ -68,11 +62,8 @@ class AssetController extends RestController
         return ['id' => $asset->getId()];
     }
 
-    /**
-     * @Route("/report/{reportId}/asset/{assetId}", requirements={"reportId":"\d+", "assetId":"\d+"}, methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/asset/{assetId}', requirements: ['reportId' => '\d+', 'assetId' => '\d+'], methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function edit(Request $request, $reportId, $assetId)
     {
         $data = $this->formatter->deserializeBodyContent($request);
@@ -92,11 +83,8 @@ class AssetController extends RestController
         return ['id' => $asset->getId()];
     }
 
-    /**
-     * @Route("/report/{reportId}/asset/{assetId}", requirements={"reportId":"\d+", "assetId":"\d+"}, methods={"DELETE"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/asset/{assetId}', requirements: ['reportId' => '\d+', 'assetId' => '\d+'], methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function delete($reportId, $assetId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);

--- a/api/app/src/Controller/Report/ClientBenefitsCheckController.php
+++ b/api/app/src/Controller/Report/ClientBenefitsCheckController.php
@@ -28,13 +28,7 @@ class ClientBenefitsCheckController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/{reportOrNdr}/client-benefits-check", methods={"POST"}, name="persist"), requirements={
-     *   "reportOrNdr" = "(report|ndr)"
-     * })))
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/{reportOrNdr}/client-benefits-check', methods: ['POST'], name: 'persist')] // , requirements={
     public function create(Request $request, string $reportOrNdr)
     {
         $this->setJmsGroups($request);
@@ -44,13 +38,7 @@ class ClientBenefitsCheckController extends RestController
         return $this->processEntity($clientBenefitsCheck, $reportOrNdr);
     }
 
-    /**
-     * @Route("/{reportOrNdr}/client-benefits-check/{id}", methods={"GET"}, name="read", requirements={
-     *   "reportOrNdr" = "(report|ndr)"
-     * })))
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/{reportOrNdr}/client-benefits-check/{id}', methods: ['GET'], name: 'read', requirements: ['reportOrNdr' => '(report|ndr)'])] // @Security("is_granted('ROLE_DEPUTY')")
     public function read(Request $request, string $id, string $reportOrNdr)
     {
         $this->setJmsGroups($request);
@@ -59,13 +47,7 @@ class ClientBenefitsCheckController extends RestController
             $this->clientBenefitsCheckRepository->findBy(['id' => $id], ['created' => 'ASC']);
     }
 
-    /**
-     * @Route("/{reportOrNdr}/client-benefits-check/{id}", methods={"PUT"}, name="update", requirements={
-     *   "reportOrNdr" = "(report|ndr)"
-     * }))))
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/{reportOrNdr}/client-benefits-check/{id}', methods: ['PUT'], name: 'update', requirements: ['reportOrNdr' => '(report|ndr)'])] // @Security("is_granted('ROLE_DEPUTY')")
     public function update(Request $request, $id, string $reportOrNdr)
     {
         $this->setJmsGroups($request);

--- a/api/app/src/Controller/Report/ContactController.php
+++ b/api/app/src/Controller/Report/ContactController.php
@@ -10,9 +10,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/report")
- */
+#[Route(path: '/report')]
 class ContactController extends RestController
 {
     private array $sectionIds = [EntityDir\Report\Report::SECTION_CONTACTS];
@@ -22,11 +20,8 @@ class ContactController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/contact/{id}", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/contact/{id}', methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getOneById(Request $request, $id)
     {
         $serialisedGroups = $request->query->has('groups')
@@ -39,11 +34,8 @@ class ContactController extends RestController
         return $contact;
     }
 
-    /**
-     * @Route("/contact/{id}", methods={"DELETE"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/contact/{id}', methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function deleteContact($id)
     {
         $contact = $this->findEntityBy(EntityDir\Report\Contact::class, $id, 'Contact not found');
@@ -59,11 +51,8 @@ class ContactController extends RestController
         return [];
     }
 
-    /**
-     * @Route("/contact", methods={"POST", "PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     **/
+    #[Route(path: '/contact', methods: ['POST', 'PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function upsertContact(Request $request)
     {
         $contactData = $this->formatter->deserializeBodyContent($request);
@@ -117,11 +106,8 @@ class ContactController extends RestController
         return ['id' => $contact->getId()];
     }
 
-    /**
-     * @Route("/{id}/contacts", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/{id}/contacts', methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getContacts($id)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $id);

--- a/api/app/src/Controller/Report/DecisionController.php
+++ b/api/app/src/Controller/Report/DecisionController.php
@@ -10,9 +10,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/report")
- */
+#[Route(path: '/report')]
 class DecisionController extends RestController
 {
     private array $sectionIds = [EntityDir\Report\Report::SECTION_DECISIONS];
@@ -24,11 +22,8 @@ class DecisionController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/decision", methods={"POST", "PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/decision', methods: ['POST', 'PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function upsertDecision(Request $request)
     {
         $data = $this->formatter->deserializeBodyContent($request);
@@ -75,12 +70,12 @@ class DecisionController extends RestController
     }
 
     /**
-     * @Route("/decision/{id}", methods={"GET"})
      *
-     * @Security("is_granted('ROLE_DEPUTY')")
      *
      * @param int $id
      */
+    #[Route(path: '/decision/{id}', methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getOneById(Request $request, $id)
     {
         $serialisedGroups = $request->query->has('groups') ? (array) $request->query->get('groups') : ['decision'];
@@ -92,11 +87,8 @@ class DecisionController extends RestController
         return $decision;
     }
 
-    /**
-     * @Route("/decision/{id}", methods={"DELETE"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/decision/{id}', methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function deleteDecision($id)
     {
         $decision = $this->findEntityBy(EntityDir\Report\Decision::class, $id, 'Decision with id:'.$id.' not found');

--- a/api/app/src/Controller/Report/DocumentController.php
+++ b/api/app/src/Controller/Report/DocumentController.php
@@ -26,14 +26,8 @@ class DocumentController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/document/{reportType}/{reportId}", requirements={
-     *     "reportId":"\d+",
-     *     "reportType" = "(report|ndr)"
-     * }, methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/document/{reportType}/{reportId}', requirements: ['reportId' => '\d+', 'reportType' => '(report|ndr)'], methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function add(Request $request, $reportType, $reportId)
     {
         if ('report' === $reportType) {
@@ -68,14 +62,8 @@ class DocumentController extends RestController
         return ['id' => $document->getId()];
     }
 
-    /**
-     * @Route("/document/{reportType}/{reportId}/overwrite", requirements={
-     *     "reportId":"\d+",
-     *     "reportType" = "(report|ndr)"
-     * }, methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_SUPER_ADMIN')")
-     */
+    #[Route(path: '/document/{reportType}/{reportId}/overwrite', requirements: ['reportId' => '\d+', 'reportType' => '(report|ndr)'], methods: ['POST'])]
+    #[Security("is_granted('ROLE_SUPER_ADMIN')")]
     public function overwriteReportPdf(Request $request, $reportType, $reportId)
     {
         if ('report' === $reportType) {
@@ -124,10 +112,10 @@ class DocumentController extends RestController
     /**
      * GET document by id.
      *
-     * @Route("/document/{id}", requirements={"id":"\d+"}, methods={"GET"})
      *
-     * @Security("is_granted('ROLE_DEPUTY')")
      */
+    #[Route(path: '/document/{id}', requirements: ['id' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getOneById(Request $request, $id)
     {
         $serialisedGroups = $request->query->has('groups')
@@ -146,14 +134,14 @@ class DocumentController extends RestController
      * Delete document.
      * Accessible only from deputy area.
      *
-     * @Route("/document/{id}", methods={"DELETE"})
      *
-     * @Security("is_granted('ROLE_DEPUTY')")
      *
      * @param int $id
      *
      * @return array
      */
+    #[Route(path: '/document/{id}', methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function delete($id)
     {
         /** @var $document EntityDir\Report\Document */
@@ -179,9 +167,8 @@ class DocumentController extends RestController
 
     /**
      * Get queued documents.
-     *
-     * @Route("/document/queued", methods={"GET"})
      */
+    #[Route(path: '/document/queued', methods: ['GET'])]
     public function getQueuedDocuments(Request $request, EntityManagerInterface $em): string
     {
         if (!$this->authService->isSecretValid($request)) {
@@ -210,9 +197,8 @@ class DocumentController extends RestController
 
     /**
      * Get queued documents.
-     *
-     * @Route("/document/update-related-statuses", methods={"PUT"})
      */
+    #[Route(path: '/document/update-related-statuses', methods: ['PUT'])]
     public function updateRelatedDocumentStatuses(Request $request, EntityManagerInterface $em): string
     {
         if (!$this->authService->isSecretValid($request)) {
@@ -230,9 +216,8 @@ class DocumentController extends RestController
 
     /**
      * Update a Document.
-     *
-     * @Route("/document/{id}", methods={"PUT"})
      */
+    #[Route(path: '/document/{id}', methods: ['PUT'])]
     public function update(Request $request, int $id, EntityManagerInterface $em): Document
     {
         if (!$this->authService->isSecretValid($request)) {

--- a/api/app/src/Controller/Report/ExpenseController.php
+++ b/api/app/src/Controller/Report/ExpenseController.php
@@ -19,11 +19,8 @@ class ExpenseController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/report/{reportId}/expense/{expenseId}", requirements={"reportId":"\d+", "expenseId":"\d+"}, methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/expense/{expenseId}', requirements: ['reportId' => '\d+', 'expenseId' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getOneById(Request $request, $reportId, $expenseId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
@@ -39,11 +36,8 @@ class ExpenseController extends RestController
         return $expense;
     }
 
-    /**
-     * @Route("/report/{reportId}/expense", requirements={"reportId":"\d+"}, methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/expense', requirements: ['reportId' => '\d+'], methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function add(Request $request, $reportId)
     {
         $data = $this->formatter->deserializeBodyContent($request);
@@ -70,11 +64,8 @@ class ExpenseController extends RestController
         return ['id' => $expense->getId()];
     }
 
-    /**
-     * @Route("/report/{reportId}/expense/{expenseId}", requirements={"reportId":"\d+", "expenseId":"\d+"}, methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/expense/{expenseId}', requirements: ['reportId' => '\d+', 'expenseId' => '\d+'], methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function edit(Request $request, $reportId, $expenseId)
     {
         $data = $this->formatter->deserializeBodyContent($request);
@@ -94,11 +85,8 @@ class ExpenseController extends RestController
         return ['id' => $expense->getId()];
     }
 
-    /**
-     * @Route("/report/{reportId}/expense/{expenseId}", requirements={"reportId":"\d+", "expenseId":"\d+"}, methods={"DELETE"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/expense/{expenseId}', requirements: ['reportId' => '\d+', 'expenseId' => '\d+'], methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function delete($reportId, $expenseId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId); /* @var $report EntityDir\Report\Report */

--- a/api/app/src/Controller/Report/GiftController.php
+++ b/api/app/src/Controller/Report/GiftController.php
@@ -19,11 +19,8 @@ class GiftController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/report/{reportId}/gift/{giftId}", requirements={"reportId":"\d+", "giftId":"\d+"}, methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/gift/{giftId}', requirements: ['reportId' => '\d+', 'giftId' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getOneById(Request $request, $reportId, $giftId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
@@ -39,11 +36,8 @@ class GiftController extends RestController
         return $gift;
     }
 
-    /**
-     * @Route("/report/{reportId}/gift", requirements={"reportId":"\d+"}, methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/gift', requirements: ['reportId' => '\d+'], methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function add(Request $request, $reportId)
     {
         $data = $this->formatter->deserializeBodyContent($request);
@@ -68,11 +62,8 @@ class GiftController extends RestController
         return ['id' => $gift->getId()];
     }
 
-    /**
-     * @Route("/report/{reportId}/gift/{giftId}", requirements={"reportId":"\d+", "giftId":"\d+"}, methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/gift/{giftId}', requirements: ['reportId' => '\d+', 'giftId' => '\d+'], methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function edit(Request $request, $reportId, $giftId)
     {
         $data = $this->formatter->deserializeBodyContent($request);
@@ -101,11 +92,8 @@ class GiftController extends RestController
         return ['id' => $gift->getId()];
     }
 
-    /**
-     * @Route("/report/{reportId}/gift/{giftId}", requirements={"reportId":"\d+", "giftId":"\d+"}, methods={"DELETE"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/gift/{giftId}', requirements: ['reportId' => '\d+', 'giftId' => '\d+'], methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function delete($reportId, $giftId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId); /* @var $report EntityDir\Report\Report */

--- a/api/app/src/Controller/Report/LifestyleController.php
+++ b/api/app/src/Controller/Report/LifestyleController.php
@@ -10,9 +10,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/report")
- */
+#[Route(path: '/report')]
 class LifestyleController extends RestController
 {
     private array $sectionIds = [EntityDir\Report\Report::SECTION_LIFESTYLE];
@@ -22,11 +20,8 @@ class LifestyleController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/lifestyle", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/lifestyle', methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function addAction(Request $request)
     {
         $lifestyle = new EntityDir\Report\Lifestyle();
@@ -47,11 +42,8 @@ class LifestyleController extends RestController
         return ['id' => $lifestyle->getId()];
     }
 
-    /**
-     * @Route("/lifestyle/{id}", methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/lifestyle/{id}', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function updateAction(Request $request, $id)
     {
         $lifestyle = $this->findEntityBy(EntityDir\Report\Lifestyle::class, $id);
@@ -69,12 +61,12 @@ class LifestyleController extends RestController
     }
 
     /**
-     * @Route("/{reportId}/lifestyle", methods={"GET"})
      *
-     * @Security("is_granted('ROLE_DEPUTY')")
      *
      * @param int $reportId
      */
+    #[Route(path: '/{reportId}/lifestyle', methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function findByReportIdAction($reportId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
@@ -86,12 +78,12 @@ class LifestyleController extends RestController
     }
 
     /**
-     * @Route("/lifestyle/{id}", methods={"GET"})
      *
-     * @Security("is_granted('ROLE_DEPUTY')")
      *
      * @param int $id
      */
+    #[Route(path: '/lifestyle/{id}', methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getOneById(Request $request, $id)
     {
         $serialiseGroups = $request->query->has('groups')
@@ -104,11 +96,8 @@ class LifestyleController extends RestController
         return $lifestyle;
     }
 
-    /**
-     * @Route("/lifestyle/{id}", methods={"DELETE"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/lifestyle/{id}', methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function deleteLifestyle($id)
     {
         $lifestyle = $this->findEntityBy(EntityDir\Report\Lifestyle::class, $id, 'VisitsCare not found');

--- a/api/app/src/Controller/Report/MentalCapacityController.php
+++ b/api/app/src/Controller/Report/MentalCapacityController.php
@@ -19,11 +19,8 @@ class MentalCapacityController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/report/{reportId}/mental-capacity", methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/mental-capacity', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function updateAction(Request $request, $reportId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
@@ -46,12 +43,12 @@ class MentalCapacityController extends RestController
     }
 
     /**
-     * @Route("/report/{reportId}/mental-capacity", methods={"GET"})
      *
-     * @Security("is_granted('ROLE_DEPUTY')")
      *
      * @param int $id
      */
+    #[Route(path: '/report/{reportId}/mental-capacity', methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getOneById(Request $request, $id)
     {
         $mc = $this->findEntityBy(EntityDir\Report\MentalCapacity::class, $id, 'MentalCapacity with id:'.$id.' not found');

--- a/api/app/src/Controller/Report/MoneyReceivedOnClientsBehalfController.php
+++ b/api/app/src/Controller/Report/MoneyReceivedOnClientsBehalfController.php
@@ -24,11 +24,8 @@ class MoneyReceivedOnClientsBehalfController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("{reportOrNdr}/money-type/delete/{moneyTypeId}", methods={"DELETE"}, name="delete_money_type")
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '{reportOrNdr}/money-type/delete/{moneyTypeId}', methods: ['DELETE'], name: 'delete_money_type')]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function delete(Request $request, string $reportOrNdr, string $moneyTypeId)
     {
         $groups = $request->get('groups') ? $request->get('groups') : ['client-benefits-check', 'report', 'ndr'];

--- a/api/app/src/Controller/Report/MoneyTransactionController.php
+++ b/api/app/src/Controller/Report/MoneyTransactionController.php
@@ -26,10 +26,8 @@ class MoneyTransactionController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/report/{reportId}/money-transaction", methods={"POST"})
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/money-transaction', methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function addMoneyTransactionAction(Request $request, $reportId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
@@ -72,10 +70,8 @@ class MoneyTransactionController extends RestController
         return $t->getId();
     }
 
-    /**
-     * @Route("/report/{reportId}/money-transaction/{transactionId}", methods={"PUT"})
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/money-transaction/{transactionId}', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function updateMoneyTransactionAction(Request $request, $reportId, $transactionId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
@@ -108,10 +104,8 @@ class MoneyTransactionController extends RestController
         return $t->getId();
     }
 
-    /**
-     * @Route("/report/{reportId}/money-transaction/{transactionId}", methods={"DELETE"})
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/money-transaction/{transactionId}', methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function deleteMoneyTransactionAction(Request $request, $reportId, $transactionId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
@@ -132,10 +126,8 @@ class MoneyTransactionController extends RestController
         return [];
     }
 
-    /**
-     * @Route("/report/{reportId}/money-transaction/soft-delete/{transactionId}", methods={"PUT"})
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/money-transaction/soft-delete/{transactionId}', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function softDeleteMoneyTransactionAction($transactionId)
     {
         $filter = $this->em->getFilters()->getFilter('softdeleteable');
@@ -154,10 +146,8 @@ class MoneyTransactionController extends RestController
         return [];
     }
 
-    /**
-     * @Route("/report/{reportId}/money-transaction/get-soft-delete", methods={"GET"})
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/money-transaction/get-soft-delete', methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getSoftDeletedMoneyTransactionItems($reportId)
     {
         $this->formatter->setJmsSerialiserGroups(['transaction']);

--- a/api/app/src/Controller/Report/MoneyTransactionShortController.php
+++ b/api/app/src/Controller/Report/MoneyTransactionShortController.php
@@ -26,10 +26,8 @@ class MoneyTransactionShortController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/report/{reportId}/money-transaction-short", methods={"POST"})
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/money-transaction-short', methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function addMoneyTransactionAction(Request $request, $reportId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId); /* @var $report EntityDir\Report\Report */
@@ -56,10 +54,8 @@ class MoneyTransactionShortController extends RestController
         return $t->getId();
     }
 
-    /**
-     * @Route("/report/{reportId}/money-transaction-short/{transactionId}", methods={"PUT"})
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/money-transaction-short/{transactionId}', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function updateMoneyTransactionAction(Request $request, $reportId, $transactionId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
@@ -79,10 +75,8 @@ class MoneyTransactionShortController extends RestController
         return $t->getId();
     }
 
-    /**
-     * @Route("/report/{reportId}/money-transaction-short/{transactionId}", methods={"DELETE"})
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/money-transaction-short/{transactionId}', methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function deleteMoneyTransactionAction(Request $request, $reportId, $transactionId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
@@ -103,10 +97,8 @@ class MoneyTransactionShortController extends RestController
         return [];
     }
 
-    /**
-     * @Route("/report/{reportId}/money-transaction-short/{transactionId}", requirements={"reportId":"\d+", "transactionId":"\d+"}, methods={"GET"})
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/money-transaction-short/{transactionId}', requirements: ['reportId' => '\d+', 'transactionId' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getOneById($reportId, $transactionId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
@@ -130,10 +122,8 @@ class MoneyTransactionShortController extends RestController
         }
     }
 
-    /**
-     * @Route("/report/{reportId}/money-transaction-short/soft-delete/{transactionId}", methods={"PUT"})
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/money-transaction-short/soft-delete/{transactionId}', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function softDeleteMoneyTransactionShortAction($transactionId)
     {
         $filter = $this->em->getFilters()->getFilter('softdeleteable');
@@ -152,10 +142,8 @@ class MoneyTransactionShortController extends RestController
         return [];
     }
 
-    /**
-     * @Route("/report/{reportId}/money-transaction-short/get-soft-delete", methods={"GET"})
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/money-transaction-short/get-soft-delete', methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getSoftDeletedMoneyTransactionShortItems($reportId)
     {
         return $this->moneyTransactionShortRepository->retrieveSoftDeleted($reportId);

--- a/api/app/src/Controller/Report/MoneyTransferController.php
+++ b/api/app/src/Controller/Report/MoneyTransferController.php
@@ -19,11 +19,8 @@ class MoneyTransferController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/report/{reportId}/money-transfers", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/money-transfers', methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function addMoneyTransferAction(Request $request, $reportId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
@@ -57,11 +54,8 @@ class MoneyTransferController extends RestController
         return $transfer->getId();
     }
 
-    /**
-     * @Route("/report/{reportId}/money-transfers/{transferId}", methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/money-transfers/{transferId}', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function editMoneyTransferAction(Request $request, $reportId, $transferId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
@@ -90,11 +84,8 @@ class MoneyTransferController extends RestController
         return $transfer->getId();
     }
 
-    /**
-     * @Route("/report/{reportId}/money-transfers/{transferId}", methods={"DELETE"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/report/{reportId}/money-transfers/{transferId}', methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function deleteMoneyTransferAction(Request $request, $reportId, $transferId)
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);

--- a/api/app/src/Controller/Report/ProfDeputyPrevCostController.php
+++ b/api/app/src/Controller/Report/ProfDeputyPrevCostController.php
@@ -19,11 +19,8 @@ class ProfDeputyPrevCostController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/report/{reportId}/prof-deputy-previous-cost", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_PROF')")
-     */
+    #[Route(path: '/report/{reportId}/prof-deputy-previous-cost', methods: ['POST'])]
+    #[Security("is_granted('ROLE_PROF')")]
     public function addAction(Request $request, $reportId)
     {
         $data = $this->formatter->deserializeBodyContent($request);
@@ -47,11 +44,8 @@ class ProfDeputyPrevCostController extends RestController
         return ['id' => $cost->getId()];
     }
 
-    /**
-     * @Route("/prof-deputy-previous-cost/{id}", methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_PROF')")
-     */
+    #[Route(path: '/prof-deputy-previous-cost/{id}', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_PROF')")]
     public function updateAction(Request $request, $id)
     {
         /** @var EntityDir\Report\ProfDeputyPreviousCost $cost */
@@ -70,12 +64,12 @@ class ProfDeputyPrevCostController extends RestController
     }
 
     /**
-     * @Route("/prof-deputy-previous-cost/{id}", methods={"GET"})
      *
-     * @Security("is_granted('ROLE_PROF')")
      *
      * @return object|null
      */
+    #[Route(path: '/prof-deputy-previous-cost/{id}', methods: ['GET'])]
+    #[Security("is_granted('ROLE_PROF')")]
     public function getOneById(Request $request, $id)
     {
         $serialiseGroups = $request->query->has('groups')
@@ -88,11 +82,8 @@ class ProfDeputyPrevCostController extends RestController
         return $cost;
     }
 
-    /**
-     * @Route("/report/{reportId}/prof-deputy-previous-cost/{id}", methods={"DELETE"})
-     *
-     * @Security("is_granted('ROLE_PROF')")
-     */
+    #[Route(path: '/report/{reportId}/prof-deputy-previous-cost/{id}', methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_PROF')")]
     public function deleteProfDeputyPreviousCost($id)
     {
         $cost = $this->findEntityBy(EntityDir\Report\ProfDeputyPreviousCost::class, $id, 'Prof Service fee not found');

--- a/api/app/src/Controller/Report/ProfServiceFeeController.php
+++ b/api/app/src/Controller/Report/ProfServiceFeeController.php
@@ -19,11 +19,8 @@ class ProfServiceFeeController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/report/{reportId}/prof-service-fee", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_PROF')")
-     */
+    #[Route(path: '/report/{reportId}/prof-service-fee', methods: ['POST'])]
+    #[Security("is_granted('ROLE_PROF')")]
     public function addAction(Request $request, $reportId)
     {
         $data = $this->formatter->deserializeBodyContent($request);
@@ -46,11 +43,8 @@ class ProfServiceFeeController extends RestController
         return ['id' => $profServiceFee->getId()];
     }
 
-    /**
-     * @Route("/prof-service-fee/{id}", methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_PROF')")
-     */
+    #[Route(path: '/prof-service-fee/{id}', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_PROF')")]
     public function updateAction(Request $request, $id)
     {
         /** @var EntityDir\Report\ProfServiceFee $profServiceFee */
@@ -69,12 +63,12 @@ class ProfServiceFeeController extends RestController
     }
 
     /**
-     * @Route("/prof-service-fee/{id}", methods={"GET"})
      *
-     * @Security("is_granted('ROLE_PROF')")
      *
      * @return object|null
      */
+    #[Route(path: '/prof-service-fee/{id}', methods: ['GET'])]
+    #[Security("is_granted('ROLE_PROF')")]
     public function getOneById(Request $request, $id)
     {
         $serialiseGroups = $request->query->has('groups')
@@ -87,11 +81,8 @@ class ProfServiceFeeController extends RestController
         return $profServiceFee;
     }
 
-    /**
-     * @Route("/prof-service-fee/{id}", methods={"DELETE"})
-     *
-     * @Security("is_granted('ROLE_PROF')")
-     */
+    #[Route(path: '/prof-service-fee/{id}', methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_PROF')")]
     public function deleteProfServiceFee($id)
     {
         $profServiceFee = $this->findEntityBy(EntityDir\Report\ProfServiceFee::class, $id, 'Prof Service fee not found');

--- a/api/app/src/Controller/Report/ReportController.php
+++ b/api/app/src/Controller/Report/ReportController.php
@@ -22,9 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/report")
- */
+#[Route(path: '/report')]
 class ReportController extends RestController
 {
     /** @var array */
@@ -57,10 +55,10 @@ class ReportController extends RestController
      * Currently only used by Lay deputy during registration steps
      * Pa report are instead created via OrgService::createReport().
      *
-     * @Route("", methods={"POST"})
      *
-     * @Security("is_granted('ROLE_DEPUTY')")
      */
+    #[Route(path: '', methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function addAction(Request $request)
     {
         $reportData = $this->formatter->deserializeBodyContent($request);
@@ -90,14 +88,14 @@ class ReportController extends RestController
     }
 
     /**
-     * @Route("/{id}", requirements={"id":"\d+"}, methods={"GET"})
      *
-     * @Security("is_granted('ROLE_DEPUTY') or is_granted('ROLE_ADMIN')")
      *
      * @param int $id
      *
      * @return Report
      */
+    #[Route(path: '/{id}', requirements: ['id' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY') or is_granted('ROLE_ADMIN')")]
     public function getById(Request $request, $id)
     {
         $groups = $request->query->has('groups')
@@ -121,11 +119,8 @@ class ReportController extends RestController
         return $report;
     }
 
-    /**
-     * @Route("/{id}/submit", requirements={"id":"\d+"}, methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/{id}/submit', requirements: ['id' => '\d+'], methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function submit(Request $request, $id)
     {
         $currentReport = $this->findEntityBy(Report::class, $id, 'Report not found');
@@ -162,11 +157,8 @@ class ReportController extends RestController
         return $nextYearReport ? $nextYearReport->getId() : null;
     }
 
-    /**
-     * @Route("/{id}", requirements={"id":"\d+"}, methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY') or is_granted('ROLE_ADMIN')")
-     */
+    #[Route(path: '/{id}', requirements: ['id' => '\d+'], methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY') or is_granted('ROLE_ADMIN')")]
     public function update(Request $request, $id)
     {
         /* @var $report Report */
@@ -542,11 +534,8 @@ class ReportController extends RestController
         return ['id' => $report->getId()];
     }
 
-    /**
-     * @Route("/{id}/unsubmit", requirements={"id":"\d+"}, methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_ADMIN')")
-     */
+    #[Route(path: '/{id}/unsubmit', requirements: ['id' => '\d+'], methods: ['PUT'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function unsubmit(Request $request, $id)
     {
         /** @var Report $report */
@@ -578,12 +567,12 @@ class ReportController extends RestController
     }
 
     /**
-     * @Route("/get-all-by-user", methods={"GET"})
      *
-     * @Security("is_granted('ROLE_ORG')")
      *
      * @throws NonUniqueResultException
      */
+    #[Route(path: '/get-all-by-user', methods: ['GET'])]
+    #[Security("is_granted('ROLE_ORG')")]
     public function getAllByUser(Request $request): array
     {
         /** @var User $user */
@@ -703,14 +692,14 @@ class ReportController extends RestController
     }
 
     /**
-     * @Route("/get-all-by-orgs", methods={"GET"})
      *
-     * @Security("is_granted('ROLE_ORG')")
      *
      * @return array
      *
      * @throws \Exception
      */
+    #[Route(path: '/get-all-by-orgs', methods: ['GET'])]
+    #[Security("is_granted('ROLE_ORG')")]
     public function getAllByOrgs(Request $request)
     {
         /** @var User $user */
@@ -726,11 +715,8 @@ class ReportController extends RestController
         return $this->getResponseByDeterminant($request, $organisationIds, ReportRepository::ORG_DETERMINANT);
     }
 
-    /**
-     * @Route("/{id}/submit-documents", requirements={"id":"\d+"}, methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/{id}/submit-documents', requirements: ['id' => '\d+'], methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function submitDocuments($id)
     {
         /* @var Report $currentReport */
@@ -748,10 +734,10 @@ class ReportController extends RestController
     /**
      * Add a checklist for the report.
      *
-     * @Route("/{report_id}/checked", requirements={"report_id":"\d+"}, methods={"POST"})
      *
-     * @Security("is_granted('ROLE_ADMIN')")
      */
+    #[Route(path: '/{report_id}/checked', requirements: ['report_id' => '\d+'], methods: ['POST'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function insertChecklist(Request $request, $report_id)
     {
         /** @var User $user */
@@ -823,10 +809,10 @@ class ReportController extends RestController
     /**
      * Update a checklist for the report.
      *
-     * @Route("/{report_id}/checked", requirements={"report_id":"\d+"}, methods={"PUT"})
      *
-     * @Security("is_granted('ROLE_ADMIN')")
      */
+    #[Route(path: '/{report_id}/checked', requirements: ['report_id' => '\d+'], methods: ['PUT'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function updateChecklist(Request $request, $report_id)
     {
         /** @var User $user */
@@ -864,10 +850,10 @@ class ReportController extends RestController
     /**
      * Get a checklist for the report.
      *
-     * @Route("/{report_id}/checklist", requirements={"report_id":"\d+"}, methods={"GET"})
      *
-     * @Security("is_granted('ROLE_ADMIN')")
      */
+    #[Route(path: '/{report_id}/checklist', requirements: ['report_id' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function getChecklist(Request $request, $report_id)
     {
         $this->formatter->setJmsSerialiserGroups(['checklist', 'last-modified', 'user']);
@@ -882,10 +868,10 @@ class ReportController extends RestController
     /**
      * Update a checklist for the report.
      *
-     * @Route("/{report_id}/checklist", requirements={"report_id":"\d+"}, methods={"POST", "PUT"})
      *
-     * @Security("is_granted('ROLE_ADMIN')")
      */
+    #[Route(path: '/{report_id}/checklist', requirements: ['report_id' => '\d+'], methods: ['POST', 'PUT'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function upsertChecklist(Request $request, $report_id)
     {
         /** @var User $user */
@@ -923,10 +909,9 @@ class ReportController extends RestController
     }
 
     /**
-     * @Route("/all-with-queued-checklists", methods={"GET"})
-     *
      * @throws DBALException
      */
+    #[Route(path: '/all-with-queued-checklists', methods: ['GET'])]
     public function getReportsWithQueuedChecklists(Request $request): array
     {
         if (!$this->authService->isSecretValid($request)) {
@@ -953,9 +938,7 @@ class ReportController extends RestController
         return $reports;
     }
 
-    /**
-     * @Route("/{reportId}/refresh-cache", methods={"POST"}, name="refresh_report_cache")
-     */
+    #[Route(path: '/{reportId}/refresh-cache', methods: ['POST'], name: 'refresh_report_cache')]
     public function refreshReportCache(Request $request, int $reportId)
     {
         $groups = $request->query->has('groups')

--- a/api/app/src/Controller/Report/ReportSubmissionController.php
+++ b/api/app/src/Controller/Report/ReportSubmissionController.php
@@ -14,9 +14,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/report-submission")
- */
+#[Route(path: '/report-submission')]
 class ReportSubmissionController extends RestController
 {
     public const QUEUEABLE_STATUSES = [
@@ -49,11 +47,8 @@ class ReportSubmissionController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_ADMIN')")
-     */
+    #[Route(path: '', methods: ['GET'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function getAll(Request $request)
     {
         /** @var ReportSubmissionRepository $repo */
@@ -74,11 +69,8 @@ class ReportSubmissionController extends RestController
         return $ret;
     }
 
-    /**
-     * @Route("/{id}", requirements={"id":"\d+"}, methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_ADMIN')")
-     */
+    #[Route(path: '/{id}', requirements: ['id' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function getOneById(Request $request, $id)
     {
         $ret = $this->em->getRepository(ReportSubmission::class)->findOneByIdUnfiltered($id);
@@ -92,10 +84,10 @@ class ReportSubmissionController extends RestController
      * Update documents
      * return array of storage references, for admin area to delete if needed.
      *
-     * @Route("/{reportSubmissionId}", requirements={"reportSubmissionId":"\d+"}, methods={"PUT"})
      *
-     * @Security("is_granted('ROLE_ADMIN')")
      */
+    #[Route(path: '/{reportSubmissionId}', requirements: ['reportSubmissionId' => '\d+'], methods: ['PUT'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function update(Request $request, $reportSubmissionId)
     {
         /* @var $reportSubmission EntityDir\Report\ReportSubmission */
@@ -116,9 +108,8 @@ class ReportSubmissionController extends RestController
     /**
      * Separating this from update() as it needs to be accessible via client secret which removes the
      * User from the request.
-     *
-     * @Route("/{reportSubmissionId}/update-uuid", requirements={"reportSubmissionId":"\d+"}, methods={"PUT"})
      */
+    #[Route(path: '/{reportSubmissionId}/update-uuid', requirements: ['reportSubmissionId' => '\d+'], methods: ['PUT'])]
     public function updateUuid(Request $request, $reportSubmissionId)
     {
         if (!$this->authService->isSecretValid($request)) {
@@ -142,9 +133,8 @@ class ReportSubmissionController extends RestController
     /**
      * Get old report submissions.
      * Called from ADMIN cron.
-     *
-     * @Route("/old", methods={"GET"})
      */
+    #[Route(path: '/old', methods: ['GET'])]
     public function getOld(Request $request)
     {
         if (!$this->authService->isSecretValidForRole(EntityDir\User::ROLE_ADMIN, $request)) {
@@ -163,9 +153,8 @@ class ReportSubmissionController extends RestController
     /**
      * Set report undownloadable (and remove the storage reference for the files.
      * Called from ADMIN cron.
-     *
-     * @Route("/{id}/set-undownloadable", requirements={"id":"\d+"}, methods={"PUT"})
      */
+    #[Route(path: '/{id}/set-undownloadable', requirements: ['id' => '\d+'], methods: ['PUT'])]
     public function setUndownloadable($id, Request $request)
     {
         if (!$this->authService->isSecretValidForRole(EntityDir\User::ROLE_ADMIN, $request)) {
@@ -187,10 +176,10 @@ class ReportSubmissionController extends RestController
     /**
      * Queue submission documents which have been synced yet.
      *
-     * @Route("/{id}/queue-documents", requirements={"id":"\d+"}, methods={"PUT"})
      *
-     * @Security("is_granted('ROLE_SUPER_ADMIN')")
      */
+    #[Route(path: '/{id}/queue-documents', requirements: ['id' => '\d+'], methods: ['PUT'])]
+    #[Security("is_granted('ROLE_SUPER_ADMIN')")]
     public function queueDocuments($id)
     {
         /** @var ReportSubmission $reportSubmission */
@@ -214,12 +203,12 @@ class ReportSubmissionController extends RestController
     }
 
     /**
-     * @Route("/pre-registration-data", name="pre_registration_data", methods={"GET"})
      *
-     * @Security("is_granted('ROLE_ADMIN')")
      *
      * @throws \Exception
      */
+    #[Route(path: '/pre-registration-data', name: 'pre_registration_data', methods: ['GET'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function getPreRegistrationData(Request $request): array
     {
         /* @var $repo EntityDir\Repository\ReportSubmissionRepository */

--- a/api/app/src/Controller/Report/VisitsCareController.php
+++ b/api/app/src/Controller/Report/VisitsCareController.php
@@ -10,9 +10,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/report")
- */
+#[Route(path: '/report')]
 class VisitsCareController extends RestController
 {
     private array $sectionIds = [EntityDir\Report\Report::SECTION_VISITS_CARE];
@@ -22,11 +20,8 @@ class VisitsCareController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/visits-care", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/visits-care', methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function addAction(Request $request)
     {
         $visitsCare = new EntityDir\Report\VisitsCare();
@@ -47,11 +42,8 @@ class VisitsCareController extends RestController
         return ['id' => $visitsCare->getId()];
     }
 
-    /**
-     * @Route("/visits-care/{id}", methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/visits-care/{id}', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function updateAction(Request $request, $id)
     {
         $visitsCare = $this->findEntityBy(EntityDir\Report\VisitsCare::class, $id);
@@ -69,12 +61,12 @@ class VisitsCareController extends RestController
     }
 
     /**
-     * @Route("/{reportId}/visits-care", methods={"GET"})
      *
-     * @Security("is_granted('ROLE_DEPUTY')")
      *
      * @param int $reportId
      */
+    #[Route(path: '/{reportId}/visits-care', methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function findByReportIdAction($reportId)
     {
         $this->formatter->setJmsSerialiserGroups(['visits-care']);
@@ -88,12 +80,12 @@ class VisitsCareController extends RestController
     }
 
     /**
-     * @Route("/visits-care/{id}", methods={"GET"})
      *
-     * @Security("is_granted('ROLE_DEPUTY')")
      *
      * @param int $id
      */
+    #[Route(path: '/visits-care/{id}', methods: ['GET'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function getOneById(Request $request, $id)
     {
         $serialiseGroups = $request->query->has('groups')
@@ -106,11 +98,8 @@ class VisitsCareController extends RestController
         return $visitsCare;
     }
 
-    /**
-     * @Route("/visits-care/{id}", methods={"DELETE"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/visits-care/{id}', methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function deleteVisitsCare($id)
     {
         $visitsCare = $this->findEntityBy(EntityDir\Report\VisitsCare::class, $id, 'VisitsCare not found');

--- a/api/app/src/Controller/SatisfactionController.php
+++ b/api/app/src/Controller/SatisfactionController.php
@@ -13,9 +13,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/satisfaction")
- */
+#[Route(path: '/satisfaction')]
 class SatisfactionController extends RestController
 {
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter, private readonly ReportRepository $reportRepository, private readonly NdrRepository $ndrRepository, private readonly SatisfactionRepository $satisfactionRepository)
@@ -52,11 +50,8 @@ class SatisfactionController extends RestController
         return $satisfaction;
     }
 
-    /**
-     * @Route("", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '', methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY')")]
     public function add(Request $request)
     {
         $data = $this->formatter->deserializeBodyContent($request, [
@@ -94,11 +89,8 @@ class SatisfactionController extends RestController
         return $satisfaction->getId();
     }
 
-    /**
-     * @Route("/satisfaction_data", name="satisfaction_data", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_SUPER_ADMIN')")
-     */
+    #[Route(path: '/satisfaction_data', name: 'satisfaction_data', methods: ['GET'])]
+    #[Security("is_granted('ROLE_SUPER_ADMIN')")]
     public function getSatisfactionData(Request $request)
     {
         /* @var $repo SatisfactionRepository */
@@ -116,9 +108,7 @@ class SatisfactionController extends RestController
         );
     }
 
-    /**
-     * @Route("/public", methods={"POST"})
-     */
+    #[Route(path: '/public', methods: ['POST'])]
     public function publicAdd(Request $request)
     {
         $data = $this->formatter->deserializeBodyContent($request, [

--- a/api/app/src/Controller/SelfRegisterController.php
+++ b/api/app/src/Controller/SelfRegisterController.php
@@ -13,9 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
-/**
- * @Route("/selfregister")
- */
+#[Route(path: '/selfregister')]
 class SelfRegisterController extends RestController
 {
     public function __construct(private readonly LoggerInterface $logger, private readonly ValidatorInterface $validator, private readonly AuthService $authService, private readonly RestFormatter $formatter, private readonly EntityManagerInterface $em)
@@ -23,9 +21,7 @@ class SelfRegisterController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("", methods={"POST"})
-     */
+    #[Route(path: '', methods: ['POST'])]
     public function register(Request $request, UserRegistrationService $userRegistrationService)
     {
         if (!$this->authService->isSecretValid($request)) {
@@ -70,9 +66,7 @@ class SelfRegisterController extends RestController
         return $user;
     }
 
-    /**
-     * @Route("/verifycodeputy", methods={"POST"})
-     */
+    #[Route(path: '/verifycodeputy', methods: ['POST'])]
     public function verifyCoDeputy(Request $request, UserRegistrationService $userRegistrationService)
     {
         if (!$this->authService->isSecretValid($request)) {
@@ -120,9 +114,7 @@ class SelfRegisterController extends RestController
         return ['verified' => $coDeputyVerified, 'coDeputyUid' => $coDeputyUid, 'existingDeputyAccounts' => $existingDeputyAccounts];
     }
 
-    /**
-     * @Route("/updatecodeputy/{userId}", requirements={"userId":"\d+"}, methods={"PUT"})
-     */
+    #[Route(path: '/updatecodeputy/{userId}', requirements: ['userId' => '\d+'], methods: ['PUT'])]
     public function updateCoDeputyWithVerificationData(Request $request, $userId): User
     {
         $user = $this->em->getRepository('App\Entity\User')->findOneBy(['id' => $userId]);

--- a/api/app/src/Controller/SettingController.php
+++ b/api/app/src/Controller/SettingController.php
@@ -9,9 +9,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/setting")
- */
+#[Route(path: '/setting')]
 class SettingController extends RestController
 {
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
@@ -19,9 +17,7 @@ class SettingController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/{id}", methods={"GET"})
-     */
+    #[Route(path: '/{id}', methods: ['GET'])]
     public function getSetting(Request $request, $id)
     {
         $setting = $this->em->getRepository(EntityDir\Setting::class)->find($id); /* @var $setting EntityDir\Setting */
@@ -31,11 +27,8 @@ class SettingController extends RestController
         return $setting ?: [];
     }
 
-    /**
-     * @Route("/{id}", methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_ADMIN')")
-     */
+    #[Route(path: '/{id}', methods: ['PUT'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function upsertSetting(Request $request, $id)
     {
         $data = $this->formatter->deserializeBodyContent($request, [

--- a/api/app/src/Controller/StatsController.php
+++ b/api/app/src/Controller/StatsController.php
@@ -41,11 +41,8 @@ class StatsController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/stats", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_ADMIN')")
-     */
+    #[Route(path: '/stats', methods: ['GET'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function getMetric(Request $request)
     {
         $params = new StatsQueryParameters($request->query->all());
@@ -54,11 +51,8 @@ class StatsController extends RestController
         return $query->execute($params);
     }
 
-    /**
-     * @Route("stats/deputies/lay/active", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_SUPER_ADMIN')")
-     */
+    #[Route(path: 'stats/deputies/lay/active', methods: ['GET'])]
+    #[Security("is_granted('ROLE_SUPER_ADMIN')")]
     public function getActiveLays(Request $request)
     {
         if ($this->authService->JWTIsValid($request)) {
@@ -68,11 +62,8 @@ class StatsController extends RestController
         throw new UnauthorisedException('JWT is not valid');
     }
 
-    /**
-     * @Route("stats/admins/report_data", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_SUPER_ADMIN')")
-     */
+    #[Route(path: 'stats/admins/report_data', methods: ['GET'])]
+    #[Security("is_granted('ROLE_SUPER_ADMIN')")]
     public function getAdminUserAccountReportData(Request $request, RestFormatter $formatter): array
     {
         $serialisedGroups = (array) $request->query->get('groups');
@@ -102,11 +93,8 @@ class StatsController extends RestController
         ];
     }
 
-    /**
-     * @Route("stats/admins/inactive_admin_users", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_SUPER_ADMIN')")
-     */
+    #[Route(path: 'stats/admins/inactive_admin_users', methods: ['GET'])]
+    #[Security("is_granted('ROLE_SUPER_ADMIN')")]
     public function getInactiveAdminUserReportData(Request $request, Restformatter $formatter): array
     {
         $serialisedGroups = (array) $request->query->get('groups');
@@ -122,11 +110,8 @@ class StatsController extends RestController
         ];
     }
 
-    /**
-     * @Route("stats/assets/total_values", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_SUPER_ADMIN')")
-     */
+    #[Route(path: 'stats/assets/total_values', methods: ['GET'])]
+    #[Security("is_granted('ROLE_SUPER_ADMIN')")]
     public function getAssetsTotalValueData()
     {
         $ret = [
@@ -167,11 +152,8 @@ class StatsController extends RestController
         return new JsonResponse($ret);
     }
 
-    /**
-     * @Route("stats/report/benefits-report-metrics", methods={"GET", "POST"})
-     *
-     * @Security("is_granted('ROLE_SUPER_ADMIN')")
-     */
+    #[Route(path: 'stats/report/benefits-report-metrics', methods: ['GET', 'POST'])]
+    #[Security("is_granted('ROLE_SUPER_ADMIN')")]
     public function getBenefitsReportMetrics(Request $request): array
     {
         $deputyType = $request->query->get('deputyType');
@@ -181,11 +163,8 @@ class StatsController extends RestController
         return $this->reportRepository->getBenefitsResponseMetrics($startDate, $endDate, $deputyType);
     }
 
-    /**
-     * @Route("stats/report/imbalance", name="imbalance_report", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_SUPER_ADMIN')")
-     */
+    #[Route(path: 'stats/report/imbalance', name: 'imbalance_report', methods: ['GET'])]
+    #[Security("is_granted('ROLE_SUPER_ADMIN')")]
     public function getImbalanceReport(Request $request)
     {
         $startDate = $this->convertDateStringToDateTime($request->get('startDate', ''));

--- a/api/app/src/Controller/UserController.php
+++ b/api/app/src/Controller/UserController.php
@@ -24,10 +24,7 @@ use Symfony\Component\Security\Core\Security as SecurityHelper;
 
 // TODO
 // http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html
-
-/**
- * @Route("/user")
- */
+#[Route(path: '/user')]
 class UserController extends RestController
 {
     public function __construct(
@@ -45,11 +42,8 @@ class UserController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD') or is_granted('ROLE_ORG_NAMED') or is_granted('ROLE_ORG_ADMIN')")
-     */
+    #[Route(path: '', methods: ['POST'])]
+    #[Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD') or is_granted('ROLE_ORG_NAMED') or is_granted('ROLE_ORG_ADMIN')")]
     public function add(Request $request)
     {
         $data = $this->formatter->deserializeBodyContent($request, [
@@ -149,9 +143,7 @@ class UserController extends RestController
         return $user;
     }
 
-    /**
-     * @Route("/{id}", methods={"PUT"})
-     */
+    #[Route(path: '/{id}', methods: ['PUT'])]
     public function update(Request $request, $id)
     {
         /** @var User $loggedInUser */
@@ -188,9 +180,7 @@ class UserController extends RestController
         return ['id' => $requestedUser->getId()];
     }
 
-    /**
-     * @Route("/{id}/is-password-correct", methods={"POST"})
-     */
+    #[Route(path: '/{id}/is-password-correct', methods: ['POST'])]
     public function isPasswordCorrect(Request $request, $id)
     {
         /** @var User $loggedInUser */
@@ -212,9 +202,8 @@ class UserController extends RestController
 
     /**
      * See RegistrationTokenAuthenticator for checks and how User is set in session.
-     *
-     * @Route("/{id}/set-password", methods={"PUT"})
      */
+    #[Route(path: '/{id}/set-password', methods: ['PUT'])]
     public function changePassword(Request $request, $id)
     {
         $data = $this->formatter->deserializeBodyContent($request, [
@@ -254,9 +243,8 @@ class UserController extends RestController
 
     /**
      * change email.
-     *
-     * @Route("/{id}/update-email", methods={"PUT"})
      */
+    #[Route(path: '/{id}/update-email', methods: ['PUT'])]
     public function changeEmail(Request $request, $id)
     {
         /** @var User $loggedInUser */
@@ -280,19 +268,13 @@ class UserController extends RestController
         return $requestedUser->getId();
     }
 
-    /**
-     * @Route("/{id}", requirements={"id":"\d+"}, methods={"GET"})
-     */
+    #[Route(path: '/{id}', requirements: ['id' => '\d+'], methods: ['GET'])]
     public function getOneById(Request $request, $id)
     {
         return $this->getOneByFilter($request, 'user_id', $id);
     }
 
-    /**
-     * @Route("/get-one-by/{what}/{filter}", requirements={
-     *   "what" = "(user_id|email|case_number)"
-     * }, methods={"GET"})
-     */
+    #[Route(path: '/get-one-by/{what}/{filter}', requirements: ['what' => '(user_id|email|case_number)'], methods: ['GET'])]
     public function getOneByFilter(Request $request, $what, $filter)
     {
         if ('email' == $what) {
@@ -361,10 +343,10 @@ class UserController extends RestController
      * Only for ROLE_PROF named and admin, when adding users to multiple teams.
      * Returns empty if user doesn't exist.
      *
-     * @Route("/get-team-names-by-email/{email}", methods={"GET"})
      *
-     * @Security("is_granted('ROLE_ORG_NAMED') or is_granted('ROLE_ORG_ADMIN')")
      */
+    #[Route(path: '/get-team-names-by-email/{email}', methods: ['GET'])]
+    #[Security("is_granted('ROLE_ORG_NAMED') or is_granted('ROLE_ORG_ADMIN')")]
     public function getUserTeamNames(Request $request, $email)
     {
         $user = $this->userRepository->findOneBy(['email' => $email]);
@@ -377,17 +359,16 @@ class UserController extends RestController
     /**
      * Delete user with clients.
      *
-     * @Route("/{id}", methods={"DELETE"})
      *
-     * @Security("is_granted('ROLE_ADMIN_MANAGER')")
      *
      * @param int $id
      *
      * @return array
-     *
      * @throws ORMException
      * @throws OptimisticLockException
      */
+    #[Route(path: '/{id}', methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_ADMIN_MANAGER')")]
     public function delete($id)
     {
         /** @var User $user */
@@ -414,11 +395,8 @@ class UserController extends RestController
         return [];
     }
 
-    /**
-     * @Route("/get-all", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
-     */
+    #[Route(path: '/get-all', methods: ['GET'])]
+    #[Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")]
     public function getAll(Request $request)
     {
         $this->formatter->setJmsSerialiserGroups(['user']);
@@ -428,9 +406,8 @@ class UserController extends RestController
 
     /**
      * Requires client secret.
-     *
-     * @Route("/recreate-token/{email}", defaults={"email": "none"}, methods={"PUT"})
      */
+    #[Route(path: '/recreate-token/{email}', defaults: ['email' => 'none'], methods: ['PUT'])]
     public function recreateToken(Request $request, $email)
     {
         if (!$this->authService->isSecretValid($request)) {
@@ -454,9 +431,7 @@ class UserController extends RestController
         return $user;
     }
 
-    /**
-     * @Route("/get-by-token/{token}", methods={"GET"})
-     */
+    #[Route(path: '/get-by-token/{token}', methods: ['GET'])]
     public function getByToken(Request $request, $token)
     {
         if (!$this->authService->isSecretValid($request)) {
@@ -476,9 +451,7 @@ class UserController extends RestController
         return $user;
     }
 
-    /**
-     * @Route("/agree-terms-use/{token}", methods={"PUT"})
-     */
+    #[Route(path: '/agree-terms-use/{token}', methods: ['PUT'])]
     public function agreeTermsUse(Request $request, $token)
     {
         if (!$this->authService->isSecretValid($request)) {
@@ -500,9 +473,7 @@ class UserController extends RestController
         return $user->getId();
     }
 
-    /**
-     * @Route("/clear-registration-token/{token}", methods={"PUT"})
-     */
+    #[Route(path: '/clear-registration-token/{token}', methods: ['PUT'])]
     public function clearRegistrationToken(Request $request, $token)
     {
         if (!$this->authService->isSecretValid($request)) {
@@ -524,11 +495,8 @@ class UserController extends RestController
         return $user->getId();
     }
 
-    /**
-     * @Route("/{id}/team", requirements={"id":"\d+"}, methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_ORG')")
-     */
+    #[Route(path: '/{id}/team', requirements: ['id' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('ROLE_ORG')")]
     public function getTeamByUserId(Request $request, $id)
     {
         /** @var User $loggedInUser */
@@ -562,10 +530,10 @@ class UserController extends RestController
     /**
      * Endpoint for getting a reg token for user.
      *
-     * @Route("/get-reg-token", methods={"GET"})
      *
      * @throws \Exception
      */
+    #[Route(path: '/get-reg-token', methods: ['GET'])]
     public function getRegToken(Request $request)
     {
         /** @var User $user */
@@ -581,9 +549,8 @@ class UserController extends RestController
 
     /**
      * Set Registration date on user.
-     *
-     * @Route("/{id}/set-registration-date", methods={"PUT"})
      */
+    #[Route(path: '/{id}/set-registration-date', methods: ['PUT'])]
     public function setRegistrationDate(Request $request, int $id): int
     {
         $data = $this->formatter->deserializeBodyContent($request);
@@ -607,9 +574,8 @@ class UserController extends RestController
 
     /**
      * Set active flag on user.
-     *
-     * @Route("/{id}/set-active", methods={"PUT"})
      */
+    #[Route(path: '/{id}/set-active', methods: ['PUT'])]
     public function setActive(Request $request, int $id): int
     {
         $data = $this->formatter->deserializeBodyContent($request);
@@ -634,10 +600,10 @@ class UserController extends RestController
     /**
      * Endpoint for getting the primary user account for user.
      *
-     * @Route("/get-primary-email/{deputyUid}", methods={"GET"})
      *
      * @throws \Exception
      */
+    #[Route(path: '/get-primary-email/{deputyUid}', methods: ['GET'])]
     public function getPrimaryEmail(int $deputyUid): string
     {
         $users = $this->userRepository->findBy(['deputyUid' => $deputyUid]);
@@ -656,10 +622,10 @@ class UserController extends RestController
     /**
      * Endpoint for getting the primary user account associated with a deputy uid.
      *
-     * @Route("/get-primary-user-account/{deputyUid}", methods={"GET"})
      *
      * @throws \Exception
      */
+    #[Route(path: '/get-primary-user-account/{deputyUid}', methods: ['GET'])]
     public function getPrimaryUserAccount(int $deputyUid): ?User
     {
         $this->formatter->setJmsSerialiserGroups(['user', 'user-list']);

--- a/api/app/src/Controller/UserResearchController.php
+++ b/api/app/src/Controller/UserResearchController.php
@@ -27,11 +27,8 @@ class UserResearchController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/user-research", name="create_user_research", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_DEPUTY') or is_granted('ROLE_ORG')")
-     */
+    #[Route(path: '/user-research', name: 'create_user_research', methods: ['POST'])]
+    #[Security("is_granted('ROLE_DEPUTY') or is_granted('ROLE_ORG')")]
     public function create(Request $request)
     {
         try {
@@ -52,11 +49,8 @@ class UserResearchController extends RestController
         }
     }
 
-    /**
-     * @Route("/user-research", name="get_user_research", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_SUPER_ADMIN')")
-     */
+    #[Route(path: '/user-research', name: 'get_user_research', methods: ['GET'])]
+    #[Security("is_granted('ROLE_SUPER_ADMIN')")]
     public function getAll(Request $request)
     {
         try {

--- a/api/app/src/v2/Controller/ClientController.php
+++ b/api/app/src/v2/Controller/ClientController.php
@@ -15,9 +15,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/client")
- */
+#[Route(path: '/client')]
 class ClientController extends RestController
 {
     use ControllerTrait;
@@ -33,11 +31,8 @@ class ClientController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @Route("/{id}", requirements={"id":"\d+"}, methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD') or is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/{id}', requirements: ['id' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD') or is_granted('ROLE_DEPUTY')")]
     public function getByIdAction(int $id): JsonResponse
     {
         if (null === ($data = $this->repository->getArrayById($id))) {
@@ -68,11 +63,8 @@ class ClientController extends RestController
         return $this->buildSuccessResponse($transformedDto);
     }
 
-    /**
-     * @Route("/case-number/{caseNumber}", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD') or is_granted('ROLE_DEPUTY')")
-     */
+    #[Route(path: '/case-number/{caseNumber}', methods: ['GET'])]
+    #[Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD') or is_granted('ROLE_DEPUTY')")]
     public function getByCaseNumber(string $caseNumber): JsonResponse
     {
         if (null === ($data = $this->repository->getArrayByCaseNumber($caseNumber))) {

--- a/api/app/src/v2/Controller/DeputyController.php
+++ b/api/app/src/v2/Controller/DeputyController.php
@@ -9,9 +9,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/deputy")
- */
+#[Route(path: '/deputy')]
 class DeputyController
 {
     use ControllerTrait;
@@ -24,10 +22,9 @@ class DeputyController
     }
 
     /**
-     * @Route("/{id}", requirements={"id":"\d+"}, methods={"GET"})
-     *
      * @return JsonResponse
      */
+    #[Route(path: '/{id}', requirements: ['id' => '\d+'], methods: ['GET'])]
     public function getByIdAction($id)
     {
         if (null === ($data = $this->repository->findUserArrayById($id))) {

--- a/api/app/src/v2/Controller/OrganisationController.php
+++ b/api/app/src/v2/Controller/OrganisationController.php
@@ -22,9 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/organisation")
- */
+#[Route(path: '/organisation')]
 class OrganisationController extends AbstractController
 {
     use ControllerTrait;
@@ -49,11 +47,8 @@ class OrganisationController extends AbstractController
         'user-list',
     ];
 
-    /**
-     * @Route("/list", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_ADMIN')")
-     */
+    #[Route(path: '/list', methods: ['GET'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function getAllAction(): JsonResponse
     {
         // Fetch all data from db
@@ -93,12 +88,12 @@ class OrganisationController extends AbstractController
     }
 
     /**
-     * @Route("/{id}", requirements={"id":"\d+"}, methods={"GET"})
      *
      * @Entity("organisation", expr="repository.find(id)")
      *
-     * @Security("is_granted('view', organisation)")
      */
+    #[Route(path: '/{id}', requirements: ['id' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('view', organisation)")]
     public function getByIdAction(Organisation $organisation): JsonResponse
     {
         $dto = $this->assembler->assembleFromEntity($organisation);
@@ -108,12 +103,12 @@ class OrganisationController extends AbstractController
     }
 
     /**
-     * @Route("/{id}/users", requirements={"id":"\d+"}, methods={"GET"})
      *
      * @Entity("organisation", expr="repository.find(id)")
      *
-     * @Security("is_granted('view', organisation)")
      */
+    #[Route(path: '/{id}/users', requirements: ['id' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('view', organisation)")]
     public function getUsers(Organisation $organisation, Request $request)
     {
         $ret = $this->userRepository->findByFiltersWithCounts(
@@ -129,12 +124,12 @@ class OrganisationController extends AbstractController
     }
 
     /**
-     * @Route("/{id}/clients", requirements={"id":"\d+"}, methods={"GET"})
      *
      * @Entity("organisation", expr="repository.find(id)")
      *
-     * @Security("is_granted('view', organisation)")
      */
+    #[Route(path: '/{id}/clients', requirements: ['id' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('view', organisation)")]
     public function getClients(Organisation $organisation, Request $request)
     {
         $ret = $this->clientRepository->findByFiltersWithCounts(
@@ -150,13 +145,13 @@ class OrganisationController extends AbstractController
     }
 
     /**
-     * @Route("", methods={"POST"})
      *
-     * @Security("is_granted('ROLE_ADMIN')")
      *
      * @throws ORMException
      * @throws OptimisticLockException
      */
+    #[Route(path: '', methods: ['POST'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function createAction(Request $request): JsonResponse
     {
         $data = json_decode($request->getContent(), true);
@@ -165,11 +160,8 @@ class OrganisationController extends AbstractController
         return $this->buildSuccessResponse(['id' => $entity->getId()], 'Organisation created', Response::HTTP_CREATED);
     }
 
-    /**
-     * @Route("/{id}", requirements={"id":"\d+"}, methods={"PUT"})
-     *
-     * @Security("is_granted('ROLE_ADMIN')")
-     */
+    #[Route(path: '/{id}', requirements: ['id' => '\d+'], methods: ['PUT'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function updateAction(Request $request, int $id): JsonResponse
     {
         $data = json_decode($request->getContent(), true);
@@ -179,13 +171,13 @@ class OrganisationController extends AbstractController
     }
 
     /**
-     * @Route("/{id}", requirements={"id":"\d+"}, methods={"DELETE"})
      *
-     * @Security("is_granted('ROLE_SUPER_ADMIN')")
      *
      * @throws ORMException
      * @throws OptimisticLockException
      */
+    #[Route(path: '/{id}', requirements: ['id' => '\d+'], methods: ['DELETE'])]
+    #[Security("is_granted('ROLE_SUPER_ADMIN')")]
     public function deleteAction(int $id): JsonResponse
     {
         $deleted = $this->restHandler->delete($id);
@@ -195,15 +187,15 @@ class OrganisationController extends AbstractController
     }
 
     /**
-     * @Route("/{orgId}/user/{userId}", requirements={"orgId":"\d+", "userId":"\d+"}, methods={"PUT"})
      *
      * @Entity("organisation", expr="repository.find(orgId)")
      *
-     * @Security("is_granted('edit', organisation)")
      *
      * @throws ORMException
      * @throws OptimisticLockException
      */
+    #[Route(path: '/{orgId}/user/{userId}', requirements: ['orgId' => '\d+', 'userId' => '\d+'], methods: ['PUT'])]
+    #[Security("is_granted('edit', organisation)")]
     public function addUserAction(Request $request, Organisation $organisation, int $userId): JsonResponse
     {
         $orgId = $organisation->getId();
@@ -213,15 +205,15 @@ class OrganisationController extends AbstractController
     }
 
     /**
-     * @Route("/{orgId}/user/{userId}", requirements={"orgId":"\d+", "userId":"\d+"}, methods={"DELETE"})
      *
      * @Entity("organisation", expr="repository.find(orgId)")
      *
-     * @Security("is_granted('edit', organisation)")
      *
      * @throws ORMException
      * @throws OptimisticLockException
      */
+    #[Route(path: '/{orgId}/user/{userId}', requirements: ['orgId' => '\d+', 'userId' => '\d+'], methods: ['DELETE'])]
+    #[Security("is_granted('edit', organisation)")]
     public function removeUserAction(Organisation $organisation, int $userId): JsonResponse
     {
         $orgId = $organisation->getId();
@@ -230,21 +222,15 @@ class OrganisationController extends AbstractController
         return $this->buildSuccessResponse([], 'User removed');
     }
 
-    /**
-     * @Route("/members", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_ORG')")
-     */
+    #[Route(path: '/members', methods: ['GET'])]
+    #[Security("is_granted('ROLE_ORG')")]
     public function getMembers(Request $request)
     {
         return $this->getUser()->getOrganisations()[0]->getUsers();
     }
 
-    /**
-     * @Route("/member/{id}", requirements={"id":"\d+"}, methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_ORG')")
-     */
+    #[Route(path: '/member/{id}', requirements: ['id' => '\d+'], methods: ['GET'])]
+    #[Security("is_granted('ROLE_ORG')")]
     public function getMemberById(string $id)
     {
         return $this->getUser()->getOrganisations()[0]->getUsers()->get($id);

--- a/api/app/src/v2/Fixture/Controller/FixtureController.php
+++ b/api/app/src/v2/Fixture/Controller/FixtureController.php
@@ -29,9 +29,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/fixture")
- */
+#[Route(path: '/fixture')]
 class FixtureController extends AbstractController
 {
     use ControllerTrait;
@@ -54,14 +52,14 @@ class FixtureController extends AbstractController
     }
 
     /**
-     * @Route("/court-order", methods={"POST"})
      *
-     * @Security("is_granted('ROLE_SUPER_ADMIN')")
      *
      * @return JsonResponse
      *
      * @throws \Exception
      */
+    #[Route(path: '/court-order', methods: ['POST'])]
+    #[Security("is_granted('ROLE_SUPER_ADMIN')")]
     public function createCourtOrderAction(Request $request)
     {
         if ('prod' === $this->symfonyEnvironment) {
@@ -340,14 +338,14 @@ class FixtureController extends AbstractController
     }
 
     /**
-     * @Route("/complete-sections/{reportType}/{reportId}", requirements={"id":"\d+"}, methods={"PUT"})
      *
-     * @Security("is_granted('ROLE_ADMIN')")
      *
      * @return JsonResponse
      *
      * @throws \Exception
      */
+    #[Route(path: '/complete-sections/{reportType}/{reportId}', requirements: ['id' => '\d+'], methods: ['PUT'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function completeReportSectionsAction(Request $request, string $reportType, $reportId)
     {
         if ('prod' === $this->symfonyEnvironment) {
@@ -377,11 +375,8 @@ class FixtureController extends AbstractController
         return $this->buildSuccessResponse([], 'Report updated', Response::HTTP_OK);
     }
 
-    /**
-     * @Route("/createAdmin", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_SUPER_ADMIN') or is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
-     */
+    #[Route(path: '/createAdmin', methods: ['POST'])]
+    #[Security("is_granted('ROLE_SUPER_ADMIN') or is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")]
     public function createAdmin(Request $request)
     {
         if ('prod' === $this->symfonyEnvironment) {
@@ -405,11 +400,8 @@ class FixtureController extends AbstractController
         return $this->buildSuccessResponse($fromRequest, 'User created');
     }
 
-    /**
-     * @Route("/getUserIDByEmail/{email}", methods={"GET"})
-     *
-     * @Security("is_granted('ROLE_SUPER_ADMIN') or is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")
-     */
+    #[Route(path: '/getUserIDByEmail/{email}', methods: ['GET'])]
+    #[Security("is_granted('ROLE_SUPER_ADMIN') or is_granted('ROLE_ADMIN') or is_granted('ROLE_AD')")]
     public function getUserIDByEmail(string $email)
     {
         if ('prod' === $this->symfonyEnvironment) {
@@ -428,10 +420,10 @@ class FixtureController extends AbstractController
     /**
      * Used for creating non-prof/pa users only as Org ID is required for those types.
      *
-     * @Route("/createUser", methods={"POST"})
      *
-     * @Security("is_granted('ROLE_ADMIN', 'ROLE_AD')")
      */
+    #[Route(path: '/createUser', methods: ['POST'])]
+    #[Security("is_granted('ROLE_ADMIN', 'ROLE_AD')")]
     public function createUser(Request $request)
     {
         if ('prod' === $this->symfonyEnvironment) {
@@ -460,10 +452,10 @@ class FixtureController extends AbstractController
     /**
      * Used for deleting users to clean up after tests.
      *
-     * @Route("/deleteUser", methods={"POST"})
      *
-     * @Security("is_granted('ROLE_SUPER_ADMIN')")
      */
+    #[Route(path: '/deleteUser', methods: ['POST'])]
+    #[Security("is_granted('ROLE_SUPER_ADMIN')")]
     public function deleteUser(Request $request)
     {
         if ('prod' === $this->symfonyEnvironment) {
@@ -480,11 +472,8 @@ class FixtureController extends AbstractController
         return $this->buildSuccessResponse($fromRequest, 'User deleted', Response::HTTP_OK);
     }
 
-    /**
-     * @Route("/createClientAttachDeputy", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_ADMIN', 'ROLE_AD')")
-     */
+    #[Route(path: '/createClientAttachDeputy', methods: ['POST'])]
+    #[Security("is_granted('ROLE_ADMIN', 'ROLE_AD')")]
     public function createClientAndAttachToDeputy(Request $request)
     {
         if ('prod' === $this->symfonyEnvironment) {
@@ -519,11 +508,9 @@ class FixtureController extends AbstractController
         return $this->buildSuccessResponse($fromRequest, 'User created', Response::HTTP_OK);
     }
 
-    /**
-     * @Route("/createClientAttachOrgs", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_ADMIN', 'ROLE_AD')")
-     */
+    
+    #[Route(path: '/createClientAttachOrgs', methods: ['POST'])]
+    #[Security("is_granted('ROLE_ADMIN', 'ROLE_AD')")]
     public function createClientAndAttachToOrgs(Request $request)
     {
         if ('prod' === $this->symfonyEnvironment) {
@@ -594,11 +581,9 @@ class FixtureController extends AbstractController
         }
     }
 
-    /**
-     * @Route("/create-pre-registration", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_ADMIN', 'ROLE_AD')")
-     */
+    
+    #[Route(path: '/create-pre-registration', methods: ['POST'])]
+    #[Security("is_granted('ROLE_ADMIN', 'ROLE_AD')")]
     public function createPreRegistration(Request $request)
     {
         if ('prod' === $this->symfonyEnvironment) {
@@ -632,12 +617,12 @@ class FixtureController extends AbstractController
     }
 
     /**
-     * @Route("/move-users-clients-to-users-org/{userEmail}", name="move_users_clients_to_org", methods={"GET"})
      *
-     * @Security("is_granted('ROLE_ADMIN')")
      *
      * @return JsonResponse
      */
+    #[Route(path: '/move-users-clients-to-users-org/{userEmail}', name: 'move_users_clients_to_org', methods: ['GET'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function moveUsersClientsToUsersOrg(string $userEmail)
     {
         if ('prod' === $this->symfonyEnvironment) {
@@ -668,12 +653,12 @@ class FixtureController extends AbstractController
     }
 
     /**
-     * @Route("/activateOrg/{orgName}", name="activate_org", methods={"GET"})
      *
-     * @Security("is_granted('ROLE_ADMIN')")
      *
      * @return JsonResponse
      */
+    #[Route(path: '/activateOrg/{orgName}', name: 'activate_org', methods: ['GET'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function activateOrg(string $orgName)
     {
         try {

--- a/api/app/src/v2/Registration/Controller/LayDeputyshipUploadController.php
+++ b/api/app/src/v2/Registration/Controller/LayDeputyshipUploadController.php
@@ -9,9 +9,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/lay-deputyship")
- */
+#[Route(path: '/lay-deputyship')]
 class LayDeputyshipUploadController
 {
     public function __construct(
@@ -22,12 +20,12 @@ class LayDeputyshipUploadController
     }
 
     /**
-     * @Route("/upload", methods={"POST"})
      *
-     * @Security("is_granted('ROLE_ADMIN')")
      *
      * @return array
      */
+    #[Route(path: '/upload', methods: ['POST'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function upload(Request $request)
     {
         ini_set('memory_limit', '1024M');

--- a/api/app/src/v2/Registration/Controller/OrgDeputyshipController.php
+++ b/api/app/src/v2/Registration/Controller/OrgDeputyshipController.php
@@ -24,11 +24,8 @@ class OrgDeputyshipController extends AbstractController
     ) {
     }
 
-    /**
-     * @Route("/org-deputyships", methods={"POST"})
-     *
-     * @Security("is_granted('ROLE_ADMIN')")
-     */
+    #[Route(path: '/org-deputyships', methods: ['POST'])]
+    #[Security("is_granted('ROLE_ADMIN')")]
     public function create(Request $request)
     {
         $decompressedData = $this->dataCompression->decompress($request->getContent());

--- a/api/app/src/v2/Tools/Controller/ToolsController.php
+++ b/api/app/src/v2/Tools/Controller/ToolsController.php
@@ -16,9 +16,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/tools")
- */
+#[Route(path: '/tools')]
 class ToolsController extends AbstractController
 {
     use ControllerTrait;
@@ -32,14 +30,14 @@ class ToolsController extends AbstractController
     }
 
     /**
-     * @Route("/reassign-reports", methods={"POST"})
      *
-     * @Security("is_granted('ROLE_SUPER_ADMIN')")
      *
      * @return JsonResponse
      *
      * @throws \Exception
      */
+    #[Route(path: '/reassign-reports', methods: ['POST'])]
+    #[Security("is_granted('ROLE_SUPER_ADMIN')")]
     public function reassignReports(Request $request)
     {
         $fromRequest = json_decode($request->getContent(), true);


### PR DESCRIPTION
Use Rector AnnotationToAttributeRector rules for;
- Symfony\Component\Routing\Annotation\Route
- Sensio\Bundle\FrameworkExtraBundle\Configuration\Security

## Purpose
Attributes are preferable to annotations for several reasons, but the key benefits for us are;
- they separate logic from comments
- and are more easily understood by tools, so the IDE and PHPStan will alert you to things like missing class imports and parameter type mismatches

## Learning
(https://www.php.net/manual/en/language.attributes.overview.php)

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
