### PR TITLE
DDLS-525 Fixes to get symfony webprofiler to load

### DIFF
--- a/client/app/config/services_dev.yml
+++ b/client/app/config/services_dev.yml
@@ -5,7 +5,7 @@ services:
     tags:
       - {
           name: data_collector,
-          template: "@App/Manage/api-collector",
+          template: "@App/Health/api-collector",
           id: "api-collector",
         }
   data_collector.CssClassCollector:
@@ -13,7 +13,7 @@ services:
     tags:
       - {
           name: data_collector,
-          template: "@App/Manage/css-class-collector",
+          template: "@App/Health/css-class-collector",
           id: "css-class-collector",
         }
     public: false

--- a/client/app/config/services_local.yml
+++ b/client/app/config/services_local.yml
@@ -5,7 +5,7 @@ services:
     tags:
       - {
           name: data_collector,
-          template: "@App/Manage/api-collector",
+          template: "@App/Health/api-collector",
           id: "api-collector",
         }
   data_collector.CssClassCollector:
@@ -13,7 +13,7 @@ services:
     tags:
       - {
           name: data_collector,
-          template: "@App/Manage/css-class-collector",
+          template: "@App/Health/css-class-collector",
           id: "css-class-collector",
         }
     public: false

--- a/client/app/templates/Layouts/moj_template.html.twig
+++ b/client/app/templates/Layouts/moj_template.html.twig
@@ -37,8 +37,7 @@
     <div id="gaCustomElements"
         data-ga-default="{{ ga.default }}"
         data-ga-gds="{{ ga.gds }}"
-        data-tracking-id="{{ app.user.gaTrackingId() }}"
-        data-ga-custom-url="{{ gaCustomUrl }}"></d>
+        data-tracking-id="{{ app.user ? app.user.gaTrackingId() : null }}"></div>
     {% include '@App/Layouts/_google_analytics_events_gtag.html.twig' %}
 {% endif %}
 


### PR DESCRIPTION
Note that the panel still doesn't load properly, but can be accessed by clicking on the "loading..." link. Even then, the CSS isn't applied properly. But the requests can be viewed, which is all I need for now.

To check, do `make enable-debug` and visit the homepage. The profiler is accessible in the bottom-left corner.

On the main branch, clicking on the "loading..." link just gives you an error page.

## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes DDLS-525

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
