### PR TITLE
DDLS-549: Add fixes raised by enable debug mode with twig templates

### DIFF
--- a/client/app/src/Controller/SettingsController.php
+++ b/client/app/src/Controller/SettingsController.php
@@ -90,6 +90,7 @@ class SettingsController extends AbstractController
 
             return [
                 'hasOrganisations' => count($user->getOrganisations()),
+                'deputyHasMultiClients' => false,
             ];
         }
 

--- a/client/app/templates/Admin/Organisation/add-user.html.twig
+++ b/client/app/templates/Admin/Organisation/add-user.html.twig
@@ -15,7 +15,7 @@
 {% block pageContent %}
     {{ form_start(form, {attr: {novalidate: 'admin-organisation-users' }}) }}
 
-    {% if user is defined and user.id %}
+    {% if user is defined and user is not empty and user.id is not null %}
         {% set infoText = 'addPage.informationBannerText' | trans( {'%user%': user.fullName} ) %}
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## Purpose
Errors were thrown on certain endpoints following investigations into [DDLS-505](https://opgtransform.atlassian.net/jira/software/c/projects/DDLS/boards/197?selectedIssue=DDLS-505), and were thrown whilst in dev mode with debug enabled.
Whilst these specific errors cause no direct issues to users and aren't thrown when debug is disabled, they still present areas to tighten up on on how variables are set and queried in twig templates.

Fixes DDLS-549

## Approach
- Set value on variable passed to Twig template for organisations - related to org/settings route
- Build on conditional logic to exclude null user id's - related to admin/organisations/{orgId}/add-user route

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values


[DDLS-505]: https://opgtransform.atlassian.net/browse/DDLS-505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ