### PR TITLE
Remove unnecessary client config

### DIFF
--- a/client/app/src/Kernel.php
+++ b/client/app/src/Kernel.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
-use Symfony\Component\Routing\RouteCollectionBuilder;
+use function dirname;
 
 class Kernel extends BaseKernel
 {
@@ -34,24 +34,9 @@ class Kernel extends BaseKernel
         }
     }
 
-    public function getRootDir()
-    {
-        return dirname(__DIR__);
-    }
-
-    public function getCacheDir()
-    {
-        return dirname(__DIR__).'/var/cache';
-    }
-
-    public function getLogDir()
-    {
-        return dirname(__DIR__).'/var/log';
-    }
-
     public function getProjectDir(): string
     {
-        return \dirname(__DIR__);
+        return dirname(__DIR__);
     }
 
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void


### PR DESCRIPTION
- getRootDir is no longer used after migration to Symfony 5
- getLogDir is set to the same value in the parent Kernel
- getCacheDir is set to a subdirectory of var/cache in parent Kernel, so overriding is not necessary

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
