### PR TITLE
DDPB-4874 Replace injection of session

### DIFF
--- a/client/app/config/services.yml
+++ b/client/app/config/services.yml
@@ -60,7 +60,7 @@ services:
         "@security.token_storage",
         "@security.authorization_checker",
         "@router",
-        "@session",
+        "@request_stack",
         "%env(ROLE)%",
         '@App\Service\Client\Internal\ClientApi',
         "@logger",

--- a/client/app/src/Service/OrgService.php
+++ b/client/app/src/Service/OrgService.php
@@ -8,7 +8,7 @@ use App\Event\OrgCreatedEvent;
 use App\EventDispatcher\ObservableEventDispatcher;
 use App\Service\Audit\AuditEvents;
 use App\Service\Client\RestClient;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Twig\Environment;
@@ -45,7 +45,7 @@ class OrgService
     public function __construct(
         private RestClient $restClient,
         private Environment $twig,
-        private SessionInterface $session,
+        private RequestStack $requestStack,
         private ObservableEventDispatcher $eventDispatcher,
         private TokenStorageInterface $tokenStorage
     ) {
@@ -152,7 +152,7 @@ class OrgService
      */
     protected function addFlashMessages()
     {
-        $flashBag = $this->session->getFlashBag();
+        $flashBag = $this->requestStack->getSession()->getFlashBag();
 
         if (count($this->output['errors'])) {
             $flash = $this->twig->render('@App/Admin/Index/_uploadErrorAlert.html.twig', [
@@ -231,7 +231,7 @@ class OrgService
         $response = $this->generateStreamedResponse();
 
         $response->setCallback(function () use ($chunks, $redirectUrl) {
-            $this->session->start();
+            $this->requestStack->getSession()->start();
 
             $this->processChunks($chunks);
 

--- a/client/app/src/Service/Redirector.php
+++ b/client/app/src/Service/Redirector.php
@@ -5,7 +5,7 @@ namespace App\Service;
 use App\Entity\User;
 use App\Service\Client\Internal\ClientApi;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\RouterInterface;
@@ -47,7 +47,7 @@ class Redirector
         protected TokenStorageInterface $tokenStorage,
         protected AuthorizationCheckerInterface $authChecker,
         protected RouterInterface $router,
-        protected Session $session,
+        protected RequestStack $requestStack,
         protected string $env,
         private ClientApi $clientApi,
         private readonly LoggerInterface $logger,
@@ -184,7 +184,7 @@ class Redirector
      */
     private function getLastAccessedUrl()
     {
-        $lastUsedUrl = $this->session->get('_security.secured_area.target_path');
+        $lastUsedUrl = $this->requestStack->getSession()->get('_security.secured_area.target_path');
         if (!$lastUsedUrl) {
             return false;
         }
@@ -209,7 +209,7 @@ class Redirector
 
     public function removeLastAccessedUrl()
     {
-        $this->session->remove('_security.secured_area.target_path');
+        $this->requestStack->getSession()->remove('_security.secured_area.target_path');
     }
 
     /**


### PR DESCRIPTION
Injecting the session into services and controllers is deprecated since Symfony 5.3 and removed in 6.

Recommendation is to avoid this entirely, but where it is necessary inject the RequestStack.

Contributes to DDLS-4874

## Learning
https://symfony.com/blog/new-in-symfony-5-3-session-service-deprecation

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
