### PR TITLE
Add PHPStan to client in CI

### DIFF
--- a/.github/workflows/_phpstan-client.yml
+++ b/.github/workflows/_phpstan-client.yml
@@ -1,0 +1,52 @@
+name: "[Tests] Client PHPStan"
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  workflow_call:
+    inputs:
+      branch_name:
+        description: "Name of the branch doing the build"
+        required: true
+        type: string
+jobs:
+  client-phpstan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: set up docker buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: cache docker layers
+        id: cache-docker
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        with:
+          path: /tmp/.buildx-cache
+          key: client-phpstan-${{ inputs.branch_name }}-${{ github.sha }}
+          restore-keys: |
+            client-phpstan-${{ inputs.branch_name }}
+            client-phpstan-main
+
+      - name: build docker images
+        run: |
+          docker buildx build \
+          -f client/docker/app/Dockerfile \
+          --cache-from=type=local,src=/tmp/.buildx-cache \
+          --cache-to=type=local,dest=/tmp/.buildx-cache-new \
+          --build-arg ENVIRONMENT=local \
+          --tag client-phpstan:latest \
+          --target ci-tests \
+          --output type=docker .
+
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      - name: run client phpstan
+        id: client-phpstan
+        run: |
+          make phpstan-client

--- a/.github/workflows/workflow-pull-request-path.yml
+++ b/.github/workflows/workflow-pull-request-path.yml
@@ -148,6 +148,14 @@ jobs:
     needs:
       - workflow_variables
 
+  client_phpstan:
+    name: client phpstan
+    uses: ./.github/workflows/_phpstan-client.yml
+    with:
+      branch_name: ${{ needs.workflow_variables.outputs.build_identifier }}
+    needs:
+      - workflow_variables
+
   client_unit_tests:
     name: client unit tests
     uses: ./.github/workflows/_unit-tests-client.yml

--- a/Makefile
+++ b/Makefile
@@ -147,22 +147,15 @@ disable-debug: ##@application Puts app in dev mode and disables debug (so the ap
 	  echo "$$c: debug disabled." ; \
 	done
 
+PHPSTAN-LEVEL := max
 phpstan-api: ##@static-analysis Runs PHPStan against API. Defaults to max level but supports passing level as an arg e.g. level=1
-ifdef level
-	docker compose -f docker-compose.yml -f docker-compose.override.yml run --no-deps --rm api-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=$(level)
-else
-	docker compose -f docker-compose.yml -f docker-compose.override.yml run --no-deps --rm api-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=max
-endif
+	docker compose -f docker-compose.yml -f docker-compose.override.yml run --no-deps --rm api-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=$(PHPSTAN-LEVEL)
 
 phpstan-api-baseline:
 	docker compose -f docker-compose.yml -f docker-compose.override.yml run --no-deps --rm api-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=max --generate-baseline
 
 phpstan-client: ##@static-analysis Runs PHPStan against client. Defaults to max level but supports passing level as an arg e.g. level=1
-ifdef level
-	docker compose -f docker-compose.yml -f docker-compose.override.yml run --no-deps --rm frontend-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=$(level)
-else
-	docker compose -f docker-compose.yml -f docker-compose.override.yml run --no-deps --rm frontend-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=max
-endif
+	docker compose -f docker-compose.yml -f docker-compose.override.yml run --no-deps --rm frontend-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=$(PHPSTAN-LEVEL)
 
 phpstan-client-baseline:
 	docker compose -f docker-compose.yml -f docker-compose.override.yml run --no-deps --rm frontend-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=max --generate-baseline

--- a/Makefile
+++ b/Makefile
@@ -159,10 +159,13 @@ phpstan-api-baseline:
 
 phpstan-client: ##@static-analysis Runs PHPStan against client. Defaults to max level but supports passing level as an arg e.g. level=1
 ifdef level
-	docker compose run --no-deps --rm frontend-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=$(level)
+	docker compose -f docker-compose.yml -f docker-compose.override.yml run --no-deps --rm frontend-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=$(level)
 else
-	docker compose run --no-deps --rm frontend-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=max
+	docker compose -f docker-compose.yml -f docker-compose.override.yml run --no-deps --rm frontend-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=max
 endif
+
+phpstan-client-baseline:
+	docker compose -f docker-compose.yml -f docker-compose.override.yml run --no-deps --rm frontend-app vendor/phpstan/phpstan/phpstan analyse src --memory-limit=1G --level=max --generate-baseline
 
 get-audit-logs: ##@localstack Get audit log groups by passing event name e.g. get-audit-logs event_name=ROLE_CHANGED (see client/Audit/src/service/Audit/AuditEvents)
 	docker compose exec localstack awslocal logs get-log-events --log-group-name audit-local --log-stream-name $(event_name)

--- a/client/app/phpstan-baseline.neon
+++ b/client/app/phpstan-baseline.neon
@@ -1,0 +1,16006 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method App\\\\Command\\\\CheckCSVUploadedCommand\\:\\:alertNoCSVsWereUploaded\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Command/CheckCSVUploadedCommand.php
+
+		-
+			message: "#^Method App\\\\Command\\\\CheckCSVUploadedCommand\\:\\:checkCsvsHaveBeenUploadedAndAlert\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Command/CheckCSVUploadedCommand.php
+
+		-
+			message: "#^Method App\\\\Command\\\\CheckCSVUploadedCommand\\:\\:getLogEvents\\(\\) should return array\\|int but returns mixed\\.$#"
+			count: 1
+			path: src/Command/CheckCSVUploadedCommand.php
+
+		-
+			message: "#^Method App\\\\Command\\\\CheckCSVUploadedCommand\\:\\:getLogStreams\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Command/CheckCSVUploadedCommand.php
+
+		-
+			message: "#^Method App\\\\Command\\\\CheckCSVUploadedCommand\\:\\:postSlackMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Command/CheckCSVUploadedCommand.php
+
+		-
+			message: "#^Method App\\\\Command\\\\DocumentRecoverCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Command/DocumentRecoverCommand.php
+
+		-
+			message: "#^Method App\\\\Command\\\\DocumentRecoverCommand\\:\\:execute\\(\\) should return int but return statement is missing\\.$#"
+			count: 1
+			path: src/Command/DocumentRecoverCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_filter expects array, array\\<int, string\\>\\|false given\\.$#"
+			count: 1
+			path: src/Command/DocumentRecoverCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file expects string, mixed given\\.$#"
+			count: 1
+			path: src/Command/DocumentRecoverCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$shortcut of method Symfony\\\\Component\\\\Console\\\\Command\\\\Command\\:\\:addOption\\(\\) expects array\\|string\\|null, int given\\.$#"
+			count: 1
+			path: src/Command/DocumentRecoverCommand.php
+
+		-
+			message: "#^Method App\\\\Command\\\\DocumentSyncCommand\\:\\:getQueuedDocumentsData\\(\\) should return array\\<App\\\\Model\\\\Sirius\\\\QueuedDocumentData\\> but returns mixed\\.$#"
+			count: 1
+			path: src/Command/DocumentSyncCommand.php
+
+		-
+			message: "#^Call to method getMessage\\(\\) on an unknown class App\\\\Command\\\\Throwable\\.$#"
+			count: 1
+			path: src/Command/ProcessLayCSVCommand.php
+
+		-
+			message: "#^Caught class App\\\\Command\\\\Throwable not found\\.$#"
+			count: 1
+			path: src/Command/ProcessLayCSVCommand.php
+
+		-
+			message: "#^Left side of && is always false\\.$#"
+			count: 1
+			path: src/Command/ProcessLayCSVCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_chunk expects array, mixed given\\.$#"
+			count: 1
+			path: src/Command/ProcessLayCSVCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$email of method App\\\\Command\\\\ProcessLayCSVCommand\\:\\:process\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Command/ProcessLayCSVCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\|bool\\|float\\|int\\|string\\|UnitEnum\\|null given\\.$#"
+			count: 4
+			path: src/Command/ProcessLayCSVCommand.php
+
+		-
+			message: "#^Parameter \\#3 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\|bool\\|float\\|int\\|string\\|UnitEnum\\|null given\\.$#"
+			count: 2
+			path: src/Command/ProcessLayCSVCommand.php
+
+		-
+			message: "#^Result of method App\\\\Command\\\\ProcessLayCSVCommand\\:\\:process\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: src/Command/ProcessLayCSVCommand.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_chunk expects array, mixed given\\.$#"
+			count: 1
+			path: src/Command/ProcessOrgCSVCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\$email of method App\\\\Command\\\\ProcessOrgCSVCommand\\:\\:process\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Command/ProcessOrgCSVCommand.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\|bool\\|float\\|int\\|string\\|UnitEnum\\|null given\\.$#"
+			count: 3
+			path: src/Command/ProcessOrgCSVCommand.php
+
+		-
+			message: "#^Parameter \\#3 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\|bool\\|float\\|int\\|string\\|UnitEnum\\|null given\\.$#"
+			count: 2
+			path: src/Command/ProcessOrgCSVCommand.php
+
+		-
+			message: "#^Property App\\\\Command\\\\ProcessOrgCSVCommand\\:\\:\\$redis is never read, only written\\.$#"
+			count: 1
+			path: src/Command/ProcessOrgCSVCommand.php
+
+		-
+			message: "#^Property App\\\\Command\\\\ProcessOrgCSVCommand\\:\\:\\$workspace is never read, only written\\.$#"
+			count: 1
+			path: src/Command/ProcessOrgCSVCommand.php
+
+		-
+			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Command/ValidationCommand.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Validator\\\\Mapping\\\\MetadataInterface\\:\\:getConstrainedProperties\\(\\)\\.$#"
+			count: 1
+			path: src/Command/ValidationCommand.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Validator\\\\Mapping\\\\MetadataInterface\\:\\:getMemberMetadatas\\(\\)\\.$#"
+			count: 1
+			path: src/Command/ValidationCommand.php
+
+		-
+			message: "#^Method App\\\\Command\\\\ValidationCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Command/ValidationCommand.php
+
+		-
+			message: "#^Method App\\\\Command\\\\ValidationCommand\\:\\:execute\\(\\) should return int but return statement is missing\\.$#"
+			count: 1
+			path: src/Command/ValidationCommand.php
+
+		-
+			message: "#^Method App\\\\Command\\\\ValidationCommand\\:\\:getClassValidationRules\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Command/ValidationCommand.php
+
+		-
+			message: "#^Method App\\\\Command\\\\ValidationCommand\\:\\:getClassValidationRules\\(\\) has parameter \\$entity with no type specified\\.$#"
+			count: 1
+			path: src/Command/ValidationCommand.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\AbstractController\\:\\:renderError\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: src/Controller/AbstractController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Admin/AdController.php
+
+		-
+			message: "#^Cannot call method getEmail\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/AdController.php
+
+		-
+			message: "#^Cannot call method getFirstname\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null\\.$#"
+			count: 1
+			path: src/Controller/Admin/AdController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null\\.$#"
+			count: 2
+			path: src/Controller/Admin/AdController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Admin/AdController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on string\\.$#"
+			count: 1
+			path: src/Controller/Admin/AdController.php
+
+		-
+			message: "#^Cannot call method getLastname\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null\\.$#"
+			count: 1
+			path: src/Controller/Admin/AdController.php
+
+		-
+			message: "#^Cannot call method getRoleName\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Admin/AdController.php
+
+		-
+			message: "#^Cannot call method setAdManaged\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Admin/AdController.php
+
+		-
+			message: "#^Cannot call method setEmail\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/AdController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\AdController\\:\\:adLoginAsDeputyAction\\(\\) has parameter \\$deputyId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/AdController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function rtrim expects string, array\\|bool\\|float\\|int\\|string\\|UnitEnum\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Admin/AdController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/AdController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/AdController.php
+
+		-
+			message: "#^Part \\$filter \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: src/Controller/Admin/AdController.php
+
+		-
+			message: "#^Part \\$what \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: src/Controller/Admin/AdController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Admin\\\\AjaxController\\:\\:\\$restClient is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/Admin/AjaxController.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$kernel$#"
+			count: 2
+			path: src/Controller/Admin/BehatController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\Client\\\\ClientController\\:\\:detailsAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ClientController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\Client\\\\ClientController\\:\\:dischargeAction\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ClientController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\Client\\\\ClientController\\:\\:dischargeConfirmAction\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ClientController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\Client\\\\ClientController\\:\\:unarchiveAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ClientController.php
+
+		-
+			message: "#^Parameter \\#1 \\$clientId of method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:getWithUsersV2\\(\\) expects int, string given\\.$#"
+			count: 3
+			path: src/Controller/Admin/Client/ClientController.php
+
+		-
+			message: "#^Parameter \\#1 \\$deputyUid of method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:getPrimaryUserAccount\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ClientController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Admin\\\\Client\\\\ClientController\\:\\:\\$restClient is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ClientController.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Cannot access offset mixed on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Cannot call method format\\(\\) on DateTime\\|null\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Cannot call method format\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Cannot call method getData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 13
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Cannot call method setData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 3
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Cannot call method setIsSubmitted\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Cannot call method setPresent\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Instanceof between App\\\\Entity\\\\Report\\\\Report and App\\\\Entity\\\\Ndr\\\\Ndr will always evaluate to false\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Match expression does not handle remaining value\\: non\\-falsy\\-string$#"
+			count: 1
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\Client\\\\ReportController\\:\\:manageCloseReportConfirmAction\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\Client\\\\ReportController\\:\\:manageConfirmAction\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Parameter \\#1 \\$sessionData of method App\\\\Controller\\\\Admin\\\\Client\\\\ReportController\\:\\:sufficientDataInSession\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Parameter \\#2 \\$sessionData of method App\\\\Controller\\\\Admin\\\\Client\\\\ReportController\\:\\:populateReportFromSession\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Parameter \\#2 \\$subject of function preg_match expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Parameter \\#2 \\$user of method App\\\\Service\\\\Client\\\\Internal\\\\ReportApi\\:\\:unsubmit\\(\\) expects App\\\\Entity\\\\User, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Part \\$form\\['dueDateChoice'\\]\\-\\>getData\\(\\) \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Admin\\\\Client\\\\ReportController\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^Variable \\$checklist in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 2
+			path: src/Controller/Admin/Client/ReportController.php
+
+		-
+			message: "#^PHPDoc tag @return with type array\\|string is not subtype of native type array\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/SearchController.php
+
+		-
+			message: "#^Parameter \\#2 \\$clients of method App\\\\Controller\\\\Admin\\\\Client\\\\SearchController\\:\\:buildViewParams\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/Client/SearchController.php
+
+		-
+			message: "#^Call to an undefined method GuzzleHttp\\\\Psr7\\\\Response\\|Symfony\\\\Component\\\\HttpFoundation\\\\Response\\:\\:getBody\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Cannot access offset 'createCoDeputy' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Cannot access offset 'deputyType' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Cannot access offset 'multiClientEnabled' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Cannot access offset 'reportType' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Cannot call method getBody\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Cannot call method getEmail\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Comparison operation \"\\>\" between 1 and 1 is always false\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\FixtureController\\:\\:completeReportSectionsAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\FixtureController\\:\\:createAdmin\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\FixtureController\\:\\:createClientAndAttachToDeputy\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\FixtureController\\:\\:createClientAndAttachToOrg\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\FixtureController\\:\\:createUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\FixtureController\\:\\:deleteUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\FixtureController\\:\\:fixtures\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\FixtureController\\:\\:getUserIDByEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\FixtureController\\:\\:getUserRegistrationToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\FixtureController\\:\\:layCourtOrdersAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\FixtureController\\:\\:orgCourtOrdersAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\FixtureController\\:\\:removeNullValues\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\FixtureController\\:\\:retrieveFormData\\(\\) has parameter \\$form with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\FixtureController\\:\\:retrieveFormData\\(\\) has parameter \\$request with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Offset 'deputyIds' does not exist on string\\.$#"
+			count: 2
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Offset 'multiClientCaseNumb…' on string on left side of \\?\\? does not exist\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Offset 1 does not exist on array\\{mixed\\}\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_reverse expects array, mixed given\\.$#"
+			count: 3
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Parameter \\#1 \\$deputiesDataArray of method App\\\\Controller\\\\Admin\\\\FixtureController\\:\\:removeNullValues\\(\\) expects array, mixed given\\.$#"
+			count: 2
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Parameter \\#1 \\$email of method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:getByEmail\\(\\) expects string, bool\\|float\\|int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, string\\|false given\\.$#"
+			count: 8
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Parameter \\#2 \\$user of method App\\\\Service\\\\Client\\\\Internal\\\\ReportApi\\:\\:unsubmit\\(\\) expects App\\\\Entity\\\\User, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Part \\$sections \\(mixed\\) of encapsed string cannot be cast to string\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Admin\\\\FixtureController\\:\\:\\$deputyProvider is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Admin\\\\FixtureController\\:\\:\\$twig is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/Admin/FixtureController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Contracts\\\\EventDispatcher\\\\EventDispatcherInterface\\:\\:addListener\\(\\)\\.$#"
+			count: 2
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Cannot call method getClient\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Cannot call method getRoleName\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Cannot call method getUser\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\TokenInterface\\|null\\.$#"
+			count: 3
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Cannot call method getUserIdentifier\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null\\.$#"
+			count: 2
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Cannot call method isDeputyOrg\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\IndexController\\:\\:dispatchAdminManagerDeletedEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\IndexController\\:\\:dispatchCSVUploadEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\IndexController\\:\\:getPopulatedUser\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\IndexController\\:\\:getPopulatedUser\\(\\) should return App\\\\Entity\\\\User but returns mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\IndexController\\:\\:handleLayUploadForm\\(\\) has parameter \\$fileName with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\IndexController\\:\\:handleLayUploadForm\\(\\) is unused\\.$#"
+			count: 1
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\IndexController\\:\\:handleOrgUploadForm\\(\\) has parameter \\$fileName with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\IndexController\\:\\:handleOrgUploadForm\\(\\) is unused\\.$#"
+			count: 1
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\IndexController\\:\\:viewAction\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:activate\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Parameter \\#1 \\$userToCreate of method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:createUser\\(\\) expects App\\\\Entity\\\\User, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Parameter \\#2 \\$currentUser of class App\\\\Event\\\\AdminManagerDeletedEvent constructor expects App\\\\Entity\\\\User, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 2
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Admin\\\\IndexController\\:\\:\\$layDeputyshipApi is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Admin\\\\IndexController\\:\\:\\$orgService is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/Admin/IndexController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 8
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Cannot access offset 'count' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Cannot access offset 'records' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Cannot call method getEmail\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Cannot call method getEmailIdentifierDisplay\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Cannot call method getFullName\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 7
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Cannot call method getName\\(\\) on mixed\\.$#"
+			count: 5
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Cannot call method getUser\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\TokenInterface\\|null\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Cannot call method hasUser\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Cannot call method isActivated\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Cannot call method isDeputyOrg\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\OrganisationController\\:\\:addAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\OrganisationController\\:\\:addUserAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\OrganisationController\\:\\:addUserAction\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\OrganisationController\\:\\:deleteAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\OrganisationController\\:\\:deleteAction\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\OrganisationController\\:\\:deleteUserAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\OrganisationController\\:\\:deleteUserAction\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\OrganisationController\\:\\:deleteUserAction\\(\\) has parameter \\$userId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\OrganisationController\\:\\:dispatchOrgCreatedEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\OrganisationController\\:\\:editAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\OrganisationController\\:\\:editAction\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\OrganisationController\\:\\:indexAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^PHPDoc tag @var has invalid value \\(\\$organisation Organisation\\)\\: Unexpected token \"\\$organisation\", expected type at offset 9$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Parameter \\#1 \\$organisation of method App\\\\Controller\\\\Admin\\\\OrganisationController\\:\\:dispatchOrgCreatedEvent\\(\\) expects App\\\\Entity\\\\Organisation, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Parameter \\#1 \\$organisation of method App\\\\Service\\\\Client\\\\Internal\\\\OrganisationApi\\:\\:addUserToOrganisation\\(\\) expects App\\\\Entity\\\\Organisation, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Parameter \\#1 \\$organisation of method App\\\\Service\\\\Client\\\\Internal\\\\OrganisationApi\\:\\:removeUserFromOrganisation\\(\\) expects App\\\\Entity\\\\Organisation, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Parameter \\#2 \\$currentUser of class App\\\\Event\\\\OrgCreatedEvent constructor expects App\\\\Entity\\\\User, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Parameter \\#2 \\$data of method App\\\\Service\\\\Client\\\\RestClient\\:\\:arrayToEntities\\(\\) expects array, mixed given\\.$#"
+			count: 2
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Parameter \\#2 \\$userToAdd of method App\\\\Service\\\\Client\\\\Internal\\\\OrganisationApi\\:\\:addUserToOrganisation\\(\\) expects App\\\\Entity\\\\User, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Parameter \\#2 \\$userToRemove of method App\\\\Service\\\\Client\\\\Internal\\\\OrganisationApi\\:\\:removeUserFromOrganisation\\(\\) expects App\\\\Entity\\\\User, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Parameter \\#3 \\$currentUser of method App\\\\Service\\\\Client\\\\Internal\\\\OrganisationApi\\:\\:addUserToOrganisation\\(\\) expects App\\\\Entity\\\\User, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Parameter \\#3 \\$currentUser of method App\\\\Service\\\\Client\\\\Internal\\\\OrganisationApi\\:\\:removeUserFromOrganisation\\(\\) expects App\\\\Entity\\\\User, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Admin/OrganisationController.php
+
+		-
+			message: "#^Cannot access offset 'archived' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/ReportSubmissionController.php
+
+		-
+			message: "#^Cannot access offset 'counts' on mixed\\.$#"
+			count: 3
+			path: src/Controller/Admin/ReportSubmissionController.php
+
+		-
+			message: "#^Cannot access offset 'new' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/ReportSubmissionController.php
+
+		-
+			message: "#^Cannot access offset 'pending' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/ReportSubmissionController.php
+
+		-
+			message: "#^Cannot access offset 'records' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/ReportSubmissionController.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_keys expects array, float\\|int\\<min, \\-1\\>\\|int\\<1, max\\>\\|string\\|true given\\.$#"
+			count: 1
+			path: src/Controller/Admin/ReportSubmissionController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strtolower expects string, bool\\|float\\|int\\|string given\\.$#"
+			count: 1
+			path: src/Controller/Admin/ReportSubmissionController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function urldecode expects string, float\\|int\\<min, \\-1\\>\\|int\\<1, max\\>\\|string\\|true given\\.$#"
+			count: 1
+			path: src/Controller/Admin/ReportSubmissionController.php
+
+		-
+			message: "#^Parameter \\#2 \\$data of method App\\\\Service\\\\Client\\\\RestClient\\:\\:arrayToEntities\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/ReportSubmissionController.php
+
+		-
+			message: "#^Parameter \\#2 \\$reportSubmissionIds of method App\\\\Service\\\\DocumentDownloader\\:\\:retrieveDocumentsFromS3ByReportSubmissionIds\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/ReportSubmissionController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Admin/SettingController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\SettingController\\:\\:serviceNotificationAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/SettingController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/SettingController.php
+
+		-
+			message: "#^Cannot access offset 'amount' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Admin/StatsController.php
+
+		-
+			message: "#^Cannot access offset 'data' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/StatsController.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 2
+			path: src/Controller/Admin/StatsController.php
+
+		-
+			message: "#^Caught class App\\\\Controller\\\\Admin\\\\Throwable not found\\.$#"
+			count: 4
+			path: src/Controller/Admin/StatsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\StatsController\\:\\:buildResponse\\(\\) has parameter \\$csvContent with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/StatsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\StatsController\\:\\:createFilterTypeForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/StatsController.php
+
+		-
+			message: "#^Parameter \\#1 \\$assetsTotals of method App\\\\Service\\\\Csv\\\\AssetsTotalsCSVGenerator\\:\\:generateAssetsTotalValuesCSV\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/StatsController.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/StatsController.php
+
+		-
+			message: "#^Parameter \\#1 \\$reportSubmissionSummaries of method App\\\\Transformer\\\\ReportSubmission\\\\ReportSubmissionBurFixedWidthTransformer\\:\\:transform\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/StatsController.php
+
+		-
+			message: "#^Parameter \\#1 \\$result of method App\\\\Controller\\\\Admin\\\\StatsController\\:\\:mapToDeputyType\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/StatsController.php
+
+		-
+			message: "#^Parameter \\#1 \\$satisfactions of method App\\\\Service\\\\Csv\\\\SatisfactionCsvGenerator\\:\\:generateSatisfactionResponsesCsv\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/StatsController.php
+
+		-
+			message: "#^Parameter \\#1 \\$userResearchResponses of method App\\\\Service\\\\Csv\\\\UserResearchResponseCsvGenerator\\:\\:generateUserResearchResponsesCsv\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/StatsController.php
+
+		-
+			message: "#^Cannot access offset 'firstClientId' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/ToolsController.php
+
+		-
+			message: "#^Cannot access offset 'secondClientId' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/ToolsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\ToolsController\\:\\:reportAssignmentAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/ToolsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\ToolsController\\:\\:tools\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/ToolsController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, string\\|false given\\.$#"
+			count: 1
+			path: src/Controller/Admin/ToolsController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\BehatController\\:\\:\\$restClient is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/BehatController.php
+
+		-
+			message: "#^Cannot access offset 'client_lastname' on mixed\\.$#"
+			count: 1
+			path: src/Controller/ClientController.php
+
+		-
+			message: "#^Cannot access offset 'deputy_firstname' on mixed\\.$#"
+			count: 1
+			path: src/Controller/ClientController.php
+
+		-
+			message: "#^Cannot access offset 'deputy_lastname' on mixed\\.$#"
+			count: 1
+			path: src/Controller/ClientController.php
+
+		-
+			message: "#^Cannot access offset 'deputy_postcode' on mixed\\.$#"
+			count: 1
+			path: src/Controller/ClientController.php
+
+		-
+			message: "#^Cannot access offset 'matching_errors' on mixed\\.$#"
+			count: 7
+			path: src/Controller/ClientController.php
+
+		-
+			message: "#^Cannot call method getActiveReport\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/ClientController.php
+
+		-
+			message: "#^Cannot call method getFirstname\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/ClientController.php
+
+		-
+			message: "#^Cannot call method setId\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/ClientController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\ClientController\\:\\:showAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/ClientController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\ClientController\\:\\:showClientDetailsAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/ClientController.php
+
+		-
+			message: "#^Parameter \\#1 \\$client of method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:create\\(\\) expects App\\\\Entity\\\\Client, mixed given\\.$#"
+			count: 1
+			path: src/Controller/ClientController.php
+
+		-
+			message: "#^Parameter \\#1 \\$preUpdateClient of method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:update\\(\\) expects App\\\\Entity\\\\Client, mixed given\\.$#"
+			count: 1
+			path: src/Controller/ClientController.php
+
+		-
+			message: "#^Parameter \\#2 \\$postUpdateClient of method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:update\\(\\) expects App\\\\Entity\\\\Client, mixed given\\.$#"
+			count: 2
+			path: src/Controller/ClientController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 2
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Cannot call method getData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 10
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Cannot call method getEmail\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Cannot call method getFirstName\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on App\\\\Entity\\\\Client\\|null\\.$#"
+			count: 2
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Cannot call method getLastName\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Cannot call method getUsers\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\CoDeputyController\\:\\:addAction\\(\\) has parameter \\$clientId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\CoDeputyController\\:\\:verificationAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function reset is passed by reference, so it expects variables only\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Parameter \\#1 \\$caseNumber of method App\\\\Entity\\\\Client\\:\\:setCaseNumber\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Parameter \\#1 \\$caseNumber of method App\\\\Model\\\\SelfRegisterData\\:\\:setCaseNumber\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Parameter \\#1 \\$clientLastname of method App\\\\Model\\\\SelfRegisterData\\:\\:setClientLastname\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Parameter \\#1 \\$email of method App\\\\Model\\\\SelfRegisterData\\:\\:setEmail\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Parameter \\#1 \\$firstname of method App\\\\Model\\\\SelfRegisterData\\:\\:setFirstname\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Parameter \\#1 \\$lastname of method App\\\\Entity\\\\Client\\:\\:setLastname\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Parameter \\#1 \\$lastname of method App\\\\Model\\\\SelfRegisterData\\:\\:setLastname\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Parameter \\#1 \\$postcode of method App\\\\Model\\\\SelfRegisterData\\:\\:setPostcode\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Parameter \\#1 \\$route of method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Controller\\\\AbstractController\\:\\:redirectToRoute\\(\\) expects string, string\\|true given\\.$#"
+			count: 2
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/CoDeputyController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 2
+			path: src/Controller/FeedbackController.php
+
+		-
+			message: "#^Cannot use array destructuring on mixed\\.$#"
+			count: 1
+			path: src/Controller/FeedbackController.php
+
+		-
+			message: "#^Parameter \\#1 \\$formResponse of method App\\\\Service\\\\Client\\\\Internal\\\\SatisfactionApi\\:\\:createGeneralFeedback\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Controller/FeedbackController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\HealthController\\:\\:containerHealthAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/HealthController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\HealthController\\:\\:servicesHealth\\(\\) has parameter \\$services with no type specified\\.$#"
+			count: 1
+			path: src/Controller/HealthController.php
+
+		-
+			message: "#^Cannot access property \\$usage on mixed\\.$#"
+			count: 1
+			path: src/Controller/IndexController.php
+
+		-
+			message: "#^Cannot call method getContent\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/IndexController.php
+
+		-
+			message: "#^Cannot call method isEnabled\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\IndexController\\:\\:accessDenied\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\IndexController\\:\\:accessibilityAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\IndexController\\:\\:cookiesAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\IndexController\\:\\:loginCheckAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\IndexController\\:\\:logoutAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\IndexController\\:\\:privacyAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\IndexController\\:\\:sessionKeepAliveAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\IndexController\\:\\:termsAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/IndexController.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, bool\\|float\\|int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Controller/IndexController.php
+
+		-
+			message: "#^Parameter \\#1 \\$seconds of static method App\\\\Service\\\\StringUtils\\:\\:secondsToHoursMinutes\\(\\) expects int, array\\|bool\\|float\\|int\\|string\\|UnitEnum\\|null given\\.$#"
+			count: 1
+			path: src/Controller/IndexController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\IndexController\\:\\:\\$deputyProvider is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/IndexController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\IndexController\\:\\:\\$eventDispatcher is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/IndexController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\IndexController\\:\\:\\$tokenStorage is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\JWT\\\\JWTController\\:\\:jwks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/JWT/JWTController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Ndr/ActionController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Ndr/ActionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\ActionController\\:\\:startAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/ActionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\ActionController\\:\\:stepAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/ActionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\ActionController\\:\\:stepAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/ActionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\ActionController\\:\\:stepAction\\(\\) has parameter \\$step with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/ActionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\ActionController\\:\\:summaryAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/ActionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\ActionController\\:\\:summaryAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/ActionController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Ndr/ActionController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Ndr\\\\ActionController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/ActionController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 3
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'address' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'address2' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'county' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'has_mg' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'hc' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'mg_oa' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'occupants' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'owned' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'owned_p' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'postcode' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'ser' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'value' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method getAddress\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method getAddress2\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method getCounty\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method getData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method getDescription\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method getHasCharges\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method getHasMortgage\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method getIsSubjectToEquityRelease\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method getMortgageOutstandingAmount\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method getOccupants\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method getOwned\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method getOwnedPercentage\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method getPostcode\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method getTitle\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method getValuationDate\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method getValue\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method setAddress\\(\\) on App\\\\Entity\\\\Ndr\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method setAddress2\\(\\) on App\\\\Entity\\\\Ndr\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method setCounty\\(\\) on App\\\\Entity\\\\Ndr\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method setHasCharges\\(\\) on App\\\\Entity\\\\Ndr\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method setHasMortgage\\(\\) on App\\\\Entity\\\\Ndr\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method setIsSubjectToEquityRelease\\(\\) on App\\\\Entity\\\\Ndr\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method setMortgageOutstandingAmount\\(\\) on App\\\\Entity\\\\Ndr\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method setOccupants\\(\\) on App\\\\Entity\\\\Ndr\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method setOwned\\(\\) on App\\\\Entity\\\\Ndr\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method setOwnedPercentage\\(\\) on App\\\\Entity\\\\Ndr\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method setPostcode\\(\\) on App\\\\Entity\\\\Ndr\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Cannot call method setValue\\(\\) on App\\\\Entity\\\\Ndr\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:addAnotherAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:addAnotherAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:deleteAction\\(\\) has parameter \\$assetId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:deleteAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:existAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:existAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:otherAddAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:otherAddAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:otherAddAction\\(\\) has parameter \\$title with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:otherEditAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:otherEditAction\\(\\) has parameter \\$assetId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:otherEditAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:propertyStepAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:propertyStepAction\\(\\) has parameter \\$assetId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:propertyStepAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:propertyStepAction\\(\\) has parameter \\$step with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:startAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:summaryAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:typeAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:typeAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Offset 'state' does not exist on string\\.$#"
+			count: 2
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Parameter \\#1 \\$noAssetToAdd of method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setNoAssetToAdd\\(\\) expects bool, int given\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 2
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 2
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/AssetController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 2
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Cannot access offset 'bank' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Cannot access offset 'is\\-joint' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Cannot access offset 'number' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Cannot access offset 'sort\\-code' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Cannot access offset 'type' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Cannot call method getAccountNumber\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Cannot call method getAccountTypeText\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Cannot call method getBalanceOnCourtOrderDate\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Cannot call method getData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^If condition is always false\\.$#"
+			count: 2
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\BankAccountController\\:\\:addAnotherAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\BankAccountController\\:\\:addAnotherAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\BankAccountController\\:\\:deleteAction\\(\\) has parameter \\$accountId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\BankAccountController\\:\\:deleteAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\BankAccountController\\:\\:startAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\BankAccountController\\:\\:stepAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\BankAccountController\\:\\:stepAction\\(\\) has parameter \\$step with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\BankAccountController\\:\\:summaryAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Offset 'state' does not exist on string\\.$#"
+			count: 2
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Parameter \\#1 \\$accountNumber of method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:setAccountNumber\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Parameter \\#1 \\$accountType of method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:setAccountType\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Parameter \\#1 \\$bank of method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:setBank\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Parameter \\#1 \\$sortCode of method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:setSortCode\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Ndr\\\\BankAccountController\\:\\:\\$clientApi has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Ndr\\\\BankAccountController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/BankAccountController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 2
+			path: src/Controller/Ndr/DebtController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DebtController\\:\\:editAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DebtController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DebtController\\:\\:editAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DebtController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DebtController\\:\\:existAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DebtController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DebtController\\:\\:existAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DebtController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DebtController\\:\\:managementAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DebtController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DebtController\\:\\:managementAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DebtController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DebtController\\:\\:startAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DebtController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DebtController\\:\\:startAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DebtController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DebtController\\:\\:summaryAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DebtController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DebtController\\:\\:summaryAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DebtController.php
+
+		-
+			message: "#^Offset 'state' does not exist on string\\.$#"
+			count: 2
+			path: src/Controller/Ndr/DebtController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 2
+			path: src/Controller/Ndr/DebtController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Ndr\\\\DebtController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DebtController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 2
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Cannot call method getAmount\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Cannot call method getData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Cannot call method getExplanation\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Cannot call method getPaidForAnything\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Cannot call method setNdr\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DeputyExpenseController\\:\\:addAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DeputyExpenseController\\:\\:addAnotherAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DeputyExpenseController\\:\\:addAnotherAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DeputyExpenseController\\:\\:deleteAction\\(\\) has parameter \\$expenseId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DeputyExpenseController\\:\\:deleteAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DeputyExpenseController\\:\\:editAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DeputyExpenseController\\:\\:editAction\\(\\) has parameter \\$expenseId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DeputyExpenseController\\:\\:editAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DeputyExpenseController\\:\\:existAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DeputyExpenseController\\:\\:existAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DeputyExpenseController\\:\\:startAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\DeputyExpenseController\\:\\:summaryAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Offset 'state' does not exist on string\\.$#"
+			count: 2
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 2
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Ndr\\\\DeputyExpenseController\\:\\:\\$clientApi has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Ndr\\\\DeputyExpenseController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/DeputyExpenseController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Ndr/IncomeBenefitController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Ndr/IncomeBenefitController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\IncomeBenefitController\\:\\:startAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/IncomeBenefitController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\IncomeBenefitController\\:\\:stepAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/IncomeBenefitController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\IncomeBenefitController\\:\\:stepAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/IncomeBenefitController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\IncomeBenefitController\\:\\:stepAction\\(\\) has parameter \\$step with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/IncomeBenefitController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\IncomeBenefitController\\:\\:summaryAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/IncomeBenefitController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\IncomeBenefitController\\:\\:summaryAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/IncomeBenefitController.php
+
+		-
+			message: "#^Offset 'state' does not exist on string\\.$#"
+			count: 2
+			path: src/Controller/Ndr/IncomeBenefitController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Ndr/IncomeBenefitController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Ndr\\\\IncomeBenefitController\\:\\:\\$clientApi has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/IncomeBenefitController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Ndr\\\\IncomeBenefitController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/IncomeBenefitController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\NdrController\\:\\:getPdfBinaryContent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/NdrController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\NdrController\\:\\:getPdfBinaryContent\\(\\) has parameter \\$ndr with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/NdrController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\NdrController\\:\\:pdfViewAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/NdrController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\NdrController\\:\\:reviewAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/NdrController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\NdrController\\:\\:submitConfirmationAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/NdrController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\NdrController\\:\\:submitFeedbackAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/NdrController.php
+
+		-
+			message: "#^Parameter \\#1 \\$deputyUid of method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:getAllClientsByDeputyUid\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Ndr/NdrController.php
+
+		-
+			message: "#^Parameter \\#1 \\$formResponse of method App\\\\Service\\\\Client\\\\Internal\\\\SatisfactionApi\\:\\:createPostSubmissionFeedback\\(\\) expects App\\\\Model\\\\FeedbackReport, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Ndr/NdrController.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\<App\\\\Entity\\\\Client\\>\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Ndr/NdrController.php
+
+		-
+			message: "#^Parameter \\#3 \\$submittedByUser of method App\\\\Service\\\\Client\\\\Internal\\\\SatisfactionApi\\:\\:createPostSubmissionFeedback\\(\\) expects App\\\\Entity\\\\User, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Ndr/NdrController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Ndr\\\\NdrController\\:\\:\\$ndrGroupsForValidation has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/NdrController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Ndr/OtherInfoController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Ndr/OtherInfoController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\OtherInfoController\\:\\:startAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/OtherInfoController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\OtherInfoController\\:\\:startAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/OtherInfoController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\OtherInfoController\\:\\:stepAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/OtherInfoController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\OtherInfoController\\:\\:stepAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/OtherInfoController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\OtherInfoController\\:\\:stepAction\\(\\) has parameter \\$step with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/OtherInfoController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\OtherInfoController\\:\\:summaryAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/OtherInfoController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\OtherInfoController\\:\\:summaryAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/OtherInfoController.php
+
+		-
+			message: "#^Offset 'state' does not exist on string\\.$#"
+			count: 2
+			path: src/Controller/Ndr/OtherInfoController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Ndr/OtherInfoController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Ndr\\\\OtherInfoController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/OtherInfoController.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Service\\\\StepRedirector\\:\\:checkDeputyHasMultiClients\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Ndr/VisitsCareController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Ndr/VisitsCareController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Ndr/VisitsCareController.php
+
+		-
+			message: "#^Cannot call method setNdr\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Ndr/VisitsCareController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\VisitsCareController\\:\\:startAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/VisitsCareController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\VisitsCareController\\:\\:stepAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/VisitsCareController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\VisitsCareController\\:\\:stepAction\\(\\) has parameter \\$step with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/VisitsCareController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Ndr\\\\VisitsCareController\\:\\:summaryAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/VisitsCareController.php
+
+		-
+			message: "#^Offset 'state' does not exist on string\\.$#"
+			count: 2
+			path: src/Controller/Ndr/VisitsCareController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Ndr/VisitsCareController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Ndr/VisitsCareController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Ndr\\\\VisitsCareController\\:\\:\\$clientApi \\(App\\\\Service\\\\StepRedirector\\) does not accept App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\.$#"
+			count: 1
+			path: src/Controller/Ndr/VisitsCareController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Ndr\\\\VisitsCareController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Ndr/VisitsCareController.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between null and int will always evaluate to false\\.$#"
+			count: 1
+			path: src/Controller/Ndr/VisitsCareController.php
+
+		-
+			message: "#^Ternary operator condition is always true\\.$#"
+			count: 1
+			path: src/Controller/Ndr/VisitsCareController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 4
+			path: src/Controller/Org/ClientContactController.php
+
+		-
+			message: "#^Cannot call method getClient\\(\\) on mixed\\.$#"
+			count: 4
+			path: src/Controller/Org/ClientContactController.php
+
+		-
+			message: "#^Cannot call method getFirstname\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Org/ClientContactController.php
+
+		-
+			message: "#^Cannot call method getLastName\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Org/ClientContactController.php
+
+		-
+			message: "#^Cannot call method getOrgName\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Org/ClientContactController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\ClientContactController\\:\\:addAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/ClientContactController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\ClientContactController\\:\\:deleteConfirmAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/ClientContactController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\ClientContactController\\:\\:deleteConfirmAction\\(\\) has parameter \\$confirmed with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/ClientContactController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\ClientContactController\\:\\:deleteConfirmAction\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/ClientContactController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\ClientContactController\\:\\:editAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/ClientContactController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\ClientContactController\\:\\:editAction\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/ClientContactController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\ClientContactController\\:\\:getContactById\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/ClientContactController.php
+
+		-
+			message: "#^PHPDoc tag @var has invalid value \\(\\$client EntityDir\\\\Client\\)\\: Unexpected token \"\\$client\", expected type at offset 9$#"
+			count: 1
+			path: src/Controller/Org/ClientContactController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Org/ClientContactController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Org/ClientContactController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Org\\\\ClientContactController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/ClientContactController.php
+
+		-
+			message: "#^Static property App\\\\Controller\\\\Org\\\\ClientContactController\\:\\:\\$jmsGroups is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/Org/ClientContactController.php
+
+		-
+			message: "#^Cannot access offset 'counts' on mixed\\.$#"
+			count: 4
+			path: src/Controller/Org/IndexController.php
+
+		-
+			message: "#^Cannot access offset 'notFinished' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Org/IndexController.php
+
+		-
+			message: "#^Cannot access offset 'notStarted' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Org/IndexController.php
+
+		-
+			message: "#^Cannot access offset 'readyToSubmit' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Org/IndexController.php
+
+		-
+			message: "#^Cannot access offset 'reports' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Org/IndexController.php
+
+		-
+			message: "#^Cannot access offset 'total' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Org/IndexController.php
+
+		-
+			message: "#^Cannot call method setId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Org/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\IndexController\\:\\:clientArchiveAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\IndexController\\:\\:clientArchiveAction\\(\\) has parameter \\$clientId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\IndexController\\:\\:clientEditAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\IndexController\\:\\:clientEditAction\\(\\) has parameter \\$clientId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/IndexController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\IndexController\\:\\:dashboardAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/IndexController.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:update\\(\\) invoked with 4 parameters, 3 required\\.$#"
+			count: 1
+			path: src/Controller/Org/IndexController.php
+
+		-
+			message: "#^Parameter \\#2 \\$data of method App\\\\Service\\\\Client\\\\RestClient\\:\\:arrayToEntities\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Org/IndexController.php
+
+		-
+			message: "#^Parameter \\#2 \\$postUpdateClient of method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:update\\(\\) expects App\\\\Entity\\\\Client, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Org/IndexController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Org\\\\IndexController\\:\\:\\$dateTimeProvider is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/Org/IndexController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Org\\\\IndexController\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/Org/IndexController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 4
+			path: src/Controller/Org/NoteController.php
+
+		-
+			message: "#^Cannot call method getClient\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Org/NoteController.php
+
+		-
+			message: "#^Cannot call method getCurrentReport\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Org/NoteController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Org/NoteController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\NoteController\\:\\:addAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/NoteController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\NoteController\\:\\:deleteConfirmAction\\(\\) has parameter \\$noteId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/NoteController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\NoteController\\:\\:editAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/NoteController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\NoteController\\:\\:editAction\\(\\) has parameter \\$noteId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/NoteController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\NoteController\\:\\:getNote\\(\\) has parameter \\$noteId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/NoteController.php
+
+		-
+			message: "#^PHPDoc tag @var has invalid value \\(\\$client EntityDir\\\\Client\\)\\: Unexpected token \"\\$client\", expected type at offset 9$#"
+			count: 1
+			path: src/Controller/Org/NoteController.php
+
+		-
+			message: "#^Parameter \\#1 \\$client of class App\\\\Entity\\\\Note constructor expects App\\\\Entity\\\\Client, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Org/NoteController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Org/NoteController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Org/NoteController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Org\\\\NoteController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/NoteController.php
+
+		-
+			message: "#^Static property App\\\\Controller\\\\Org\\\\NoteController\\:\\:\\$jmsGroups is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/Org/NoteController.php
+
+		-
+			message: "#^Cannot access offset 'count' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Org/OrganisationController.php
+
+		-
+			message: "#^Cannot access offset 'records' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Org/OrganisationController.php
+
+		-
+			message: "#^Cannot call method getEmail\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Org/OrganisationController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 7
+			path: src/Controller/Org/OrganisationController.php
+
+		-
+			message: "#^Cannot call method getUserById\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Org/OrganisationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\OrganisationController\\:\\:addAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/OrganisationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\OrganisationController\\:\\:deleteConfirmAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/OrganisationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\OrganisationController\\:\\:editAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/OrganisationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\OrganisationController\\:\\:listAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/OrganisationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Org\\\\OrganisationController\\:\\:viewAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Org/OrganisationController.php
+
+		-
+			message: "#^PHPDoc tag @var has invalid value \\(\\$organisation EntityDir\\\\Organisation\\)\\: Unexpected token \"\\$organisation\", expected type at offset 9$#"
+			count: 1
+			path: src/Controller/Org/OrganisationController.php
+
+		-
+			message: "#^Parameter \\#1 \\$organisation of method App\\\\Service\\\\Client\\\\Internal\\\\OrganisationApi\\:\\:addUserToOrganisation\\(\\) expects App\\\\Entity\\\\Organisation, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Org/OrganisationController.php
+
+		-
+			message: "#^Parameter \\#1 \\$organisation of method App\\\\Service\\\\Client\\\\Internal\\\\OrganisationApi\\:\\:removeUserFromOrganisation\\(\\) expects App\\\\Entity\\\\Organisation, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Org/OrganisationController.php
+
+		-
+			message: "#^Parameter \\#2 \\$data of method App\\\\Service\\\\Client\\\\RestClient\\:\\:arrayToEntities\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Org/OrganisationController.php
+
+		-
+			message: "#^Parameter \\#2 \\$postUpdateUser of method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:update\\(\\) expects App\\\\Entity\\\\User, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Org/OrganisationController.php
+
+		-
+			message: "#^Parameter \\#3 \\$currentUser of method App\\\\Service\\\\Client\\\\Internal\\\\OrganisationApi\\:\\:addUserToOrganisation\\(\\) expects App\\\\Entity\\\\User, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Org/OrganisationController.php
+
+		-
+			message: "#^Parameter \\#3 \\$currentUser of method App\\\\Service\\\\Client\\\\Internal\\\\OrganisationApi\\:\\:removeUserFromOrganisation\\(\\) expects App\\\\Entity\\\\User, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Org/OrganisationController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Org\\\\OrganisationController\\:\\:\\$dateTimeProvider is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/Org/OrganisationController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/ActionController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/ActionController.php
+
+		-
+			message: "#^Cannot access offset 'state' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/ActionController.php
+
+		-
+			message: "#^Cannot call method setReport\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ActionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ActionController\\:\\:startAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ActionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ActionController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ActionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ActionController\\:\\:stepAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ActionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ActionController\\:\\:stepAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ActionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ActionController\\:\\:stepAction\\(\\) has parameter \\$step with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ActionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ActionController\\:\\:summaryAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ActionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ActionController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ActionController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/ActionController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\ActionController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ActionController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 3
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Call to method getId\\(\\) on an unknown class App\\\\Entity\\\\Report\\\\Traits\\\\Asset\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'address' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'address2' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'county' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'has_mg' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'hc' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'mg_oa' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'occupants' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'owned' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'owned_p' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'postcode' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'ser' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'state' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot access offset 'value' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method getAddress\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method getAddress2\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method getCounty\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method getData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method getDescription\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method getHasCharges\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method getHasMortgage\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method getIsSubjectToEquityRelease\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method getMortgageOutstandingAmount\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method getOccupants\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method getOwned\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method getOwnedPercentage\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method getPostcode\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method getTitle\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method getValuationDate\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method getValue\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method setAddress\\(\\) on App\\\\Entity\\\\Report\\\\AssetProperty\\|App\\\\Entity\\\\Report\\\\Traits\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method setAddress2\\(\\) on App\\\\Entity\\\\Report\\\\AssetProperty\\|App\\\\Entity\\\\Report\\\\Traits\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method setCounty\\(\\) on App\\\\Entity\\\\Report\\\\AssetProperty\\|App\\\\Entity\\\\Report\\\\Traits\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method setHasCharges\\(\\) on App\\\\Entity\\\\Report\\\\AssetProperty\\|App\\\\Entity\\\\Report\\\\Traits\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method setHasMortgage\\(\\) on App\\\\Entity\\\\Report\\\\AssetProperty\\|App\\\\Entity\\\\Report\\\\Traits\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method setIsSubjectToEquityRelease\\(\\) on App\\\\Entity\\\\Report\\\\AssetProperty\\|App\\\\Entity\\\\Report\\\\Traits\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method setMortgageOutstandingAmount\\(\\) on App\\\\Entity\\\\Report\\\\AssetProperty\\|App\\\\Entity\\\\Report\\\\Traits\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method setOccupants\\(\\) on App\\\\Entity\\\\Report\\\\AssetProperty\\|App\\\\Entity\\\\Report\\\\Traits\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method setOwned\\(\\) on App\\\\Entity\\\\Report\\\\AssetProperty\\|App\\\\Entity\\\\Report\\\\Traits\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method setOwnedPercentage\\(\\) on App\\\\Entity\\\\Report\\\\AssetProperty\\|App\\\\Entity\\\\Report\\\\Traits\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method setPostcode\\(\\) on App\\\\Entity\\\\Report\\\\AssetProperty\\|App\\\\Entity\\\\Report\\\\Traits\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Cannot call method setValue\\(\\) on App\\\\Entity\\\\Report\\\\AssetProperty\\|App\\\\Entity\\\\Report\\\\Traits\\\\Asset\\|null\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:addAnotherAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:deleteAction\\(\\) has parameter \\$assetId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:deleteAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:existAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:existAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:otherAddAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:otherAddAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:otherAddAction\\(\\) has parameter \\$title with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:otherEditAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:otherEditAction\\(\\) has parameter \\$assetId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:otherEditAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:propertyStepAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:propertyStepAction\\(\\) has parameter \\$assetId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:propertyStepAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:propertyStepAction\\(\\) has parameter \\$step with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:typeAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:typeAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Parameter \\#1 \\$noAssetToAdd of method App\\\\Entity\\\\Report\\\\Report\\:\\:setNoAssetToAdd\\(\\) expects bool, int given\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 2
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 2
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\AssetController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/AssetController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\BalanceController\\:\\:balanceAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/BalanceController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/BalanceController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\BalanceController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/BalanceController.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 3
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Cannot access offset 'bank' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Cannot access offset 'closing\\-balance' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Cannot access offset 'is\\-joint' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Cannot access offset 'moneyTransfers' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Cannot access offset 'number' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Cannot access offset 'opening\\-balance' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Cannot access offset 'sort\\-code' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Cannot access offset 'state' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Cannot access offset 'transactions' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Cannot access offset 'transactionsCount' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Cannot access offset 'type' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Cannot call method getData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^If condition is always false\\.$#"
+			count: 2
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\BankAccountController\\:\\:addAnotherAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\BankAccountController\\:\\:deleteConfirmAction\\(\\) has parameter \\$accountId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\BankAccountController\\:\\:deleteConfirmAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\BankAccountController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\BankAccountController\\:\\:stepAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\BankAccountController\\:\\:stepAction\\(\\) has parameter \\$step with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\BankAccountController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Parameter \\#1 \\$accountType of method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setAccountType\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Parameter \\#1 \\$closingBalance of method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setClosingBalance\\(\\) expects float, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Symfony\\\\Contracts\\\\Translation\\\\TranslatorInterface\\:\\:trans\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\BankAccountController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: "#^Argument of an invalid type Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Controller/Report/ClientBenefitsCheckController.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\Ndr\\\\ClientBenefitsCheck\\|App\\\\Entity\\\\Report\\\\ClientBenefitsCheck\\:\\:setNdr\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/ClientBenefitsCheckController.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\Ndr\\\\Ndr\\|App\\\\Entity\\\\Report\\\\Report\\:\\:getStatus\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/ClientBenefitsCheckController.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\Ndr\\\\Ndr\\|App\\\\Entity\\\\Report\\\\Report\\:\\:getStatusService\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/ClientBenefitsCheckController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/ClientBenefitsCheckController.php
+
+		-
+			message: "#^Cannot call method getAmount\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ClientBenefitsCheckController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/ClientBenefitsCheckController.php
+
+		-
+			message: "#^Cannot call method getMoneyType\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ClientBenefitsCheckController.php
+
+		-
+			message: "#^Cannot call method getTypesOfMoneyReceivedOnClientsBehalf\\(\\) on App\\\\Entity\\\\Ndr\\\\ClientBenefitsCheck\\|App\\\\Entity\\\\Report\\\\ClientBenefitsCheck\\|null\\.$#"
+			count: 1
+			path: src/Controller/Report/ClientBenefitsCheckController.php
+
+		-
+			message: "#^Cannot call method getWhoReceivedMoney\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ClientBenefitsCheckController.php
+
+		-
+			message: "#^Cannot call method setNdr\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ClientBenefitsCheckController.php
+
+		-
+			message: "#^Cannot call method setReport\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ClientBenefitsCheckController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ClientBenefitsCheckController\\:\\:incomeNotReceivedByOthers\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ClientBenefitsCheckController.php
+
+		-
+			message: "#^Parameter \\#1 \\$clientBenefitsCheck of method App\\\\Service\\\\Client\\\\Internal\\\\ClientBenefitsCheckApi\\:\\:post\\(\\) expects App\\\\Entity\\\\ClientBenefitsCheckInterface, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/ClientBenefitsCheckController.php
+
+		-
+			message: "#^Parameter \\#1 \\$clientBenefitsCheck of method App\\\\Service\\\\Client\\\\Internal\\\\ClientBenefitsCheckApi\\:\\:put\\(\\) expects App\\\\Entity\\\\ClientBenefitsCheckInterface, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/ClientBenefitsCheckController.php
+
+		-
+			message: "#^Variable \\$formData in PHPDoc tag @var does not match assigned variable \\$clientBenefitsCheck\\.$#"
+			count: 1
+			path: src/Controller/Report/ClientBenefitsCheckController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 2
+			path: src/Controller/Report/ContactController.php
+
+		-
+			message: "#^Cannot access offset 'state' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/ContactController.php
+
+		-
+			message: "#^Cannot call method getContactName\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ContactController.php
+
+		-
+			message: "#^Cannot call method getData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 2
+			path: src/Controller/Report/ContactController.php
+
+		-
+			message: "#^Cannot call method getExplanation\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ContactController.php
+
+		-
+			message: "#^Cannot call method getRelationship\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ContactController.php
+
+		-
+			message: "#^Cannot call method setReport\\(\\) on mixed\\.$#"
+			count: 3
+			path: src/Controller/Report/ContactController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ContactController\\:\\:addAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ContactController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ContactController\\:\\:addAnotherAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ContactController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ContactController\\:\\:deleteAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ContactController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ContactController\\:\\:editAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ContactController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ContactController\\:\\:existAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ContactController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ContactController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ContactController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ContactController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ContactController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/ContactController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/ContactController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\ContactController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ContactController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 2
+			path: src/Controller/Report/DebtController.php
+
+		-
+			message: "#^Cannot access offset 'state' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/DebtController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DebtController\\:\\:editAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DebtController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DebtController\\:\\:existAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DebtController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DebtController\\:\\:managementAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DebtController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DebtController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DebtController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DebtController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DebtController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 2
+			path: src/Controller/Report/DebtController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\DebtController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DebtController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
+			count: 2
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 4
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Cannot access offset 'state' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Cannot call method getData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 2
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Cannot call method getDecisions\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Cannot call method getDescription\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Cannot call method setReasonForNoDecisions\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Cannot call method setReport\\(\\) on mixed\\.$#"
+			count: 5
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:addAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:addAnotherAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:deleteAction\\(\\) has parameter \\$decisionId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:deleteAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:editAction\\(\\) has parameter \\$decisionId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:editAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:existAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:mentalAssessmentAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:mentalCapacityAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:updateReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:updateReport\\(\\) has parameter \\$fields with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:updateReport\\(\\) has parameter \\$report with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:updateReport\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Parameter \\#1 \\$route of method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Controller\\\\AbstractController\\:\\:generateUrl\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 3
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\DecisionController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 2
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Cannot access offset 'state' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Cannot call method getAmount\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Cannot call method getBankAccount\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Cannot call method getData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 1
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Cannot call method getExplanation\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Cannot call method getPaidForAnything\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Cannot call method setBankAccountId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Cannot call method setReport\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DeputyExpenseController\\:\\:addAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DeputyExpenseController\\:\\:addAnotherAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DeputyExpenseController\\:\\:deleteAction\\(\\) has parameter \\$expenseId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DeputyExpenseController\\:\\:deleteAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DeputyExpenseController\\:\\:editAction\\(\\) has parameter \\$expenseId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DeputyExpenseController\\:\\:editAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DeputyExpenseController\\:\\:existAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DeputyExpenseController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DeputyExpenseController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 2
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\DeputyExpenseController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DeputyExpenseController.php
+
+		-
+			message: "#^Cannot access offset 'files' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/DocumentController.php
+
+		-
+			message: "#^Cannot call method getDeputyDocuments\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/DocumentController.php
+
+		-
+			message: "#^Cannot call method getStorageReference\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/DocumentController.php
+
+		-
+			message: "#^Cannot call method getWishToProvideDocumentation\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/DocumentController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:deleteConfirmAction\\(\\) has parameter \\$documentId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DocumentController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:deleteDocument\\(\\) has parameter \\$documentId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DocumentController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:deleteMissingS3DocFromDocumentTable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DocumentController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:deleteMissingS3DocFromDocumentTable\\(\\) has parameter \\$documentId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DocumentController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:getDocument\\(\\) should return App\\\\Entity\\\\Report\\\\Document but returns mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/DocumentController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:identifyMissingFilesInS3Bucket\\(\\) has parameter \\$report with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DocumentController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DocumentController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:step1Action\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DocumentController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:submitMoreConfirmAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DocumentController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:submitMoreConfirmedAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DocumentController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DocumentController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/DocumentController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\DocumentController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/DocumentController.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: src/Controller/Report/DocumentController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:getClickedButton\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 2
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Cannot access offset 'state' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Cannot call method getAmount\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Cannot call method getBankAccount\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Cannot call method getExplanation\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Cannot call method getGiftsExist\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Cannot call method setBankAccountId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Cannot call method setReport\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:addAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:deleteAction\\(\\) has parameter \\$giftId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:deleteAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:editAction\\(\\) has parameter \\$giftId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:editAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:existAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 2
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\GiftController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/GiftController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/LifestyleController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/LifestyleController.php
+
+		-
+			message: "#^Cannot call method setReport\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/LifestyleController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\LifestyleController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/LifestyleController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\LifestyleController\\:\\:stepAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/LifestyleController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\LifestyleController\\:\\:stepAction\\(\\) has parameter \\$step with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/LifestyleController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\LifestyleController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/LifestyleController.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: src/Controller/Report/LifestyleController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/LifestyleController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/LifestyleController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\LifestyleController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/LifestyleController.php
+
+		-
+			message: "#^Ternary operator condition is always true\\.$#"
+			count: 1
+			path: src/Controller/Report/LifestyleController.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with App\\\\Entity\\\\Report\\\\MoneyTransaction will always evaluate to false\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Cannot access offset 'category' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Cannot access offset 'state' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Cannot call method getData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 3
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Cannot call method getNameOneLine\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Cannot call method getStatus\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Cannot call method getType\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Cannot call method setMoneyInExists\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Cannot call method setReasonForNoMoneyIn\\(\\) on mixed\\.$#"
+			count: 3
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^If condition is always false\\.$#"
+			count: 2
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInController\\:\\:addAnotherAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInController\\:\\:deleteAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInController\\:\\:deleteAction\\(\\) has parameter \\$transactionId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInController\\:\\:existAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInController\\:\\:handleSoftDeletionOfMoneyTransactionItems\\(\\) has parameter \\$answer with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInController\\:\\:handleSoftDeletionOfMoneyTransactionItems\\(\\) has parameter \\$report with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInController\\:\\:handleSoftDeletionOfMoneyTransactionItems\\(\\) has parameter \\$softDeletedTransactionIds with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInController\\:\\:noMoneyInToReport\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInController\\:\\:stepAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInController\\:\\:stepAction\\(\\) has parameter \\$step with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 4
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\MoneyInController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInController.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 3
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Cannot access offset 'state' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Cannot access offset 'type' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Cannot call method getAmount\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Cannot call method getData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 3
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Cannot call method getDate\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Cannot call method getDescription\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Cannot call method getMoneyTransactionsShortIn\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Cannot call method getMoneyTransactionsShortInExist\\(\\) on mixed\\.$#"
+			count: 3
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Cannot call method getStatus\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Cannot call method setMoneyInExists\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Cannot call method setReasonForNoMoneyIn\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInShortController\\:\\:addAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInShortController\\:\\:addAnotherAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInShortController\\:\\:categoryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInShortController\\:\\:cleanDataIfAnswerIsChangedFromYesToNo\\(\\) has parameter \\$report with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInShortController\\:\\:deleteAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInShortController\\:\\:deleteAction\\(\\) has parameter \\$transactionId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInShortController\\:\\:editAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInShortController\\:\\:editAction\\(\\) has parameter \\$transactionId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInShortController\\:\\:existAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInShortController\\:\\:noMoneyInShortToReport\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInShortController\\:\\:oneOffPaymentsExistAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInShortController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyInShortController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 7
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\MoneyInShortController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyInShortController.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with App\\\\Entity\\\\Report\\\\MoneyTransaction will always evaluate to false\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Cannot access offset 'category' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Cannot access offset 'state' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Cannot call method getData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 3
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Cannot call method getNameOneLine\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Cannot call method getStatus\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Cannot call method getType\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Cannot call method setMoneyOutExists\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Cannot call method setReasonForNoMoneyOut\\(\\) on mixed\\.$#"
+			count: 3
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^If condition is always false\\.$#"
+			count: 2
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutController\\:\\:addAnotherAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutController\\:\\:deleteAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutController\\:\\:deleteAction\\(\\) has parameter \\$transactionId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutController\\:\\:existAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutController\\:\\:handleSoftDeletionOfMoneyTransactionItems\\(\\) has parameter \\$answer with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutController\\:\\:handleSoftDeletionOfMoneyTransactionItems\\(\\) has parameter \\$report with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutController\\:\\:handleSoftDeletionOfMoneyTransactionItems\\(\\) has parameter \\$softDeletedTransactionIds with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutController\\:\\:noMoneyOutToReport\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutController\\:\\:stepAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutController\\:\\:stepAction\\(\\) has parameter \\$step with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 4
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\MoneyOutController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutController.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 3
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Cannot access offset 'state' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Cannot access offset 'type' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Cannot call method getAmount\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Cannot call method getData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 3
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Cannot call method getDate\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Cannot call method getDescription\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Cannot call method getMoneyTransactionsShortOut\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Cannot call method getMoneyTransactionsShortOutExist\\(\\) on mixed\\.$#"
+			count: 3
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Cannot call method getStatus\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Cannot call method setMoneyOutExists\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Cannot call method setReasonForNoMoneyOut\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutShortController\\:\\:addAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutShortController\\:\\:addAnotherAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutShortController\\:\\:categoryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutShortController\\:\\:cleanDataIfAnswerIsChangedFromYesToNo\\(\\) has parameter \\$report with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutShortController\\:\\:deleteAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutShortController\\:\\:deleteAction\\(\\) has parameter \\$transactionId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutShortController\\:\\:editAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutShortController\\:\\:editAction\\(\\) has parameter \\$transactionId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutShortController\\:\\:existAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutShortController\\:\\:noMoneyOutShortToReport\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutShortController\\:\\:oneOffPaymentsExistAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutShortController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyOutShortController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 7
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\MoneyOutShortController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyOutShortController.php
+
+		-
+			message: "#^Cannot access offset 'from\\-id' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/MoneyTransferController.php
+
+		-
+			message: "#^Cannot access offset 'state' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/MoneyTransferController.php
+
+		-
+			message: "#^Cannot access offset 'to\\-id' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/MoneyTransferController.php
+
+		-
+			message: "#^Cannot call method getData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyTransferController.php
+
+		-
+			message: "#^If condition is always false\\.$#"
+			count: 2
+			path: src/Controller/Report/MoneyTransferController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:addAnotherAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyTransferController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:deleteAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyTransferController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:existAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyTransferController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyTransferController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:stepAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyTransferController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:stepAction\\(\\) has parameter \\$step with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyTransferController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyTransferController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/MoneyTransferController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/OtherInfoController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/OtherInfoController.php
+
+		-
+			message: "#^Cannot access offset 'state' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/OtherInfoController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\OtherInfoController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/OtherInfoController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\OtherInfoController\\:\\:stepAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/OtherInfoController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\OtherInfoController\\:\\:stepAction\\(\\) has parameter \\$step with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/OtherInfoController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\OtherInfoController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/OtherInfoController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/OtherInfoController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\OtherInfoController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/OtherInfoController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 3
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Cannot call method getAmount\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Cannot call method getData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 2
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Cannot call method getExplanation\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Cannot call method getPaidForAnything\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Cannot call method setReport\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\PaFeeExpenseController\\:\\:deleteAction\\(\\) has parameter \\$expenseId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\PaFeeExpenseController\\:\\:deleteAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\PaFeeExpenseController\\:\\:feeEditAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\PaFeeExpenseController\\:\\:feeExistAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\PaFeeExpenseController\\:\\:otherAddAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\PaFeeExpenseController\\:\\:otherAddAnotherAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\PaFeeExpenseController\\:\\:otherEditAction\\(\\) has parameter \\$expenseId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\PaFeeExpenseController\\:\\:otherEditAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\PaFeeExpenseController\\:\\:otherExistAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\PaFeeExpenseController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\PaFeeExpenseController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Parameter \\#1 \\$reasonForNoFees of method App\\\\Entity\\\\Report\\\\Report\\:\\:setReasonForNoFees\\(\\) expects string, null given\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 3
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\PaFeeExpenseController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/PaFeeExpenseController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:getClickedButton\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfCurrentFeesController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfCurrentFeesController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 5
+			path: src/Controller/Report/ProfCurrentFeesController.php
+
+		-
+			message: "#^Cannot call method getServiceTypeId\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/ProfCurrentFeesController.php
+
+		-
+			message: "#^Cannot call method setReport\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfCurrentFeesController.php
+
+		-
+			message: "#^If condition is always false\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfCurrentFeesController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfCurrentFeesController\\:\\:deleteAction\\(\\) has parameter \\$feeId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfCurrentFeesController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfCurrentFeesController\\:\\:deleteAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfCurrentFeesController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfCurrentFeesController\\:\\:existAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfCurrentFeesController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfCurrentFeesController\\:\\:previousEstimatesAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfCurrentFeesController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfCurrentFeesController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfCurrentFeesController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfCurrentFeesController\\:\\:stepAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfCurrentFeesController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfCurrentFeesController\\:\\:stepAction\\(\\) has parameter \\$step with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfCurrentFeesController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfCurrentFeesController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfCurrentFeesController.php
+
+		-
+			message: "#^Parameter \\#1 \\$serviceTypeId of method App\\\\Entity\\\\Report\\\\ProfServiceFee\\:\\:setServiceTypeId\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfCurrentFeesController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfCurrentFeesController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 3
+			path: src/Controller/Report/ProfCurrentFeesController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\ProfCurrentFeesController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfCurrentFeesController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:getClickedButton\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 10
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Cannot call method getAmount\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Cannot call method getEndDate\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Cannot call method getProfDeputyCostsHasInterim\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Cannot call method getProfDeputyCostsHasPrevious\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Cannot call method getStartDate\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^If condition is always false\\.$#"
+			count: 2
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsController\\:\\:amountToSccoAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsController\\:\\:breakdown\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsController\\:\\:fixedCostAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsController\\:\\:howChargedAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsController\\:\\:interim\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsController\\:\\:interimExists\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsController\\:\\:previousCostDelete\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsController\\:\\:previousReceived\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsController\\:\\:previousReceivedExists\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Parameter \\#2 \\$amount of class App\\\\Entity\\\\Report\\\\ProfDeputyOtherCost constructor expects App\\\\Entity\\\\Report\\\\decimal, null given\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 4
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Parameter \\#4 \\$moreDetails of class App\\\\Entity\\\\Report\\\\ProfDeputyOtherCost constructor expects string, null given\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\ProfDeputyCostsController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Variable \\$previousReceivedId in empty\\(\\) always exists and is always falsy\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 3
+			path: src/Controller/Report/ProfDeputyCostsEstimateController.php
+
+		-
+			message: "#^Cannot call method getProfDeputyCostsEstimateHowCharged\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsEstimateController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsEstimateController\\:\\:answerHasChangedFromFixedToNonFixed\\(\\) has parameter \\$originalHowChargedValue with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsEstimateController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsEstimateController\\:\\:answerHasChangedFromFixedToNonFixed\\(\\) has parameter \\$updatedHowCharged with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsEstimateController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsEstimateController\\:\\:breakdownAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsEstimateController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsEstimateController\\:\\:determineNextRouteFromHowCharged\\(\\) has parameter \\$originalHowChargedValue with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsEstimateController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsEstimateController\\:\\:howChargedAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsEstimateController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsEstimateController\\:\\:moreInfoAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsEstimateController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsEstimateController\\:\\:persistUpdate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsEstimateController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsEstimateController\\:\\:persistUpdate\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsEstimateController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsEstimateController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsEstimateController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyCostsEstimateController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsEstimateController.php
+
+		-
+			message: "#^Parameter \\#2 \\$amount of class App\\\\Entity\\\\Report\\\\ProfDeputyEstimateCost constructor expects App\\\\Entity\\\\Report\\\\decimal, null given\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsEstimateController.php
+
+		-
+			message: "#^Parameter \\#2 \\$report of method App\\\\Controller\\\\Report\\\\ProfDeputyCostsEstimateController\\:\\:persistUpdate\\(\\) expects App\\\\Entity\\\\Report\\\\Report, mixed given\\.$#"
+			count: 3
+			path: src/Controller/Report/ProfDeputyCostsEstimateController.php
+
+		-
+			message: "#^Parameter \\#4 \\$moreDetails of class App\\\\Entity\\\\Report\\\\ProfDeputyEstimateCost constructor expects string, null given\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsEstimateController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\ProfDeputyCostsEstimateController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsEstimateController.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: src/Controller/Report/ProfDeputyCostsEstimateController.php
+
+		-
+			message: "#^Cannot call method getStorageReference\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Cannot call method getUsers\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Cannot call method isLayDeputy\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Cannot call method setUsers\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:checkIfDocumentsExistInS3\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:checkIfDocumentsExistInS3\\(\\) has parameter \\$report with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:createAction\\(\\) has parameter \\$action with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:createAction\\(\\) has parameter \\$clientId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:declarationAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:editAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:generateClient\\(\\) has parameter \\$clientId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:generateClient\\(\\) should return App\\\\Entity\\\\Client but returns mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:overviewAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:pdfDebugAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:pdfViewAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:reviewAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:reviewAction\\(\\) should return Symfony\\\\Component\\\\HttpFoundation\\\\RedirectResponse but returns array\\<string, mixed\\>\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:submitConfirmationAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:transactionsCsvViewAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Parameter \\#1 \\$client of method App\\\\Entity\\\\Report\\\\Report\\:\\:setClient\\(\\) expects App\\\\Entity\\\\Client, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Parameter \\#1 \\$client of method App\\\\Service\\\\Client\\\\Internal\\\\ReportApi\\:\\:getReportsIndexedById\\(\\) expects App\\\\Entity\\\\Client, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Parameter \\#1 \\$clientId of method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:getById\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Parameter \\#1 \\$clientId of method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:getWithUsersV2\\(\\) expects int, string given\\.$#"
+			count: 2
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Parameter \\#1 \\$deputyUid of method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:getAllClientsByDeputyUid\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Parameter \\#1 \\$deputyUid of method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:returnPrimaryEmail\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Parameter \\#1 \\$formResponse of method App\\\\Service\\\\Client\\\\Internal\\\\SatisfactionApi\\:\\:createPostSubmissionFeedback\\(\\) expects App\\\\Model\\\\FeedbackReport, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\<App\\\\Entity\\\\Client\\>\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Parameter \\#3 \\$submittedByUser of method App\\\\Service\\\\Client\\\\Internal\\\\SatisfactionApi\\:\\:createPostSubmissionFeedback\\(\\) expects App\\\\Entity\\\\User, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\ReportController\\:\\:\\$ndrGroupsForValidation has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/VisitsCareController.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/VisitsCareController.php
+
+		-
+			message: "#^Cannot access offset 'state' on mixed\\.$#"
+			count: 2
+			path: src/Controller/Report/VisitsCareController.php
+
+		-
+			message: "#^Cannot call method setReport\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Report/VisitsCareController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\VisitsCareController\\:\\:startAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/VisitsCareController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\VisitsCareController\\:\\:stepAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/VisitsCareController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\VisitsCareController\\:\\:stepAction\\(\\) has parameter \\$step with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/VisitsCareController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Report\\\\VisitsCareController\\:\\:summaryAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/VisitsCareController.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: src/Controller/Report/VisitsCareController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/VisitsCareController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Report/VisitsCareController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Report\\\\VisitsCareController\\:\\:\\$jmsGroups has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Report/VisitsCareController.php
+
+		-
+			message: "#^Ternary operator condition is always true\\.$#"
+			count: 1
+			path: src/Controller/Report/VisitsCareController.php
+
+		-
+			message: "#^Cannot access offset 'new_email' on bool\\|float\\|int\\|string\\|null\\.$#"
+			count: 1
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Cannot access offset 'password' on bool\\|float\\|int\\|string\\|null\\.$#"
+			count: 1
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Cannot call method isDeputyOrg\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null\\.$#"
+			count: 3
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Cannot call method isDeputyPA\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Cannot call method isDeputyProf\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Cannot call method setRoleName\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\SettingsController\\:\\:emailEditAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\SettingsController\\:\\:indexAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\SettingsController\\:\\:passwordEditAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\SettingsController\\:\\:profileAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\SettingsController\\:\\:profileEditAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Parameter \\#1 \\$route of method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Controller\\\\AbstractController\\:\\:redirectToRoute\\(\\) expects string, string\\|true given\\.$#"
+			count: 1
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, string\\|false given\\.$#"
+			count: 2
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Parameter \\#2 \\$postUpdateUser of method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:update\\(\\) expects App\\\\Entity\\\\User, mixed given\\.$#"
+			count: 1
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\SettingsController\\:\\:\\$dateTimeProvider is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\SettingsController\\:\\:\\$eventDispatcher is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\SettingsController\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\SettingsController\\:\\:\\$mailFactory is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\SettingsController\\:\\:\\$mailSender is never read, only written\\.$#"
+			count: 1
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 1
+			path: src/Controller/SettingsController.php
+
+		-
+			message: "#^Call to an undefined method Throwable\\:\\:getData\\(\\)\\.$#"
+			count: 2
+			path: src/Controller/UserController.php
+
+		-
+			message: "#^Cannot access offset 'client_lastname' on mixed\\.$#"
+			count: 1
+			path: src/Controller/UserController.php
+
+		-
+			message: "#^Cannot access offset 'deputy_firstname' on mixed\\.$#"
+			count: 1
+			path: src/Controller/UserController.php
+
+		-
+			message: "#^Cannot access offset 'deputy_lastname' on mixed\\.$#"
+			count: 1
+			path: src/Controller/UserController.php
+
+		-
+			message: "#^Cannot access offset 'deputy_postcode' on mixed\\.$#"
+			count: 1
+			path: src/Controller/UserController.php
+
+		-
+			message: "#^Cannot access offset 'matching_errors' on mixed\\.$#"
+			count: 4
+			path: src/Controller/UserController.php
+
+		-
+			message: "#^Cannot call method getEmail\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/UserController.php
+
+		-
+			message: "#^Parameter \\#1 \\$selfRegisterData of method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:selfRegister\\(\\) expects App\\\\Model\\\\SelfRegisterData, mixed given\\.$#"
+			count: 1
+			path: src/Controller/UserController.php
+
+		-
+			message: "#^Parameter \\#1 \\$type of method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Controller\\\\AbstractController\\:\\:createForm\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/UserController.php
+
+		-
+			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/UserController.php
+
+		-
+			message: "#^Parameter \\#2 \\$statusCode of method App\\\\Controller\\\\AbstractController\\:\\:renderError\\(\\) expects int, string given\\.$#"
+			count: 1
+			path: src/Controller/UserController.php
+
+		-
+			message: "#^Parameter \\#3 \\$jmsGroups of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Controller/UserController.php
+
+		-
+			message: "#^Cannot access offset 'satisfaction' on mixed\\.$#"
+			count: 1
+			path: src/Controller/UserResearchController.php
+
+		-
+			message: "#^Cannot call method isLayDeputy\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null\\.$#"
+			count: 1
+			path: src/Controller/UserResearchController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\UserResearchController\\:\\:postSubmissionUserResearch\\(\\) should return array but returns Symfony\\\\Component\\\\HttpFoundation\\\\RedirectResponse\\.$#"
+			count: 1
+			path: src/Controller/UserResearchController.php
+
+		-
+			message: "#^Parameter \\#1 \\$ndrId of method App\\\\Service\\\\Client\\\\Internal\\\\NdrApi\\:\\:getNdr\\(\\) expects int, int\\|null given\\.$#"
+			count: 2
+			path: src/Controller/UserResearchController.php
+
+		-
+			message: "#^Parameter \\#1 \\$userResearchFormData of method App\\\\Service\\\\Client\\\\Internal\\\\UserResearchApi\\:\\:createPostSubmissionUserResearch\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Controller/UserResearchController.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\BankAccountInterface\\:\\:getAccountTypeText\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/BankAccountInterface.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\BankAccountInterface\\:\\:getBank\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/BankAccountInterface.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\BankAccountInterface\\:\\:getClosingBalance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/BankAccountInterface.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\BankAccountInterface\\:\\:getIsClosed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/BankAccountInterface.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\BankAccountInterface\\:\\:getIsJointAccount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/BankAccountInterface.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\BankAccountInterface\\:\\:getNameOneLine\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/BankAccountInterface.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:addUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:addUser\\(\\) has parameter \\$user with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:getAge\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:getClientContacts\\(\\) return type with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:getFullname\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:getNotes\\(\\) return type with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:hasDetails\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:hasReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:removeReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:removeReport\\(\\) has parameter \\$report with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:setClientContacts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:setClientContacts\\(\\) has parameter \\$clientContacts with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection but does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:setCourtDateWithoutTime\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:setCourtDateWithoutTime\\(\\) has parameter \\$courtDate with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:setExpectedReportStartDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:setNdr\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:setNotes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:setNotes\\(\\) has parameter \\$notes with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection but does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:setTotalReportCount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:setUsers\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:setUsers\\(\\) has parameter \\$users with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Client\\:\\:userBelongsToClientsOrganisation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Negated boolean expression is always true\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Client\\:\\:\\$address2 \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Client\\:\\:\\$address3 \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Client\\:\\:\\$address4 \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Client\\:\\:\\$address5 \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Client\\:\\:\\$archivedAt is never written, only read\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Client\\:\\:\\$clientContacts with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Client\\:\\:\\$deletedAt has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Client\\:\\:\\$notes with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: src/Entity/Client.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\ClientContact\\:\\:setAddress1\\(\\) should return string but returns \\$this\\(App\\\\Entity\\\\ClientContact\\)\\.$#"
+			count: 1
+			path: src/Entity/ClientContact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\ClientContact\\:\\:setAddress2\\(\\) should return string but returns \\$this\\(App\\\\Entity\\\\ClientContact\\)\\.$#"
+			count: 1
+			path: src/Entity/ClientContact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\ClientContact\\:\\:setAddress3\\(\\) should return string but returns \\$this\\(App\\\\Entity\\\\ClientContact\\)\\.$#"
+			count: 1
+			path: src/Entity/ClientContact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\ClientContact\\:\\:setAddressCountry\\(\\) should return string but returns \\$this\\(App\\\\Entity\\\\ClientContact\\)\\.$#"
+			count: 1
+			path: src/Entity/ClientContact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\ClientContact\\:\\:setAddressPostcode\\(\\) should return string but returns \\$this\\(App\\\\Entity\\\\ClientContact\\)\\.$#"
+			count: 1
+			path: src/Entity/ClientContact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\ClientContact\\:\\:setClient\\(\\) should return string but returns \\$this\\(App\\\\Entity\\\\ClientContact\\)\\.$#"
+			count: 1
+			path: src/Entity/ClientContact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\ClientContact\\:\\:setEmail\\(\\) should return string but returns \\$this\\(App\\\\Entity\\\\ClientContact\\)\\.$#"
+			count: 1
+			path: src/Entity/ClientContact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\ClientContact\\:\\:setFirstName\\(\\) should return string but returns \\$this\\(App\\\\Entity\\\\ClientContact\\)\\.$#"
+			count: 1
+			path: src/Entity/ClientContact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\ClientContact\\:\\:setJobTitle\\(\\) should return string but returns \\$this\\(App\\\\Entity\\\\ClientContact\\)\\.$#"
+			count: 1
+			path: src/Entity/ClientContact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\ClientContact\\:\\:setLastName\\(\\) should return string but returns \\$this\\(App\\\\Entity\\\\ClientContact\\)\\.$#"
+			count: 1
+			path: src/Entity/ClientContact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\ClientContact\\:\\:setOrgName\\(\\) should return string but returns \\$this\\(App\\\\Entity\\\\ClientContact\\)\\.$#"
+			count: 1
+			path: src/Entity/ClientContact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\ClientContact\\:\\:setPhone\\(\\) should return string but returns \\$this\\(App\\\\Entity\\\\ClientContact\\)\\.$#"
+			count: 1
+			path: src/Entity/ClientContact.php
+
+		-
+			message: "#^Parameter \\#1 \\$client of method App\\\\Entity\\\\ClientContact\\:\\:setClient\\(\\) expects string, App\\\\Entity\\\\Client given\\.$#"
+			count: 1
+			path: src/Entity/ClientContact.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\ClientContact\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: src/Entity/ClientContact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Deputy\\:\\:getEmail\\(\\) should return \\$this\\(App\\\\Entity\\\\Deputy\\) but returns string\\.$#"
+			count: 1
+			path: src/Entity/Deputy.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Deputy\\:\\:getEmail1\\(\\) should return \\$this\\(App\\\\Entity\\\\Deputy\\) but returns string\\.$#"
+			count: 1
+			path: src/Entity/Deputy.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Deputy\\:\\:\\$deputyUid is unused\\.$#"
+			count: 1
+			path: src/Entity/Deputy.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\DeputyInterface\\:\\:getAddressNotEmptyParts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/DeputyInterface.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\DeputyInterface\\:\\:getEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/DeputyInterface.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\DeputyInterface\\:\\:getFullName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/DeputyInterface.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\DeputyInterface\\:\\:getPhoneAlternative\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/DeputyInterface.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\DeputyInterface\\:\\:getPhoneMain\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/DeputyInterface.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\DocumentInterface\\:\\:getId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/DocumentInterface.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\DocumentInterface\\:\\:getStorageReference\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/DocumentInterface.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with string will always evaluate to false\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Asset.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Asset\\:\\:getId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Asset.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Asset\\:\\:getValuationDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Asset.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Asset\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Asset.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Asset\\:\\:setId\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Asset.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Asset\\:\\:setNdr\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Asset.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Asset\\:\\:setValuationDate\\(\\) has parameter \\$valuationDate with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Asset.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Asset\\:\\:setValue\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Asset.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Asset\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Asset.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Asset\\:\\:\\$ndr has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Asset.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Asset\\:\\:\\$title has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Asset.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Asset\\:\\:\\$type has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Asset.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Asset\\:\\:\\$valuationDate has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Asset.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Asset\\:\\:\\$value has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Asset.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetOther\\:\\:getType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetOther.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetOther\\:\\:getValuationDate\\(\\) should return DateTime but returns Date\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetOther.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\AssetOther\\:\\:\\$description has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetOther.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\AssetOther\\:\\:\\$valuationDate \\(Date\\) does not accept DateTime\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetOther.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\AssetOther\\:\\:\\$valuationDate has unknown class Date as its type\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetOther.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:getAddress\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:getAddressValidLines\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:getHasCharges\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:getHasMortgage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:getIsRentedOut\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:getIsSubjectToEquityRelease\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:getMortgageOutstandingAmount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:getOccupants\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:getOwned\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:getOwnedPercentage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:getPostcode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:getRentAgreementEndDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:getRentIncomeMonth\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:getType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setAddress\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setAddress2\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setCounty\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setHasCharges\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setHasCharges\\(\\) has parameter \\$hasCharges with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setHasMortgage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setHasMortgage\\(\\) has parameter \\$hasMortgage with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setIsRentedOut\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setIsRentedOut\\(\\) has parameter \\$isRentedOut with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setIsSubjectToEquityRelease\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setIsSubjectToEquityRelease\\(\\) has parameter \\$isSubjectToEquityRelease with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setMortgageOutstandingAmount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setMortgageOutstandingAmount\\(\\) has parameter \\$mortgageOutstandingAmount with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setOccupants\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setOccupants\\(\\) has parameter \\$occupants with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setOwned\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setOwned\\(\\) has parameter \\$owned with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setOwnedPercentage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setOwnedPercentage\\(\\) has parameter \\$ownedPercentage with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setPostcode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setRentAgreementEndDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setRentAgreementEndDate\\(\\) has parameter \\$rentAgreementEndDate with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setRentIncomeMonth\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:setRentIncomeMonth\\(\\) has parameter \\$rentIncomeMonth with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\AssetProperty\\:\\:\\$isSubjectToEquityRelease has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:getBalanceOnCourtOrderDate\\(\\) has invalid return type App\\\\Entity\\\\Ndr\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:getClosingBalance\\(\\) has invalid return type App\\\\Entity\\\\Ndr\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:getIsJointAccount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:requiresBankName\\(\\) should return string but returns bool\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:requiresSortCode\\(\\) should return string but returns bool\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:setAccountNumber\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:setAccountType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:setAccountTypeText\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:setBalanceOnCourtOrderDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:setBank\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:setIsJointAccount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:setIsJointAccount\\(\\) has parameter \\$isJointAccount with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:setNdr\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:setSortCode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:setTypes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Parameter \\$balanceOnCourtOrderDate of method App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:setBalanceOnCourtOrderDate\\(\\) has invalid type App\\\\Entity\\\\Ndr\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:\\$balanceOnCourtOrderDate has unknown class App\\\\Entity\\\\Ndr\\\\decimal as its type\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:\\$ndr has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:\\$types has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:\\$typesNotRequiringBankName has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\BankAccount\\:\\:\\$typesNotRequiringSortCode has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/BankAccount.php
+
+		-
+			message: "#^Cannot call method add\\(\\) on Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\|null\\.$#"
+			count: 1
+			path: src/Entity/Ndr/ClientBenefitsCheck.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\ClientBenefitsCheck\\:\\:getTypesOfMoneyReceivedOnClientsBehalf\\(\\) return type with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Ndr/ClientBenefitsCheck.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\ClientBenefitsCheck\\:\\:setNdr\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/ClientBenefitsCheck.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\ClientBenefitsCheck\\:\\:setTypesOfMoneyReceivedOnClientsBehalf\\(\\) has parameter \\$typesOfMoneyReceivedOnClientsBehalf with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection but does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Ndr/ClientBenefitsCheck.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\ClientBenefitsCheck\\:\\:\\$ndr has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/ClientBenefitsCheck.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\ClientBenefitsCheck\\:\\:\\$typesOfMoneyReceivedOnClientsBehalf with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Ndr/ClientBenefitsCheck.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Debt\\:\\:__construct\\(\\) has parameter \\$debtTypeId with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Debt.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Debt\\:\\:getAmount\\(\\) has invalid return type App\\\\Entity\\\\Ndr\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Debt.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Debt\\:\\:setAmount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Debt.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Debt\\:\\:setDebtTypeId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Debt.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Debt\\:\\:setHasMoreDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Debt.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Debt\\:\\:setMoreDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Debt.php
+
+		-
+			message: "#^Parameter \\$amount of method App\\\\Entity\\\\Ndr\\\\Debt\\:\\:__construct\\(\\) has invalid type App\\\\Entity\\\\Ndr\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Debt.php
+
+		-
+			message: "#^Parameter \\$amount of method App\\\\Entity\\\\Ndr\\\\Debt\\:\\:setAmount\\(\\) has invalid type App\\\\Entity\\\\Ndr\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Debt.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Debt\\:\\:\\$amount has unknown class App\\\\Entity\\\\Ndr\\\\decimal as its type\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Debt.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Debt\\:\\:\\$debtTypeId has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Debt.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Expense\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Expense.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Expense\\:\\:setNdr\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Expense.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Expense\\:\\:\\$amount has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Expense.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Expense\\:\\:\\$explanation \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Expense.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Expense\\:\\:\\$id \\(int\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Expense.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Expense\\:\\:\\$ndr has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Expense.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\MoneyReceivedOnClientsBehalf\\:\\:\\$amountDontKnow is never read, only written\\.$#"
+			count: 1
+			path: src/Entity/Ndr/MoneyReceivedOnClientsBehalf.php
+
+		-
+			message: "#^Call to method isPresent\\(\\) on an unknown class App\\\\Entity\\\\Ndr\\\\Traits\\\\OneOff\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Expression in empty\\(\\) is not falsy\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:addExpense\\(\\) has invalid return type App\\\\Entity\\\\Ndr\\\\Traits\\\\NdrExpensesTrait\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:addExpense\\(\\) should return App\\\\Entity\\\\Ndr\\\\Traits\\\\NdrExpensesTrait but returns \\$this\\(App\\\\Entity\\\\Ndr\\\\Ndr\\)\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:debtsValid\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:getOneOff\\(\\) has invalid return type App\\\\Entity\\\\Ndr\\\\Traits\\\\OneOff\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:getOneOffPresent\\(\\) should return array\\<App\\\\Entity\\\\Ndr\\\\StateBenefit\\> but returns array\\<App\\\\Entity\\\\Ndr\\\\Traits\\\\OneOff\\>\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:getStateBenefitOther\\(\\) should return App\\\\Entity\\\\Ndr\\\\StateBenefit but return statement is missing\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:hasAtLeastOneAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:isDue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setActionGiveGiftsToClient\\(\\) has invalid return type App\\\\Entity\\\\Ndr\\\\Traits\\\\ActionTrait\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setActionGiveGiftsToClient\\(\\) should return App\\\\Entity\\\\Ndr\\\\Traits\\\\ActionTrait but returns \\$this\\(App\\\\Entity\\\\Ndr\\\\Ndr\\)\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setActionGiveGiftsToClientDetails\\(\\) has invalid return type App\\\\Entity\\\\Ndr\\\\Traits\\\\ActionTrait\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setActionGiveGiftsToClientDetails\\(\\) should return App\\\\Entity\\\\Ndr\\\\Traits\\\\ActionTrait but returns \\$this\\(App\\\\Entity\\\\Ndr\\\\Ndr\\)\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setActionMoreInfo\\(\\) has invalid return type App\\\\Entity\\\\Ndr\\\\Traits\\\\ActionTrait\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setActionMoreInfo\\(\\) should return App\\\\Entity\\\\Ndr\\\\Traits\\\\ActionTrait but returns \\$this\\(App\\\\Entity\\\\Ndr\\\\Ndr\\)\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setActionMoreInfoDetails\\(\\) has invalid return type App\\\\Entity\\\\Ndr\\\\Traits\\\\ActionTrait\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setActionMoreInfoDetails\\(\\) should return App\\\\Entity\\\\Ndr\\\\Traits\\\\ActionTrait but returns \\$this\\(App\\\\Entity\\\\Ndr\\\\Ndr\\)\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setActionPropertyBuy\\(\\) has invalid return type App\\\\Entity\\\\Ndr\\\\Traits\\\\ActionTrait\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setActionPropertyBuy\\(\\) should return App\\\\Entity\\\\Ndr\\\\Traits\\\\ActionTrait but returns \\$this\\(App\\\\Entity\\\\Ndr\\\\Ndr\\)\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setActionPropertyMaintenance\\(\\) has invalid return type App\\\\Entity\\\\Ndr\\\\Traits\\\\ActionTrait\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setActionPropertyMaintenance\\(\\) should return App\\\\Entity\\\\Ndr\\\\Traits\\\\ActionTrait but returns \\$this\\(App\\\\Entity\\\\Ndr\\\\Ndr\\)\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setActionPropertySellingRent\\(\\) has invalid return type App\\\\Entity\\\\Ndr\\\\Traits\\\\ActionTrait\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setActionPropertySellingRent\\(\\) should return App\\\\Entity\\\\Ndr\\\\Traits\\\\ActionTrait but returns \\$this\\(App\\\\Entity\\\\Ndr\\\\Ndr\\)\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setAgree\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setAgreedBehalfDeputy\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setAgreedBehalfDeputyExplanation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setBankAccounts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setClient\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setClient\\(\\) has parameter \\$client with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setDebtManagement\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setDebts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setDebtsTotalAmount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setExpectCompensationDamages\\(\\) has invalid return type App\\\\Entity\\\\Ndr\\\\Traits\\\\NdrIncomeBenefitTrait\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setExpectCompensationDamages\\(\\) should return App\\\\Entity\\\\Ndr\\\\Traits\\\\NdrIncomeBenefitTrait but returns \\$this\\(App\\\\Entity\\\\Ndr\\\\Ndr\\)\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setExpenses\\(\\) has invalid return type App\\\\Entity\\\\Ndr\\\\Traits\\\\NdrExpensesTrait\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setExpenses\\(\\) should return App\\\\Entity\\\\Ndr\\\\Traits\\\\NdrExpensesTrait but returns \\$this\\(App\\\\Entity\\\\Ndr\\\\Ndr\\)\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setHasDebts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setOneOff\\(\\) has invalid return type App\\\\Entity\\\\Ndr\\\\Traits\\\\NdrIncomeBenefitTrait\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setOneOff\\(\\) should return App\\\\Entity\\\\Ndr\\\\Traits\\\\NdrIncomeBenefitTrait but returns \\$this\\(App\\\\Entity\\\\Ndr\\\\Ndr\\)\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setPaidForAnything\\(\\) has invalid return type App\\\\Entity\\\\Ndr\\\\Traits\\\\NdrExpensesTrait\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setPaidForAnything\\(\\) should return App\\\\Entity\\\\Ndr\\\\Traits\\\\NdrExpensesTrait but returns \\$this\\(App\\\\Entity\\\\Ndr\\\\Ndr\\)\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setReceiveOtherIncomeDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setSubmitted\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setVisitsCare\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Parameter \\$oneOff of method App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:setOneOff\\(\\) has invalid type App\\\\Entity\\\\Ndr\\\\Traits\\\\OneOff\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:\\$actionGiveGiftsToClient has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:\\$actionGiveGiftsToClientDetails has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:\\$actionMoreInfo has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:\\$actionMoreInfoDetails has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:\\$actionPropertyBuy has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:\\$actionPropertyMaintenance has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:\\$actionPropertySellingRent has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:\\$expenses \\(array\\<App\\\\Entity\\\\Ndr\\\\Expense\\>\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\Ndr\\:\\:\\$oneOff has unknown class App\\\\Entity\\\\Ndr\\\\Traits\\\\OneOff as its type\\.$#"
+			count: 1
+			path: src/Entity/Ndr/Ndr.php
+
+		-
+			message: "#^Default value of the parameter \\#3 \\$hasMoreDetails \\(false\\) of method App\\\\Entity\\\\Ndr\\\\OneOff\\:\\:__construct\\(\\) is incompatible with type string\\.$#"
+			count: 1
+			path: src/Entity/Ndr/OneOff.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\OneOff\\:\\:__construct\\(\\) has parameter \\$typeId with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/OneOff.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\OneOff\\:\\:setHasMoreDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/OneOff.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\OneOff\\:\\:setMoreDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/OneOff.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\OneOff\\:\\:setPresent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/OneOff.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\OneOff\\:\\:setTypeId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/OneOff.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\OneOff\\:\\:\\$moreDetails \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Entity/Ndr/OneOff.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\OneOff\\:\\:\\$typeId has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/OneOff.php
+
+		-
+			message: "#^Default value of the parameter \\#3 \\$hasMoreDetails \\(false\\) of method App\\\\Entity\\\\Ndr\\\\StateBenefit\\:\\:__construct\\(\\) is incompatible with type string\\.$#"
+			count: 1
+			path: src/Entity/Ndr/StateBenefit.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\StateBenefit\\:\\:__construct\\(\\) has parameter \\$typeId with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/StateBenefit.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\StateBenefit\\:\\:moreDetailsValidate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/StateBenefit.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\StateBenefit\\:\\:setHasMoreDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/StateBenefit.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\StateBenefit\\:\\:setMoreDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/StateBenefit.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\StateBenefit\\:\\:setPresent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/StateBenefit.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\StateBenefit\\:\\:setTypeId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/StateBenefit.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\StateBenefit\\:\\:\\$moreDetails \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Entity/Ndr/StateBenefit.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\StateBenefit\\:\\:\\$typeId has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/StateBenefit.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:setHowOftenDoYouContactClient\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/VisitsCare.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/VisitsCare.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:setNdr\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/VisitsCare.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:setPlanMoveNewResidence\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/VisitsCare.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:setPlanMoveNewResidenceDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/VisitsCare.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:\\$doYouLiveWithClient has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/VisitsCare.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:\\$doesClientHaveACarePlan has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/VisitsCare.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:\\$doesClientReceivePaidCare has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/VisitsCare.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:\\$howIsCareFunded has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/VisitsCare.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:\\$howOftenDoYouContactClient has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/VisitsCare.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:\\$ndr has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/VisitsCare.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:\\$planMoveNewResidence has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/VisitsCare.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:\\$planMoveNewResidenceDetails has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/VisitsCare.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:\\$whenWasCarePlanLastReviewed has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/VisitsCare.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:\\$whoIsDoingTheCaring has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Ndr/VisitsCare.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Note\\:\\:__construct\\(\\) has parameter \\$category with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Note.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Note\\:\\:__construct\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Note.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Note\\:\\:__construct\\(\\) has parameter \\$title with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Note.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Note\\:\\:\\$categories has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Note.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Entity/Organisation.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Organisation\\:\\:getClients\\(\\) should return array\\<App\\\\Entity\\\\Client\\> but returns Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\.$#"
+			count: 1
+			path: src/Entity/Organisation.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Organisation\\:\\:getEmailIdentifierDisplay\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Organisation.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Organisation\\:\\:getUserById\\(\\) should return App\\\\Entity\\\\User\\|null but returns mixed\\.$#"
+			count: 1
+			path: src/Entity/Organisation.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Organisation\\:\\:getUsers\\(\\) should return array\\<App\\\\Entity\\\\User\\> but returns Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\.$#"
+			count: 1
+			path: src/Entity/Organisation.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Organisation\\:\\:isActivated\\(\\) should return string but returns bool\\.$#"
+			count: 1
+			path: src/Entity/Organisation.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Organisation\\:\\:setTotalClientCount\\(\\) has parameter \\$count with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Organisation.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Organisation\\:\\:setTotalUserCount\\(\\) has parameter \\$count with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Organisation.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(int\\)\\: Unexpected token \"\\\\n     \\*\", expected variable at offset 21$#"
+			count: 2
+			path: src/Entity/Organisation.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Organisation\\:\\:\\$clients \\(Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\) does not accept array\\<App\\\\Entity\\\\Client\\>\\.$#"
+			count: 1
+			path: src/Entity/Organisation.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Organisation\\:\\:\\$clients with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Organisation.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Organisation\\:\\:\\$isActivated \\(bool\\) does not accept string\\.$#"
+			count: 1
+			path: src/Entity/Organisation.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Organisation\\:\\:\\$users \\(Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\) does not accept array\\<App\\\\Entity\\\\User\\>\\.$#"
+			count: 1
+			path: src/Entity/Organisation.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Organisation\\:\\:\\$users with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Organisation.php
+
+		-
+			message: "#^Ternary operator condition is always true\\.$#"
+			count: 1
+			path: src/Entity/Organisation.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\PreRegistration\\:\\:\\$caseNumber is never written, only read\\.$#"
+			count: 1
+			path: src/Entity/PreRegistration.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\PreRegistration\\:\\:\\$clientLastname is never written, only read\\.$#"
+			count: 1
+			path: src/Entity/PreRegistration.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\PreRegistration\\:\\:\\$deputyPostCode is never written, only read\\.$#"
+			count: 1
+			path: src/Entity/PreRegistration.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\PreRegistration\\:\\:\\$deputySurname is never written, only read\\.$#"
+			count: 1
+			path: src/Entity/PreRegistration.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\PreRegistration\\:\\:\\$deputyUid is never written, only read\\.$#"
+			count: 1
+			path: src/Entity/PreRegistration.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\PreRegistration\\:\\:\\$id is unused\\.$#"
+			count: 1
+			path: src/Entity/PreRegistration.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\PreRegistration\\:\\:\\$orderType has no type specified\\.$#"
+			count: 1
+			path: src/Entity/PreRegistration.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\PreRegistration\\:\\:\\$orderType is never written, only read\\.$#"
+			count: 1
+			path: src/Entity/PreRegistration.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\PreRegistration\\:\\:\\$otherColumns has no type specified\\.$#"
+			count: 1
+			path: src/Entity/PreRegistration.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\PreRegistration\\:\\:\\$otherColumns is unused\\.$#"
+			count: 1
+			path: src/Entity/PreRegistration.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\PreRegistration\\:\\:\\$typeOfReport has no type specified\\.$#"
+			count: 1
+			path: src/Entity/PreRegistration.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\PreRegistration\\:\\:\\$typeOfReport is never written, only read\\.$#"
+			count: 1
+			path: src/Entity/PreRegistration.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Action\\:\\:setReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Action.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Action\\:\\:\\$doYouExpectFinancialDecisions has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Action.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Action\\:\\:\\$doYouExpectFinancialDecisionsDetails has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Action.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Action\\:\\:\\$doYouHaveConcerns has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Action.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Action\\:\\:\\$doYouHaveConcernsDetails has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Action.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Action\\:\\:\\$report has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Action.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with string will always evaluate to false\\.$#"
+			count: 1
+			path: src/Entity/Report/Asset.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Asset\\:\\:getId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Asset.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Asset\\:\\:getValuationDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Asset.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Asset\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Asset.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Asset\\:\\:setId\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Asset.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Asset\\:\\:setReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Asset.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Asset\\:\\:setValuationDate\\(\\) has parameter \\$valuationDate with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Asset.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Asset\\:\\:setValue\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Asset.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Asset\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Asset.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Asset\\:\\:\\$report has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Asset.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Asset\\:\\:\\$title has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Asset.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Asset\\:\\:\\$type has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Asset.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Asset\\:\\:\\$valuationDate has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Asset.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Asset\\:\\:\\$value has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Asset.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Asset\\:\\:\\$valueTotal is never written, only read\\.$#"
+			count: 1
+			path: src/Entity/Report/Asset.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetOther\\:\\:getType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetOther.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetOther\\:\\:getValuationDate\\(\\) should return DateTime but returns Date\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetOther.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\AssetOther\\:\\:\\$description has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetOther.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\AssetOther\\:\\:\\$valuationDate \\(Date\\) does not accept DateTime\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetOther.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\AssetOther\\:\\:\\$valuationDate has unknown class Date as its type\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetOther.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:getAddress\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:getAddressValidLines\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:getHasCharges\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:getHasMortgage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:getIsRentedOut\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:getIsSubjectToEquityRelease\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:getMortgageOutstandingAmount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:getOccupants\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:getOwned\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:getOwnedPercentage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:getPostcode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:getRentAgreementEndDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:getRentIncomeMonth\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:getType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setAddress\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setAddress2\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setCounty\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setHasCharges\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setHasCharges\\(\\) has parameter \\$hasCharges with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setHasMortgage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setHasMortgage\\(\\) has parameter \\$hasMortgage with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setIsRentedOut\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setIsRentedOut\\(\\) has parameter \\$isRentedOut with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setIsSubjectToEquityRelease\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setIsSubjectToEquityRelease\\(\\) has parameter \\$isSubjectToEquityRelease with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setMortgageOutstandingAmount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setMortgageOutstandingAmount\\(\\) has parameter \\$mortgageOutstandingAmount with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setOccupants\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setOccupants\\(\\) has parameter \\$occupants with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setOwned\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setOwned\\(\\) has parameter \\$owned with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setOwnedPercentage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setOwnedPercentage\\(\\) has parameter \\$ownedPercentage with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setPostcode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setRentAgreementEndDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setRentAgreementEndDate\\(\\) has parameter \\$rentAgreementEndDate with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setRentIncomeMonth\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:setRentIncomeMonth\\(\\) has parameter \\$rentIncomeMonth with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\AssetProperty\\:\\:\\$isSubjectToEquityRelease has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/AssetProperty.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with App\\\\Entity\\\\Report\\\\decimal will always evaluate to false\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:getAccountNumber\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:getAccountTypeText\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:getBank\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:getClosingBalance\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:getDisplayName\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:getId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:getIsClosed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:getIsJointAccount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:getMeta\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:getOpeningBalance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:getSortCode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:isClosingBalanceZero\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:requiresBankName\\(\\) should return string but returns bool\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:requiresSortCode\\(\\) should return string but returns bool\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setAccountNumber\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setAccountNumber\\(\\) has parameter \\$accountNumber with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setAccountType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setBank\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setBank\\(\\) has parameter \\$bank with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setId\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setIsClosed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setIsClosed\\(\\) has parameter \\$isClosed with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setIsJointAccount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setIsJointAccount\\(\\) has parameter \\$isJointAccount with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setMeta\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setMeta\\(\\) has parameter \\$meta with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setOpeningBalance\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setOpeningBalance\\(\\) has parameter \\$openingBalance with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setSortCode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setSortCode\\(\\) has parameter \\$sortCode with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Parameter \\#1 \\$num of function round expects float\\|int, App\\\\Entity\\\\Report\\\\decimal given\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\BankAccount\\:\\:\\$accountTypeText is never written, only read\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\BankAccount\\:\\:\\$closingBalance \\(App\\\\Entity\\\\Report\\\\decimal\\) does not accept float\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\BankAccount\\:\\:\\$closingBalance has unknown class App\\\\Entity\\\\Report\\\\decimal as its type\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\BankAccount\\:\\:\\$openingBalance has unknown class App\\\\Entity\\\\Report\\\\decimal as its type\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\BankAccount\\:\\:\\$report has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\BankAccount\\:\\:\\$types has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\BankAccount\\:\\:\\$typesNotRequiringBankName has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\BankAccount\\:\\:\\$typesNotRequiringSortCode has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between 0\\.0 and \\*NEVER\\* will always evaluate to false\\.$#"
+			count: 1
+			path: src/Entity/Report/BankAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Checklist\\:\\:getChecklistInformation\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\ArrayCollection\\.$#"
+			count: 1
+			path: src/Entity/Report/Checklist.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Checklist\\:\\:getChecklistInformation\\(\\) should return App\\\\Entity\\\\Report\\\\ArrayCollection but returns array\\<App\\\\Entity\\\\Report\\\\CheclistInformation\\>\\.$#"
+			count: 1
+			path: src/Entity/Report/Checklist.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Checklist\\:\\:setChecklistInformation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Checklist.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Checklist\\:\\:setFurtherInformationReceived\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Checklist.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Checklist\\:\\:setFurtherInformationReceived\\(\\) has parameter \\$furtherInformationReceived with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Checklist.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Checklist\\:\\:setHasDeputyOverchargedFromPreviousEstimates\\(\\) has parameter \\$hasDeputyOverchargedFromPreviousEstimates with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Checklist.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Checklist\\:\\:setNextBillingEstimatesSatisfactory\\(\\) has parameter \\$nextBillingEstimatesSatisfactory with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Checklist.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Checklist\\:\\:setProfCostsReasonableAndProportionate\\(\\) has parameter \\$profCostsReasonableAndProportionate with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Checklist.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Checklist\\:\\:setReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Checklist.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$furtherInformation$#"
+			count: 1
+			path: src/Entity/Report/Checklist.php
+
+		-
+			message: "#^Parameter \\#1 \\$report of method App\\\\Entity\\\\Report\\\\Checklist\\:\\:setReport\\(\\) expects App\\\\Entity\\\\Report\\\\Report, App\\\\Entity\\\\ReportInterface given\\.$#"
+			count: 1
+			path: src/Entity/Report/Checklist.php
+
+		-
+			message: "#^Parameter \\$checklistInformation of method App\\\\Entity\\\\Report\\\\Checklist\\:\\:setChecklistInformation\\(\\) has invalid type App\\\\Entity\\\\Report\\\\ArrayCollection\\.$#"
+			count: 1
+			path: src/Entity/Report/Checklist.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Checklist\\:\\:\\$checklistInformation \\(array\\<App\\\\Entity\\\\Report\\\\CheclistInformation\\>\\) does not accept App\\\\Entity\\\\Report\\\\ArrayCollection\\.$#"
+			count: 1
+			path: src/Entity/Report/Checklist.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Checklist\\:\\:\\$checklistInformation has unknown class App\\\\Entity\\\\Report\\\\CheclistInformation as its type\\.$#"
+			count: 1
+			path: src/Entity/Report/Checklist.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Checklist\\:\\:\\$report has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Checklist.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ChecklistInformation\\:\\:__construct\\(\\) has parameter \\$information with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ChecklistInformation.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ChecklistInformation\\:\\:setChecklist\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ChecklistInformation.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ChecklistInformation\\:\\:setInformation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ChecklistInformation.php
+
+		-
+			message: "#^Cannot call method add\\(\\) on Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\|null\\.$#"
+			count: 1
+			path: src/Entity/Report/ClientBenefitsCheck.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ClientBenefitsCheck\\:\\:getTypesOfMoneyReceivedOnClientsBehalf\\(\\) return type with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Report/ClientBenefitsCheck.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ClientBenefitsCheck\\:\\:setReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ClientBenefitsCheck.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ClientBenefitsCheck\\:\\:setTypesOfMoneyReceivedOnClientsBehalf\\(\\) has parameter \\$typesOfMoneyReceivedOnClientsBehalf with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection but does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Report/ClientBenefitsCheck.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ClientBenefitsCheck\\:\\:\\$report has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ClientBenefitsCheck.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ClientBenefitsCheck\\:\\:\\$typesOfMoneyReceivedOnClientsBehalf with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Report/ClientBenefitsCheck.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:getAddress\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:getAddress2\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:getContactName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:getCountry\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:getCounty\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:getExplanation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:getId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:getPhone\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:getPostcode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:getRelationship\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setAddress\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setAddress\\(\\) has parameter \\$address with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setAddress2\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setAddress2\\(\\) has parameter \\$address2 with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setContactName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setContactName\\(\\) has parameter \\$contactName with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setCountry\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setCountry\\(\\) has parameter \\$country with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setCounty\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setCounty\\(\\) has parameter \\$county with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setExplanation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setExplanation\\(\\) has parameter \\$explanation with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setId\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setPhone\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setPhone\\(\\) has parameter \\$phone with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setPostcode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setPostcode\\(\\) has parameter \\$postcode with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setRelationship\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setRelationship\\(\\) has parameter \\$relationship with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Contact\\:\\:setReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Contact\\:\\:\\$address has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Contact\\:\\:\\$address2 has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Contact\\:\\:\\$country has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Contact\\:\\:\\$county has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Contact\\:\\:\\$explanation has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Contact\\:\\:\\$phone has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Contact\\:\\:\\$postcode has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Contact\\:\\:\\$relationship has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Contact\\:\\:\\$report has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Contact.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Debt\\:\\:__construct\\(\\) has parameter \\$debtTypeId with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Debt.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Debt\\:\\:getAmount\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Report/Debt.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Debt\\:\\:setAmount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Debt.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Debt\\:\\:setDebtTypeId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Debt.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Debt\\:\\:setHasMoreDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Debt.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Debt\\:\\:setMoreDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Debt.php
+
+		-
+			message: "#^Parameter \\$amount of method App\\\\Entity\\\\Report\\\\Debt\\:\\:__construct\\(\\) has invalid type App\\\\Entity\\\\Report\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Report/Debt.php
+
+		-
+			message: "#^Parameter \\$amount of method App\\\\Entity\\\\Report\\\\Debt\\:\\:setAmount\\(\\) has invalid type App\\\\Entity\\\\Report\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Report/Debt.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Debt\\:\\:\\$amount has unknown class App\\\\Entity\\\\Report\\\\decimal as its type\\.$#"
+			count: 1
+			path: src/Entity/Report/Debt.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Debt\\:\\:\\$debtTypeId has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Debt.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Decision\\:\\:setReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Decision.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Decision\\:\\:\\$report has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Decision.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with string will always evaluate to false\\.$#"
+			count: 1
+			path: src/Entity/Report/Document.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Document\\:\\:isTransactionDocument\\(\\) never returns int so it can be removed from the return type\\.$#"
+			count: 1
+			path: src/Entity/Report/Document.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Document\\:\\:setReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Document.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Document\\:\\:\\$report has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Document.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Expense\\:\\:setBankAccount\\(\\) has parameter \\$bankAccount with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Expense.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Expense\\:\\:setBankAccountId\\(\\) has parameter \\$bankAccountId with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Expense.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Expense\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Expense.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Expense\\:\\:setReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Expense.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Expense\\:\\:\\$amount has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Expense.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Expense\\:\\:\\$bankAccount has unknown class App\\\\Entity\\\\Report\\\\Traits\\\\App\\\\Entity\\\\Report\\\\BankAccount as its type\\.$#"
+			count: 1
+			path: src/Entity/Report/Expense.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Expense\\:\\:\\$bankAccountId has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Expense.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Expense\\:\\:\\$explanation \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Expense.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Expense\\:\\:\\$id \\(int\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Expense.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Expense\\:\\:\\$report has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Expense.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Fee\\:\\:getAmount\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Report/Fee.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Fee\\:\\:setAmount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Fee.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Fee\\:\\:setFeeTypeId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Fee.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Fee\\:\\:setHasMoreDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Fee.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Fee\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Fee.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Fee\\:\\:setMoreDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Fee.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Fee\\:\\:setReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Fee.php
+
+		-
+			message: "#^Parameter \\$amount of method App\\\\Entity\\\\Report\\\\Fee\\:\\:setAmount\\(\\) has invalid type App\\\\Entity\\\\Report\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Report/Fee.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Fee\\:\\:\\$amount has unknown class App\\\\Entity\\\\Report\\\\decimal as its type\\.$#"
+			count: 1
+			path: src/Entity/Report/Fee.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Fee\\:\\:\\$feeTypeId has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Fee.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Fee\\:\\:\\$id \\(int\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Fee.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Fee\\:\\:\\$report has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Fee.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Gift\\:\\:setBankAccount\\(\\) has parameter \\$bankAccount with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Gift.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Gift\\:\\:setBankAccountId\\(\\) has parameter \\$bankAccountId with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Gift.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Gift\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Gift.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Gift\\:\\:setReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Gift.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Gift\\:\\:\\$amount has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Gift.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Gift\\:\\:\\$bankAccount has unknown class App\\\\Entity\\\\Report\\\\Traits\\\\App\\\\Entity\\\\Report\\\\BankAccount as its type\\.$#"
+			count: 1
+			path: src/Entity/Report/Gift.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Gift\\:\\:\\$bankAccountId has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Gift.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Gift\\:\\:\\$explanation \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Gift.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Gift\\:\\:\\$id \\(int\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Gift.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Gift\\:\\:\\$report has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Gift.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Lifestyle\\:\\:setActivityDetailsNo\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Lifestyle.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Lifestyle\\:\\:setActivityDetailsYes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Lifestyle.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Lifestyle\\:\\:setCareAppointments\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Lifestyle.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Lifestyle\\:\\:setDoesClientUndertakeSocialActivities\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Lifestyle.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Lifestyle\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Lifestyle.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Lifestyle\\:\\:setReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Lifestyle.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Lifestyle\\:\\:\\$activityDetailsNo has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Lifestyle.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Lifestyle\\:\\:\\$activityDetailsYes has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Lifestyle.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Lifestyle\\:\\:\\$careAppointments has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Lifestyle.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Lifestyle\\:\\:\\$doesClientUndertakeSocialActivities has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Lifestyle.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Lifestyle\\:\\:\\$report has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Lifestyle.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MentalCapacity\\:\\:getHasCapacityChanged\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MentalCapacity.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MentalCapacity\\:\\:getHasCapacityChangedDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MentalCapacity.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MentalCapacity\\:\\:getId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MentalCapacity.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MentalCapacity\\:\\:getMentalAssessmentDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MentalCapacity.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MentalCapacity\\:\\:setHasCapacityChanged\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MentalCapacity.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MentalCapacity\\:\\:setHasCapacityChanged\\(\\) has parameter \\$hasCapacityChanged with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MentalCapacity.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MentalCapacity\\:\\:setHasCapacityChangedDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MentalCapacity.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MentalCapacity\\:\\:setHasCapacityChangedDetails\\(\\) has parameter \\$hasCapacityChangedDetails with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MentalCapacity.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MentalCapacity\\:\\:setMentalAssessmentDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MentalCapacity.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MentalCapacity\\:\\:setMentalAssessmentDate\\(\\) has parameter \\$mentalAssessmentDate with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MentalCapacity.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MentalCapacity\\:\\:setReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MentalCapacity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MentalCapacity\\:\\:\\$hasCapacityChanged has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MentalCapacity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MentalCapacity\\:\\:\\$hasCapacityChangedDetails has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MentalCapacity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MentalCapacity\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: src/Entity/Report/MentalCapacity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MentalCapacity\\:\\:\\$mentalAssessmentDate has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MentalCapacity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MentalCapacity\\:\\:\\$report has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MentalCapacity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MoneyReceivedOnClientsBehalf\\:\\:\\$amountDontKnow is never read, only written\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyReceivedOnClientsBehalf.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MoneyShortCategory\\:\\:__construct\\(\\) has parameter \\$typeId with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyShortCategory.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MoneyShortCategory\\:\\:setPresent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyShortCategory.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MoneyShortCategory\\:\\:setTypeId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyShortCategory.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MoneyShortCategory\\:\\:\\$typeId has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyShortCategory.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:getCategoriesGrouped\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:getCategoriesGrouped\\(\\) has parameter \\$typeFilter with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:getType\\(\\) should return string but returns null\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:setAmount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:setBankAccount\\(\\) has parameter \\$bankAccount with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:setBankAccountId\\(\\) has parameter \\$bankAccountId with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:setCategory\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:setDescription\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:setGroup\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Parameter \\#1 \\$category of static method App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:isValidCategory\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:\\$bankAccount has unknown class App\\\\Entity\\\\Report\\\\Traits\\\\App\\\\Entity\\\\Report\\\\BankAccount as its type\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:\\$bankAccountId has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:\\$categories has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:\\$category has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:\\$description \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:\\$group has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:\\$type has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:\\$type is unused\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransaction.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MoneyTransactionShort\\:\\:getDate\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\DateTime\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransactionShort.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MoneyTransactionShort\\:\\:setType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransactionShort.php
+
+		-
+			message: "#^Parameter \\$date of method App\\\\Entity\\\\Report\\\\MoneyTransactionShort\\:\\:setDate\\(\\) has invalid type App\\\\Entity\\\\Report\\\\DateTime\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransactionShort.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MoneyTransactionShort\\:\\:\\$date has unknown class App\\\\Entity\\\\Report\\\\DateTime as its type\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransactionShort.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MoneyTransfer\\:\\:setAccountFromId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransfer.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MoneyTransfer\\:\\:setAccountToId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransfer.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\MoneyTransfer\\:\\:setDescription\\(\\) has parameter \\$description with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransfer.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MoneyTransfer\\:\\:\\$accountFromId has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransfer.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MoneyTransfer\\:\\:\\$accountToId has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransfer.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\MoneyTransfer\\:\\:\\$id is never written, only read\\.$#"
+			count: 1
+			path: src/Entity/Report/MoneyTransfer.php
+
+		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyEstimateCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyEstimateCost\\:\\:__construct\\(\\) has parameter \\$profDeputyEstimateCostTypeId with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyEstimateCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyEstimateCost\\:\\:getAmount\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyEstimateCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyEstimateCost\\:\\:moreDetailsValidate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyEstimateCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyEstimateCost\\:\\:setAmount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyEstimateCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyEstimateCost\\:\\:setHasMoreDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyEstimateCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyEstimateCost\\:\\:setMoreDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyEstimateCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyEstimateCost\\:\\:setProfDeputyEstimateCostTypeId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyEstimateCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyEstimateCost\\:\\:setProfDeputyEstimateCostTypeId\\(\\) has parameter \\$profDeputyEstimateCostTypeId with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyEstimateCost.php
+
+		-
+			message: "#^Parameter \\$amount of method App\\\\Entity\\\\Report\\\\ProfDeputyEstimateCost\\:\\:__construct\\(\\) has invalid type App\\\\Entity\\\\Report\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyEstimateCost.php
+
+		-
+			message: "#^Parameter \\$amount of method App\\\\Entity\\\\Report\\\\ProfDeputyEstimateCost\\:\\:setAmount\\(\\) has invalid type App\\\\Entity\\\\Report\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyEstimateCost.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ProfDeputyEstimateCost\\:\\:\\$amount has unknown class App\\\\Entity\\\\Report\\\\decimal as its type\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyEstimateCost.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ProfDeputyEstimateCost\\:\\:\\$profDeputyEstimateCostTypeId has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyEstimateCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyInterimCost\\:\\:setAmount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyInterimCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyInterimCost\\:\\:setDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyInterimCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyInterimCost\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyInterimCost.php
+
+		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyOtherCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyOtherCost\\:\\:__construct\\(\\) has parameter \\$profDeputyOtherCostTypeId with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyOtherCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyOtherCost\\:\\:getAmount\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyOtherCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyOtherCost\\:\\:moreDetailsValidate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyOtherCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyOtherCost\\:\\:setAmount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyOtherCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyOtherCost\\:\\:setHasMoreDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyOtherCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyOtherCost\\:\\:setMoreDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyOtherCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyOtherCost\\:\\:setProfDeputyOtherCostTypeId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyOtherCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyOtherCost\\:\\:setProfDeputyOtherCostTypeId\\(\\) has parameter \\$profDeputyOtherCostTypeId with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyOtherCost.php
+
+		-
+			message: "#^Parameter \\$amount of method App\\\\Entity\\\\Report\\\\ProfDeputyOtherCost\\:\\:__construct\\(\\) has invalid type App\\\\Entity\\\\Report\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyOtherCost.php
+
+		-
+			message: "#^Parameter \\$amount of method App\\\\Entity\\\\Report\\\\ProfDeputyOtherCost\\:\\:setAmount\\(\\) has invalid type App\\\\Entity\\\\Report\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyOtherCost.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ProfDeputyOtherCost\\:\\:\\$amount has unknown class App\\\\Entity\\\\Report\\\\decimal as its type\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyOtherCost.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ProfDeputyOtherCost\\:\\:\\$profDeputyOtherCostTypeId has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyOtherCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfDeputyPreviousCost\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfDeputyPreviousCost.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfServiceFee\\:\\:setAmountCharged\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfServiceFee.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfServiceFee\\:\\:setAmountReceived\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfServiceFee.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfServiceFee\\:\\:setAssessedOrFixed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfServiceFee.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfServiceFee\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfServiceFee.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfServiceFee\\:\\:setOtherFeeDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfServiceFee.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfServiceFee\\:\\:setPaymentReceived\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfServiceFee.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfServiceFee\\:\\:setPaymentReceivedDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfServiceFee.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfServiceFee\\:\\:setReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfServiceFee.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ProfServiceFee\\:\\:setServiceTypeId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfServiceFee.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ProfServiceFee\\:\\:\\$feeTypeId has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfServiceFee.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ProfServiceFee\\:\\:\\$feeTypeId is unused\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfServiceFee.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ProfServiceFee\\:\\:\\$id \\(int\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfServiceFee.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ProfServiceFee\\:\\:\\$otherFeeDetails has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfServiceFee.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ProfServiceFee\\:\\:\\$paymentReceivedDate \\(DateTime\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfServiceFee.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ProfServiceFee\\:\\:\\$report has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ProfServiceFee.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with string will always evaluate to false\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Call to method getId\\(\\) on an unknown class App\\\\Entity\\\\Report\\\\Traits\\\\Asset\\.$#"
+			count: 2
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Call to method getTitle\\(\\) on an unknown class App\\\\Entity\\\\Report\\\\Traits\\\\Asset\\.$#"
+			count: 4
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Call to method getValueTotal\\(\\) on an unknown class App\\\\Entity\\\\Report\\\\Traits\\\\Asset\\.$#"
+			count: 3
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Expression in empty\\(\\) is not falsy\\.$#"
+			count: 2
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:addExpense\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\Traits\\\\NdrExpensesTrait\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:addExpense\\(\\) should return App\\\\Entity\\\\Report\\\\Traits\\\\NdrExpensesTrait but returns \\$this\\(App\\\\Entity\\\\Report\\\\Report\\)\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:addProfDeputyInterimCosts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:debtsValid\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:determineReportType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:feesValid\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:getAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:getAssets\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\Traits\\\\Asset\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:getAssetsTotalsSummaryPage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:getBankAccountById\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:getBankAccountById\\(\\) should return App\\\\Entity\\\\Report\\\\BankAccount but return statement is missing\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:getDebtById\\(\\) has parameter \\$debtId with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:getDebtsTotalAmount\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\Traits\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:getDecisions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:getFeeTotals\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:getFeesTotal\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\Traits\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:getMoneyTransferWithId\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:getProfDeputyCostsEstimateMoreInfoDetails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:getProfDeputyEstimateCostByTypeId\\(\\) should return App\\\\Entity\\\\Report\\\\ProfDeputyEstimateCost but return statement is missing\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:getProfDeputyOtherCostByTypeId\\(\\) should return App\\\\Entity\\\\Report\\\\ProfDeputyOtherCost but return statement is missing\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:getSignificantDecisionsMade\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:getTotalValue\\(\\) should return int but returns float\\|int\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:getWishToProvideDocumentation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:hasContacts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:hasMoneyIn\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:hasMoneyOut\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:isSectionFlaggedForAttention\\(\\) has parameter \\$sectionId with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:profCostsInterimAtLeastOne\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setAccountsOpeningBalanceTotal\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setActionMoreInfo\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\Traits\\\\ActionTrait\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setActionMoreInfo\\(\\) should return App\\\\Entity\\\\Report\\\\Traits\\\\ActionTrait but returns \\$this\\(App\\\\Entity\\\\Report\\\\Report\\)\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setActionMoreInfoDetails\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\Traits\\\\ActionTrait\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setActionMoreInfoDetails\\(\\) should return App\\\\Entity\\\\Report\\\\Traits\\\\ActionTrait but returns \\$this\\(App\\\\Entity\\\\Report\\\\Report\\)\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setAgree\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setAgreedBehalfDeputy\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setAgreedBehalfDeputyExplanation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setBalanceMismatchExplanation\\(\\) should return App\\\\Entity\\\\Report\\\\Report but return statement is missing\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setCurrentProfPaymentsReceived\\(\\) has parameter \\$currentProfPaymentsReceived with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setDebtsTotalAmount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setDocuments\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setExpenses\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\Traits\\\\NdrExpensesTrait\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setExpenses\\(\\) should return App\\\\Entity\\\\Report\\\\Traits\\\\NdrExpensesTrait but returns \\$this\\(App\\\\Entity\\\\Report\\\\Report\\)\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setExpensesTotal\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setFees\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setFeesTotal\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setGiftsExist\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setHas106flag\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setHasContacts\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setHasContacts\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setHasDebts\\(\\) has parameter \\$hasDebts with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setHasDecisions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setHasDecisions\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setHasFees\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setLifestyle\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setMentalCapacity\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setMoneyShortCategoriesIn\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setMoneyShortCategoriesOut\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setMoneyTransactionsShortIn\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setMoneyTransactionsShortInExist\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setMoneyTransactionsShortOut\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setMoneyTransactionsShortOutExist\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setPaidForAnything\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfDeputyCostsEstimateHasMoreInfo\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\Traits\\\\ReportProfDeputyCostsEstimateTrait\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfDeputyCostsEstimateHasMoreInfo\\(\\) should return App\\\\Entity\\\\Report\\\\Traits\\\\ReportProfDeputyCostsEstimateTrait but returns \\$this\\(App\\\\Entity\\\\Report\\\\Report\\)\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfDeputyCostsEstimateMoreInfoDetails\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\Traits\\\\ReportProfDeputyCostsEstimateTrait\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfDeputyCostsEstimateMoreInfoDetails\\(\\) has parameter \\$profDeputyCostsEstimateMoreInfoDetails with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfDeputyCostsEstimateMoreInfoDetails\\(\\) should return App\\\\Entity\\\\Report\\\\Traits\\\\ReportProfDeputyCostsEstimateTrait but returns \\$this\\(App\\\\Entity\\\\Report\\\\Report\\)\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfDeputyCostsHowCharged\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfDeputyEstimateCostTypeIds\\(\\) has parameter \\$profDeputyEstimateCostTypeIds with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfDeputyManagementCostAmount\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\Traits\\\\ReportProfDeputyCostsEstimateTrait\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfDeputyManagementCostAmount\\(\\) should return App\\\\Entity\\\\Report\\\\Traits\\\\ReportProfDeputyCostsEstimateTrait but returns \\$this\\(App\\\\Entity\\\\Report\\\\Report\\)\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfDeputyManagementCostTypeIds\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\Traits\\\\ReportProfDeputyCostsEstimateTrait\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfDeputyManagementCostTypeIds\\(\\) should return App\\\\Entity\\\\Report\\\\Traits\\\\ReportProfDeputyCostsEstimateTrait but returns \\$this\\(App\\\\Entity\\\\Report\\\\Report\\)\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfDeputyOtherCostIds\\(\\) should return \\$this\\(App\\\\Entity\\\\Report\\\\Report\\) but return statement is missing\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfDeputyOtherCostTypeIds\\(\\) has parameter \\$profDeputyOtherCostTypeIds with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfDeputyOtherCosts\\(\\) has parameter \\$profDeputyOtherCosts with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfDeputyTotalCostsTakenFromClient\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfDeputyTotalCostsTakenFromClient\\(\\) has parameter \\$profDeputyTotalCostsTakenFromClient with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setProfServiceFees\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setReasonForNoFees\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setReportSeen\\(\\) should return App\\\\Entity\\\\Report\\\\Report but return statement is missing\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setReviewChecklist\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setSignificantDecisionsMade\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setSignificantDecisionsMade\\(\\) has parameter \\$significantDecisionsMade with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setStatus\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setTotalsMatch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setUnsubmittedSection\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setVisitsCare\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:unsubmittedSectionAtLeastOnce\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^PHPDoc tag @var above a method has no effect\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^PHPDoc tag @var does not specify variable name\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Parameter \\$debtsTotalAmount of method App\\\\Entity\\\\Report\\\\Report\\:\\:setDebtsTotalAmount\\(\\) has invalid type App\\\\Entity\\\\Report\\\\Traits\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Parameter \\$feesTotal of method App\\\\Entity\\\\Report\\\\Report\\:\\:setFeesTotal\\(\\) has invalid type App\\\\Entity\\\\Report\\\\Traits\\\\decimal\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$actionMoreInfo has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$actionMoreInfoDetails has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$assets has unknown class App\\\\Entity\\\\Report\\\\Traits\\\\Asset as its type\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$cashAssetTitles has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$clientBenefitsCheck \\(App\\\\Entity\\\\Report\\\\ClientBenefitsCheck\\) does not accept App\\\\Entity\\\\Report\\\\ClientBenefitsCheck\\|null\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$debtsTotalAmount has unknown class App\\\\Entity\\\\Report\\\\Traits\\\\decimal as its type\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$expenses \\(array\\<App\\\\Entity\\\\Report\\\\Expense\\>\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$expensesTotal has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$feesTotal has unknown class App\\\\Entity\\\\Report\\\\Traits\\\\decimal as its type\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$isDue is never written, only read\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$moneyInExists has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$moneyOutExists has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$moneyTransactionsShortOut \\(array\\<App\\\\Entity\\\\Report\\\\MoneyTransactionShort\\>\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$profDeputyCostsEstimateMoreInfoDetails has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$profDeputyEstimateCostTypeIds has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$profDeputyManagementCostTypeIds has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$profDeputyOtherCostTypeIds has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$reasonForNoMoneyIn has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$reasonForNoMoneyOut \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$significantDecisionsMade has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$submittedBy \\(App\\\\Entity\\\\User\\) does not accept App\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$wishToProvideDocumentation has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between App\\\\Entity\\\\Report\\\\decimal and null will always evaluate to false\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between null and DateTime will always evaluate to false\\.$#"
+			count: 2
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between null and string will always evaluate to false\\.$#"
+			count: 2
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Variable \\$submittedCost in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 4
+			path: src/Entity/Report/Report.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ReportSubmissionSummary\\:\\:\\$caseNumber has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ReportSubmissionSummary.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ReportSubmissionSummary\\:\\:\\$dateReceived has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ReportSubmissionSummary.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ReportSubmissionSummary\\:\\:\\$documentId has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ReportSubmissionSummary.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ReportSubmissionSummary\\:\\:\\$documentType has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ReportSubmissionSummary.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ReportSubmissionSummary\\:\\:\\$formType has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ReportSubmissionSummary.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ReportSubmissionSummary\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ReportSubmissionSummary.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ReportSubmissionSummary\\:\\:\\$scanDate has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ReportSubmissionSummary.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\ReviewChecklist\\:\\:getAnswers\\(\\) should return App\\\\Model\\\\FullReviewChecklist\\|null but returns App\\\\Entity\\\\Report\\\\App\\\\Model\\\\FullReviewChecklist\\.$#"
+			count: 1
+			path: src/Entity/Report/ReviewChecklist.php
+
+		-
+			message: "#^PHPDoc tag @param for parameter \\$answers with type array is incompatible with native type App\\\\Model\\\\FullReviewChecklist\\.$#"
+			count: 1
+			path: src/Entity/Report/ReviewChecklist.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ReviewChecklist\\:\\:\\$answers \\(App\\\\Entity\\\\Report\\\\App\\\\Model\\\\FullReviewChecklist\\) does not accept App\\\\Model\\\\FullReviewChecklist\\.$#"
+			count: 1
+			path: src/Entity/Report/ReviewChecklist.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ReviewChecklist\\:\\:\\$answers has unknown class App\\\\Entity\\\\Report\\\\App\\\\Model\\\\FullReviewChecklist as its type\\.$#"
+			count: 1
+			path: src/Entity/Report/ReviewChecklist.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\ReviewChecklist\\:\\:\\$report has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/ReviewChecklist.php
+
+		-
+			message: "#^Ternary operator condition is always true\\.$#"
+			count: 1
+			path: src/Entity/Report/ReviewChecklist.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Satisfaction\\:\\:getUserResearchResponse\\(\\) has invalid return type App\\\\Entity\\\\Report\\\\UserResearchResponse\\.$#"
+			count: 1
+			path: src/Entity/Report/Satisfaction.php
+
+		-
+			message: "#^Parameter \\$userResearchResponse of method App\\\\Entity\\\\Report\\\\Satisfaction\\:\\:setUserResearchResponse\\(\\) has invalid type App\\\\Entity\\\\Report\\\\UserResearchResponse\\.$#"
+			count: 1
+			path: src/Entity/Report/Satisfaction.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Satisfaction\\:\\:\\$comments has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Satisfaction.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Satisfaction\\:\\:\\$created has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Satisfaction.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Satisfaction\\:\\:\\$deputyrole has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Satisfaction.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Satisfaction\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Satisfaction.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Satisfaction\\:\\:\\$reporttype has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Satisfaction.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Satisfaction\\:\\:\\$score has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Satisfaction.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Satisfaction\\:\\:\\$userResearchResponse has unknown class App\\\\Entity\\\\Report\\\\UserResearchResponse as its type\\.$#"
+			count: 1
+			path: src/Entity/Report/Satisfaction.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:getState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setActionsState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setAssetsState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setBalanceState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setBankAccountsState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setContactsState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setDebtsState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setDecisionsState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setDocumentsState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setExpensesState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setGiftsState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setIsReadyToSubmit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setLifestyleState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setMoneyInShortState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setMoneyInState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setMoneyOutShortState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setMoneyOutState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setMoneyTransferState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setOtherInfoState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setPaFeesExpensesState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setProfCurrentFeesState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setProfDeputyCostsEstimateState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setProfDeputyCostsState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setStatus\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\Status\\:\\:setVisitsCareState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$actionsState \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$assetsState \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$balanceState \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$bankAccountsState \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$contactsState \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$debtsState \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$decisionsState \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$expensesState \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$giftsState \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$isReadyToSubmit \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$moneyInShortState \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$moneyInState \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$moneyOutShortState \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$moneyOutState \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$moneyTransferState \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$otherInfoState \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$report is never read, only written\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$status \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\Status\\:\\:\\$visitsCareState \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Entity/Report/Status.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\UnsubmittedSection\\:\\:getId\\(\\) should return int but returns string\\.$#"
+			count: 1
+			path: src/Entity/Report/UnsubmittedSection.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\UnsubmittedSection\\:\\:setPresent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/UnsubmittedSection.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\VisitsCare\\:\\:setHowOftenDoYouContactClient\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/VisitsCare.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\VisitsCare\\:\\:setId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/VisitsCare.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Report\\\\VisitsCare\\:\\:setReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/VisitsCare.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\VisitsCare\\:\\:\\$doYouLiveWithClient has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/VisitsCare.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\VisitsCare\\:\\:\\$doesClientHaveACarePlan has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/VisitsCare.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\VisitsCare\\:\\:\\$doesClientReceivePaidCare has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/VisitsCare.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\VisitsCare\\:\\:\\$howIsCareFunded has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/VisitsCare.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\VisitsCare\\:\\:\\$howOftenDoYouContactClient has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/VisitsCare.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\VisitsCare\\:\\:\\$report has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/VisitsCare.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\VisitsCare\\:\\:\\$whenWasCarePlanLastReviewed has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/VisitsCare.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Report\\\\VisitsCare\\:\\:\\$whoIsDoingTheCaring has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Report/VisitsCare.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\ReportInterface\\:\\:createAttachmentName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/ReportInterface.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\ReportInterface\\:\\:createAttachmentName\\(\\) has parameter \\$format with no type specified\\.$#"
+			count: 1
+			path: src/Entity/ReportInterface.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\ReportInterface\\:\\:getId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/ReportInterface.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with string will always evaluate to false\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Cannot call method isActivated\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:eraseCredentials\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getActiveReportId\\(\\) should return int but returns int\\|null\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getAddress1\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getAddress2\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getAddress3\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getAddress4\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getAddress5\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getAddressCountry\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getAddressPostcode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getClients\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getDeputyNo\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getIsCoDeputy\\(\\) should return bool but returns bool\\|null\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getJobTitle\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getNumberOfReports\\(\\) should return int but returns int\\|null\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getOrganisations\\(\\) return type with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getPhoneAlternative\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getPhoneMain\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getRegistrationToken\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getRoleFullName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getRoleName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:getTokenDate\\(\\) should return DateTime but returns DateTime\\|null\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:hasReports\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:isAccountNonExpired\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:isAccountNonLocked\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:isAdManaged\\(\\) should return bool but returns bool\\|null\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:isCredentialsNonExpired\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:isEnabled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:isNdrEnabled\\(\\) should return bool but returns bool\\|null\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setActiveReportId\\(\\) has invalid return type App\\\\Entity\\\\Traits\\\\HasReportTrait\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setActiveReportId\\(\\) should return App\\\\Entity\\\\Traits\\\\HasReportTrait but returns \\$this\\(App\\\\Entity\\\\User\\)\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setAdManaged\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setAddress1\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setAddress1\\(\\) has parameter \\$address1 with no type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setAddress2\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setAddress2\\(\\) has parameter \\$address2 with no type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setAddress3\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setAddress3\\(\\) has parameter \\$address3 with no type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setAddress4\\(\\) has parameter \\$address4 with no type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setAddress5\\(\\) has parameter \\$address5 with no type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setAddressCountry\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setAddressCountry\\(\\) has parameter \\$addressCountry with no type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setAddressPostcode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setAddressPostcode\\(\\) has parameter \\$addressPostcode with no type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setClients\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setDeputyNo\\(\\) has parameter \\$deputyNo with no type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setIdOfClientWithDetails\\(\\) has invalid return type App\\\\Entity\\\\Traits\\\\HasReportTrait\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setIdOfClientWithDetails\\(\\) should return App\\\\Entity\\\\Traits\\\\HasReportTrait but returns \\$this\\(App\\\\Entity\\\\User\\)\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setLastLoggedIn\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setNdrEnabled\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setNumberOfReports\\(\\) has invalid return type App\\\\Entity\\\\Traits\\\\HasReportTrait\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setNumberOfReports\\(\\) should return App\\\\Entity\\\\Traits\\\\HasReportTrait but returns \\$this\\(App\\\\Entity\\\\User\\)\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setOrganisations\\(\\) has parameter \\$organisations with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection but does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setPhoneAlternative\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setPhoneAlternative\\(\\) has parameter \\$phoneAlternative with no type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setPhoneMain\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setPhoneMain\\(\\) has parameter \\$phoneMain with no type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setRoleName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setRoleName\\(\\) has parameter \\$roleName with no type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setSalt\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\User\\:\\:setSalt\\(\\) has parameter \\$salt with no type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^PHPDoc tag @return with type App\\\\Entity\\\\User is not subtype of native type static\\(App\\\\Entity\\\\User\\)\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\User\\:\\:\\$allowedRoles has no type specified\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\User\\:\\:\\$createdBy \\(App\\\\Entity\\\\User\\) does not accept App\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\User\\:\\:\\$deputyUid \\(int\\) does not accept int\\|null\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\User\\:\\:\\$organisations \\(Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\) in empty\\(\\) is not falsy\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\User\\:\\:\\$organisations with generic class Doctrine\\\\Common\\\\Collections\\\\ArrayCollection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\User\\:\\:\\$salt is never read, only written\\.$#"
+			count: 1
+			path: src/Entity/User.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\UserResearch\\\\ResearchType\\:\\:getCommaSeparatedTypesAgreed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/UserResearch/ResearchType.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\UserResearch\\\\ResearchType\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: src/Entity/UserResearch/ResearchType.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\UserResearch\\\\ResearchType\\:\\:\\$userResearchResponse has no type specified\\.$#"
+			count: 1
+			path: src/Entity/UserResearch/ResearchType.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\UserResearch\\\\UserResearchResponse\\:\\:\\$created has no type specified\\.$#"
+			count: 1
+			path: src/Entity/UserResearch/UserResearchResponse.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\UserResearch\\\\UserResearchResponse\\:\\:\\$researchType has no type specified\\.$#"
+			count: 1
+			path: src/Entity/UserResearch/UserResearchResponse.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\UserResearch\\\\UserResearchResponse\\:\\:\\$satisfaction has no type specified\\.$#"
+			count: 1
+			path: src/Entity/UserResearch/UserResearchResponse.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\UserResearch\\\\UserResearchResponse\\:\\:\\$user \\(App\\\\Entity\\\\User\\) does not accept App\\\\Entity\\\\User\\|null\\.$#"
+			count: 1
+			path: src/Entity/UserResearch/UserResearchResponse.php
+
+		-
+			message: "#^Method App\\\\Event\\\\CSVUploadedEvent\\:\\:__construct\\(\\) has parameter \\$roleType with no type specified\\.$#"
+			count: 1
+			path: src/Event/CSVUploadedEvent.php
+
+		-
+			message: "#^Method App\\\\Event\\\\CSVUploadedEvent\\:\\:__construct\\(\\) has parameter \\$trigger with no type specified\\.$#"
+			count: 1
+			path: src/Event/CSVUploadedEvent.php
+
+		-
+			message: "#^Property App\\\\Event\\\\ClientDeletedEvent\\:\\:\\$currentUser \\(App\\\\Entity\\\\User\\) does not accept Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null\\.$#"
+			count: 1
+			path: src/Event/ClientDeletedEvent.php
+
+		-
+			message: "#^Property App\\\\Event\\\\ClientUpdatedEvent\\:\\:\\$changedBy \\(App\\\\Entity\\\\User\\) does not accept Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Event/ClientUpdatedEvent.php
+
+		-
+			message: "#^Property App\\\\Event\\\\ClientUpdatedEvent\\:\\:\\$postUpdateClient has no type specified\\.$#"
+			count: 1
+			path: src/Event/ClientUpdatedEvent.php
+
+		-
+			message: "#^Method App\\\\Event\\\\ReportSubmittedEvent\\:\\:__construct\\(\\) has parameter \\$newYearReportId with no type specified\\.$#"
+			count: 1
+			path: src/Event/ReportSubmittedEvent.php
+
+		-
+			message: "#^Method App\\\\Event\\\\ReportUnsubmittedEvent\\:\\:getTrigger\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Event/ReportUnsubmittedEvent.php
+
+		-
+			message: "#^Property App\\\\Event\\\\UserDeletedEvent\\:\\:\\$deletedBy has no type specified\\.$#"
+			count: 1
+			path: src/Event/UserDeletedEvent.php
+
+		-
+			message: "#^Property App\\\\Event\\\\UserUpdatedEvent\\:\\:\\$currentUser has no type specified\\.$#"
+			count: 1
+			path: src/Event/UserUpdatedEvent.php
+
+		-
+			message: "#^Property App\\\\Event\\\\UserUpdatedEvent\\:\\:\\$preUpdateUser has no type specified\\.$#"
+			count: 1
+			path: src/Event/UserUpdatedEvent.php
+
+		-
+			message: "#^Method App\\\\EventDispatcher\\\\ObservableEventDispatcher\\:\\:dispatch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventDispatcher/ObservableEventDispatcher.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:setFlash\\(\\)\\.$#"
+			count: 1
+			path: src/EventListener/AuthenticationHandler.php
+
+		-
+			message: "#^Instantiated class App\\\\EventListener\\\\RedirectResponse not found\\.$#"
+			count: 1
+			path: src/EventListener/AuthenticationHandler.php
+
+		-
+			message: "#^Method App\\\\EventListener\\\\AuthenticationHandler\\:\\:onAuthenticationFailure\\(\\) should return Symfony\\\\Component\\\\HttpFoundation\\\\Response but returns App\\\\EventListener\\\\RedirectResponse\\.$#"
+			count: 1
+			path: src/EventListener/AuthenticationHandler.php
+
+		-
+			message: "#^Method App\\\\EventListener\\\\ForbiddenExceptionListener\\:\\:onKernelException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventListener/ForbiddenExceptionListener.php
+
+		-
+			message: "#^Method App\\\\EventListener\\\\NotFoundExceptionListener\\:\\:onKernelException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventListener/NotFoundExceptionListener.php
+
+		-
+			message: "#^Property App\\\\EventListener\\\\NotFoundExceptionListener\\:\\:\\$logger has no type specified\\.$#"
+			count: 1
+			path: src/EventListener/NotFoundExceptionListener.php
+
+		-
+			message: "#^Property App\\\\EventListener\\\\NotFoundExceptionListener\\:\\:\\$twig has no type specified\\.$#"
+			count: 1
+			path: src/EventListener/NotFoundExceptionListener.php
+
+		-
+			message: "#^Method App\\\\EventListener\\\\ResponseNoCacheListener\\:\\:onKernelResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventListener/ResponseNoCacheListener.php
+
+		-
+			message: "#^Method App\\\\EventListener\\\\SessionListener\\:\\:handleTimeout\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventListener/SessionListener.php
+
+		-
+			message: "#^Method App\\\\EventListener\\\\SessionListener\\:\\:hasReachedTimeout\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventListener/SessionListener.php
+
+		-
+			message: "#^Method App\\\\EventListener\\\\SessionListener\\:\\:onKernelRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventListener/SessionListener.php
+
+		-
+			message: "#^Method App\\\\EventListener\\\\UnauthorizedExceptionListener\\:\\:onKernelException\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventListener/UnauthorizedExceptionListener.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\AdminUserLifeCycleSubscriber\\:\\:logAdminManagerCreatedEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/AdminUserLifeCycleSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\AdminUserLifeCycleSubscriber\\:\\:logAdminManagerDeletedEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/AdminUserLifeCycleSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\AdminUserLifeCycleSubscriber\\:\\:sendEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/AdminUserLifeCycleSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\CSVUploadedSubscriber\\:\\:auditLog\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/CSVUploadedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\ClientDeletedSubscriber\\:\\:logEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/ClientDeletedSubscriber.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\:\\:getEmail\\(\\)\\.$#"
+			count: 1
+			path: src/EventSubscriber/ClientUpdatedSubscriber.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\:\\:isLayDeputy\\(\\)\\.$#"
+			count: 1
+			path: src/EventSubscriber/ClientUpdatedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\ClientUpdatedSubscriber\\:\\:clientDetailsHaveChanged\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/ClientUpdatedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\ClientUpdatedSubscriber\\:\\:clientsAreTheSame\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/ClientUpdatedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\ClientUpdatedSubscriber\\:\\:logEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/ClientUpdatedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\ClientUpdatedSubscriber\\:\\:sendEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/ClientUpdatedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\ClientUpdatedSubscriber\\:\\:shouldSendEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/ClientUpdatedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\CoDeputyCreationSubscriber\\:\\:sendEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/CoDeputyCreationSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\DeputyChangedOrgSubscriber\\:\\:auditLog\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/DeputyChangedOrgSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\DeputyInvitedSubscriber\\:\\:sendEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/DeputyInvitedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\DeputySelfRegisteredSubscriber\\:\\:sendEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/DeputySelfRegisteredSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\FeedbackSubmittedSubscriber\\:\\:sendGeneralFeedbackEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/FeedbackSubmittedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\FeedbackSubmittedSubscriber\\:\\:sendPostSubmissionFeedbackEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/FeedbackSubmittedSubscriber.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Service\\\\Client\\\\RestClientInterface\\:\\:logout\\(\\)\\.$#"
+			count: 1
+			path: src/EventSubscriber/LogoutSubscriber.php
+
+		-
+			message: "#^Property App\\\\EventSubscriber\\\\LogoutSubscriber\\:\\:\\$router is never read, only written\\.$#"
+			count: 1
+			path: src/EventSubscriber/LogoutSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\NdrSubmittedSubscriber\\:\\:sendEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/NdrSubmittedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\OrgCreatedSubscriber\\:\\:auditLog\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/OrgCreatedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\OrgUserCreatedSubscriber\\:\\:sendEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/OrgUserCreatedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\OrgUserMembershipSubscriber\\:\\:logUserAddedEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/OrgUserMembershipSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\OrgUserMembershipSubscriber\\:\\:logUserRemovedEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/OrgUserMembershipSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\RegistrationFailedSubscriber\\:\\:logAuditEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/RegistrationFailedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\RegistrationSucceededSubscriber\\:\\:logAdminEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/RegistrationSucceededSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\RegistrationSucceededSubscriber\\:\\:logDeputyEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/RegistrationSucceededSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\RegistrationSucceededSubscriber\\:\\:updateRegistrationProps\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/RegistrationSucceededSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\ReportSubmittedSubscriber\\:\\:logResubmittedReport\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/ReportSubmittedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\ReportSubmittedSubscriber\\:\\:sendEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/ReportSubmittedSubscriber.php
+
+		-
+			message: "#^Property App\\\\EventSubscriber\\\\ReportSubmittedSubscriber\\:\\:\\$mailer has no type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/ReportSubmittedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\ReportUnsubmittedSubscriber\\:\\:logReportUnsubmittedEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/ReportUnsubmittedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\UserActivatedSubscriber\\:\\:sendEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/UserActivatedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\UserDeletedSubscriber\\:\\:logEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/UserDeletedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\UserPasswordResetSubscriber\\:\\:sendEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/UserPasswordResetSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\UserUpdatedSubscriber\\:\\:auditLog\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/UserUpdatedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\UserUpdatedSubscriber\\:\\:layDeputyDetailsChanged\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/UserUpdatedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\UserUpdatedSubscriber\\:\\:roleHasChanged\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/UserUpdatedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\UserUpdatedSubscriber\\:\\:sendEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/UserUpdatedSubscriber.php
+
+		-
+			message: "#^Method App\\\\EventSubscriber\\\\UserUpdatedSubscriber\\:\\:userDetailsHaveChanged\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventSubscriber/UserUpdatedSubscriber.php
+
+		-
+			message: "#^Property App\\\\Exception\\\\DisplayableException\\:\\:\\$code has no type specified\\.$#"
+			count: 1
+			path: src/Exception/DisplayableException.php
+
+		-
+			message: "#^Method App\\\\Exception\\\\RestClientException\\:\\:__construct\\(\\) has parameter \\$code with no type specified\\.$#"
+			count: 1
+			path: src/Exception/RestClientException.php
+
+		-
+			message: "#^Method App\\\\Exception\\\\RestClientException\\:\\:__construct\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: src/Exception/RestClientException.php
+
+		-
+			message: "#^Property App\\\\Exception\\\\RestClientException\\:\\:\\$data has no type specified\\.$#"
+			count: 1
+			path: src/Exception/RestClientException.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ad\\\\AddUserType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ad/AddUserType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ad\\\\AddUserType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ad/AddUserType.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_flip expects array\\<int\\|string\\>, mixed given\\.$#"
+			count: 1
+			path: src/Form/Ad/AddUserType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\AdLoginAsUserType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/AdLoginAsUserType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\AdLoginAsUserType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/AdLoginAsUserType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\AddAnotherRecordType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/AddAnotherRecordType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\AddAnotherRecordType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/AddAnotherRecordType.php
+
+		-
+			message: "#^Cannot access offset 'roleName' on mixed\\.$#"
+			count: 1
+			path: src/Form/Admin/AddUserType.php
+
+		-
+			message: "#^Cannot access offset 'roleType' on mixed\\.$#"
+			count: 1
+			path: src/Form/Admin/AddUserType.php
+
+		-
+			message: "#^Cannot access offset non\\-falsy\\-string on mixed\\.$#"
+			count: 1
+			path: src/Form/Admin/AddUserType.php
+
+		-
+			message: "#^Cannot call method getRoleName\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null\\.$#"
+			count: 1
+			path: src/Form/Admin/AddUserType.php
+
+		-
+			message: "#^Cannot call method getRoleName\\(\\) on mixed\\.$#"
+			count: 4
+			path: src/Form/Admin/AddUserType.php
+
+		-
+			message: "#^Cannot call method getUser\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\TokenInterface\\|null\\.$#"
+			count: 1
+			path: src/Form/Admin/AddUserType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\AddUserType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/AddUserType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\AddUserType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/AddUserType.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function ucfirst expects string, mixed given\\.$#"
+			count: 1
+			path: src/Form/Admin/AddUserType.php
+
+		-
+			message: "#^Cannot call method getEndDate\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Form/Admin/BenefitsMetricsFilterType.php
+
+		-
+			message: "#^Cannot call method setEndDate\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Admin/BenefitsMetricsFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\BenefitsMetricsFilterType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/BenefitsMetricsFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\BenefitsMetricsFilterType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/BenefitsMetricsFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\BenefitsMetricsFilterType\\:\\:onPostSubmit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/BenefitsMetricsFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\CloseReportConfirmType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/CloseReportConfirmType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\CloseReportConfirmType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/CloseReportConfirmType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\CloseReportType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/CloseReportType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\CloseReportType\\:\\:setTranslator\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/CloseReportType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\CloseReportType\\:\\:translate\\(\\) has parameter \\$domain with no type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/CloseReportType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\CloseReportType\\:\\:translate\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/CloseReportType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\CloseReportType\\:\\:translate\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/CloseReportType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Admin\\\\CloseReportType\\:\\:\\$translator \\(Symfony\\\\Component\\\\Translation\\\\Translator\\) does not accept Symfony\\\\Contracts\\\\Translation\\\\TranslatorInterface\\.$#"
+			count: 1
+			path: src/Form/Admin/CloseReportType.php
+
+		-
+			message: "#^Cannot call method isLayDeputy\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Form/Admin/EditUserType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\EditUserType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/EditUserType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\EditUserType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/EditUserType.php
+
+		-
+			message: "#^Parameter \\#1 \\$operatingUser of method App\\\\Form\\\\Admin\\\\EditUserType\\:\\:getEventListener\\(\\) expects App\\\\Entity\\\\User, mixed given\\.$#"
+			count: 1
+			path: src/Form/Admin/EditUserType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\Fixture\\\\LayCourtOrderFixtureType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/Fixture/LayCourtOrderFixtureType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\Fixture\\\\LayCourtOrderFixtureType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/Fixture/LayCourtOrderFixtureType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\Fixture\\\\OrgCourtOrderFixtureType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/Fixture/OrgCourtOrderFixtureType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\Fixture\\\\OrgCourtOrderFixtureType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/Fixture/OrgCourtOrderFixtureType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\Fixture\\\\PreRegistrationFixtureType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/Fixture/PreRegistrationFixtureType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\Fixture\\\\PreRegistrationFixtureType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/Fixture/PreRegistrationFixtureType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\FullReviewChecklistType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/FullReviewChecklistType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\FullReviewChecklistType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/FullReviewChecklistType.php
+
+		-
+			message: "#^Cannot call method getEndDate\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Form/Admin/ImbalanceMetricsFilterType.php
+
+		-
+			message: "#^Cannot call method setEndDate\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Admin/ImbalanceMetricsFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ImbalanceMetricsFilterType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ImbalanceMetricsFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ImbalanceMetricsFilterType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ImbalanceMetricsFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ImbalanceMetricsFilterType\\:\\:onPostSubmit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ImbalanceMetricsFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\InactiveAdminReportFilterType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/InactiveAdminReportFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\InactiveAdminReportFilterType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/InactiveAdminReportFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ManageActiveReportType\\:\\:setTranslator\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ManageActiveReportType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ManageActiveReportType\\:\\:translate\\(\\) has parameter \\$domain with no type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ManageActiveReportType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ManageActiveReportType\\:\\:translate\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ManageActiveReportType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ManageActiveReportType\\:\\:translate\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ManageActiveReportType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Admin\\\\ManageActiveReportType\\:\\:\\$translator \\(Symfony\\\\Component\\\\Translation\\\\Translator\\) does not accept Symfony\\\\Contracts\\\\Translation\\\\TranslatorInterface\\.$#"
+			count: 1
+			path: src/Form/Admin/ManageActiveReportType.php
+
+		-
+			message: "#^Cannot call method isSubmitted\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Admin/ManageReportConfirmType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ManageReportConfirmType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ManageReportConfirmType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ManageReportConfirmType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ManageReportConfirmType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ManageSubmittedReportType\\:\\:setTranslator\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ManageSubmittedReportType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ManageSubmittedReportType\\:\\:translate\\(\\) has parameter \\$domain with no type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ManageSubmittedReportType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ManageSubmittedReportType\\:\\:translate\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ManageSubmittedReportType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ManageSubmittedReportType\\:\\:translate\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ManageSubmittedReportType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Admin\\\\ManageSubmittedReportType\\:\\:\\$translator \\(Symfony\\\\Component\\\\Translation\\\\Translator\\) does not accept Symfony\\\\Contracts\\\\Translation\\\\TranslatorInterface\\.$#"
+			count: 1
+			path: src/Form/Admin/ManageSubmittedReportType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\OrganisationAddUserType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/OrganisationAddUserType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\OrganisationAddUserType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/OrganisationAddUserType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\OrganisationEditType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/OrganisationEditType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\OrganisationEditType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/OrganisationEditType.php
+
+		-
+			message: "#^Cannot access offset 'emailAddress'\\|'emailDomain' on mixed\\.$#"
+			count: 1
+			path: src/Form/Admin/OrganisationType.php
+
+		-
+			message: "#^Cannot access offset 'emailIdentifier' on mixed\\.$#"
+			count: 1
+			path: src/Form/Admin/OrganisationType.php
+
+		-
+			message: "#^Cannot access offset 'emailIdentifierType' on mixed\\.$#"
+			count: 1
+			path: src/Form/Admin/OrganisationType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\OrganisationType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/OrganisationType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\OrganisationType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/OrganisationType.php
+
+		-
+			message: "#^Cannot call method hasSection\\(\\) on mixed\\.$#"
+			count: 8
+			path: src/Form/Admin/ReportChecklistType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ReportChecklistType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ReportChecklistType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ReportChecklistType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ReportChecklistType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Admin\\\\ReportChecklistType\\:\\:\\$report \\(App\\\\Entity\\\\Report\\\\Report\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Form/Admin/ReportChecklistType.php
+
+		-
+			message: "#^Cannot call method getEndDate\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Form/Admin/ReportSubmissionDownloadFilterType.php
+
+		-
+			message: "#^Cannot call method setEndDate\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Admin/ReportSubmissionDownloadFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ReportSubmissionDownloadFilterType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ReportSubmissionDownloadFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ReportSubmissionDownloadFilterType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ReportSubmissionDownloadFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ReportSubmissionDownloadFilterType\\:\\:onPostSubmit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ReportSubmissionDownloadFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ReviewChecklistType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ReviewChecklistType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\ReviewChecklistType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/ReviewChecklistType.php
+
+		-
+			message: "#^Cannot call method getEndDate\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Form/Admin/SatisfactionFilterType.php
+
+		-
+			message: "#^Cannot call method setEndDate\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Admin/SatisfactionFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\SatisfactionFilterType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/SatisfactionFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\SatisfactionFilterType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/SatisfactionFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\SatisfactionFilterType\\:\\:onPostSubmit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/SatisfactionFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\SearchClientType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/SearchClientType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\SearchClientType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/SearchClientType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\SearchType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/SearchType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\SearchType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/SearchType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\SettingType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/SettingType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\SettingType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/SettingType.php
+
+		-
+			message: "#^Cannot access offset 'endDate' on mixed\\.$#"
+			count: 3
+			path: src/Form/Admin/StatPeriodType.php
+
+		-
+			message: "#^Cannot access offset 'period' on mixed\\.$#"
+			count: 1
+			path: src/Form/Admin/StatPeriodType.php
+
+		-
+			message: "#^Cannot access offset 'startDate' on mixed\\.$#"
+			count: 3
+			path: src/Form/Admin/StatPeriodType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\StatPeriodType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/StatPeriodType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\StatPeriodType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/StatPeriodType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\Tool\\\\ReportReassignmentType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/Tool/ReportReassignmentType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\Tool\\\\ReportReassignmentType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/Tool/ReportReassignmentType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\UnsubmittedSectionType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/UnsubmittedSectionType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\UnsubmittedSectionType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/UnsubmittedSectionType.php
+
+		-
+			message: "#^Cannot call method getEndDate\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Form/Admin/UserResearchResponseFilterType.php
+
+		-
+			message: "#^Cannot call method setEndDate\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Admin/UserResearchResponseFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\UserResearchResponseFilterType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/UserResearchResponseFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\UserResearchResponseFilterType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/UserResearchResponseFilterType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Admin\\\\UserResearchResponseFilterType\\:\\:onPostSubmit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Admin/UserResearchResponseFilterType.php
+
+		-
+			message: "#^Cannot call method getEmail\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null\\.$#"
+			count: 1
+			path: src/Form/ChangeEmailType.php
+
+		-
+			message: "#^Cannot call method getUser\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\TokenInterface\\|null\\.$#"
+			count: 1
+			path: src/Form/ChangeEmailType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\ChangeEmailType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/ChangeEmailType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\ChangeEmailType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/ChangeEmailType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\ChangePasswordType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/ChangePasswordType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\ChangePasswordType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/ChangePasswordType.php
+
+		-
+			message: "#^Cannot access offset 'firstname' on mixed\\.$#"
+			count: 2
+			path: src/Form/ClientType.php
+
+		-
+			message: "#^Cannot access offset 'lastname' on mixed\\.$#"
+			count: 2
+			path: src/Form/ClientType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\ClientType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/ClientType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\ClientType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/ClientType.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strip_tags expects string, mixed given\\.$#"
+			count: 2
+			path: src/Form/ClientType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\ClientVerifyType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/ClientVerifyType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\ClientVerifyType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/ClientVerifyType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\CoDeputyInviteType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/CoDeputyInviteType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\CoDeputyInviteType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/CoDeputyInviteType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\CoDeputyVerificationType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/CoDeputyVerificationType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\CoDeputyVerificationType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/CoDeputyVerificationType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\ConfirmDeleteType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/ConfirmDeleteType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\CookiePermissionsType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/CookiePermissionsType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\CookiePermissionsType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/CookiePermissionsType.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, mixed given\\.$#"
+			count: 1
+			path: src/Form/DataTransformer/ArrayToStringTransformer.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, mixed given\\.$#"
+			count: 2
+			path: src/Form/DataTransformer/ArrayToStringTransformer.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of function implode expects array\\<string\\>, mixed given\\.$#"
+			count: 1
+			path: src/Form/DataTransformer/ArrayToStringTransformer.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of function implode expects array\\|null, mixed given\\.$#"
+			count: 1
+			path: src/Form/DataTransformer/ArrayToStringTransformer.php
+
+		-
+			message: "#^Parameter \\#2 \\$offset of function substr expects int, float\\|int given\\.$#"
+			count: 2
+			path: src/Form/DataTransformer/ArrayToStringTransformer.php
+
+		-
+			message: "#^Parameter \\#3 \\$length of function substr expects int\\|null, float given\\.$#"
+			count: 1
+			path: src/Form/DataTransformer/ArrayToStringTransformer.php
+
+		-
+			message: "#^Property App\\\\Form\\\\DataTransformer\\\\ArrayToStringTransformer\\:\\:\\$keys has no type specified\\.$#"
+			count: 1
+			path: src/Form/DataTransformer/ArrayToStringTransformer.php
+
+		-
+			message: "#^Method App\\\\Form\\\\FeedbackReportType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/FeedbackReportType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\FeedbackReportType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/FeedbackReportType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\FeedbackReportType\\:\\:setTranslator\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/FeedbackReportType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\FeedbackReportType\\:\\:translate\\(\\) has parameter \\$domain with no type specified\\.$#"
+			count: 1
+			path: src/Form/FeedbackReportType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\FeedbackReportType\\:\\:translate\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Form/FeedbackReportType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\FeedbackReportType\\:\\:translate\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Form/FeedbackReportType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\FeedbackReportType\\:\\:\\$translator \\(Symfony\\\\Component\\\\Translation\\\\Translator\\) does not accept Symfony\\\\Contracts\\\\Translation\\\\TranslatorInterface\\.$#"
+			count: 1
+			path: src/Form/FeedbackReportType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\FeedbackType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/FeedbackType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\FeedbackType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/FeedbackType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\LoginType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/LoginType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\LoginType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/LoginType.php
+
+		-
+			message: "#^Cannot call method getActionGiveGiftsToClient\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/ActionType.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Form/Ndr/ActionType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\ActionType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/ActionType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\ActionType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/ActionType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Ndr\\\\ActionType\\:\\:\\$step has no type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/ActionType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Asset\\\\AbstractAssetType\\:\\:addFields\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AbstractAssetType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Asset\\\\AbstractAssetType\\:\\:addFields\\(\\) has parameter \\$builder with no type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AbstractAssetType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Asset\\\\AbstractAssetType\\:\\:addFields\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AbstractAssetType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Asset\\\\AbstractAssetType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AbstractAssetType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Asset\\\\AbstractAssetType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AbstractAssetType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Asset\\\\AbstractAssetType\\:\\:getValidationGroups\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AbstractAssetType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Asset\\\\AssetTypeOther\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AssetTypeOther.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Asset\\\\AssetTypeOther\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AssetTypeOther.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Asset\\\\AssetTypeOther\\:\\:getValidationGroups\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AssetTypeOther.php
+
+		-
+			message: "#^Cannot access offset 'day' on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Cannot access offset 'month' on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Cannot access offset 'rentAgreementEndDate' on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Cannot access offset 'year' on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Cannot call method getHasMortgage\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Cannot call method getIsRentedOut\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Cannot call method getOwned\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Asset\\\\AssetTypeProperty\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Asset\\\\AssetTypeProperty\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Asset\\\\AssetTypeProperty\\:\\:getValidationGroups\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^PHPDoc tag @var has invalid value \\(\\$asset \\\\App\\\\Entity\\\\Report\\\\AssetProperty\\)\\: Unexpected token \"\\$asset\", expected type at offset 9$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Ndr\\\\Asset\\\\AssetTypeProperty\\:\\:\\$step has no type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Asset\\\\AssetTypeTitle\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/AssetTypeTitle.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Asset\\\\NoAssetToAddType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/NoAssetToAddType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Asset\\\\NoAssetToAddType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Asset/NoAssetToAddType.php
+
+		-
+			message: "#^Cannot call method requiresBankName\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/BankAccountType.php
+
+		-
+			message: "#^Cannot call method requiresSortCode\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/BankAccountType.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Form/Ndr/BankAccountType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\BankAccountType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/BankAccountType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\BankAccountType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/BankAccountType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Ndr\\\\BankAccountType\\:\\:\\$step has no type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/BankAccountType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Debt\\\\DebtManagementType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Debt/DebtManagementType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Debt\\\\DebtManagementType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Debt/DebtManagementType.php
+
+		-
+			message: "#^Cannot call method getAmount\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/Debt/DebtSingleType.php
+
+		-
+			message: "#^Cannot call method getHasMoreDetails\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Form/Ndr/Debt/DebtSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Debt\\\\DebtSingleType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Debt/DebtSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Debt\\\\DebtSingleType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Debt/DebtSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Debt\\\\DebtsType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Debt/DebtsType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\Debt\\\\DebtsType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/Debt/DebtsType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\DeputyExpenseType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/DeputyExpenseType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\DeputyExpenseType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/DeputyExpenseType.php
+
+		-
+			message: "#^Cannot call method getExpectCompensationDamages\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/IncomeBenefitType.php
+
+		-
+			message: "#^Cannot call method getReceiveOtherIncome\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/IncomeBenefitType.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Form/Ndr/IncomeBenefitType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\IncomeBenefitType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/IncomeBenefitType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\IncomeBenefitType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/IncomeBenefitType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Ndr\\\\IncomeBenefitType\\:\\:\\$clientFirstName \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/IncomeBenefitType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Ndr\\\\IncomeBenefitType\\:\\:\\$clientFirstName is never read, only written\\.$#"
+			count: 1
+			path: src/Form/Ndr/IncomeBenefitType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Ndr\\\\IncomeBenefitType\\:\\:\\$translator \\(Symfony\\\\Contracts\\\\Translation\\\\TranslatorInterface\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/IncomeBenefitType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Ndr\\\\IncomeBenefitType\\:\\:\\$translator is never read, only written\\.$#"
+			count: 1
+			path: src/Form/Ndr/IncomeBenefitType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\OneOffType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/OneOffType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\OneOffType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/OneOffType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Ndr\\\\OtherInfoType\\:\\:\\$translationDomain has no type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/OtherInfoType.php
+
+		-
+			message: "#^Cannot call method getAgreedBehalfDeputy\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/ReportDeclarationType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\ReportDeclarationType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/ReportDeclarationType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\ReportDeclarationType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/ReportDeclarationType.php
+
+		-
+			message: "#^Cannot call method getHasMoreDetails\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/StateBenefitType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\StateBenefitType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/StateBenefitType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\StateBenefitType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/StateBenefitType.php
+
+		-
+			message: "#^Cannot access offset 'day' on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/VisitsCareType.php
+
+		-
+			message: "#^Cannot access offset 'doesClientHaveACare…' on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/VisitsCareType.php
+
+		-
+			message: "#^Cannot access offset 'month' on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/VisitsCareType.php
+
+		-
+			message: "#^Cannot access offset 'whenWasCarePlanLast…' on mixed\\.$#"
+			count: 2
+			path: src/Form/Ndr/VisitsCareType.php
+
+		-
+			message: "#^Cannot access offset 'year' on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/VisitsCareType.php
+
+		-
+			message: "#^Cannot call method getDoYouLiveWithClient\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/VisitsCareType.php
+
+		-
+			message: "#^Cannot call method getDoesClientHaveACarePlan\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/VisitsCareType.php
+
+		-
+			message: "#^Cannot call method getDoesClientReceivePaidCare\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/VisitsCareType.php
+
+		-
+			message: "#^Cannot call method getPlanMoveNewResidence\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/VisitsCareType.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Form/Ndr/VisitsCareType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\VisitsCareType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/VisitsCareType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\VisitsCareType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/VisitsCareType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\VisitsCareType\\:\\:translate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/VisitsCareType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Ndr\\\\VisitsCareType\\:\\:translate\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: src/Form/Ndr/VisitsCareType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Ndr\\\\VisitsCareType\\:\\:\\$clientFirstName \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/VisitsCareType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Ndr\\\\VisitsCareType\\:\\:\\$translator \\(Symfony\\\\Contracts\\\\Translation\\\\TranslatorInterface\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Form/Ndr/VisitsCareType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\NdrType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/NdrType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Org\\\\ClientArchiveType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Org/ClientArchiveType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Org\\\\ClientArchiveType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Org/ClientArchiveType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Org\\\\ClientContactType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Org/ClientContactType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Org\\\\ClientContactType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Org/ClientContactType.php
+
+		-
+			message: "#^PHPDoc tag @param for parameter \\$resolver with type App\\\\Form\\\\Org\\\\OptionsResolverInterface is not subtype of native type Symfony\\\\Component\\\\OptionsResolver\\\\OptionsResolver\\.$#"
+			count: 1
+			path: src/Form/Org/ClientContactType.php
+
+		-
+			message: "#^Parameter \\$resolver of method App\\\\Form\\\\Org\\\\ClientContactType\\:\\:configureOptions\\(\\) has invalid type App\\\\Form\\\\Org\\\\OptionsResolverInterface\\.$#"
+			count: 1
+			path: src/Form/Org/ClientContactType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Org\\\\ClientType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Org/ClientType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Org\\\\ClientType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Org/ClientType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Org\\\\NoteType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Org/NoteType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Org\\\\NoteType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Org/NoteType.php
+
+		-
+			message: "#^Cannot call method getActive\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Org/OrganisationMemberType.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Org/OrganisationMemberType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Org\\\\OrganisationMemberType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Org/OrganisationMemberType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Org\\\\OrganisationMemberType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Org/OrganisationMemberType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\PasswordForgottenType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/PasswordForgottenType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\PasswordForgottenType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/PasswordForgottenType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\ProcessCSVType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/ProcessCSVType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\ProcessCSVType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/ProcessCSVType.php
+
+		-
+			message: "#^Cannot call method getDoYouExpectFinancialDecisions\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/ActionType.php
+
+		-
+			message: "#^Cannot call method getDoYouHaveConcerns\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/ActionType.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Form/Report/ActionType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ActionType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ActionType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ActionType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ActionType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Report\\\\ActionType\\:\\:\\$clientFirstName has no type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ActionType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Report\\\\ActionType\\:\\:\\$clientFirstName is never read, only written\\.$#"
+			count: 1
+			path: src/Form/Report/ActionType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Report\\\\ActionType\\:\\:\\$translator \\(Symfony\\\\Contracts\\\\Translation\\\\TranslatorInterface\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Form/Report/ActionType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Report\\\\ActionType\\:\\:\\$translator is never read, only written\\.$#"
+			count: 1
+			path: src/Form/Report/ActionType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\Asset\\\\AssetTypeOther\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeOther.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\Asset\\\\AssetTypeOther\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeOther.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\Asset\\\\AssetTypeOther\\:\\:getValidationGroups\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeOther.php
+
+		-
+			message: "#^Cannot access offset 'day' on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Cannot access offset 'month' on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Cannot access offset 'rentAgreementEndDate' on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Cannot access offset 'year' on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Cannot call method getHasMortgage\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Cannot call method getIsRentedOut\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Cannot call method getOwned\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\Asset\\\\AssetTypeProperty\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\Asset\\\\AssetTypeProperty\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\Asset\\\\AssetTypeProperty\\:\\:getValidationGroups\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^PHPDoc tag @var has invalid value \\(\\$asset \\\\App\\\\Entity\\\\Report\\\\AssetProperty\\)\\: Unexpected token \"\\$asset\", expected type at offset 9$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Report\\\\Asset\\\\AssetTypeProperty\\:\\:\\$step has no type specified\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeProperty.php
+
+		-
+			message: "#^Call to method trans\\(\\) on an unknown class App\\\\Form\\\\Report\\\\Asset\\\\Translator\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeTitle.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\Asset\\\\AssetTypeTitle\\:\\:__construct\\(\\) has parameter \\$translatorDomain with no type specified\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeTitle.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\Asset\\\\AssetTypeTitle\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeTitle.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\Asset\\\\AssetTypeTitle\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeTitle.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Report\\\\Asset\\\\AssetTypeTitle\\:\\:\\$translator \\(App\\\\Form\\\\Report\\\\Asset\\\\Translator\\) does not accept Symfony\\\\Contracts\\\\Translation\\\\TranslatorInterface\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeTitle.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Report\\\\Asset\\\\AssetTypeTitle\\:\\:\\$translator has unknown class App\\\\Form\\\\Report\\\\Asset\\\\Translator as its type\\.$#"
+			count: 1
+			path: src/Form/Report/Asset/AssetTypeTitle.php
+
+		-
+			message: "#^Cannot call method requiresBankName\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/BankAccountType.php
+
+		-
+			message: "#^Cannot call method requiresSortCode\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/BankAccountType.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Form/Report/BankAccountType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\BankAccountType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/BankAccountType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\BankAccountType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/BankAccountType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Report\\\\BankAccountType\\:\\:\\$step has no type specified\\.$#"
+			count: 1
+			path: src/Form/Report/BankAccountType.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\MoneyReceivedOnClientsBehalfInterface\\:\\:getAmount\\(\\)\\.$#"
+			count: 1
+			path: src/Form/Report/ClientBenefitsCheckType.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\MoneyReceivedOnClientsBehalfInterface\\:\\:getAmountDontKnow\\(\\)\\.$#"
+			count: 1
+			path: src/Form/Report/ClientBenefitsCheckType.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\MoneyReceivedOnClientsBehalfInterface\\:\\:getMoneyType\\(\\)\\.$#"
+			count: 1
+			path: src/Form/Report/ClientBenefitsCheckType.php
+
+		-
+			message: "#^Cannot access offset 'clientFirstname' on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/ClientBenefitsCheckType.php
+
+		-
+			message: "#^Cannot access offset 'dateLastCheckedEnti…' on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/ClientBenefitsCheckType.php
+
+		-
+			message: "#^Cannot access offset 'day' on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/ClientBenefitsCheckType.php
+
+		-
+			message: "#^Cannot access offset 'month' on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/ClientBenefitsCheckType.php
+
+		-
+			message: "#^Cannot access offset 'year' on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/ClientBenefitsCheckType.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Form/Report/ClientBenefitsCheckType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ClientBenefitsCheckType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ClientBenefitsCheckType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ClientBenefitsCheckType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ClientBenefitsCheckType.php
+
+		-
+			message: "#^Cannot call method getData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 1
+			path: src/Form/Report/ContactExistType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ContactExistType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ContactExistType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ContactExistType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ContactExistType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ContactType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ContactType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ContactType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ContactType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\Debt\\\\DebtManagementType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/Debt/DebtManagementType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\Debt\\\\DebtManagementType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/Debt/DebtManagementType.php
+
+		-
+			message: "#^Cannot call method getAmount\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/Debt/DebtSingleType.php
+
+		-
+			message: "#^Cannot call method getHasMoreDetails\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Form/Report/Debt/DebtSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\Debt\\\\DebtSingleType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/Debt/DebtSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\Debt\\\\DebtSingleType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/Debt/DebtSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\Debt\\\\DebtsType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/Debt/DebtsType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\Debt\\\\DebtsType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/Debt/DebtsType.php
+
+		-
+			message: "#^Cannot call method getSignificantDecisionsMade\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/DecisionExistType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\DecisionExistType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/DecisionExistType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\DecisionExistType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/DecisionExistType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\DecisionType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/DecisionType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\DecisionType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/DecisionType.php
+
+		-
+			message: "#^Cannot call method canLinkToBankAccounts\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/DeputyExpenseType.php
+
+		-
+			message: "#^Cannot call method getBankAccountOptions\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Form/Report/DeputyExpenseType.php
+
+		-
+			message: "#^Cannot call method getType\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/DeputyExpenseType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\DeputyExpenseType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/DeputyExpenseType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\DeputyExpenseType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/DeputyExpenseType.php
+
+		-
+			message: "#^Cannot call method getWishToProvideDocumentation\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/DocumentType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\DocumentType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/DocumentType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\DocumentType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/DocumentType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\DoesMoneyInExistType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/DoesMoneyInExistType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\DoesMoneyInExistType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/DoesMoneyInExistType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\DoesMoneyOutExistType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/DoesMoneyOutExistType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\DoesMoneyOutExistType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/DoesMoneyOutExistType.php
+
+		-
+			message: "#^Cannot call method getAmount\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/FeeSingleType.php
+
+		-
+			message: "#^Cannot call method getHasMoreDetails\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Form/Report/FeeSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\FeeSingleType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/FeeSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\FeeSingleType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/FeeSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\FeesType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/FeesType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\FeesType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/FeesType.php
+
+		-
+			message: "#^Cannot call method canLinkToBankAccounts\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/GiftType.php
+
+		-
+			message: "#^Cannot call method getBankAccountOptions\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Form/Report/GiftType.php
+
+		-
+			message: "#^Cannot call method getType\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/GiftType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\GiftType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/GiftType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\GiftType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/GiftType.php
+
+		-
+			message: "#^Cannot call method getDoesClientUndertakeSocialActivities\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Form/Report/LifestyleType.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Form/Report/LifestyleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\LifestyleType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/LifestyleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\LifestyleType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/LifestyleType.php
+
+		-
+			message: "#^Cannot access offset 'day' on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/MentalAssessment.php
+
+		-
+			message: "#^Cannot access offset 'mentalAssessmentDate' on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/MentalAssessment.php
+
+		-
+			message: "#^Cannot access offset 'month' on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/MentalAssessment.php
+
+		-
+			message: "#^Cannot access offset 'year' on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/MentalAssessment.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\MentalAssessment\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/MentalAssessment.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\MentalAssessment\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/MentalAssessment.php
+
+		-
+			message: "#^Cannot call method getHasCapacityChanged\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/MentalCapacityType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\MentalCapacityType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/MentalCapacityType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\MentalCapacityType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/MentalCapacityType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\MoneyShortCategoryType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyShortCategoryType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\MoneyShortCategoryType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyShortCategoryType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\MoneyShortTransactionType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyShortTransactionType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\MoneyShortTransactionType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyShortTransactionType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\MoneyShortType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyShortType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\MoneyShortType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyShortType.php
+
+		-
+			message: "#^Parameter \\#1 \\$child of method Symfony\\\\Component\\\\Form\\\\FormBuilderInterface\\:\\:add\\(\\) expects string\\|Symfony\\\\Component\\\\Form\\\\FormBuilderInterface, mixed given\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyShortType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Report\\\\MoneyShortType\\:\\:\\$field has no type specified\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyShortType.php
+
+		-
+			message: "#^Cannot call method canLinkToBankAccounts\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyTransactionType.php
+
+		-
+			message: "#^Cannot call method getBankAccountOptions\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Form/Report/MoneyTransactionType.php
+
+		-
+			message: "#^Cannot call method getType\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyTransactionType.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyTransactionType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\MoneyTransactionType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyTransactionType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\MoneyTransactionType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyTransactionType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\MoneyTransactionType\\:\\:isDescriptionMandatory\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyTransactionType.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function ucfirst expects string, mixed given\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyTransactionType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Report\\\\MoneyTransactionType\\:\\:\\$authorizationChecker \\(Symfony\\\\Component\\\\Security\\\\Core\\\\Authorization\\\\AuthorizationCheckerInterface\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyTransactionType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Report\\\\MoneyTransactionType\\:\\:\\$selectedCategory \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyTransactionType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Report\\\\MoneyTransactionType\\:\\:\\$type \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyTransactionType.php
+
+		-
+			message: "#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyTransferType.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyTransferType.php
+
+		-
+			message: "#^Cannot call method getNameOneLine\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyTransferType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\MoneyTransferType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyTransferType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\MoneyTransferType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/MoneyTransferType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\NoAssetToAddType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/NoAssetToAddType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\NoAssetToAddType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/NoAssetToAddType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\NoMoneyInType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/NoMoneyInType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\NoMoneyInType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/NoMoneyInType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\NoMoneyOutType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/NoMoneyOutType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\NoMoneyOutType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/NoMoneyOutType.php
+
+		-
+			message: "#^Cannot call method getActionMoreInfo\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/OtherInfoType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\OtherInfoType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/OtherInfoType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\OtherInfoType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/OtherInfoType.php
+
+		-
+			message: "#^Cannot call method getData\\(\\) on Symfony\\\\Component\\\\Form\\\\FormInterface\\|null\\.$#"
+			count: 1
+			path: src/Form/Report/PaFeeExistType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\PaFeeExistType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/PaFeeExistType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\PaFeeExistType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/PaFeeExistType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyCostHowType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyCostHowType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyCostHowType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyCostHowType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyCostInterimSingleType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyCostInterimSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyCostInterimSingleType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyCostInterimSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyCostInterimType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyCostInterimType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyCostInterimType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyCostInterimType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyCostPreviousType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyCostPreviousType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyCostPreviousType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyCostPreviousType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyCostSccoType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyCostSccoType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyCostSccoType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyCostSccoType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyCostsEstimateHowType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyCostsEstimateHowType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyCostsEstimateHowType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyCostsEstimateHowType.php
+
+		-
+			message: "#^Cannot call method getProfDeputyCostsEstimateHasMoreInfo\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyCostsEstimateMoreInfoType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyCostsEstimateMoreInfoType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyCostsEstimateMoreInfoType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyCostsEstimateMoreInfoType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyCostsEstimateMoreInfoType.php
+
+		-
+			message: "#^Cannot call method getHasMoreDetails\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyEstimateCostSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyEstimateCostSingleType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyEstimateCostSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyEstimateCostSingleType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyEstimateCostSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyEstimateCostsType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyEstimateCostsType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyEstimateCostsType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyEstimateCostsType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyFixedCostType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyFixedCostType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyFixedCostType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyFixedCostType.php
+
+		-
+			message: "#^Cannot call method getHasMoreDetails\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyOtherCostSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyOtherCostSingleType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyOtherCostSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyOtherCostSingleType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyOtherCostSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyOtherCostsType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyOtherCostsType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfDeputyOtherCostsType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfDeputyOtherCostsType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfServiceFeeExistType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfServiceFeeExistType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfServiceFeeExistType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfServiceFeeExistType.php
+
+		-
+			message: "#^Cannot call method getPaymentReceived\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/ProfServiceFeeType.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Form/Report/ProfServiceFeeType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfServiceFeeType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfServiceFeeType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfServiceFeeType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfServiceFeeType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfServiceFeeType\\:\\:getServiceFeeTypes\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfServiceFeeType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfServiceFeeType\\:\\:getValidationGroups\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfServiceFeeType.php
+
+		-
+			message: "#^PHPDoc tag @var has invalid value \\(\\$asset \\\\App\\\\Entity\\\\Report\\\\ProfServiceFee\\)\\: Unexpected token \"\\$asset\", expected type at offset 9$#"
+			count: 1
+			path: src/Form/Report/ProfServiceFeeType.php
+
+		-
+			message: "#^Array has 2 duplicate keys with value 'translation_domain' \\('translation_domain', 'translation_domain'\\)\\.$#"
+			count: 1
+			path: src/Form/Report/ProfServicePreviousFeesEstimateType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfServicePreviousFeesEstimateType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfServicePreviousFeesEstimateType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ProfServicePreviousFeesEstimateType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ProfServicePreviousFeesEstimateType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ReasonForBalanceType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ReasonForBalanceType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ReasonForBalanceType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ReasonForBalanceType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ReasonForNoContactType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ReasonForNoContactType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ReasonForNoContactType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ReasonForNoContactType.php
+
+		-
+			message: "#^Parameter \\#1 \\$action of method Symfony\\\\Component\\\\Form\\\\FormConfigBuilderInterface\\:\\:setAction\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Form/Report/ReasonForNoContactType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ReasonForNoDecisionType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ReasonForNoDecisionType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ReasonForNoDecisionType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ReasonForNoDecisionType.php
+
+		-
+			message: "#^Parameter \\#1 \\$action of method Symfony\\\\Component\\\\Form\\\\FormConfigBuilderInterface\\:\\:setAction\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Form/Report/ReasonForNoDecisionType.php
+
+		-
+			message: "#^Cannot call method getAgreedBehalfDeputy\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/ReportDeclarationType.php
+
+		-
+			message: "#^Cannot call method getUser\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\TokenInterface\\|null\\.$#"
+			count: 1
+			path: src/Form/Report/ReportDeclarationType.php
+
+		-
+			message: "#^Cannot call method isLayDeputy\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null\\.$#"
+			count: 1
+			path: src/Form/Report/ReportDeclarationType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ReportDeclarationType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ReportDeclarationType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ReportDeclarationType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ReportDeclarationType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ReportResubmitType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ReportResubmitType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ReportResubmitType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ReportResubmitType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ReportType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ReportType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\ReportType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/ReportType.php
+
+		-
+			message: "#^Cannot call method getHasMoreDetails\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/TransactionSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\TransactionSingleType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/TransactionSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\TransactionSingleType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/TransactionSingleType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\UploadType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/UploadType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\UploadType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/UploadType.php
+
+		-
+			message: "#^Cannot access offset 'day' on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/VisitsCareType.php
+
+		-
+			message: "#^Cannot access offset 'doesClientHaveACare…' on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/VisitsCareType.php
+
+		-
+			message: "#^Cannot access offset 'month' on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/VisitsCareType.php
+
+		-
+			message: "#^Cannot access offset 'whenWasCarePlanLast…' on mixed\\.$#"
+			count: 2
+			path: src/Form/Report/VisitsCareType.php
+
+		-
+			message: "#^Cannot access offset 'year' on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/VisitsCareType.php
+
+		-
+			message: "#^Cannot call method getDoYouLiveWithClient\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/VisitsCareType.php
+
+		-
+			message: "#^Cannot call method getDoesClientHaveACarePlan\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/VisitsCareType.php
+
+		-
+			message: "#^Cannot call method getDoesClientReceivePaidCare\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Report/VisitsCareType.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 1
+			path: src/Form/Report/VisitsCareType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\VisitsCareType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/VisitsCareType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\VisitsCareType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/VisitsCareType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\VisitsCareType\\:\\:translate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Report/VisitsCareType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Report\\\\VisitsCareType\\:\\:translate\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: src/Form/Report/VisitsCareType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Report\\\\VisitsCareType\\:\\:\\$clientFirstName \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Form/Report/VisitsCareType.php
+
+		-
+			message: "#^Property App\\\\Form\\\\Report\\\\VisitsCareType\\:\\:\\$translator \\(Symfony\\\\Contracts\\\\Translation\\\\TranslatorInterface\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Form/Report/VisitsCareType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\ResetPasswordType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/ResetPasswordType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\ResetPasswordType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/ResetPasswordType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\SelfRegisterDataType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/SelfRegisterDataType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\SelfRegisterDataType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/SelfRegisterDataType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\SetPasswordType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/SetPasswordType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\SetPasswordType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/SetPasswordType.php
+
+		-
+			message: "#^Cannot call method isDeputyOrg\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Settings/ProfileType.php
+
+		-
+			message: "#^Cannot call method isOrgAdministrator\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Form/Settings/ProfileType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Settings\\\\ProfileType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Settings/ProfileType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Settings\\\\ProfileType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Settings/ProfileType.php
+
+		-
+			message: "#^Parameter \\#1 \\$report of method App\\\\Form\\\\Subscriber\\\\ReportTypeChoicesSubscriber\\:\\:resolveReportTypeOptions\\(\\) expects App\\\\Entity\\\\Report\\\\Report, mixed given\\.$#"
+			count: 1
+			path: src/Form/Subscriber/ReportTypeChoicesSubscriber.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Type\\\\SortCodeType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Type/SortCodeType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\UploadCsvType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/UploadCsvType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\UploadCsvType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/UploadCsvType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\User\\\\AgreeTermsType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/User/AgreeTermsType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\User\\\\AgreeTermsType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/User/AgreeTermsType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\User\\\\SearchUserType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/User/SearchUserType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\User\\\\SearchUserType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/User/SearchUserType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\User\\\\UpdateTermsType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/User/UpdateTermsType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\User\\\\UpdateTermsType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/User/UpdateTermsType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\User\\\\UserDetailsBasicType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/User/UserDetailsBasicType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\User\\\\UserDetailsBasicType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/User/UserDetailsBasicType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\User\\\\UserDetailsFullType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/User/UserDetailsFullType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\User\\\\UserDetailsFullType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/User/UserDetailsFullType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\User\\\\UserDetailsPaType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/User/UserDetailsPaType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\User\\\\UserDetailsPaType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/User/UserDetailsPaType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\UserResearchResponseType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/UserResearchResponseType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\UserResearchResponseType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/UserResearchResponseType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\YesNoType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/YesNoType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\YesNoType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/YesNoType.php
+
+		-
+			message: "#^Parameter \\#1 \\$child of method Symfony\\\\Component\\\\Form\\\\FormBuilderInterface\\:\\:add\\(\\) expects string\\|Symfony\\\\Component\\\\Form\\\\FormBuilderInterface, mixed given\\.$#"
+			count: 1
+			path: src/Form/YesNoType.php
+
+		-
+			message: "#^Method App\\\\Kernel\\:\\:__construct\\(\\) has parameter \\$debug with no type specified\\.$#"
+			count: 1
+			path: src/Kernel.php
+
+		-
+			message: "#^Method App\\\\Kernel\\:\\:__construct\\(\\) has parameter \\$environment with no type specified\\.$#"
+			count: 1
+			path: src/Kernel.php
+
+		-
+			message: "#^Offset 'line' does not exist on array\\{function\\: string, line\\?\\: int, file\\: string, class\\?\\: class\\-string, type\\?\\: '\\-\\>'\\|'\\:\\:', args\\?\\: array, object\\?\\: object\\}\\.$#"
+			count: 1
+			path: src/Logger/OpgJsonFormatter.php
+
+		-
+			message: "#^Method App\\\\Logger\\\\OpgLineFormatter\\:\\:format\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: src/Logger/OpgLineFormatter.php
+
+		-
+			message: "#^Parameter \\#2 \\$subject of function preg_match expects string, mixed given\\.$#"
+			count: 1
+			path: src/Logger/OpgLineFormatter.php
+
+		-
+			message: "#^Method App\\\\Mapper\\\\DateRangeQuery\\:\\:getEndDate\\(\\) should return DateTime but returns DateTime\\|null\\.$#"
+			count: 1
+			path: src/Mapper/DateRangeQuery.php
+
+		-
+			message: "#^Method App\\\\Mapper\\\\DateRangeQuery\\:\\:getStartDate\\(\\) should return DateTime but returns DateTime\\|null\\.$#"
+			count: 1
+			path: src/Mapper/DateRangeQuery.php
+
+		-
+			message: "#^Property App\\\\Mapper\\\\DateRangeQuery\\:\\:\\$orderBy \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Mapper/DateRangeQuery.php
+
+		-
+			message: "#^Property App\\\\Mapper\\\\DateRangeQuery\\:\\:\\$sortOrder \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Mapper/DateRangeQuery.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 2
+			path: src/Mapper/ReportSatisfaction/ReportSatisfactionSummaryMapper.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 2
+			path: src/Mapper/ReportSubmission/ReportSubmissionSummaryMapper.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$restClient$#"
+			count: 1
+			path: src/Mapper/UserResearchResponse/UserResearchResponseSummaryMapper.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Email\\:\\:\\$fromEmailNotifyID has no type specified\\.$#"
+			count: 1
+			path: src/Model/Email.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Email\\:\\:\\$fromName has no type specified\\.$#"
+			count: 1
+			path: src/Model/Email.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Email\\:\\:\\$parameters has no type specified\\.$#"
+			count: 1
+			path: src/Model/Email.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Email\\:\\:\\$subject has no type specified\\.$#"
+			count: 1
+			path: src/Model/Email.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Email\\:\\:\\$template has no type specified\\.$#"
+			count: 1
+			path: src/Model/Email.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Email\\:\\:\\$toEmail has no type specified\\.$#"
+			count: 1
+			path: src/Model/Email.php
+
+		-
+			message: "#^Method App\\\\Model\\\\EmailAttachment\\:\\:__construct\\(\\) has parameter \\$content with no type specified\\.$#"
+			count: 1
+			path: src/Model/EmailAttachment.php
+
+		-
+			message: "#^Method App\\\\Model\\\\EmailAttachment\\:\\:__construct\\(\\) has parameter \\$contentType with no type specified\\.$#"
+			count: 1
+			path: src/Model/EmailAttachment.php
+
+		-
+			message: "#^Method App\\\\Model\\\\EmailAttachment\\:\\:__construct\\(\\) has parameter \\$filename with no type specified\\.$#"
+			count: 1
+			path: src/Model/EmailAttachment.php
+
+		-
+			message: "#^Method App\\\\Model\\\\EmailAttachment\\:\\:getContent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Model/EmailAttachment.php
+
+		-
+			message: "#^Method App\\\\Model\\\\EmailAttachment\\:\\:getContentType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Model/EmailAttachment.php
+
+		-
+			message: "#^Method App\\\\Model\\\\EmailAttachment\\:\\:getFilename\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Model/EmailAttachment.php
+
+		-
+			message: "#^Property App\\\\Model\\\\EmailAttachment\\:\\:\\$content has no type specified\\.$#"
+			count: 1
+			path: src/Model/EmailAttachment.php
+
+		-
+			message: "#^Property App\\\\Model\\\\EmailAttachment\\:\\:\\$contentType has no type specified\\.$#"
+			count: 1
+			path: src/Model/EmailAttachment.php
+
+		-
+			message: "#^Property App\\\\Model\\\\EmailAttachment\\:\\:\\$filename has no type specified\\.$#"
+			count: 1
+			path: src/Model/EmailAttachment.php
+
+		-
+			message: "#^Method App\\\\Model\\\\FeedbackReport\\:\\:getSatisfactionLevel\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Model/FeedbackReport.php
+
+		-
+			message: "#^Method App\\\\Model\\\\FeedbackReport\\:\\:setSatisfactionLevel\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Model/FeedbackReport.php
+
+		-
+			message: "#^Method App\\\\Model\\\\FeedbackReport\\:\\:setSatisfactionLevel\\(\\) has parameter \\$satisfactionLevel with no type specified\\.$#"
+			count: 1
+			path: src/Model/FeedbackReport.php
+
+		-
+			message: "#^Property App\\\\Model\\\\FeedbackReport\\:\\:\\$satisfactionLevel has no type specified\\.$#"
+			count: 1
+			path: src/Model/FeedbackReport.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\QueuedChecklistData\\:\\:\\$caseNumber has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/QueuedChecklistData.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\QueuedChecklistData\\:\\:\\$checklistFileContents has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/QueuedChecklistData.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\QueuedChecklistData\\:\\:\\$checklistUuid \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Model/Sirius/QueuedChecklistData.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\QueuedChecklistData\\:\\:\\$reportEndDate has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/QueuedChecklistData.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\QueuedChecklistData\\:\\:\\$reportType has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/QueuedChecklistData.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\QueuedChecklistData\\:\\:\\$submitterEmail has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/QueuedChecklistData.php
+
+		-
+			message: "#^Method App\\\\Model\\\\Sirius\\\\QueuedDocumentData\\:\\:supportingDocumentCanBeSynced\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/QueuedDocumentData.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\QueuedDocumentData\\:\\:\\$caseNumber has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/QueuedDocumentData.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\QueuedDocumentData\\:\\:\\$documentSyncAttempts has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/QueuedDocumentData.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\QueuedDocumentData\\:\\:\\$reportEndDate has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/QueuedDocumentData.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\QueuedDocumentData\\:\\:\\$reportSubmissionId has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/QueuedDocumentData.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\QueuedDocumentData\\:\\:\\$reportSubmissionUuid has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/QueuedDocumentData.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\QueuedDocumentData\\:\\:\\$reportSubmitDate has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/QueuedDocumentData.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\QueuedDocumentData\\:\\:\\$s3Reference has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/QueuedDocumentData.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\QueuedDocumentData\\:\\:\\$s3Reference is unused\\.$#"
+			count: 1
+			path: src/Model/Sirius/QueuedDocumentData.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\QueuedDocumentData\\:\\:\\$storageReference has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/QueuedDocumentData.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\SiriusApiError\\:\\:\\$code has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/SiriusApiError.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\SiriusApiError\\:\\:\\$detail has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/SiriusApiError.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\SiriusApiError\\:\\:\\$title \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Model/Sirius/SiriusApiError.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\SiriusChecklistPdfDocumentMetadata\\:\\:\\$reportingPeriodTo has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/SiriusChecklistPdfDocumentMetadata.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\SiriusChecklistPdfDocumentMetadata\\:\\:\\$type has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/SiriusChecklistPdfDocumentMetadata.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\SiriusDocumentUpload\\:\\:\\$attributes \\(App\\\\Model\\\\Sirius\\\\SiriusReportPdfDocumentMetadata\\) does not accept App\\\\Model\\\\Sirius\\\\SiriusMetadataInterface\\|null\\.$#"
+			count: 1
+			path: src/Model/Sirius/SiriusDocumentUpload.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\SiriusReportPdfDocumentMetadata\\:\\:\\$dateSubmitted has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/SiriusReportPdfDocumentMetadata.php
+
+		-
+			message: "#^Property App\\\\Model\\\\Sirius\\\\SiriusReportPdfDocumentMetadata\\:\\:\\$reportingPeriodTo has no type specified\\.$#"
+			count: 1
+			path: src/Model/Sirius/SiriusReportPdfDocumentMetadata.php
+
+		-
+			message: "#^Method App\\\\Resolver\\\\SubSectionRoute\\\\ProfCostsEstimateSubSectionRouteResolver\\:\\:breakdownSubsectionIsIncomplete\\(\\) has parameter \\$state with no type specified\\.$#"
+			count: 1
+			path: src/Resolver/SubSectionRoute/ProfCostsEstimateSubSectionRouteResolver.php
+
+		-
+			message: "#^Method App\\\\Resolver\\\\SubSectionRoute\\\\ProfCostsEstimateSubSectionRouteResolver\\:\\:moreInfoSubsectionIsIncomplete\\(\\) has parameter \\$state with no type specified\\.$#"
+			count: 1
+			path: src/Resolver/SubSectionRoute/ProfCostsEstimateSubSectionRouteResolver.php
+
+		-
+			message: "#^Method App\\\\Resolver\\\\SubSectionRoute\\\\ProfCostsEstimateSubSectionRouteResolver\\:\\:resolve\\(\\) has parameter \\$state with no type specified\\.$#"
+			count: 1
+			path: src/Resolver/SubSectionRoute/ProfCostsEstimateSubSectionRouteResolver.php
+
+		-
+			message: "#^Method App\\\\Resolver\\\\SubSectionRoute\\\\ProfCostsEstimateSubSectionRouteResolver\\:\\:resolve\\(\\) should return string but empty return statement found\\.$#"
+			count: 1
+			path: src/Resolver/SubSectionRoute/ProfCostsEstimateSubSectionRouteResolver.php
+
+		-
+			message: "#^Method App\\\\Resolver\\\\SubSectionRoute\\\\ProfCostsEstimateSubSectionRouteResolver\\:\\:resolve\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: src/Resolver/SubSectionRoute/ProfCostsEstimateSubSectionRouteResolver.php
+
+		-
+			message: "#^Method App\\\\Resolver\\\\SubSectionRoute\\\\ProfCostsEstimateSubSectionRouteResolver\\:\\:sectionIsComplete\\(\\) has parameter \\$state with no type specified\\.$#"
+			count: 1
+			path: src/Resolver/SubSectionRoute/ProfCostsEstimateSubSectionRouteResolver.php
+
+		-
+			message: "#^Method App\\\\Resolver\\\\SubSectionRoute\\\\ProfCostsEstimateSubSectionRouteResolver\\:\\:sectionNotStarted\\(\\) has parameter \\$state with no type specified\\.$#"
+			count: 1
+			path: src/Resolver/SubSectionRoute/ProfCostsEstimateSubSectionRouteResolver.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: src/Resolver/SubSectionRoute/ProfCostsEstimateSubSectionRouteResolver.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between null and string will always evaluate to false\\.$#"
+			count: 1
+			path: src/Resolver/SubSectionRoute/ProfCostsEstimateSubSectionRouteResolver.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with string will always evaluate to false\\.$#"
+			count: 1
+			path: src/Resolver/SubSectionRoute/ProfCostsSubSectionRouteResolver.php
+
+		-
+			message: "#^Method App\\\\Resolver\\\\SubSectionRoute\\\\ProfCostsSubSectionRouteResolver\\:\\:determineCurrentFixedCostSection\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: src/Resolver/SubSectionRoute/ProfCostsSubSectionRouteResolver.php
+
+		-
+			message: "#^Method App\\\\Resolver\\\\SubSectionRoute\\\\ProfCostsSubSectionRouteResolver\\:\\:determineCurrentNonFixedCostSection\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: src/Resolver/SubSectionRoute/ProfCostsSubSectionRouteResolver.php
+
+		-
+			message: "#^Method App\\\\Resolver\\\\SubSectionRoute\\\\ProfCostsSubSectionRouteResolver\\:\\:resolve\\(\\) has parameter \\$state with no type specified\\.$#"
+			count: 1
+			path: src/Resolver/SubSectionRoute/ProfCostsSubSectionRouteResolver.php
+
+		-
+			message: "#^Method App\\\\Resolver\\\\SubSectionRoute\\\\ProfCostsSubSectionRouteResolver\\:\\:resolve\\(\\) should return string but empty return statement found\\.$#"
+			count: 1
+			path: src/Resolver/SubSectionRoute/ProfCostsSubSectionRouteResolver.php
+
+		-
+			message: "#^Method App\\\\Resolver\\\\SubSectionRoute\\\\ProfCostsSubSectionRouteResolver\\:\\:sectionIsComplete\\(\\) has parameter \\$state with no type specified\\.$#"
+			count: 1
+			path: src/Resolver/SubSectionRoute/ProfCostsSubSectionRouteResolver.php
+
+		-
+			message: "#^Method App\\\\Resolver\\\\SubSectionRoute\\\\ProfCostsSubSectionRouteResolver\\:\\:sectionNotStarted\\(\\) has parameter \\$state with no type specified\\.$#"
+			count: 1
+			path: src/Resolver/SubSectionRoute/ProfCostsSubSectionRouteResolver.php
+
+		-
+			message: "#^Negated boolean expression is always true\\.$#"
+			count: 1
+			path: src/Resolver/SubSectionRoute/ProfCostsSubSectionRouteResolver.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: src/Resolver/SubSectionRoute/ProfCostsSubSectionRouteResolver.php
+
+		-
+			message: "#^Property App\\\\Security\\\\ClientContactVoter\\:\\:\\$decisionManager is never read, only written\\.$#"
+			count: 1
+			path: src/Security/ClientContactVoter.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: src/Security/ClientContactVoter.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: src/Security/ClientContactVoter.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\Client\\:\\:getUserIds\\(\\)\\.$#"
+			count: 2
+			path: src/Security/ClientVoter.php
+
+		-
+			message: "#^Cannot access offset '_token' on bool\\|float\\|int\\|string\\|null\\.$#"
+			count: 1
+			path: src/Security/LoginFormAuthenticator.php
+
+		-
+			message: "#^Cannot access offset 'email' on mixed\\.$#"
+			count: 1
+			path: src/Security/LoginFormAuthenticator.php
+
+		-
+			message: "#^Cannot access offset 'password' on mixed\\.$#"
+			count: 1
+			path: src/Security/LoginFormAuthenticator.php
+
+		-
+			message: "#^Cannot use array destructuring on App\\\\Entity\\\\User\\.$#"
+			count: 1
+			path: src/Security/LoginFormAuthenticator.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function urldecode expects string, bool\\|float\\|int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Security/LoginFormAuthenticator.php
+
+		-
+			message: "#^Parameter \\#1 \\$userIdentifier of class Symfony\\\\Component\\\\Security\\\\Http\\\\Authenticator\\\\Passport\\\\Badge\\\\UserBadge constructor expects string, mixed given\\.$#"
+			count: 1
+			path: src/Security/LoginFormAuthenticator.php
+
+		-
+			message: "#^Property App\\\\Security\\\\NoteVoter\\:\\:\\$decisionManager is never read, only written\\.$#"
+			count: 1
+			path: src/Security/NoteVoter.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: src/Security/NoteVoter.php
+
+		-
+			message: "#^Parameter \\#1 \\$data of function unserialize expects string, mixed given\\.$#"
+			count: 2
+			path: src/Security/SessionAuthenticator.php
+
+		-
+			message: "#^Property App\\\\Security\\\\SessionAuthenticator\\:\\:\\$tokenStorage is never read, only written\\.$#"
+			count: 1
+			path: src/Security/SessionAuthenticator.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\:\\:getId\\(\\)\\.$#"
+			count: 1
+			path: src/Security/UserProvider.php
+
+		-
+			message: "#^Method App\\\\Security\\\\UserProvider\\:\\:loadUserByIdentifier\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Security/UserProvider.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: src/Security/UserProvider.php
+
+		-
+			message: "#^Method App\\\\Security\\\\UserVoter\\:\\:determineCanAddPermission\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Security/UserVoter.php
+
+		-
+			message: "#^Parameter \\#2 \\$deletee of method App\\\\Security\\\\UserVoter\\:\\:determineDeletePermission\\(\\) expects App\\\\Entity\\\\User, mixed given\\.$#"
+			count: 1
+			path: src/Security/UserVoter.php
+
+		-
+			message: "#^Parameter \\#2 \\$subject of method App\\\\Security\\\\UserVoter\\:\\:determineAddEditPermission\\(\\) expects App\\\\Entity\\\\User\\|null, mixed given\\.$#"
+			count: 1
+			path: src/Security/UserVoter.php
+
+		-
+			message: "#^Cannot access offset 'file' on array\\|ArrayObject\\|bool\\|float\\|int\\|string\\|null\\.$#"
+			count: 1
+			path: src/Serializer/SiriusDocumentUploadSerializer.php
+
+		-
+			message: "#^Method App\\\\Service\\\\AWS\\\\RequestSigner\\:\\:signRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/AWS/RequestSigner.php
+
+		-
+			message: "#^Method App\\\\Service\\\\ApiCollector\\:\\:collect\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/ApiCollector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\ApiCollector\\:\\:getCalls\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/ApiCollector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\ApiCollector\\:\\:reset\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/ApiCollector.php
+
+		-
+			message: "#^Cannot call method getEmail\\(\\) on App\\\\Entity\\\\User\\|string\\.$#"
+			count: 1
+			path: src/Service/Audit/AuditEvents.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Audit\\\\AuditEvents\\:\\:buildEmailEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Audit/AuditEvents.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Audit\\\\AuditEvents\\:\\:clientEmailChanged\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Audit/AuditEvents.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Audit\\\\AuditEvents\\:\\:userEmailChanged\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Audit/AuditEvents.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_flip expects array\\<int\\|string\\>, array\\<string, mixed\\> given\\.$#"
+			count: 1
+			path: src/Service/Audit/AuditEvents.php
+
+		-
+			message: "#^Cannot access offset 'uploadSequenceToken' on mixed\\.$#"
+			count: 1
+			path: src/Service/Audit/AwsAuditLogHandler.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 1
+			path: src/Service/Audit/AwsAuditLogHandler.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Audit\\\\AwsAuditLogHandler\\:\\:__construct\\(\\) has parameter \\$group with no type specified\\.$#"
+			count: 1
+			path: src/Service/Audit/AwsAuditLogHandler.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Audit\\\\AwsAuditLogHandler\\:\\:getLogStreams\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Audit/AwsAuditLogHandler.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Audit\\\\AwsAuditLogHandler\\:\\:initialize\\(\\) should return string\\|null but returns mixed\\.$#"
+			count: 1
+			path: src/Service/Audit/AwsAuditLogHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$streams of method App\\\\Service\\\\Audit\\\\AwsAuditLogHandler\\:\\:extractExistingStreamNames\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Service/Audit/AwsAuditLogHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fclose expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Service/Audit/LocalAuditLogHandler.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fwrite expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Service/Audit/LocalAuditLogHandler.php
+
+		-
+			message: "#^Cannot access offset 'errors' on mixed\\.$#"
+			count: 1
+			path: src/Service/Availability/ApiAvailability.php
+
+		-
+			message: "#^Cannot access offset 'healthy' on mixed\\.$#"
+			count: 1
+			path: src/Service/Availability/ApiAvailability.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Availability\\\\ApiAvailability\\:\\:ping\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Availability/ApiAvailability.php
+
+		-
+			message: "#^Property App\\\\Service\\\\Availability\\\\ServiceAvailabilityAbstract\\:\\:\\$errors \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Service/Availability/ApiAvailability.php
+
+		-
+			message: "#^Property App\\\\Service\\\\Availability\\\\ServiceAvailabilityAbstract\\:\\:\\$isHealthy \\(bool\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Service/Availability/ApiAvailability.php
+
+		-
+			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:get\\(\\)\\.$#"
+			count: 1
+			path: src/Service/Availability/ClamAvAvailability.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Availability\\\\ClamAvAvailability\\:\\:ping\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Availability/ClamAvAvailability.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Availability\\\\HtmlToPdfAvailability\\:\\:ping\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Availability/HtmlToPdfAvailability.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Availability\\\\NotifyAvailability\\:\\:ping\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Availability/NotifyAvailability.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Availability\\\\NotifyAvailability\\:\\:pingNotify\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Availability/NotifyAvailability.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Availability\\\\RedisAvailability\\:\\:__construct\\(\\) has parameter \\$workspace with no type specified\\.$#"
+			count: 1
+			path: src/Service/Availability/RedisAvailability.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Availability\\\\RedisAvailability\\:\\:ping\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Availability/RedisAvailability.php
+
+		-
+			message: "#^Property App\\\\Service\\\\Availability\\\\RedisAvailability\\:\\:\\$container is never read, only written\\.$#"
+			count: 1
+			path: src/Service/Availability/RedisAvailability.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Availability\\\\ServiceAvailabilityAbstract\\:\\:getCustomMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Availability/ServiceAvailabilityAbstract.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Availability\\\\ServiceAvailabilityAbstract\\:\\:ping\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Availability/ServiceAvailabilityAbstract.php
+
+		-
+			message: "#^PHPDoc tag @var has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 15$#"
+			count: 1
+			path: src/Service/Availability/ServiceAvailabilityAbstract.php
+
+		-
+			message: "#^Property App\\\\Service\\\\Availability\\\\ServiceAvailabilityAbstract\\:\\:\\$customMessage has no type specified\\.$#"
+			count: 1
+			path: src/Service/Availability/ServiceAvailabilityAbstract.php
+
+		-
+			message: "#^Cannot call method getStatusCode\\(\\) on mixed\\.$#"
+			count: 2
+			path: src/Service/Availability/SiriusApiAvailability.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Availability\\\\SiriusApiAvailability\\:\\:ping\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Availability/SiriusApiAvailability.php
+
+		-
+			message: "#^Property App\\\\Service\\\\ChecklistPdfGenerator\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: src/Service/ChecklistPdfGenerator.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between false and string will always evaluate to false\\.$#"
+			count: 1
+			path: src/Service/ChecklistPdfGenerator.php
+
+		-
+			message: "#^Call to an undefined method Throwable\\:\\:getResponse\\(\\)\\.$#"
+			count: 1
+			path: src/Service/ChecklistSyncService.php
+
+		-
+			message: "#^Cannot access offset 'data' on mixed\\.$#"
+			count: 1
+			path: src/Service/ChecklistSyncService.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: src/Service/ChecklistSyncService.php
+
+		-
+			message: "#^Cannot call method getBody\\(\\) on class\\-string\\|object\\.$#"
+			count: 2
+			path: src/Service/ChecklistSyncService.php
+
+		-
+			message: "#^Cannot call method getBody\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Service/ChecklistSyncService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\ChecklistSyncService\\:\\:updateChecklistWithError\\(\\) has parameter \\$e with no type specified\\.$#"
+			count: 1
+			path: src/Service/ChecklistSyncService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\ChecklistSyncService\\:\\:updateChecklistWithSuccess\\(\\) has parameter \\$uuid with no type specified\\.$#"
+			count: 1
+			path: src/Service/ChecklistSyncService.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$content$#"
+			count: 1
+			path: src/Service/ChecklistSyncService.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$report$#"
+			count: 1
+			path: src/Service/ChecklistSyncService.php
+
+		-
+			message: "#^Parameter \\#1 \\$mimetype of method App\\\\Model\\\\Sirius\\\\SiriusDocumentFile\\:\\:setMimetype\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Service/ChecklistSyncService.php
+
+		-
+			message: "#^Parameter \\#1 \\$reportEndDate of method App\\\\Model\\\\Sirius\\\\QueuedChecklistData\\:\\:setReportEndDate\\(\\) expects DateTime, DateTime\\|null given\\.$#"
+			count: 1
+			path: src/Service/ChecklistSyncService.php
+
+		-
+			message: "#^Parameter \\#1 \\$reportStartDate of method App\\\\Model\\\\Sirius\\\\QueuedChecklistData\\:\\:setReportStartDate\\(\\) expects DateTime, DateTime\\|null given\\.$#"
+			count: 1
+			path: src/Service/ChecklistSyncService.php
+
+		-
+			message: "#^Parameter \\#2 \\$reportSubmissionUuid of method App\\\\Service\\\\ChecklistSyncService\\:\\:postChecklist\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Service/ChecklistSyncService.php
+
+		-
+			message: "#^Parameter \\#2 \\$reportSubmissionUuid of method App\\\\Service\\\\ChecklistSyncService\\:\\:putChecklist\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Service/ChecklistSyncService.php
+
+		-
+			message: "#^Parameter \\#4 \\$checklistUuid of method App\\\\Service\\\\Client\\\\Sirius\\\\SiriusApiGatewayClient\\:\\:putChecklistPdf\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Service/ChecklistSyncService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\GovUK\\\\BankHolidaysAPIClient\\:\\:getBankHolidays\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Service/Client/GovUK/BankHolidaysAPIClient.php
+
+		-
+			message: "#^Property App\\\\Service\\\\Client\\\\GovUK\\\\BankHolidaysAPIClient\\:\\:\\$logger is never read, only written\\.$#"
+			count: 1
+			path: src/Service/Client/GovUK/BankHolidaysAPIClient.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Service\\\\Client\\\\RestClientInterface\\:\\:delete\\(\\)\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ClientApi.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Service\\\\Client\\\\RestClientInterface\\:\\:get\\(\\)\\.$#"
+			count: 5
+			path: src/Service/Client/Internal/ClientApi.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Service\\\\Client\\\\RestClientInterface\\:\\:put\\(\\)\\.$#"
+			count: 3
+			path: src/Service/Client/Internal/ClientApi.php
+
+		-
+			message: "#^Cannot call method getUser\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\TokenInterface\\|null\\.$#"
+			count: 4
+			path: src/Service/Client/Internal/ClientApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ClientApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:getAllClientsByDeputyUid\\(\\) has parameter \\$groups with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ClientApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:getByCaseNumber\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ClientApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:getById\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ClientApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:getWithUsersV2\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ClientApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:update\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ClientApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:updateDeputy\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ClientApi.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\<App\\\\Entity\\\\Client\\>\\|null given\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ClientApi.php
+
+		-
+			message: "#^Parameter \\#3 \\$changedBy of class App\\\\Event\\\\ClientUpdatedEvent constructor expects Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ClientApi.php
+
+		-
+			message: "#^Property App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:\\$dateTimeProvider is never read, only written\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ClientApi.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ClientApi.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\ClientBenefitsCheckInterface\\:\\:getId\\(\\)\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ClientBenefitsCheckApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\ClientBenefitsCheckApi\\:\\:post\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ClientBenefitsCheckApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\ClientBenefitsCheckApi\\:\\:put\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ClientBenefitsCheckApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\DeputyApi\\:\\:createDeputyFromUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/DeputyApi.php
+
+		-
+			message: "#^Property App\\\\Service\\\\Client\\\\Internal\\\\DeputyApi\\:\\:\\$restClient \\(App\\\\Service\\\\Client\\\\RestClient\\) does not accept App\\\\Service\\\\Client\\\\RestClientInterface\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/DeputyApi.php
+
+		-
+			message: "#^Property App\\\\Service\\\\Client\\\\Internal\\\\DeputyApi\\:\\:\\$tokenStorage is never read, only written\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/DeputyApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\LayDeputyshipApi\\:\\:uploadLayDeputyShip\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/LayDeputyshipApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\MoneyReceivedOnClientsBehalfApi\\:\\:deleteMoneyType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/MoneyReceivedOnClientsBehalfApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\NdrApi\\:\\:getNdr\\(\\) should return App\\\\Entity\\\\Ndr\\\\Ndr but returns mixed\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/NdrApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\NdrApi\\:\\:submit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/NdrApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\OrganisationApi\\:\\:addUserToOrganisation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/OrganisationApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\OrganisationApi\\:\\:removeUserFromOrganisation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/OrganisationApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\PreRegistrationApi\\:\\:clientHasCoDeputies\\(\\) should return bool but returns mixed\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/PreRegistrationApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\PreRegistrationApi\\:\\:count\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/PreRegistrationApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\PreRegistrationApi\\:\\:deleteAll\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/PreRegistrationApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\PreRegistrationApi\\:\\:verify\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/PreRegistrationApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\ReportApi\\:\\:getNdr\\(\\) should return App\\\\Entity\\\\Ndr\\\\Ndr but returns mixed\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ReportApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\ReportApi\\:\\:getReport\\(\\) should return App\\\\Entity\\\\Report\\\\Report but returns mixed\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ReportApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\ReportApi\\:\\:getSectionId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ReportApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\ReportApi\\:\\:refreshReportStatusCache\\(\\) should return App\\\\Entity\\\\Report\\\\Report but returns string\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ReportApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\ReportApi\\:\\:submit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/ReportApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\SatisfactionApi\\:\\:createPostSubmissionFeedback\\(\\) should return int but returns string\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/SatisfactionApi.php
+
+		-
+			message: "#^Property App\\\\Service\\\\Client\\\\Internal\\\\SatisfactionApi\\:\\:\\$restClient \\(App\\\\Service\\\\Client\\\\RestClient\\) does not accept App\\\\Service\\\\Client\\\\RestClientInterface\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/SatisfactionApi.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Service\\\\Client\\\\RestClientInterface\\:\\:get\\(\\)\\.$#"
+			count: 6
+			path: src/Service/Client/Internal/StatsApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\StatsApi\\:\\:getBenefitsReportMetrics\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/StatsApi.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Service\\\\Client\\\\RestClientInterface\\:\\:apiCall\\(\\)\\.$#"
+			count: 4
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Service\\\\Client\\\\RestClientInterface\\:\\:delete\\(\\)\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Service\\\\Client\\\\RestClientInterface\\:\\:get\\(\\)\\.$#"
+			count: 6
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Service\\\\Client\\\\RestClientInterface\\:\\:put\\(\\)\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Cannot access offset 'data' on mixed\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Cannot call method getUser\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\TokenInterface\\|null\\.$#"
+			count: 4
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:activate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:agreeTermsUse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:agreeTermsUse\\(\\) has parameter \\$token with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:clearRegistrationToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:createOrgUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:createUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:delete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:dispatchAdminManagerCreatedEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:getByEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:getByEmailOrgAdmins\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:reInviteCoDeputy\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:reInviteDeputy\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:resetPassword\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:returnPrimaryEmail\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:selfRegister\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:update\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Parameter \\#2 \\$currentUser of class App\\\\Event\\\\AdminManagerCreatedEvent constructor expects App\\\\Entity\\\\User, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Parameter \\#3 \\$currentUser of class App\\\\Event\\\\UserUpdatedEvent constructor expects App\\\\Entity\\\\User, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserResearchApi\\:\\:createPostSubmissionUserResearch\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserResearchApi.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\UserResearchApi\\:\\:getUserResearchResponseData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserResearchApi.php
+
+		-
+			message: "#^Property App\\\\Service\\\\Client\\\\Internal\\\\UserResearchApi\\:\\:\\$restClient \\(App\\\\Service\\\\Client\\\\RestClient\\) does not accept App\\\\Service\\\\Client\\\\RestClientInterface\\.$#"
+			count: 1
+			path: src/Service/Client/Internal/UserResearchApi.php
+
+		-
+			message: "#^Ternary operator condition is always true\\.$#"
+			count: 2
+			path: src/Service/Client/Internal/UserResearchApi.php
+
+		-
+			message: "#^Call to an undefined method Lcobucci\\\\JWT\\\\Token\\:\\:claims\\(\\)\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Cannot access offset 'data' on mixed\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Cannot access offset 'jku' on mixed\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Cannot access offset 'message' on mixed\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Cannot access offset 'success' on mixed\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Dead catch \\- App\\\\Exception\\\\RestClientException is never thrown in the try block\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:agreeTermsUse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:apiCall\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:apiCall\\(\\) has parameter \\$authenticated with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:apiCall\\(\\) has parameter \\$data with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:arrayToEntity\\(\\) should return object but returns mixed\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:debugJsonString\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:debugJsonString\\(\\) has parameter \\$jsonString with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:extractDataArray\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:logRequest\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:login\\(\\) should return App\\\\Entity\\\\User but returns array\\<int, mixed\\>\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:logout\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) has parameter \\$expectedResponseType with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:post\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:rawSafeCall\\(\\) has parameter \\$method with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:rawSafeCall\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:rawSafeCall\\(\\) has parameter \\$url with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:setLoggedUserId\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:setTimeout\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClient\\:\\:toJson\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Parameter \\#2 \\$jwks of method App\\\\Service\\\\JWT\\\\JWTService\\:\\:decodeAndVerifyWithJWK\\(\\) expects array, mixed given\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Parameter \\#2 \\$url of method Symfony\\\\Contracts\\\\HttpClient\\\\HttpClientInterface\\:\\:request\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Parameter \\#3 \\$data of class App\\\\Exception\\\\RestClientException constructor expects array, mixed given\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Property App\\\\Service\\\\Client\\\\RestClient\\:\\:\\$saveHistory \\(bool\\) does not accept array\\|bool\\|float\\|int\\|string\\|UnitEnum\\|null\\.$#"
+			count: 1
+			path: src/Service/Client/RestClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClientInterface\\:\\:post\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClientInterface.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClientInterface\\:\\:post\\(\\) has parameter \\$endpoint with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClientInterface.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClientInterface\\:\\:post\\(\\) has parameter \\$expectedResponseType with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClientInterface.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClientInterface\\:\\:post\\(\\) has parameter \\$mixed with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClientInterface.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClientMock\\:\\:appendResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClientMock.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClientMock\\:\\:getLoggedUserId\\(\\) is unused\\.$#"
+			count: 1
+			path: src/Service/Client/RestClientMock.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClientMock\\:\\:getLoggedUserId\\(\\) never returns bool so it can be removed from the return type\\.$#"
+			count: 1
+			path: src/Service/Client/RestClientMock.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClientMock\\:\\:post\\(\\) has parameter \\$endpoint with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClientMock.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\RestClientMock\\:\\:post\\(\\) has parameter \\$mixed with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/RestClientMock.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$content$#"
+			count: 1
+			path: src/Service/Client/Sirius/SiriusApiGatewayClient.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\TokenStorage\\\\RedisStorage\\:\\:get\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/TokenStorage/RedisStorage.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\TokenStorage\\\\RedisStorage\\:\\:get\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/TokenStorage/RedisStorage.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\TokenStorage\\\\RedisStorage\\:\\:remove\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/TokenStorage/RedisStorage.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\TokenStorage\\\\RedisStorage\\:\\:remove\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/TokenStorage/RedisStorage.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\TokenStorage\\\\RedisStorage\\:\\:set\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/TokenStorage/RedisStorage.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\TokenStorage\\\\RedisStorage\\:\\:set\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/TokenStorage/RedisStorage.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\TokenStorage\\\\RedisStorage\\:\\:set\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/TokenStorage/RedisStorage.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\TokenStorage\\\\TokenStorageInterface\\:\\:get\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/TokenStorage/TokenStorageInterface.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\TokenStorage\\\\TokenStorageInterface\\:\\:get\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/TokenStorage/TokenStorageInterface.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\TokenStorage\\\\TokenStorageInterface\\:\\:remove\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/TokenStorage/TokenStorageInterface.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\TokenStorage\\\\TokenStorageInterface\\:\\:remove\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/TokenStorage/TokenStorageInterface.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\TokenStorage\\\\TokenStorageInterface\\:\\:set\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Client/TokenStorage/TokenStorageInterface.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\TokenStorage\\\\TokenStorageInterface\\:\\:set\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/TokenStorage/TokenStorageInterface.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Client\\\\TokenStorage\\\\TokenStorageInterface\\:\\:set\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Service/Client/TokenStorage/TokenStorageInterface.php
+
+		-
+			message: "#^Call to function array_key_exists\\(\\) with non\\-empty\\-string and array\\{\\} will always evaluate to false\\.$#"
+			count: 1
+			path: src/Service/CssClassCollector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\CssClassCollector\\:\\:collect\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/CssClassCollector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\CssClassCollector\\:\\:getData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/CssClassCollector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\CssClassCollector\\:\\:reset\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/CssClassCollector.php
+
+		-
+			message: "#^Parameter \\#2 \\$subject of function preg_match_all expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Service/CssClassCollector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Csv\\\\CsvBuilder\\:\\:buildCsv\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Service/Csv/CsvBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fclose expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Service/Csv/CsvBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function fputcsv expects resource, resource\\|false given\\.$#"
+			count: 2
+			path: src/Service/Csv/CsvBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function rewind expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Service/Csv/CsvBuilder.php
+
+		-
+			message: "#^Parameter \\#1 \\$stream of function stream_get_contents expects resource, resource\\|false given\\.$#"
+			count: 1
+			path: src/Service/Csv/CsvBuilder.php
+
+		-
+			message: "#^Variable \\$csvRows might not be defined\\.$#"
+			count: 1
+			path: src/Service/Csv/ReportImbalanceCsvGenerator.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Csv\\\\SatisfactionCsvGenerator\\:\\:generateSatisfactionResponsesCsv\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Csv/SatisfactionCsvGenerator.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\ReportInterface\\:\\:getExpenses\\(\\)\\.$#"
+			count: 1
+			path: src/Service/Csv/TransactionsCsvGenerator.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\ReportInterface\\:\\:getGifts\\(\\)\\.$#"
+			count: 1
+			path: src/Service/Csv/TransactionsCsvGenerator.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\ReportInterface\\:\\:getMoneyTransactionsIn\\(\\)\\.$#"
+			count: 1
+			path: src/Service/Csv/TransactionsCsvGenerator.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\ReportInterface\\:\\:getMoneyTransactionsOut\\(\\)\\.$#"
+			count: 1
+			path: src/Service/Csv/TransactionsCsvGenerator.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\Report\\\\Expense\\|App\\\\Entity\\\\Report\\\\Gift\\|App\\\\Entity\\\\Report\\\\MoneyTransaction\\:\\:getCategory\\(\\)\\.$#"
+			count: 1
+			path: src/Service/Csv/TransactionsCsvGenerator.php
+
+		-
+			message: "#^Cannot call method getBank\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Service/Csv/TransactionsCsvGenerator.php
+
+		-
+			message: "#^Cannot call method getDisplayName\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Service/Csv/TransactionsCsvGenerator.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Csv\\\\TransactionsCsvGenerator\\:\\:generateTransactionRows\\(\\) has parameter \\$transactions with no type specified\\.$#"
+			count: 1
+			path: src/Service/Csv/TransactionsCsvGenerator.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Csv\\\\TransactionsCsvGenerator\\:\\:generateTransactionRows\\(\\) has parameter \\$type with no type specified\\.$#"
+			count: 1
+			path: src/Service/Csv/TransactionsCsvGenerator.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Csv\\\\TransactionsCsvGenerator\\:\\:generateTransactionsCsvLines\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Csv/TransactionsCsvGenerator.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: src/Service/Csv/TransactionsCsvGenerator.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Csv\\\\UserResearchResponseCsvGenerator\\:\\:getCommaSeparatedTypesAgreedFromArrayData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Csv/UserResearchResponseCsvGenerator.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Csv\\\\UserResearchResponseCsvGenerator\\:\\:transformDeputyshipLength\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Csv/UserResearchResponseCsvGenerator.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\[\\]UserResearchResponse \\$userResearchResponses\\)\\: Unexpected token \"\\[\", expected type at offset 18$#"
+			count: 1
+			path: src/Service/Csv/UserResearchResponseCsvGenerator.php
+
+		-
+			message: "#^Parameter \\#1 \\$data of function gzcompress expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Service/CsvUploader.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function base64_encode expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Service/CsvUploader.php
+
+		-
+			message: "#^Constructor of class App\\\\Service\\\\DataImporter\\\\CsvToArray has an unused parameter \\$autoDetectLineEndings\\.$#"
+			count: 1
+			path: src/Service/DataImporter/CsvToArray.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DataImporter\\\\CsvToArray\\:\\:getFirstRow\\(\\) should return array but returns array\\|false\\|null\\.$#"
+			count: 1
+			path: src/Service/DataImporter/CsvToArray.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DataImporter\\\\CsvToArray\\:\\:getRow\\(\\) never returns null so it can be removed from the return type\\.$#"
+			count: 1
+			path: src/Service/DataImporter/CsvToArray.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DataImporter\\\\CsvToArray\\:\\:setExpectedColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/DataImporter/CsvToArray.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DataImporter\\\\CsvToArray\\:\\:setOptionalColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/DataImporter/CsvToArray.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DataImporter\\\\CsvToArray\\:\\:setUnexpectedColumns\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/DataImporter/CsvToArray.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|false given\\.$#"
+			count: 1
+			path: src/Service/DataImporter/CsvToArray.php
+
+		-
+			message: "#^Property App\\\\Service\\\\DataImporter\\\\CsvToArray\\:\\:\\$firstRow \\(array\\) does not accept array\\|false\\|null\\.$#"
+			count: 1
+			path: src/Service/DataImporter/CsvToArray.php
+
+		-
+			message: "#^Variable \\$header in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: src/Service/DataImporter/CsvToArray.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\:\\:getId\\(\\)\\.$#"
+			count: 1
+			path: src/Service/DeputyProvider.php
+
+		-
+			message: "#^Cannot use array destructuring on App\\\\Entity\\\\User\\.$#"
+			count: 1
+			path: src/Service/DeputyProvider.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DeputyProvider\\:\\:refreshUser\\(\\) should return App\\\\Entity\\\\User but returns Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\.$#"
+			count: 1
+			path: src/Service/DeputyProvider.php
+
+		-
+			message: "#^Parameter \\#1 \\$id \\(int\\) of method App\\\\Service\\\\DeputyProvider\\:\\:loadUserByUsername\\(\\) should be compatible with parameter \\$username \\(string\\) of method Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserProviderInterface\\:\\:loadUserByUsername\\(\\)$#"
+			count: 1
+			path: src/Service/DeputyProvider.php
+
+		-
+			message: "#^Property App\\\\Service\\\\DeputyProvider\\:\\:\\$restClient \\(App\\\\Service\\\\Client\\\\RestClient\\) does not accept App\\\\Service\\\\Client\\\\RestClientInterface\\.$#"
+			count: 1
+			path: src/Service/DeputyProvider.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 1
+			path: src/Service/DocumentDownloader.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DocumentDownloader\\:\\:generateDownloadResponse\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/DocumentDownloader.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DocumentDownloader\\:\\:setMissingDocsFlashMessage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/DocumentDownloader.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DocumentDownloader\\:\\:zipDownloadedDocuments\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/DocumentDownloader.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\[\\]string \\$reportSubmissionIds, an Array of ReportSubmission ids to be downloaded\\)\\: Unexpected token \"\\[\", expected type at offset 87$#"
+			count: 1
+			path: src/Service/DocumentDownloader.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of method Symfony\\\\Component\\\\HttpFoundation\\\\Response\\:\\:setContent\\(\\) expects string\\|null, string\\|false given\\.$#"
+			count: 1
+			path: src/Service/DocumentDownloader.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DocumentService\\:\\:deleteFromS3\\(\\) should return bool but returns array\\.$#"
+			count: 1
+			path: src/Service/DocumentService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DocumentService\\:\\:log\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/DocumentService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DocumentService\\:\\:log\\(\\) has parameter \\$level with no type specified\\.$#"
+			count: 1
+			path: src/Service/DocumentService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DocumentService\\:\\:log\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: src/Service/DocumentService.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\[\\]MissingDocument \\$missingDocuments\\)\\: Unexpected token \"\\[\", expected type at offset 18$#"
+			count: 1
+			path: src/Service/DocumentService.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\[\\]ReportSubmission \\$reportSubmissions\\)\\: Unexpected token \"\\[\", expected type at offset 266$#"
+			count: 1
+			path: src/Service/DocumentService.php
+
+		-
+			message: "#^Cannot access offset 'data' on mixed\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Cannot access offset 'id' on mixed\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Cannot call method format\\(\\) on DateTime\\|null\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Cannot call method getBody\\(\\) on class\\-string\\|object\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Cannot call method getBody\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DocumentSyncService\\:\\:addToSyncErrorSubmissionIds\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DocumentSyncService\\:\\:buildUpload\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DocumentSyncService\\:\\:determineEndDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DocumentSyncService\\:\\:determineReportType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DocumentSyncService\\:\\:handleSyncErrors\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DocumentSyncService\\:\\:retrieveDocumentContentFromS3\\(\\) is unused\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DocumentSyncService\\:\\:setDocsNotSyncedCount\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DocumentSyncService\\:\\:setSubmissionsDocumentsToPermanentError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DocumentSyncService\\:\\:syncReportDocument\\(\\) should return App\\\\Entity\\\\Report\\\\Document\\|null but returns mixed\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\DocumentSyncService\\:\\:syncSupportingDocument\\(\\) should return App\\\\Entity\\\\Report\\\\Document\\|null but returns mixed\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$document$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Parameter \\#1 \\$dateSubmitted of method App\\\\Model\\\\Sirius\\\\SiriusReportPdfDocumentMetadata\\:\\:setDateSubmitted\\(\\) expects DateTime, DateTime\\|null given\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of static method GuzzleHttp\\\\Psr7\\\\MimeType\\:\\:fromFilename\\(\\) expects string, array\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Parameter \\#1 \\$name of method App\\\\Model\\\\Sirius\\\\SiriusDocumentFile\\:\\:setName\\(\\) expects string, array\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Parameter \\#1 \\$reportingPeriodFrom of method App\\\\Model\\\\Sirius\\\\SiriusReportPdfDocumentMetadata\\:\\:setReportingPeriodFrom\\(\\) expects DateTime, DateTime\\|null given\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Parameter \\#2 \\$submissionUuid of method App\\\\Service\\\\Client\\\\Sirius\\\\SiriusApiGatewayClient\\:\\:sendSupportingDocument\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Parameter \\#2 \\$uuid of method App\\\\Service\\\\DocumentSyncService\\:\\:handleReportSubmissionUpdate\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Service/DocumentSyncService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\DocumentsZipFileCreator\\:\\:cleanUp\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/File/DocumentsZipFileCreator.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\[\\]RetrievedDocument \\$retrievedDocuments\\)\\: Unexpected token \"\\[\", expected type at offset 18$#"
+			count: 1
+			path: src/Service/File/DocumentsZipFileCreator.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$document$#"
+			count: 1
+			path: src/Service/File/DocumentsZipFileCreator.php
+
+		-
+			message: "#^Parameter \\#1 \\$as_float of function microtime expects bool, int given\\.$#"
+			count: 2
+			path: src/Service/File/DocumentsZipFileCreator.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: src/Service/File/FileNameFixer.php
+
+		-
+			message: "#^Parameter \\#3 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, array\\|bool\\|string given\\.$#"
+			count: 1
+			path: src/Service/File/FileNameFixer.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\FileUtility\\:\\:mimeToExtension\\(\\) has parameter \\$mime with no type specified\\.$#"
+			count: 1
+			path: src/Service/File/FileUtility.php
+
+		-
+			message: "#^Match expression does not handle remaining value\\: mixed$#"
+			count: 1
+			path: src/Service/File/ImageConvertor.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\ImageConvertor\\:\\:convert\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/File/ImageConvertor.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\ImageConvertor\\:\\:convertsFrom\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/File/ImageConvertor.php
+
+		-
+			message: "#^Offset 'extension' does not exist on array\\{dirname\\?\\: string, basename\\: string, extension\\?\\: string, filename\\: string\\}\\.$#"
+			count: 1
+			path: src/Service/File/ImageConvertor.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function unlink expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Service/File/ImageConvertor.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Service\\\\File\\\\Storage\\\\StorageInterface\\:\\:removeFromS3\\(\\)\\.$#"
+			count: 1
+			path: src/Service/File/S3FileUploader.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\S3FileUploader\\:\\:getSanitisedFileName\\(\\) should return string but returns array\\|string\\|null\\.$#"
+			count: 1
+			path: src/Service/File/S3FileUploader.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\S3FileUploader\\:\\:persistDocument\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/File/S3FileUploader.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\S3FileUploader\\:\\:persistDocumentOverwrite\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/File/S3FileUploader.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\S3FileUploader\\:\\:removeFileFromS3\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/File/S3FileUploader.php
+
+		-
+			message: "#^Parameter \\#1 \\$fileName of method App\\\\Service\\\\File\\\\FileNameFixer\\:\\:removeUnusualCharacters\\(\\) expects string, array\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Service/File/S3FileUploader.php
+
+		-
+			message: "#^Parameter \\#2 \\$fileBody of method App\\\\Service\\\\File\\\\MimeTypeAndExtensionChecker\\:\\:check\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Service/File/S3FileUploader.php
+
+		-
+			message: "#^Property App\\\\Service\\\\File\\\\S3FileUploader\\:\\:\\$options is never read, only written\\.$#"
+			count: 1
+			path: src/Service/File/S3FileUploader.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with string will always evaluate to false\\.$#"
+			count: 1
+			path: src/Service/File/Scanner/ClamFileScanner.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\Scanner\\\\ClamFileScanner\\:\\:scanFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/File/Scanner/ClamFileScanner.php
+
+		-
+			message: "#^PHPDoc tag @return with type mixed is not subtype of native type Psr\\\\Http\\\\Message\\\\ResponseInterface\\.$#"
+			count: 1
+			path: src/Service/File/Scanner/ClamFileScanner.php
+
+		-
+			message: "#^Parameter \\#1 \\$response of method App\\\\Service\\\\File\\\\Scanner\\\\ClamFileScanner\\:\\:scanResultIsPass\\(\\) expects GuzzleHttp\\\\Psr7\\\\Response, Psr\\\\Http\\\\Message\\\\ResponseInterface given\\.$#"
+			count: 1
+			path: src/Service/File/Scanner/ClamFileScanner.php
+
+		-
+			message: "#^Parameter \\#2 \\$subject of function preg_match expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Service/File/Scanner/ClamFileScanner.php
+
+		-
+			message: "#^Property App\\\\Service\\\\File\\\\Scanner\\\\Exception\\\\RiskyFileException\\:\\:\\$message has no type specified\\.$#"
+			count: 1
+			path: src/Service/File/Scanner/Exception/RiskyFileException.php
+
+		-
+			message: "#^Property App\\\\Service\\\\File\\\\Scanner\\\\Exception\\\\VirusFoundException\\:\\:\\$message has no type specified\\.$#"
+			count: 1
+			path: src/Service/File/Scanner/Exception/VirusFoundException.php
+
+		-
+			message: "#^Binary operation \"\\.\" between 'Invalid Reference…' and 0\\|0\\.0\\|''\\|'0'\\|array\\{\\}\\|false\\|null results in an error\\.$#"
+			count: 1
+			path: src/Service/File/Storage/S3Storage.php
+
+		-
+			message: "#^Call to an undefined method Aws\\\\S3\\\\S3ClientInterface\\:\\:deleteObject\\(\\)\\.$#"
+			count: 1
+			path: src/Service/File/Storage/S3Storage.php
+
+		-
+			message: "#^Call to an undefined method Aws\\\\S3\\\\S3ClientInterface\\:\\:deleteObjects\\(\\)\\.$#"
+			count: 1
+			path: src/Service/File/Storage/S3Storage.php
+
+		-
+			message: "#^Call to an undefined method Aws\\\\S3\\\\S3ClientInterface\\:\\:getObject\\(\\)\\.$#"
+			count: 1
+			path: src/Service/File/Storage/S3Storage.php
+
+		-
+			message: "#^Call to an undefined method Aws\\\\S3\\\\S3ClientInterface\\:\\:getObjectTagging\\(\\)\\.$#"
+			count: 1
+			path: src/Service/File/Storage/S3Storage.php
+
+		-
+			message: "#^Call to an undefined method Aws\\\\S3\\\\S3ClientInterface\\:\\:listObjectVersions\\(\\)\\.$#"
+			count: 1
+			path: src/Service/File/Storage/S3Storage.php
+
+		-
+			message: "#^Call to an undefined method Aws\\\\S3\\\\S3ClientInterface\\:\\:putObject\\(\\)\\.$#"
+			count: 1
+			path: src/Service/File/Storage/S3Storage.php
+
+		-
+			message: "#^Call to an undefined method Aws\\\\S3\\\\S3ClientInterface\\:\\:putObjectTagging\\(\\)\\.$#"
+			count: 1
+			path: src/Service/File/Storage/S3Storage.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\Storage\\\\S3Storage\\:\\:appendTagset\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: src/Service/File/Storage/S3Storage.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\Storage\\\\S3Storage\\:\\:appendTagset\\(\\) has parameter \\$newTagset with no type specified\\.$#"
+			count: 1
+			path: src/Service/File/Storage/S3Storage.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\Storage\\\\S3Storage\\:\\:checkFileExistsInS3\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/File/Storage/S3Storage.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\Storage\\\\S3Storage\\:\\:checkFileExistsInS3\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: src/Service/File/Storage/S3Storage.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\Storage\\\\S3Storage\\:\\:delete\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: src/Service/File/Storage/S3Storage.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\Storage\\\\S3Storage\\:\\:log\\(\\) has parameter \\$level with no type specified\\.$#"
+			count: 1
+			path: src/Service/File/Storage/S3Storage.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\Storage\\\\S3Storage\\:\\:log\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: src/Service/File/Storage/S3Storage.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\Storage\\\\S3Storage\\:\\:store\\(\\) has parameter \\$body with no type specified\\.$#"
+			count: 1
+			path: src/Service/File/Storage/S3Storage.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\Storage\\\\S3Storage\\:\\:store\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: src/Service/File/Storage/S3Storage.php
+
+		-
+			message: "#^Parameter \\#1 \\$length of method GuzzleHttp\\\\Psr7\\\\Stream\\:\\:read\\(\\) expects int, int\\|null given\\.$#"
+			count: 1
+			path: src/Service/File/Storage/S3Storage.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\Storage\\\\StorageInterface\\:\\:delete\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/File/Storage/StorageInterface.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\Storage\\\\StorageInterface\\:\\:delete\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: src/Service/File/Storage/StorageInterface.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\Storage\\\\StorageInterface\\:\\:retrieve\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/File/Storage/StorageInterface.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\Storage\\\\StorageInterface\\:\\:store\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/File/Storage/StorageInterface.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\Storage\\\\StorageInterface\\:\\:store\\(\\) has parameter \\$body with no type specified\\.$#"
+			count: 1
+			path: src/Service/File/Storage/StorageInterface.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\Storage\\\\StorageInterface\\:\\:store\\(\\) has parameter \\$key with no type specified\\.$#"
+			count: 1
+			path: src/Service/File/Storage/StorageInterface.php
+
+		-
+			message: "#^Cannot call method getMessage\\(\\) on Symfony\\\\Component\\\\Validator\\\\ConstraintViolationInterface\\|null\\.$#"
+			count: 1
+			path: src/Service/File/Verifier/ConstraintVerifier.php
+
+		-
+			message: "#^Parameter \\#1 \\$message of class Symfony\\\\Component\\\\Form\\\\FormError constructor expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Service/File/Verifier/MultiFileFormUploadVerifier.php
+
+		-
+			message: "#^Method App\\\\Service\\\\File\\\\Verifier\\\\VerificationStatus\\:\\:addError\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: src/Service/File/Verifier/VerificationStatus.php
+
+		-
+			message: "#^Method App\\\\Service\\\\HtmlToPdfGenerator\\:\\:__construct\\(\\) has parameter \\$timeoutSeconds with no type specified\\.$#"
+			count: 1
+			path: src/Service/HtmlToPdfGenerator.php
+
+		-
+			message: "#^Method App\\\\Service\\\\HtmlToPdfGenerator\\:\\:getPdfFromHtml\\(\\) should return string but returns bool\\|string\\.$#"
+			count: 1
+			path: src/Service/HtmlToPdfGenerator.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Service/HtmlToPdfGenerator.php
+
+		-
+			message: "#^Call to an undefined method Lcobucci\\\\JWT\\\\Token\\:\\:claims\\(\\)\\.$#"
+			count: 1
+			path: src/Service/JWT/JWTService.php
+
+		-
+			message: "#^Call to an undefined method Lcobucci\\\\JWT\\\\Token\\:\\:signature\\(\\)\\.$#"
+			count: 1
+			path: src/Service/JWT/JWTService.php
+
+		-
+			message: "#^Cannot access offset 'kid' on mixed\\.$#"
+			count: 1
+			path: src/Service/JWT/JWTService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\JWT\\\\JWTService\\:\\:base64EncodeJWT\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/JWT/JWTService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\JWT\\\\JWTService\\:\\:getPublicKeyByJWK\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/JWT/JWTService.php
+
+		-
+			message: "#^Parameter \\#1 \\$index of method Jose\\\\Component\\\\Core\\\\JWKSet\\:\\:get\\(\\) expects int\\|string, mixed given\\.$#"
+			count: 1
+			path: src/Service/JWT/JWTService.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function base64_encode expects string, string\\|false given\\.$#"
+			count: 3
+			path: src/Service/JWT/JWTService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Logger\\:\\:debug\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Logger.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Logger\\:\\:notice\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Logger.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Logger\\:\\:warning\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Logger.php
+
+		-
+			message: "#^Parameter \\#2 \\$context of method Psr\\\\Log\\\\LoggerInterface\\:\\:debug\\(\\) expects array, array\\|null given\\.$#"
+			count: 1
+			path: src/Service/Logger.php
+
+		-
+			message: "#^Parameter \\#2 \\$context of method Psr\\\\Log\\\\LoggerInterface\\:\\:warning\\(\\) expects array, array\\|null given\\.$#"
+			count: 1
+			path: src/Service/Logger.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\ReportInterface\\:\\:getEndDate\\(\\)\\.$#"
+			count: 1
+			path: src/Service/Mailer/MailFactory.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\ReportInterface\\:\\:getStartDate\\(\\)\\.$#"
+			count: 1
+			path: src/Service/Mailer/MailFactory.php
+
+		-
+			message: "#^Cannot call method format\\(\\) on DateTime\\|null\\.$#"
+			count: 4
+			path: src/Service/Mailer/MailFactory.php
+
+		-
+			message: "#^Cannot call method getCaseNumber\\(\\) on App\\\\Entity\\\\Client\\|null\\.$#"
+			count: 1
+			path: src/Service/Mailer/MailFactory.php
+
+		-
+			message: "#^Cannot clone DateTime\\|null\\.$#"
+			count: 2
+			path: src/Service/Mailer/MailFactory.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Mailer\\\\MailFactory\\:\\:createPostSubmissionFeedbackEmail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Mailer/MailFactory.php
+
+		-
+			message: "#^Property App\\\\Service\\\\Mailer\\\\MailFactory\\:\\:\\$templating has unknown class App\\\\Service\\\\Mailer\\\\EngineInterface as its type\\.$#"
+			count: 1
+			path: src/Service/Mailer/MailFactory.php
+
+		-
+			message: "#^Property App\\\\Service\\\\Mailer\\\\MailFactory\\:\\:\\$templating is unused\\.$#"
+			count: 1
+			path: src/Service/Mailer/MailFactory.php
+
+		-
+			message: "#^Parameter \\#2 \\$loggedInUser of method App\\\\Service\\\\Audit\\\\AuditEvents\\:\\:emailNotSent\\(\\) expects App\\\\Entity\\\\User\\|string\\|null, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Service/Mailer/MailSender.php
+
+		-
+			message: "#^Parameter \\#2 \\$loggedInUser of method App\\\\Service\\\\Audit\\\\AuditEvents\\:\\:emailSent\\(\\) expects App\\\\Entity\\\\User\\|string\\|null, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Service/Mailer/MailSender.php
+
+		-
+			message: "#^Parameter \\#2 \\$templateId of method Alphagov\\\\Notifications\\\\Client\\:\\:sendEmail\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Service/Mailer/MailSender.php
+
+		-
+			message: "#^Parameter \\#3 \\$personalisation of method Alphagov\\\\Notifications\\\\Client\\:\\:sendEmail\\(\\) expects array, array\\|null given\\.$#"
+			count: 1
+			path: src/Service/Mailer/MailSender.php
+
+		-
+			message: "#^Using nullsafe method call on non\\-nullable type Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\Storage\\\\TokenStorageInterface\\. Use \\-\\> instead\\.$#"
+			count: 2
+			path: src/Service/Mailer/MailSender.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Mailer\\\\NotifyClientMock\\:\\:getSentEmails\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Mailer/NotifyClientMock.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Mailer\\\\NotifyClientMock\\:\\:sendEmail\\(\\) has parameter \\$emailReplyToId with no type specified\\.$#"
+			count: 1
+			path: src/Service/Mailer/NotifyClientMock.php
+
+		-
+			message: "#^Cannot call method count\\(\\) on Doctrine\\\\Common\\\\Collections\\\\ArrayCollection\\|null\\.$#"
+			count: 1
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\NdrStatusService\\:\\:getActionsState\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\NdrStatusService\\:\\:getAssetsState\\(\\) should return string but returns array\\<string, int\\<0, max\\>\\|string\\>\\.$#"
+			count: 1
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\NdrStatusService\\:\\:getAssetsState\\(\\) should return string but returns array\\<string, int\\|string\\>\\.$#"
+			count: 1
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\NdrStatusService\\:\\:getBankAccountsState\\(\\) should return string but returns array\\<string, int\\<1, max\\>\\|string\\>\\.$#"
+			count: 1
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\NdrStatusService\\:\\:getBankAccountsState\\(\\) should return string but returns array\\<string, int\\|string\\>\\.$#"
+			count: 1
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\NdrStatusService\\:\\:getDebtsState\\(\\) should return string but returns array\\<string, int\\<0, max\\>\\|string\\>\\.$#"
+			count: 2
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\NdrStatusService\\:\\:getDebtsState\\(\\) should return string but returns array\\<string, int\\|string\\>\\.$#"
+			count: 1
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\NdrStatusService\\:\\:getExpensesState\\(\\) should return string but returns array\\<string, int\\<0, max\\>\\|string\\>\\.$#"
+			count: 1
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\NdrStatusService\\:\\:getExpensesState\\(\\) should return string but returns array\\<string, int\\|string\\>\\.$#"
+			count: 1
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\NdrStatusService\\:\\:getIncomeBenefitsState\\(\\) should return string but returns array\\<string, int\\|string\\>\\.$#"
+			count: 2
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\NdrStatusService\\:\\:getOtherInfoState\\(\\) should return string but returns array\\<string, int\\|string\\>\\.$#"
+			count: 2
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\NdrStatusService\\:\\:getSubmitState\\(\\) should return string but returns array\\<string, int\\|string\\>\\.$#"
+			count: 1
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\NdrStatusService\\:\\:getVisitsCareState\\(\\) should return string but returns array\\<string, int\\|string\\>\\.$#"
+			count: 3
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Offset 'doOthersReceiveInco…' does not exist on array\\{\\}\\|array\\{whenChecked\\: string, doOthersReceiveIncome\\: string\\|null, incomeTypes\\: true\\|null\\}\\.$#"
+			count: 1
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Offset 'state' does not exist on string\\.$#"
+			count: 7
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Result of && is always true\\.$#"
+			count: 2
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Right side of \\|\\| is always true\\.$#"
+			count: 1
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 2
+			path: src/Service/NdrStatusService.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\HttpFoundation\\\\Session\\\\SessionInterface\\:\\:getFlashBag\\(\\)\\.$#"
+			count: 1
+			path: src/Service/OrgService.php
+
+		-
+			message: "#^Cannot call method getUser\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\TokenInterface\\|null\\.$#"
+			count: 1
+			path: src/Service/OrgService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\OrgService\\:\\:addFlashMessages\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/OrgService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\OrgService\\:\\:dispatchCSVUploadEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/OrgService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\OrgService\\:\\:dispatchDeputyChangingOrganisationEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/OrgService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\OrgService\\:\\:dispatchOrgCreatedEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/OrgService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\OrgService\\:\\:finishStream\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/OrgService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\OrgService\\:\\:log\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/OrgService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\OrgService\\:\\:logProgress\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/OrgService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\OrgService\\:\\:processChunks\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/OrgService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\OrgService\\:\\:storeChunkOutput\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/OrgService.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_chunk expects array, mixed given\\.$#"
+			count: 1
+			path: src/Service/OrgService.php
+
+		-
+			message: "#^Parameter \\#2 \\$currentUser of class App\\\\Event\\\\OrgCreatedEvent constructor expects App\\\\Entity\\\\User, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
+			count: 1
+			path: src/Service/OrgService.php
+
+		-
+			message: "#^Cannot access offset 'Value' on mixed\\.$#"
+			count: 2
+			path: src/Service/ParameterStoreService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\ParameterStoreService\\:\\:getFeatureFlag\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/ParameterStoreService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\ParameterStoreService\\:\\:getParameter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/ParameterStoreService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\ParameterStoreService\\:\\:putFeatureFlag\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/ParameterStoreService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\ParameterStoreService\\:\\:putParameter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/ParameterStoreService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Redirector\\:\\:getCorrectLayHomepage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Redirector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Redirector\\:\\:getHomepageRedirect\\(\\) should return string but returns false\\.$#"
+			count: 1
+			path: src/Service/Redirector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Redirector\\:\\:getLayDeputyHomepage\\(\\) has parameter \\$activeClientId with no type specified\\.$#"
+			count: 1
+			path: src/Service/Redirector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Redirector\\:\\:getLoggedUser\\(\\) should return App\\\\Entity\\\\User\\|null but returns Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null\\.$#"
+			count: 1
+			path: src/Service/Redirector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\Redirector\\:\\:removeLastAccessedUrl\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/Redirector.php
+
+		-
+			message: "#^Parameter \\#1 \\$name of method Symfony\\\\Component\\\\Routing\\\\Generator\\\\UrlGeneratorInterface\\:\\:generate\\(\\) expects string, string\\|true given\\.$#"
+			count: 2
+			path: src/Service/Redirector.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\ReportInterface\\:\\:hasSection\\(\\)\\.$#"
+			count: 3
+			path: src/Service/ReportSectionsLinkService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\ReportSectionsLinkService\\:\\:getSectionParams\\(\\) has parameter \\$sectionId with no type specified\\.$#"
+			count: 1
+			path: src/Service/ReportSectionsLinkService.php
+
+		-
+			message: "#^Call to method render\\(\\) on an unknown class App\\\\Service\\\\Templating\\.$#"
+			count: 2
+			path: src/Service/ReportSubmissionService.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Service/ReportSubmissionService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\ReportSubmissionService\\:\\:assertReportSubmissionIsDownloadable\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/ReportSubmissionService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\ReportSubmissionService\\:\\:generateReportDocuments\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/ReportSubmissionService.php
+
+		-
+			message: "#^Method App\\\\Service\\\\ReportSubmissionService\\:\\:getReportSubmissionById\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/ReportSubmissionService.php
+
+		-
+			message: "#^PHPDoc tag @throws with type App\\\\Service\\\\ReportSubmissionDocumentsNotDownloadableExceptionAlias is not subtype of Throwable$#"
+			count: 1
+			path: src/Service/ReportSubmissionService.php
+
+		-
+			message: "#^Property App\\\\Service\\\\ReportSubmissionService\\:\\:\\$mailFactory is never read, only written\\.$#"
+			count: 1
+			path: src/Service/ReportSubmissionService.php
+
+		-
+			message: "#^Property App\\\\Service\\\\ReportSubmissionService\\:\\:\\$mailSender is never read, only written\\.$#"
+			count: 1
+			path: src/Service/ReportSubmissionService.php
+
+		-
+			message: "#^Property App\\\\Service\\\\ReportSubmissionService\\:\\:\\$templating \\(App\\\\Service\\\\Templating\\) does not accept Twig\\\\Environment\\.$#"
+			count: 1
+			path: src/Service/ReportSubmissionService.php
+
+		-
+			message: "#^Property App\\\\Service\\\\ReportSubmissionService\\:\\:\\$templating has unknown class App\\\\Service\\\\Templating as its type\\.$#"
+			count: 1
+			path: src/Service/ReportSubmissionService.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between false and string will always evaluate to false\\.$#"
+			count: 1
+			path: src/Service/ReportSubmissionService.php
+
+		-
+			message: "#^Cannot call method getCurrentRequest\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Service/RequestIdLoggerProcessor.php
+
+		-
+			message: "#^Method App\\\\Service\\\\RequestIdLoggerProcessor\\:\\:getRequestIdFromContainer\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/RequestIdLoggerProcessor.php
+
+		-
+			message: "#^Method App\\\\Service\\\\SecretManagerService\\:\\:getSecret\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/SecretManagerService.php
+
+		-
+			message: "#^Cannot access offset 'error' on mixed\\.$#"
+			count: 1
+			path: src/Service/SiriusApiErrorTranslator.php
+
+		-
+			message: "#^Cannot call method getCode\\(\\) on App\\\\Model\\\\Sirius\\\\SiriusApiError\\|string\\.$#"
+			count: 1
+			path: src/Service/SiriusApiErrorTranslator.php
+
+		-
+			message: "#^Cannot call method getDetail\\(\\) on App\\\\Model\\\\Sirius\\\\SiriusApiError\\|string\\.$#"
+			count: 1
+			path: src/Service/SiriusApiErrorTranslator.php
+
+		-
+			message: "#^Method App\\\\Service\\\\SiriusApiErrorTranslator\\:\\:deserializeError\\(\\) should return App\\\\Model\\\\Sirius\\\\SiriusApiError\\|string but returns mixed\\.$#"
+			count: 1
+			path: src/Service/SiriusApiErrorTranslator.php
+
+		-
+			message: "#^Method App\\\\Service\\\\SiriusApiErrorTranslator\\:\\:jsonIsInUnexpectedFormat\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/SiriusApiErrorTranslator.php
+
+		-
+			message: "#^Method App\\\\Service\\\\SiriusApiErrorTranslator\\:\\:translateApiError\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/SiriusApiErrorTranslator.php
+
+		-
+			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, mixed given\\.$#"
+			count: 1
+			path: src/Service/SiriusApiErrorTranslator.php
+
+		-
+			message: "#^Binary operation \"\\+\" between string and 1 results in an error\\.$#"
+			count: 2
+			path: src/Service/StepRedirector.php
+
+		-
+			message: "#^Binary operation \"\\-\" between string and 1 results in an error\\.$#"
+			count: 1
+			path: src/Service/StepRedirector.php
+
+		-
+			message: "#^Cannot cast mixed to int\\.$#"
+			count: 2
+			path: src/Service/StepRedirector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\StepRedirector\\:\\:generateUrl\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/StepRedirector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\StepRedirector\\:\\:generateUrl\\(\\) has parameter \\$route with no type specified\\.$#"
+			count: 1
+			path: src/Service/StepRedirector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\StepRedirector\\:\\:getBackLink\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/StepRedirector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\StepRedirector\\:\\:getRedirectLinkAfterSaving\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/StepRedirector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\StepRedirector\\:\\:getSkipLink\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/StepRedirector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\StepRedirector\\:\\:setFromPage\\(\\) has parameter \\$fromPage with no type specified\\.$#"
+			count: 1
+			path: src/Service/StepRedirector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\StepRedirector\\:\\:setRoutes\\(\\) has parameter \\$routeStep with no type specified\\.$#"
+			count: 1
+			path: src/Service/StepRedirector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\StepRedirector\\:\\:setRoutes\\(\\) has parameter \\$routeSummary with no type specified\\.$#"
+			count: 1
+			path: src/Service/StepRedirector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\StepRedirector\\:\\:setRoutes\\(\\) has parameter \\$step1BackLink with no type specified\\.$#"
+			count: 1
+			path: src/Service/StepRedirector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\StepRedirector\\:\\:setTotalSteps\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/StepRedirector.php
+
+		-
+			message: "#^PHPDoc tag @param for parameter \\$stepUrlAdditionalParams with type mixed is not subtype of native type array\\.$#"
+			count: 1
+			path: src/Service/StepRedirector.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(mixed \\$this \\-\\>fromPage\\)\\: Unexpected token \"\\$this\", expected variable at offset 24$#"
+			count: 1
+			path: src/Service/StepRedirector.php
+
+		-
+			message: "#^Property App\\\\Service\\\\StepRedirector\\:\\:\\$currentStep \\(string\\) does not accept int\\.$#"
+			count: 1
+			path: src/Service/StepRedirector.php
+
+		-
+			message: "#^Property App\\\\Service\\\\StepRedirector\\:\\:\\$totalSteps \\(string\\) does not accept int\\.$#"
+			count: 1
+			path: src/Service/StepRedirector.php
+
+		-
+			message: "#^Method App\\\\Service\\\\StringUtils\\:\\:implodeWithDifferentLast\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Service/StringUtils.php
+
+		-
+			message: "#^Method App\\\\TestHelpers\\\\ClientHelpers\\:\\:createValidCaseNumber\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/TestHelpers/ClientHelpers.php
+
+		-
+			message: "#^Method App\\\\TestHelpers\\\\DeputyHelper\\:\\:createDeputy\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/TestHelpers/DeputyHelper.php
+
+		-
+			message: "#^Class App\\\\Entity\\\\Report\\\\Document does not have a constructor and must be instantiated without any parameters\\.$#"
+			count: 1
+			path: src/TestHelpers/DocumentHelpers.php
+
+		-
+			message: "#^Method App\\\\TestHelpers\\\\DocumentHelpers\\:\\:createReportPdfDocument\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/TestHelpers/DocumentHelpers.php
+
+		-
+			message: "#^Method App\\\\TestHelpers\\\\DocumentHelpers\\:\\:createSupportingDocument\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/TestHelpers/DocumentHelpers.php
+
+		-
+			message: "#^Parameter \\#1 \\$parameters of method App\\\\Model\\\\Email\\:\\:setParameters\\(\\) expects array, array\\|string given\\.$#"
+			count: 1
+			path: src/TestHelpers/EmailHelpers.php
+
+		-
+			message: "#^Cannot call method setOrganisations\\(\\) on array\\|object\\.$#"
+			count: 2
+			path: src/TestHelpers/OrganisationHelpers.php
+
+		-
+			message: "#^Method App\\\\TestHelpers\\\\OrganisationHelpers\\:\\:createInactiveOrganisation\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/TestHelpers/OrganisationHelpers.php
+
+		-
+			message: "#^Parameter \\#1 \\$isActivated of method App\\\\Entity\\\\Organisation\\:\\:setIsActivated\\(\\) expects string, false given\\.$#"
+			count: 1
+			path: src/TestHelpers/OrganisationHelpers.php
+
+		-
+			message: "#^Parameter \\#1 \\$isActivated of method App\\\\Entity\\\\Organisation\\:\\:setIsActivated\\(\\) expects string, true given\\.$#"
+			count: 1
+			path: src/TestHelpers/OrganisationHelpers.php
+
+		-
+			message: "#^Parameter \\#1 \\$submittedBy of method App\\\\Entity\\\\Report\\\\Report\\:\\:setSubmittedBy\\(\\) expects App\\\\Entity\\\\User\\|null, array\\|object given\\.$#"
+			count: 1
+			path: src/TestHelpers/ReportHelpers.php
+
+		-
+			message: "#^Parameter \\#1 \\$deputyrole of method App\\\\Entity\\\\Report\\\\Satisfaction\\:\\:setDeputyrole\\(\\) expects string, int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/TestHelpers/SatisfactionHelpers.php
+
+		-
+			message: "#^Argument of an invalid type array\\|object supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/TestHelpers/UserHelpers.php
+
+		-
+			message: "#^Cannot call method deserialize\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: src/TestHelpers/UserHelpers.php
+
+		-
+			message: "#^Cannot call method setEmail\\(\\) on array\\|object\\.$#"
+			count: 1
+			path: src/TestHelpers/UserHelpers.php
+
+		-
+			message: "#^Cannot call method setRoleName\\(\\) on array\\|object\\.$#"
+			count: 12
+			path: src/TestHelpers/UserHelpers.php
+
+		-
+			message: "#^Parameter \\#1 \\$deputyshipLength of method App\\\\Entity\\\\UserResearch\\\\UserResearchResponse\\:\\:setDeputyshipLength\\(\\) expects string, int\\|string\\|null given\\.$#"
+			count: 1
+			path: src/TestHelpers/UserResearchResponseHelpers.php
+
+		-
+			message: "#^Parameter \\#1 \\$user of method App\\\\Entity\\\\UserResearch\\\\UserResearchResponse\\:\\:setUser\\(\\) expects App\\\\Entity\\\\User\\|null, array\\|object given\\.$#"
+			count: 1
+			path: src/TestHelpers/UserResearchResponseHelpers.php
+
+		-
+			message: "#^Method App\\\\Transformer\\\\ReportSubmission\\\\ReportSubmissionBurFixedWidthTransformer\\:\\:transformItem\\(\\) has parameter \\$reportSubmissionSummary with no type specified\\.$#"
+			count: 1
+			path: src/Transformer/ReportSubmission/ReportSubmissionBurFixedWidthTransformer.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function str_pad expects string, null given\\.$#"
+			count: 1
+			path: src/Transformer/ReportSubmission/ReportSubmissionBurFixedWidthTransformer.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of method App\\\\Transformer\\\\ReportSubmission\\\\ReportSubmissionBurFixedWidthTransformer\\:\\:fixLineLength\\(\\) expects null, string given\\.$#"
+			count: 4
+			path: src/Transformer/ReportSubmission/ReportSubmissionBurFixedWidthTransformer.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\AssetsExtension\\:\\:assetSourceFilter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Twig/AssetsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\AssetsExtension\\:\\:assetSourceFilter\\(\\) has parameter \\$originalUrl with no type specified\\.$#"
+			count: 1
+			path: src/Twig/AssetsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\AssetsExtension\\:\\:assetUrlFilter\\(\\) has parameter \\$originalUrl with no type specified\\.$#"
+			count: 1
+			path: src/Twig/AssetsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\AssetsExtension\\:\\:getName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Twig/AssetsExtension.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function array_diff expects array, array\\<int, string\\>\\|false given\\.$#"
+			count: 1
+			path: src/Twig/AssetsExtension.php
+
+		-
+			message: "#^Unable to resolve the template type T in call to function array_values$#"
+			count: 1
+			path: src/Twig/AssetsExtension.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Contracts\\\\Translation\\\\TranslatorInterface\\:\\:transChoice\\(\\)\\.$#"
+			count: 2
+			path: src/Twig/ComponentsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\ComponentsExtension\\:\\:getName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Twig/ComponentsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\ComponentsExtension\\:\\:progressBarRegistration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Twig/ComponentsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\ComponentsExtension\\:\\:progressBarRegistration\\(\\) has parameter \\$selectedStepId with no type specified\\.$#"
+			count: 1
+			path: src/Twig/ComponentsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\ComponentsExtension\\:\\:renderHiddenGaEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Twig/ComponentsExtension.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\\\DateTime from\\)\\: Unexpected token \"from\", expected variable at offset 28$#"
+			count: 1
+			path: src/Twig/ComponentsExtension.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\\\DateTime to\\)\\: Unexpected token \"to\", expected variable at offset 57$#"
+			count: 1
+			path: src/Twig/ComponentsExtension.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(string defaultDateFormat e\\.g\\. d F Y\\)\\: Unexpected token \"defaultDateFormat\", expected variable at offset 120$#"
+			count: 1
+			path: src/Twig/ComponentsExtension.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(string translationDomain\\)\\: Unexpected token \"translationDomain\", expected variable at offset 170$#"
+			count: 1
+			path: src/Twig/ComponentsExtension.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(string translationPrefix\\)\\: Unexpected token \"translationPrefix\", expected variable at offset 81$#"
+			count: 1
+			path: src/Twig/ComponentsExtension.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strtolower expects string, array\\<int, string\\>\\|string given\\.$#"
+			count: 1
+			path: src/Twig/ComponentsExtension.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, array\\<int, string\\>\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Twig/ComponentsExtension.php
+
+		-
+			message: "#^Cannot access property \\$vars on mixed\\.$#"
+			count: 2
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:getName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderCheckboxGroup\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderCheckboxGroup\\(\\) has parameter \\$elementName with no type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderCheckboxGroup\\(\\) has parameter \\$transIndex with no type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderCheckboxGroup\\(\\) has parameter \\$vars with no type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderCheckboxGroupNew\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderCheckboxGroupNew\\(\\) has parameter \\$elementName with no type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderCheckboxGroupNew\\(\\) has parameter \\$transIndex with no type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderCheckboxGroupNew\\(\\) has parameter \\$vars with no type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderCheckboxInput\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderFormDropDown\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderFormErrors\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderFormErrors\\(\\) has parameter \\$element with no type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderFormErrorsList\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderFormInput\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderFormKnownDate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderFormKnownDate\\(\\) has parameter \\$element with no type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderFormKnownDate\\(\\) has parameter \\$elementName with no type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderFormKnownDate\\(\\) has parameter \\$transIndex with no type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderFormSortCode\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderFormSortCode\\(\\) has parameter \\$element with no type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderFormSortCode\\(\\) has parameter \\$elementName with no type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderFormSortCode\\(\\) has parameter \\$transIndex with no type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderFormSubmit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Method App\\\\Twig\\\\FormFieldsExtension\\:\\:renderGATrackedFormSubmit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^PHPDoc tag @param for parameter \\$gaTrackingAction with type string\\|null is not subtype of native type string\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^PHPDoc tag @param for parameter \\$gaTrackingCategory with type string\\|null is not subtype of native type string\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Parameter \\#1 \\$element of method App\\\\Twig\\\\FormFieldsExtension\\:\\:getFormComponentTwigVariables\\(\\) expects Symfony\\\\Component\\\\Form\\\\FormView, mixed given\\.$#"
+			count: 3
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Parameter \\#3 \\$gaTrackingLabel of method App\\\\Twig\\\\FormFieldsExtension\\:\\:addGaAttrsToElementAttrs\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Parameter \\#4 \\$transIndex of method App\\\\Twig\\\\FormFieldsExtension\\:\\:getFormComponentTwigVariables\\(\\) expects string\\|null, int\\|null given\\.$#"
+			count: 3
+			path: src/Twig/FormFieldsExtension.php
+
+		-
+			message: "#^Property App\\\\Validator\\\\Constraints\\\\Chain\\:\\:\\$constraints has no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/Chain.php
+
+		-
+			message: "#^Property App\\\\Validator\\\\Constraints\\\\Chain\\:\\:\\$stopOnError has no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/Chain.php
+
+		-
+			message: "#^Access to an undefined property Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:\\$constraints\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ChainValidator.php
+
+		-
+			message: "#^Access to an undefined property Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:\\$stopOnError\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ChainValidator.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Validator\\\\Context\\\\ExecutionContextInterface\\:\\:validateValue\\(\\)\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ChainValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ChainValidator\\:\\:validate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ChainValidator.php
+
+		-
+			message: "#^Property App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheck\\:\\:\\$mode has no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheck.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\ClientBenefitsCheckInterface\\:\\:getDoOthersReceiveMoneyOnClientsBehalf\\(\\)\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\ClientBenefitsCheckInterface\\:\\:getTypesOfMoneyReceivedOnClientsBehalf\\(\\)\\.$#"
+			count: 3
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\ClientBenefitsCheckInterface\\:\\:getWhenLastCheckedEntitlement\\(\\)\\.$#"
+			count: 2
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Cannot call method getNdr\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Cannot call method getReport\\(\\) on object\\|null\\.$#"
+			count: 2
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:dateLastCheckedEntitlementValid\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:dateLastCheckedEntitlementValid\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:dontKnowMoneyExplanationValid\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:dontKnowMoneyExplanationValid\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:moneyOnClientsBehalfValid\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:moneyOnClientsBehalfValid\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:neverCheckedExplanationValid\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:neverCheckedExplanationValid\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:typesOfMoneyReceivedOnClientsBehalfValid\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:typesOfMoneyReceivedOnClientsBehalfValid\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:validate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:whenLastCheckedEntitlementValid\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:whenLastCheckedEntitlementValid\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Parameter \\#2 \\$object of method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:dateLastCheckedEntitlementValid\\(\\) expects App\\\\Entity\\\\ClientBenefitsCheckInterface, object\\|null given\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Parameter \\#2 \\$object of method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:dontKnowMoneyExplanationValid\\(\\) expects App\\\\Entity\\\\ClientBenefitsCheckInterface, object\\|null given\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Parameter \\#2 \\$object of method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:moneyOnClientsBehalfValid\\(\\) expects App\\\\Entity\\\\ClientBenefitsCheckInterface, object\\|null given\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Parameter \\#2 \\$object of method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:neverCheckedExplanationValid\\(\\) expects App\\\\Entity\\\\ClientBenefitsCheckInterface, object\\|null given\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Parameter \\#2 \\$object of method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:typesOfMoneyReceivedOnClientsBehalfValid\\(\\) expects App\\\\Entity\\\\ClientBenefitsCheckInterface, object\\|null given\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Parameter \\#2 \\$object of method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\ClientBenefitsCheckValidator\\:\\:whenLastCheckedEntitlementValid\\(\\) expects App\\\\Entity\\\\ClientBenefitsCheckInterface, object\\|null given\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Parameter \\#2 \\$value of method Symfony\\\\Component\\\\Validator\\\\Violation\\\\ConstraintViolationBuilderInterface\\:\\:setParameter\\(\\) expects string, string\\|null given\\.$#"
+			count: 9
+			path: src/Validator/Constraints/ClientBenefitsCheck/ClientBenefitsCheckValidator.php
+
+		-
+			message: "#^Property App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\MoneyReceivedOnClientsBehalf\\:\\:\\$mode has no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/MoneyReceivedOnClientsBehalf.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\MoneyReceivedOnClientsBehalfInterface\\:\\:getAmount\\(\\)\\.$#"
+			count: 2
+			path: src/Validator/Constraints/ClientBenefitsCheck/MoneyReceivedOnClientsBehalfValidator.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\MoneyReceivedOnClientsBehalfInterface\\:\\:getAmountDontKnow\\(\\)\\.$#"
+			count: 2
+			path: src/Validator/Constraints/ClientBenefitsCheck/MoneyReceivedOnClientsBehalfValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\MoneyReceivedOnClientsBehalfValidator\\:\\:amountDontKnowValid\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/MoneyReceivedOnClientsBehalfValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\MoneyReceivedOnClientsBehalfValidator\\:\\:amountDontKnowValid\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/MoneyReceivedOnClientsBehalfValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\MoneyReceivedOnClientsBehalfValidator\\:\\:amountValid\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/MoneyReceivedOnClientsBehalfValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\MoneyReceivedOnClientsBehalfValidator\\:\\:amountValid\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/MoneyReceivedOnClientsBehalfValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ClientBenefitsCheck\\\\MoneyReceivedOnClientsBehalfValidator\\:\\:validate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ClientBenefitsCheck/MoneyReceivedOnClientsBehalfValidator.php
+
+		-
+			message: "#^Property App\\\\Validator\\\\Constraints\\\\CommonPassword\\:\\:\\$message has no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/CommonPassword.php
+
+		-
+			message: "#^Access to an undefined property Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:\\$message\\.$#"
+			count: 1
+			path: src/Validator/Constraints/CommonPasswordValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\CommonPasswordValidator\\:\\:checkCommonPasswordsFileExists\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/CommonPasswordValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\CommonPasswordValidator\\:\\:passwordMatchesCommonPasswords\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/CommonPasswordValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\CommonPasswordValidator\\:\\:validate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/CommonPasswordValidator.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Validator/Constraints/CommonPasswordValidator.php
+
+		-
+			message: "#^Parameter \\#1 \\$searchTerm of method App\\\\Validator\\\\Constraints\\\\CommonPasswordValidator\\:\\:passwordMatchesCommonPasswords\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Validator/Constraints/CommonPasswordValidator.php
+
+		-
+			message: "#^Property App\\\\Validator\\\\Constraints\\\\DUserPassword\\:\\:\\$service has no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/DUserPassword.php
+
+		-
+			message: "#^Access to an undefined property Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:\\$message\\.$#"
+			count: 1
+			path: src/Validator/Constraints/DUserPasswordValidator.php
+
+		-
+			message: "#^Cannot call method getUser\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\TokenInterface\\|null\\.$#"
+			count: 1
+			path: src/Validator/Constraints/DUserPasswordValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\DUserPasswordValidator\\:\\:isOldPasswordValid\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/DUserPasswordValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\DUserPasswordValidator\\:\\:isOldPasswordValid\\(\\) has parameter \\$password with no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/DUserPasswordValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\DUserPasswordValidator\\:\\:isOldPasswordValid\\(\\) has parameter \\$user with no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/DUserPasswordValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\DUserPasswordValidator\\:\\:validate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/DUserPasswordValidator.php
+
+		-
+			message: "#^Cannot access offset 'groups'\\|'message' on mixed\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EmailSameDomain.php
+
+		-
+			message: "#^Class Symfony\\\\Component\\\\Validator\\\\Exception\\\\MissingOptionsException constructor invoked with 1 parameter, 2 required\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EmailSameDomain.php
+
+		-
+			message: "#^PHPDoc type array of property App\\\\Validator\\\\Constraints\\\\EmailSameDomain\\:\\:\\$groups is not covariant with PHPDoc type array\\<string\\> of overridden property Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:\\$groups\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EmailSameDomain.php
+
+		-
+			message: "#^Property App\\\\Validator\\\\Constraints\\\\EmailSameDomain\\:\\:\\$groups \\(array\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EmailSameDomain.php
+
+		-
+			message: "#^Property App\\\\Validator\\\\Constraints\\\\EmailSameDomain\\:\\:\\$message \\(string\\) does not accept mixed\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EmailSameDomain.php
+
+		-
+			message: "#^Access to an undefined property Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:\\$message\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EmailSameDomainValidator.php
+
+		-
+			message: "#^Cannot call method getUser\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\TokenInterface\\|null\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EmailSameDomainValidator.php
+
+		-
+			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EmailSameDomainValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\EmailSameDomainValidator\\:\\:getDomain\\(\\) has parameter \\$email with no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EmailSameDomainValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\EmailSameDomainValidator\\:\\:getLoggedUser\\(\\) should return App\\\\Entity\\\\User but returns Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EmailSameDomainValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\EmailSameDomainValidator\\:\\:setTokenStorage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EmailSameDomainValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\EmailSameDomainValidator\\:\\:setTranslator\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EmailSameDomainValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\EmailSameDomainValidator\\:\\:translate\\(\\) has parameter \\$domain with no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EmailSameDomainValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\EmailSameDomainValidator\\:\\:translate\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EmailSameDomainValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\EmailSameDomainValidator\\:\\:translate\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EmailSameDomainValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\EmailSameDomainValidator\\:\\:validate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EmailSameDomainValidator.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EmailSameDomainValidator.php
+
+		-
+			message: "#^Property App\\\\Validator\\\\Constraints\\\\EmailSameDomainValidator\\:\\:\\$translator \\(Symfony\\\\Component\\\\Translation\\\\Translator\\) does not accept Symfony\\\\Contracts\\\\Translation\\\\TranslatorInterface\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EmailSameDomainValidator.php
+
+		-
+			message: "#^Access to an undefined property Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:\\$message\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EndDateNotBeforeStartDateValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\EndDateNotBeforeStartDateValidator\\:\\:validate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EndDateNotBeforeStartDateValidator.php
+
+		-
+			message: "#^Access to an undefined property Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:\\$message\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EndDateNotGreaterThanFifteenMonthsValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\EndDateNotGreaterThanFifteenMonthsValidator\\:\\:validate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/EndDateNotGreaterThanFifteenMonthsValidator.php
+
+		-
+			message: "#^Access to an undefined property Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:\\$message\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ProfDeputyCostsEstimate/CostBreakdownNotGreaterThanTotalValidator.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\ReportInterface\\:\\:getProfDeputyEstimateCosts\\(\\)\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ProfDeputyCostsEstimate/CostBreakdownNotGreaterThanTotalValidator.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\ReportInterface\\:\\:getProfDeputyManagementCostAmount\\(\\)\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ProfDeputyCostsEstimate/CostBreakdownNotGreaterThanTotalValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\ProfDeputyCostsEstimate\\\\CostBreakdownNotGreaterThanTotalValidator\\:\\:validate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/ProfDeputyCostsEstimate/CostBreakdownNotGreaterThanTotalValidator.php
+
+		-
+			message: "#^Access to an undefined property Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:\\$message\\.$#"
+			count: 2
+			path: src/Validator/Constraints/YearMustBeFourDigitsAndValidValidator.php
+
+		-
+			message: "#^Cannot call method format\\(\\) on DateTime\\|null\\.$#"
+			count: 1
+			path: src/Validator/Constraints/YearMustBeFourDigitsAndValidValidator.php
+
+		-
+			message: "#^Cannot call method getCourtDate\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Validator/Constraints/YearMustBeFourDigitsAndValidValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\YearMustBeFourDigitsAndValidValidator\\:\\:validate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/YearMustBeFourDigitsAndValidValidator.php
+
+		-
+			message: "#^Property App\\\\Validator\\\\Constraints\\\\YesNoNa\\:\\:\\$message has no type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/YesNoNa.php
+
+		-
+			message: "#^Access to an undefined property Symfony\\\\Component\\\\Validator\\\\Constraint\\:\\:\\$message\\.$#"
+			count: 1
+			path: src/Validator/Constraints/YesNoNaValidator.php
+
+		-
+			message: "#^Method App\\\\Validator\\\\Constraints\\\\YesNoNaValidator\\:\\:validate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Validator/Constraints/YesNoNaValidator.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$data$#"
+			count: 1
+			path: src/Validator/Constraints/YesNoNaValidator.php

--- a/client/app/phpstan.neon
+++ b/client/app/phpstan.neon
@@ -2,4 +2,7 @@ includes:
   - vendor/phpstan/phpstan-mockery/extension.neon
   - vendor/phpstan/phpstan-phpunit/extension.neon
   - vendor/jangregor/phpstan-prophecy/extension.neon
+  - phpstan-baseline.neon
 parameters:
+    ignoreErrors:
+        - identifier: missingType.iterableValue

--- a/client/app/src/Command/ProcessLayCSVCommand.php
+++ b/client/app/src/Command/ProcessLayCSVCommand.php
@@ -128,6 +128,8 @@ class ProcessLayCSVCommand extends Command
         } catch (Throwable $e) {
             $this->verboseLogger->error(sprintf('Error processing CSV file: %s', $e->getMessage()));
         }
+
+        return [];
     }
 
     private function process(mixed $data, string $email): void

--- a/client/app/src/Command/ProcessOrgCSVCommand.php
+++ b/client/app/src/Command/ProcessOrgCSVCommand.php
@@ -149,6 +149,8 @@ class ProcessOrgCSVCommand extends Command
         } catch (\Throwable $e) {
             $this->logger->error(sprintf('Error processing CSV: %s', $e->getMessage()));
         }
+
+        return [];
     }
 
     private function process(mixed $data, string $email): bool

--- a/client/app/src/Form/Admin/FullReviewChecklistType.php
+++ b/client/app/src/Form/Admin/FullReviewChecklistType.php
@@ -25,7 +25,7 @@ class FullReviewChecklistType extends AbstractType
         ];
 
         $builder
-            ->add('decisionExplanation', FormTypes\TextAreaType::class)
+            ->add('decisionExplanation', FormTypes\TextareaType::class)
             ->add('fullBankStatementsExist', FormTypes\ChoiceType::class, $yesNoNaOptions)
             ->add('anyLodgingConcerns', FormTypes\ChoiceType::class, $yesNoNaOptions)
             ->add('spendingAcceptable', FormTypes\ChoiceType::class, $yesNoNaOptions)

--- a/client/docker/app/Dockerfile
+++ b/client/docker/app/Dockerfile
@@ -79,6 +79,7 @@ COPY --chown=www-data:www-data client/resources/assets assets
 COPY --chown=www-data:www-data client/app/translations translations
 COPY --chown=www-data:www-data client/app/tests tests
 COPY --chown=www-data:www-data client/app/phpstan.neon .
+COPY --chown=www-data:www-data client/app/phpstan-baseline.neon .
 COPY --chown=www-data:www-data client/app/frontend.env frontend.env
 COPY --chown=www-data:www-data client/app/admin.env admin.env
 COPY --chown=www-data:www-data client/docker/app/config/www.conf /usr/local/etc/php-fpm.d/www.conf

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -21,6 +21,7 @@ services:
       - ./client/app/templates:/var/www/templates
       - ./client/app/translations:/var/www/translations
       - ./client/app/phpstan.neon:/var/www/phpstan.neon
+      - ./client/app/phpstan-baseline.neon:/var/www/phpstan-baseline.neon
       - ./client/app/composer.json:/var/www/composer.json
       - ./client/app/composer.lock:/var/www/composer.lock
       - ./scripts/miscellaneous/install-composer.sh:/var/www/install-composer.sh


### PR DESCRIPTION
## Purpose
Add PHPStan checks for client app to CI to catch issues that are easy to miss in manual review

Fixes DDLS-579

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
