### PR TITLE
DDLS-540 + DDLS-541 Always show "Your clients" link in nav / redirect single client deputy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ down-app: ##@application Tears down the app
 end-to-end-tests: up-app reset-database ##@end-to-end-tests Brings the app up using test env vars (see test.env)
 	REQUIRE_XDEBUG_CLIENT=0 REQUIRE_XDEBUG_API=0 docker compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml build frontend-app frontend-webserver admin-app admin-webserver api-app end-to-end-tests
 	REQUIRE_XDEBUG_CLIENT=0 REQUIRE_XDEBUG_API=0 docker compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml up -d load-balancer
-	APP_DEBUG=0 docker compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml run --remove-orphans end-to-end-tests sh ./tests/Behat/run-tests.sh --tags @v2
+	APP_DEBUG=0 docker compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml run --remove-orphans end-to-end-tests sh ./tests/Behat/run-tests.sh --tags @lay-pfa-high-not-started-multi-client-deputy
 
 end-to-end-tests-rerun: ##@end-to-end-tests Rerun end to end tests (requires you to have run end-to-end-tests previously), argument in format: tag=your_tag
 	APP_DEBUG=0 docker compose -f docker-compose.yml -f docker-compose.behat.yml -f docker-compose.override.yml run --remove-orphans end-to-end-tests sh ./tests/Behat/run-tests.sh --tags @v2

--- a/api/app/tests/Behat/bootstrap/v2/Common/INavigateToFrontendTrait.php
+++ b/api/app/tests/Behat/bootstrap/v2/Common/INavigateToFrontendTrait.php
@@ -25,20 +25,11 @@ trait INavigateToFrontendTrait
     }
 
     /**
-     * @When /^the Lay deputy navigates back to the Choose a Client homepage$/
+     * @When /^the Lay deputy navigates to the Choose a client page$/
      */
-    public function theLayDeputyNavigatesBackToTheChooseAClientHomepage()
+    public function theLayDeputyNavigatesToTheChooseAClientPage()
     {
-        $this->clickLink('Complete the deputy report');
-        $this->iAmOnChooseAClientMainPage();
-    }
-
-    /**
-     * @When /^the Lay deputy navigates back to the Choose a Client homepage using the breadcrumb$/
-     */
-    public function theLayDeputyNavigatesBackToTheChooseAClientHomepageUsingBreadcrumb()
-    {
-        $this->clickLink('Choose a client');
+        $this->visitPath('/choose-a-client');
         $this->iAmOnChooseAClientMainPage();
     }
 

--- a/api/app/tests/Behat/bootstrap/v2/Deputyship/DeputyshipFeatureContext.php
+++ b/api/app/tests/Behat/bootstrap/v2/Deputyship/DeputyshipFeatureContext.php
@@ -144,8 +144,7 @@ class DeputyshipFeatureContext extends BaseFeatureContext
      */
     public function deputyIsRedirectedToTheirSingleClient()
     {
-        // check we're on the /client/<id> page for the right client
-        assert(str_contains($this->getCurrentUrl(), '/client/'.$this->deputyHasASingleClient_id));
+        assert(str_contains($this->getCurrentUrl(), '/deputyship-details/client/'.$this->deputyHasASingleClient_id));
 
         $this->assertPageContainsText($this->deputyHasASingleClient_familyName);
     }

--- a/api/app/tests/Behat/features-v2/acl/login/login.feature
+++ b/api/app/tests/Behat/features-v2/acl/login/login.feature
@@ -52,7 +52,7 @@ Feature: Users logging into the service
         Then they should be on the Choose a Client homepage
         When they choose their "primary" Client
         Then they should be on the "primary" Client's dashboard
-        When the Lay deputy navigates back to the Choose a Client homepage
+        When the Lay deputy navigates to the Choose a client page
         When they choose their "non-primary" Client
         Then they should be on the "non-primary" Client's dashboard
         And when they log out they shouldn't see a flash message for non primary accounts
@@ -63,7 +63,7 @@ Feature: Users logging into the service
         Then they should be on the Choose a Client homepage
         When they choose their "primary" Client
         Then they should be on the "primary" Client's dashboard
-        When the Lay deputy navigates back to the Choose a Client homepage
+        When the Lay deputy navigates to the Choose a client page
         When they choose their "non-primary" Client
         Then they should be on the "non-primary" Client's dashboard
         And when they log out they shouldn't see a flash message for non primary accounts
@@ -73,7 +73,7 @@ Feature: Users logging into the service
         And a Lay Deputy tries to login with their "primary" email address
         When they choose their "primary" Client
         Then they should be on the "primary" Client's dashboard
-        And the Lay deputy navigates back to the Choose a Client homepage using the breadcrumb
+        And the Lay deputy navigates to the Choose a client page
 
     @lay-pfa-high-not-started-multi-client-deputy
     Scenario: A user logs in with their primary account and uses breadcrumbs to navigate report overview page
@@ -84,21 +84,21 @@ Feature: Users logging into the service
         And the Lay Deputy navigates back to the Client dashboard using the breadcrumb
         Then they should be on the "primary" Client's dashboard
         When the Lay deputy navigates to the report overview page
-        And the Lay deputy navigates back to the Choose a Client homepage using the breadcrumb
+        And the Lay deputy navigates to the Choose a client page
 
     @lay-pfa-high-not-started-multi-client-deputy
-    Scenario: A user logs in with their primary account and uses breadcrumbs to navigate Your details page
+    Scenario: A user logs in with their primary account and uses breadcrumbs to navigate to Your details page
         And a Lay Deputy tries to login with their "primary" email address
         When the Lay deputy navigates to your details page
-        And the Lay deputy navigates back to the Choose a Client homepage using the breadcrumb
+        And the Lay deputy navigates to the Choose a client page
 
     @lay-pfa-high-not-started-multi-client-deputy
-    Scenario: A user logs in with their primary account and uses breadcrumbs to navigate Client details page
+    Scenario: A user logs in with their primary account and uses breadcrumbs to navigate to Client details page
         And a Lay Deputy tries to login with their "primary" email address
         When they choose their "primary" Client
         Then they should be on the "primary" Client's dashboard
         When the Lay deputy navigates to client details page
-        And the Lay deputy navigates back to the Choose a Client homepage using the breadcrumb
+        And the Lay deputy navigates to the Choose a client page
         When they choose their "primary" Client
         Then they should be on the "primary" Client's dashboard
         When the Lay deputy navigates to client details page

--- a/api/app/tests/Behat/features-v2/acl/login/login.feature
+++ b/api/app/tests/Behat/features-v2/acl/login/login.feature
@@ -101,9 +101,6 @@ Feature: Users logging into the service
         And the Lay deputy navigates to the Choose a client page
         When they choose their "primary" Client
         Then they should be on the "primary" Client's dashboard
-        When the Lay deputy navigates to client details page
-        And the Lay Deputy navigates back to the Client dashboard using the breadcrumb
-        Then they should be on the "primary" Client's dashboard
 
     @lay-pfa-high-started-multi-client-deputy-primary-client-discharged-two-active-clients
     Scenario: A user logs into the service with their primary account given they're active clients are linked to their secondary accounts

--- a/api/app/tests/Behat/features-v2/client-management/deputy/edit-client.feature
+++ b/api/app/tests/Behat/features-v2/client-management/deputy/edit-client.feature
@@ -38,4 +38,4 @@ Feature: View client details
         Then I should see "Client details"
         When I select the "Client details" link I should see the details of the chosen client
         And I click on the button to edit my client's details
-        Then the Lay deputy navigates back to the Choose a Client homepage using the breadcrumb
+        Then the Lay deputy navigates to the Choose a client page

--- a/api/app/tests/Behat/features-v2/client-management/deputy/edit-client.feature
+++ b/api/app/tests/Behat/features-v2/client-management/deputy/edit-client.feature
@@ -25,17 +25,8 @@ Feature: View client details
         Then I should not see the link for client details
 
     @lay-pfa-high-not-started-multi-client-deputy
-    Scenario: A user does not see Client details in nav bar on choose a client homepage
-        Given a Lay Deputy tries to login with their "primary" email address
-        Then they should be on the Choose a Client homepage
-        Then I should not see "Client details"
-
-    @lay-pfa-high-not-started-multi-client-deputy
     Scenario: A user has access to the client details page of the client they have selected and correct breadcrumbs
         Given a Lay Deputy tries to login with their "primary" email address
         Then they should be on the Choose a Client homepage
         When I select the first client from the Choose a Client page
         Then I should see "Client details"
-        When I select the "Client details" link I should see the details of the chosen client
-        And I click on the button to edit my client's details
-        Then the Lay deputy navigates to the Choose a client page

--- a/api/app/tests/Behat/features-v2/deputyship-details/client-list.feature
+++ b/api/app/tests/Behat/features-v2/deputyship-details/client-list.feature
@@ -11,3 +11,11 @@ Feature: List clients for a deputy
         Given they have multiple clients
         When they navigate to the client list page
         Then they should see their clients listed in ascending alphabetical order by first name
+
+    @deputyship-details-client-list
+    Scenario: A deputy with one client is redirected to the page for that client
+        Given a lay deputy with surname Oblobamm exists
+        And they have a single client with family name Voltaz
+        When they log in
+        And they navigate to the client list page
+        Then they should be redirected to the page for their single client

--- a/client/app/phpstan-baseline.neon
+++ b/client/app/phpstan-baseline.neon
@@ -1821,11 +1821,6 @@ parameters:
 			path: src/Controller/Ndr/BankAccountController.php
 
 		-
-			message: "#^Property App\\\\Controller\\\\Ndr\\\\BankAccountController\\:\\:\\$clientApi has no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/BankAccountController.php
-
-		-
 			message: "#^Property App\\\\Controller\\\\Ndr\\\\BankAccountController\\:\\:\\$jmsGroups has no type specified\\.$#"
 			count: 1
 			path: src/Controller/Ndr/BankAccountController.php
@@ -2011,11 +2006,6 @@ parameters:
 			path: src/Controller/Ndr/DeputyExpenseController.php
 
 		-
-			message: "#^Property App\\\\Controller\\\\Ndr\\\\DeputyExpenseController\\:\\:\\$clientApi has no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/DeputyExpenseController.php
-
-		-
 			message: "#^Property App\\\\Controller\\\\Ndr\\\\DeputyExpenseController\\:\\:\\$jmsGroups has no type specified\\.$#"
 			count: 1
 			path: src/Controller/Ndr/DeputyExpenseController.php
@@ -2071,11 +2061,6 @@ parameters:
 			path: src/Controller/Ndr/IncomeBenefitController.php
 
 		-
-			message: "#^Property App\\\\Controller\\\\Ndr\\\\IncomeBenefitController\\:\\:\\$clientApi has no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/IncomeBenefitController.php
-
-		-
 			message: "#^Property App\\\\Controller\\\\Ndr\\\\IncomeBenefitController\\:\\:\\$jmsGroups has no type specified\\.$#"
 			count: 1
 			path: src/Controller/Ndr/IncomeBenefitController.php
@@ -2111,17 +2096,7 @@ parameters:
 			path: src/Controller/Ndr/NdrController.php
 
 		-
-			message: "#^Parameter \\#1 \\$deputyUid of method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:getAllClientsByDeputyUid\\(\\) expects int, int\\|null given\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
 			message: "#^Parameter \\#1 \\$formResponse of method App\\\\Service\\\\Client\\\\Internal\\\\SatisfactionApi\\:\\:createPostSubmissionFeedback\\(\\) expects App\\\\Model\\\\FeedbackReport, mixed given\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\<App\\\\Entity\\\\Client\\>\\|null given\\.$#"
 			count: 1
 			path: src/Controller/Ndr/NdrController.php
 
@@ -2196,11 +2171,6 @@ parameters:
 			path: src/Controller/Ndr/OtherInfoController.php
 
 		-
-			message: "#^Call to an undefined method App\\\\Service\\\\StepRedirector\\:\\:checkDeputyHasMultiClients\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Ndr/VisitsCareController.php
-
-		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Form\\\\FormInterface\\:\\:isClicked\\(\\)\\.$#"
 			count: 1
 			path: src/Controller/Ndr/VisitsCareController.php
@@ -2247,11 +2217,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$mixed of method App\\\\Service\\\\Client\\\\RestClient\\:\\:put\\(\\) expects array\\|object\\|string, mixed given\\.$#"
-			count: 1
-			path: src/Controller/Ndr/VisitsCareController.php
-
-		-
-			message: "#^Property App\\\\Controller\\\\Ndr\\\\VisitsCareController\\:\\:\\$clientApi \\(App\\\\Service\\\\StepRedirector\\) does not accept App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\.$#"
 			count: 1
 			path: src/Controller/Ndr/VisitsCareController.php
 
@@ -5056,11 +5021,6 @@ parameters:
 			path: src/Controller/Report/ReportController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:reviewAction\\(\\) should return Symfony\\\\Component\\\\HttpFoundation\\\\RedirectResponse but returns array\\<string, mixed\\>\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
 			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:submitConfirmationAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportController.php
@@ -5091,22 +5051,12 @@ parameters:
 			path: src/Controller/Report/ReportController.php
 
 		-
-			message: "#^Parameter \\#1 \\$deputyUid of method App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:getAllClientsByDeputyUid\\(\\) expects int, int\\|null given\\.$#"
-			count: 2
-			path: src/Controller/Report/ReportController.php
-
-		-
 			message: "#^Parameter \\#1 \\$deputyUid of method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:returnPrimaryEmail\\(\\) expects int, int\\|null given\\.$#"
 			count: 2
 			path: src/Controller/Report/ReportController.php
 
 		-
 			message: "#^Parameter \\#1 \\$formResponse of method App\\\\Service\\\\Client\\\\Internal\\\\SatisfactionApi\\:\\:createPostSubmissionFeedback\\(\\) expects App\\\\Model\\\\FeedbackReport, mixed given\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\<App\\\\Entity\\\\Client\\>\\|null given\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportController.php
 
@@ -5252,31 +5202,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$postUpdateUser of method App\\\\Service\\\\Client\\\\Internal\\\\UserApi\\:\\:update\\(\\) expects App\\\\Entity\\\\User, mixed given\\.$#"
-			count: 1
-			path: src/Controller/SettingsController.php
-
-		-
-			message: "#^Property App\\\\Controller\\\\SettingsController\\:\\:\\$dateTimeProvider is never read, only written\\.$#"
-			count: 1
-			path: src/Controller/SettingsController.php
-
-		-
-			message: "#^Property App\\\\Controller\\\\SettingsController\\:\\:\\$eventDispatcher is never read, only written\\.$#"
-			count: 1
-			path: src/Controller/SettingsController.php
-
-		-
-			message: "#^Property App\\\\Controller\\\\SettingsController\\:\\:\\$logger is never read, only written\\.$#"
-			count: 1
-			path: src/Controller/SettingsController.php
-
-		-
-			message: "#^Property App\\\\Controller\\\\SettingsController\\:\\:\\$mailFactory is never read, only written\\.$#"
-			count: 1
-			path: src/Controller/SettingsController.php
-
-		-
-			message: "#^Property App\\\\Controller\\\\SettingsController\\:\\:\\$mailSender is never read, only written\\.$#"
 			count: 1
 			path: src/Controller/SettingsController.php
 

--- a/client/app/phpstan-baseline.neon
+++ b/client/app/phpstan-baseline.neon
@@ -13311,17 +13311,7 @@ parameters:
 			path: src/Service/Client/Internal/ClientApi.php
 
 		-
-			message: "#^Parameter \\#1 \\$value of function count expects array\\|Countable, array\\<App\\\\Entity\\\\Client\\>\\|null given\\.$#"
-			count: 1
-			path: src/Service/Client/Internal/ClientApi.php
-
-		-
 			message: "#^Parameter \\#3 \\$changedBy of class App\\\\Event\\\\ClientUpdatedEvent constructor expects Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
-			count: 1
-			path: src/Service/Client/Internal/ClientApi.php
-
-		-
-			message: "#^Property App\\\\Service\\\\Client\\\\Internal\\\\ClientApi\\:\\:\\$dateTimeProvider is never read, only written\\.$#"
 			count: 1
 			path: src/Service/Client/Internal/ClientApi.php
 

--- a/client/app/src/Controller/ClientController.php
+++ b/client/app/src/Controller/ClientController.php
@@ -65,11 +65,8 @@ class ClientController extends AbstractController
 
         $client = $this->clientApi->getById($clientId);
 
-        $deputyHasMultiClients = $this->clientApi->checkDeputyHasMultiClients($user);
-
         return [
             'client' => $client,
-            'deputyHasMultiClients' => $deputyHasMultiClients,
         ];
     }
 
@@ -95,7 +92,6 @@ class ClientController extends AbstractController
     public function editClientDetailsAction(Request $request, int $clientId)
     {
         $user = $this->userApi->getUserWithData();
-        $deputyHasMultiClients = $this->clientApi->checkDeputyHasMultiClients($user);
 
         $from = $request->get('from');
         $preUpdateClient = $this->clientApi->getById($clientId);
@@ -134,7 +130,6 @@ class ClientController extends AbstractController
         return [
             'client' => $preUpdateClient,
             'form' => $form->createView(),
-            'deputyHasMultiClients' => $deputyHasMultiClients,
         ];
     }
 

--- a/client/app/src/Controller/DeputyshipController.php
+++ b/client/app/src/Controller/DeputyshipController.php
@@ -47,7 +47,13 @@ class DeputyshipController extends AbstractController
             $clients = [];
         }
 
-        if (count($clients) > 0) {
+        $numClients = count($clients);
+
+        if (1 === $numClients) {
+            return new RedirectResponse($this->generateUrl('lay_home', ['clientId' => reset($clients)->getId()]));
+        }
+
+        if ($numClients > 1) {
             usort($clients, function ($client1, $client2) {
                 return strnatcmp($client1->getFirstName(), $client2->getFirstName());
             });

--- a/client/app/src/Controller/DeputyshipController.php
+++ b/client/app/src/Controller/DeputyshipController.php
@@ -50,7 +50,10 @@ class DeputyshipController extends AbstractController
         $numClients = count($clients);
 
         if (1 === $numClients) {
-            return new RedirectResponse($this->generateUrl('lay_home', ['clientId' => reset($clients)->getId()]));
+            /** @var Client $client */
+            $client = reset($clients);
+
+            return new RedirectResponse($this->generateUrl('lay_home', ['clientId' => $client->getId()]));
         }
 
         if ($numClients > 1) {

--- a/client/app/src/Controller/DeputyshipController.php
+++ b/client/app/src/Controller/DeputyshipController.php
@@ -53,7 +53,7 @@ class DeputyshipController extends AbstractController
             /** @var Client $client */
             $client = reset($clients);
 
-            return new RedirectResponse($this->generateUrl('lay_home', ['clientId' => $client->getId()]));
+            return new RedirectResponse($this->generateUrl('client_show', ['clientId' => $client->getId()]));
         }
 
         if ($numClients > 1) {

--- a/client/app/src/Controller/Ndr/ActionController.php
+++ b/client/app/src/Controller/Ndr/ActionController.php
@@ -3,9 +3,7 @@
 namespace App\Controller\Ndr;
 
 use App\Controller\AbstractController;
-use App\Entity\User;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\Service\NdrStatusService;
@@ -17,42 +15,17 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class ActionController extends AbstractController
 {
-    /**
-     * @var ReportApi
-     */
-    private $reportApi;
-
-    /**
-     * @var RestClient
-     */
-    private $restClient;
-
-    /**
-     * @var StepRedirector
-     */
-    private $stepRedirector;
-
     private static $jmsGroups = [
         'ndr-action-give-gifts',
         'ndr-action-property',
         'ndr-action-more-info',
     ];
 
-    /**
-     * @var ClientApi
-     */
-    private $clientApi;
-
     public function __construct(
-        ReportApi $reportApi,
-        RestClient $restClient,
-        StepRedirector $stepRedirector,
-        ClientApi $clientApi
+        private readonly ReportApi $reportApi,
+        private readonly RestClient $restClient,
+        private readonly StepRedirector $stepRedirector,
     ) {
-        $this->reportApi = $reportApi;
-        $this->restClient = $restClient;
-        $this->stepRedirector = $stepRedirector;
-        $this->clientApi = $clientApi;
     }
 
     /**
@@ -64,10 +37,6 @@ class ActionController extends AbstractController
      */
     public function startAction($ndrId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $ndr = $this->reportApi->getNdrIfNotSubmitted($ndrId, self::$jmsGroups);
         if (NdrStatusService::STATE_NOT_STARTED != $ndr->getStatusService()->getActionsState()['state']) {
             return $this->redirectToRoute('ndr_actions_summary', ['ndrId' => $ndrId]);
@@ -75,7 +44,6 @@ class ActionController extends AbstractController
 
         return [
             'ndr' => $ndr,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Ndr/AssetController.php
+++ b/client/app/src/Controller/Ndr/AssetController.php
@@ -4,9 +4,7 @@ namespace App\Controller\Ndr;
 
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
-use App\Entity\User;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\Service\NdrStatusService;
@@ -20,36 +18,11 @@ class AssetController extends AbstractController
 {
     private static $jmsGroups = ['ndr-asset'];
 
-    /**
-     * @var ReportApi
-     */
-    private $reportApi;
-
-    /**
-     * @var RestClient
-     */
-    private $restClient;
-
-    /**
-     * @var StepRedirector
-     */
-    private $stepRedirector;
-
-    /**
-     * @var ClientApi
-     */
-    private $clientApi;
-
     public function __construct(
-        ReportApi $reportApi,
-        RestClient $restClient,
-        StepRedirector $stepRedirector,
-        ClientApi $clientApi
+        private readonly ReportApi $reportApi,
+        private readonly RestClient $restClient,
+        private readonly StepRedirector $stepRedirector,
     ) {
-        $this->reportApi = $reportApi;
-        $this->restClient = $restClient;
-        $this->stepRedirector = $stepRedirector;
-        $this->clientApi = $clientApi;
     }
 
     /**
@@ -61,10 +34,6 @@ class AssetController extends AbstractController
      */
     public function startAction($ndrId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $ndr = $this->reportApi->getNdrIfNotSubmitted($ndrId, self::$jmsGroups);
         if (NdrStatusService::STATE_NOT_STARTED != $ndr->getStatusService()->getAssetsState()['state']) {
             return $this->redirectToRoute('ndr_assets_summary', ['ndrId' => $ndrId]);
@@ -72,7 +41,6 @@ class AssetController extends AbstractController
 
         return [
             'ndr' => $ndr,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -126,8 +94,7 @@ class AssetController extends AbstractController
     public function typeAction(Request $request, $ndrId)
     {
         $ndr = $this->reportApi->getNdrIfNotSubmitted($ndrId, self::$jmsGroups);
-        $form = $this->createForm(FormDir\Ndr\Asset\AssetTypeTitle::class, new EntityDir\Ndr\AssetOther(), [
-        ]);
+        $form = $this->createForm(FormDir\Ndr\Asset\AssetTypeTitle::class, new EntityDir\Ndr\AssetOther(), []);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/client/app/src/Controller/Ndr/BankAccountController.php
+++ b/client/app/src/Controller/Ndr/BankAccountController.php
@@ -6,7 +6,6 @@ use App\Controller\AbstractController;
 use App\Entity as EntityDir;
 use App\Entity\User;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\Service\NdrStatusService;
@@ -20,32 +19,11 @@ class BankAccountController extends AbstractController
 {
     private static $jmsGroups = ['ndr-account'];
 
-    /**
-     * @var ReportApi
-     */
-    private $reportApi;
-
-    /**
-     * @var RestClient
-     */
-    private $restClient;
-
-    /**
-     * @var StepRedirector
-     */
-    private $stepRedirector;
-    private $clientApi;
-
     public function __construct(
-        ReportApi $reportApi,
-        RestClient $restClient,
-        StepRedirector $stepRedirector,
-        ClientApi $clientApi
+        private readonly ReportApi $reportApi,
+        private readonly RestClient $restClient,
+        private readonly StepRedirector $stepRedirector,
     ) {
-        $this->reportApi = $reportApi;
-        $this->restClient = $restClient;
-        $this->stepRedirector = $stepRedirector;
-        $this->clientApi = $clientApi;
     }
 
     /**
@@ -57,10 +35,6 @@ class BankAccountController extends AbstractController
      */
     public function startAction($ndrId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $ndr = $this->reportApi->getNdrIfNotSubmitted($ndrId, self::$jmsGroups);
         if (NdrStatusService::STATE_NOT_STARTED != $ndr->getStatusService()->getBankAccountsState()['state']) {
             return $this->redirectToRoute('ndr_bank_accounts_summary', ['ndrId' => $ndrId]);
@@ -68,7 +42,6 @@ class BankAccountController extends AbstractController
 
         return [
             'ndr' => $ndr,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Ndr/DebtController.php
+++ b/client/app/src/Controller/Ndr/DebtController.php
@@ -3,9 +3,7 @@
 namespace App\Controller\Ndr;
 
 use App\Controller\AbstractController;
-use App\Entity\User;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\Service\NdrStatusService;
@@ -17,29 +15,10 @@ class DebtController extends AbstractController
 {
     private static $jmsGroups = ['ndr-debt', 'ndr-debt-management'];
 
-    /**
-     * @var ReportApi
-     */
-    private $reportApi;
-
-    /**
-     * @var RestClient
-     */
-    private $restClient;
-
-    /**
-     * @var ClientApi
-     */
-    private $clientApi;
-
     public function __construct(
-        ReportApi $reportApi,
-        RestClient $restClient,
-        ClientApi $clientApi
+        private readonly ReportApi $reportApi,
+        private readonly RestClient $restClient,
     ) {
-        $this->reportApi = $reportApi;
-        $this->restClient = $restClient;
-        $this->clientApi = $clientApi;
     }
 
     /**
@@ -49,11 +28,6 @@ class DebtController extends AbstractController
      */
     public function startAction(Request $request, $ndrId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $ndr = $this->reportApi->getNdrIfNotSubmitted($ndrId, self::$jmsGroups);
         if (NdrStatusService::STATE_NOT_STARTED != $ndr->getStatusService()->getDebtsState()['state']) {
             return $this->redirectToRoute('ndr_debts_summary', ['ndrId' => $ndr->getId()]);
@@ -61,7 +35,6 @@ class DebtController extends AbstractController
 
         return [
             'ndr' => $ndr,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Ndr/DeputyExpenseController.php
+++ b/client/app/src/Controller/Ndr/DeputyExpenseController.php
@@ -4,9 +4,7 @@ namespace App\Controller\Ndr;
 
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
-use App\Entity\User;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\Service\NdrStatusService;
@@ -23,26 +21,11 @@ class DeputyExpenseController extends AbstractController
         'ndr-expenses',
     ];
 
-    /** @var ReportApi */
-    private $reportApi;
-
-    /** @var RestClient */
-    private $restClient;
-
-    /** @var RouterInterface */
-    private $router;
-    private $clientApi;
-
     public function __construct(
-        ReportApi $reportApi,
-        RestClient $restClient,
-        RouterInterface $router,
-        ClientApi $clientApi
+        private readonly ReportApi $reportApi,
+        private readonly RestClient $restClient,
+        private readonly RouterInterface $router,
     ) {
-        $this->reportApi = $reportApi;
-        $this->restClient = $restClient;
-        $this->router = $router;
-        $this->clientApi = $clientApi;
     }
 
     /**
@@ -54,10 +37,6 @@ class DeputyExpenseController extends AbstractController
      */
     public function startAction($ndrId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $ndr = $this->reportApi->getNdrIfNotSubmitted($ndrId, self::$jmsGroups);
 
         if (NdrStatusService::STATE_NOT_STARTED != $ndr->getStatusService()->getExpensesState()['state']) {
@@ -66,7 +45,6 @@ class DeputyExpenseController extends AbstractController
 
         return [
             'ndr' => $ndr,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Ndr/IncomeBenefitController.php
+++ b/client/app/src/Controller/Ndr/IncomeBenefitController.php
@@ -4,9 +4,7 @@ namespace App\Controller\Ndr;
 
 use App\Controller\AbstractController;
 use App\Entity\Ndr\Ndr;
-use App\Entity\User;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\Service\NdrStatusService;
@@ -26,32 +24,11 @@ class IncomeBenefitController extends AbstractController
         'one-off',
     ];
 
-    /**
-     * @var ReportApi
-     */
-    private $reportApi;
-
-    /**
-     * @var RestClient
-     */
-    private $restClient;
-
-    /**
-     * @var StepRedirector
-     */
-    private $stepRedirector;
-    private $clientApi;
-
     public function __construct(
-        ReportApi $reportApi,
-        RestClient $restClient,
-        StepRedirector $stepRedirector,
-        ClientApi $clientApi
+        private readonly ReportApi $reportApi,
+        private readonly RestClient $restClient,
+        private readonly StepRedirector $stepRedirector,
     ) {
-        $this->reportApi = $reportApi;
-        $this->restClient = $restClient;
-        $this->stepRedirector = $stepRedirector;
-        $this->clientApi = $clientApi;
     }
 
     /**
@@ -63,10 +40,6 @@ class IncomeBenefitController extends AbstractController
      */
     public function startAction($ndrId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $ndr = $this->reportApi->getNdrIfNotSubmitted($ndrId, self::$jmsGroups);
         if (NdrStatusService::STATE_NOT_STARTED != $ndr->getStatusService()->getIncomeBenefitsState()['state']) {
             return $this->redirectToRoute('ndr_income_benefits_summary', ['ndrId' => $ndrId]);
@@ -74,7 +47,6 @@ class IncomeBenefitController extends AbstractController
 
         return [
             'ndr' => $ndr,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Ndr/NdrController.php
+++ b/client/app/src/Controller/Ndr/NdrController.php
@@ -57,7 +57,7 @@ class NdrController extends AbstractController
         private SatisfactionApi $satisfactionApi,
         private NdrApi $ndrApi,
         private HtmlToPdfGenerator $htmlToPdf,
-        private LoggerInterface $logger
+        private LoggerInterface $logger,
     ) {
     }
 
@@ -106,13 +106,10 @@ class NdrController extends AbstractController
 
         $ndrStatus = new NdrStatusService($ndr);
 
-        $deputyHasMultiClients = !$user->isDeputyOrg() && count($this->clientApi->getAllClientsByDeputyUid($user->getDeputyUid())) > 1;
-
         return [
             'client' => $client,
             'ndr' => $ndr,
             'ndrStatus' => $ndrStatus,
-            'deputyHasMultiClients' => $deputyHasMultiClients,
         ];
     }
 
@@ -139,7 +136,6 @@ class NdrController extends AbstractController
 
         /** @var User $user */
         $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
 
         $backLink = $this->generateUrl('lay_home', ['clientId' => $clientId]);
 
@@ -147,7 +143,6 @@ class NdrController extends AbstractController
             'ndr' => $ndr,
             'deputy' => $user,
             'ndrStatus' => $ndrStatusService,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
             'backLink' => $backLink,
         ];
     }
@@ -224,10 +219,6 @@ class NdrController extends AbstractController
             throw new ReportSubmittedException();
         }
 
-        /** @var User $currentUser */
-        $currentUser = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($currentUser);
-
         $form = $this->createForm(FormDir\Ndr\ReportDeclarationType::class, $ndr);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
@@ -263,7 +254,6 @@ class NdrController extends AbstractController
             'ndr' => $ndr,
             'client' => $client,
             'form' => $form->createView(),
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Ndr/OtherInfoController.php
+++ b/client/app/src/Controller/Ndr/OtherInfoController.php
@@ -3,9 +3,7 @@
 namespace App\Controller\Ndr;
 
 use App\Controller\AbstractController;
-use App\Entity\User;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\Service\NdrStatusService;
@@ -20,36 +18,11 @@ class OtherInfoController extends AbstractController
         'ndr-action-more-info',
     ];
 
-    /**
-     * @var ReportApi
-     */
-    private $reportApi;
-
-    /**
-     * @var RestClient
-     */
-    private $restClient;
-
-    /**
-     * @var StepRedirector
-     */
-    private $stepRedirector;
-
-    /**
-     * @var ClientApi
-     */
-    private $clientApi;
-
     public function __construct(
-        ReportApi $reportApi,
-        RestClient $restClient,
-        StepRedirector $stepRedirector,
-        ClientApi $clientApi
+        private readonly ReportApi $reportApi,
+        private readonly RestClient $restClient,
+        private readonly StepRedirector $stepRedirector,
     ) {
-        $this->reportApi = $reportApi;
-        $this->restClient = $restClient;
-        $this->stepRedirector = $stepRedirector;
-        $this->clientApi = $clientApi;
     }
 
     /**
@@ -59,10 +32,6 @@ class OtherInfoController extends AbstractController
      */
     public function startAction(Request $request, $ndrId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $ndr = $this->reportApi->getNdrIfNotSubmitted($ndrId, self::$jmsGroups);
         if (NdrStatusService::STATE_NOT_STARTED != $ndr->getStatusService()->getOtherInfoState()['state']) {
             return $this->redirectToRoute('ndr_other_info_summary', ['ndrId' => $ndrId]);
@@ -70,7 +39,6 @@ class OtherInfoController extends AbstractController
 
         return [
             'ndr' => $ndr,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Ndr/VisitsCareController.php
+++ b/client/app/src/Controller/Ndr/VisitsCareController.php
@@ -4,9 +4,7 @@ namespace App\Controller\Ndr;
 
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
-use App\Entity\User;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\Service\NdrStatusService;
@@ -23,36 +21,11 @@ class VisitsCareController extends AbstractController
         'visits-care',
     ];
 
-    /**
-     * @var ReportApi
-     */
-    private $reportApi;
-
-    /**
-     * @var RestClient
-     */
-    private $restClient;
-
-    /**
-     * @var StepRedirector
-     */
-    private $stepRedirector;
-
-    /**
-     * @var StepRedirector
-     */
-    private $clientApi;
-
     public function __construct(
-        ReportApi $reportApi,
-        RestClient $restClient,
-        StepRedirector $stepRedirector,
-        ClientApi $clientApi
+        private readonly ReportApi $reportApi,
+        private readonly RestClient $restClient,
+        private readonly StepRedirector $stepRedirector,
     ) {
-        $this->reportApi = $reportApi;
-        $this->restClient = $restClient;
-        $this->stepRedirector = $stepRedirector;
-        $this->clientApi = $clientApi;
     }
 
     /**
@@ -64,10 +37,6 @@ class VisitsCareController extends AbstractController
      */
     public function startAction(Request $request, $ndrId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $ndr = $this->reportApi->getNdrIfNotSubmitted($ndrId, self::$jmsGroups);
         if (NdrStatusService::STATE_NOT_STARTED != $ndr->getStatusService()->getVisitsCareState()['state']) {
             return $this->redirectToRoute('ndr_visits_care_summary', ['ndrId' => $ndrId]);
@@ -75,7 +44,6 @@ class VisitsCareController extends AbstractController
 
         return [
             'ndr' => $ndr,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/ActionController.php
+++ b/client/app/src/Controller/Report/ActionController.php
@@ -4,7 +4,6 @@ namespace App\Controller\Report;
 
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
-use App\Entity\User;
 use App\Form as FormDir;
 use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
@@ -49,10 +48,6 @@ class ActionController extends AbstractController
      */
     public function startAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (EntityDir\Report\Status::STATE_NOT_STARTED != $report->getStatus()->getActionsState()['state']) {
             return $this->redirectToRoute('actions_summary', ['reportId' => $reportId]);
@@ -60,7 +55,6 @@ class ActionController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -131,10 +125,6 @@ class ActionController extends AbstractController
      */
     public function summaryAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $fromPage = $request->get('from');
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (EntityDir\Report\Status::STATE_NOT_STARTED == $report->getStatus()->getActionsState()['state'] && 'skip-step' != $fromPage) {
@@ -145,7 +135,6 @@ class ActionController extends AbstractController
             'comingFromLastStep' => 'skip-step' == $fromPage || 'last-step' == $fromPage,
             'report' => $report,
             'status' => $report->getStatus(),
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/ActionController.php
+++ b/client/app/src/Controller/Report/ActionController.php
@@ -5,7 +5,6 @@ namespace App\Controller\Report;
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\Service\StepRedirector;
@@ -21,24 +20,11 @@ class ActionController extends AbstractController
         'action-state',
     ];
 
-    /** @var RestClient */
-    private $restClient;
-
-    /** @var ReportApi */
-    private $reportApi;
-
-    /** @var StepRedirector */
-    private $stepRedirector;
-
     public function __construct(
-        RestClient $restClient,
-        ReportApi $reportApi,
-        StepRedirector $stepRedirector,
-        private ClientApi $clientApi,
+        private readonly RestClient $restClient,
+        private readonly ReportApi $reportApi,
+        private readonly StepRedirector $stepRedirector,
     ) {
-        $this->restClient = $restClient;
-        $this->reportApi = $reportApi;
-        $this->stepRedirector = $stepRedirector;
     }
 
     /**

--- a/client/app/src/Controller/Report/AssetController.php
+++ b/client/app/src/Controller/Report/AssetController.php
@@ -4,9 +4,7 @@ namespace App\Controller\Report;
 
 use App\Controller\AbstractController;
 use App\Entity\Report;
-use App\Entity\User;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\Service\StepRedirector;
@@ -26,7 +24,6 @@ class AssetController extends AbstractController
         private RestClient $restClient,
         private ReportApi $reportApi,
         private StepRedirector $stepRedirector,
-        private ClientApi $clientApi,
     ) {
     }
 

--- a/client/app/src/Controller/Report/AssetController.php
+++ b/client/app/src/Controller/Report/AssetController.php
@@ -39,10 +39,6 @@ class AssetController extends AbstractController
      */
     public function startAction($reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (Report\Status::STATE_NOT_STARTED != $report->getStatus()->getAssetsState()['state']) {
             return $this->redirectToRoute('assets_summary', ['reportId' => $reportId]);
@@ -50,7 +46,6 @@ class AssetController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -352,10 +347,6 @@ class AssetController extends AbstractController
      */
     public function summaryAction($reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (Report\Status::STATE_NOT_STARTED == $report->getStatus()->getAssetsState()['state']) {
             return $this->redirect($this->generateUrl('assets', ['reportId' => $reportId]));
@@ -363,7 +354,6 @@ class AssetController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/BalanceController.php
+++ b/client/app/src/Controller/Report/BalanceController.php
@@ -3,7 +3,6 @@
 namespace App\Controller\Report;
 
 use App\Controller\AbstractController;
-use App\Entity\User;
 use App\Form as FormDir;
 use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
@@ -52,10 +51,6 @@ class BalanceController extends AbstractController
      */
     public function balanceAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         $form = $this->createForm(FormDir\Report\ReasonForBalanceType::class, $report);
         $form->handleRequest($request);
@@ -71,7 +66,6 @@ class BalanceController extends AbstractController
             'report' => $report,
             'form' => $form->createView(),
             'backLink' => $this->generateUrl('report_overview', ['reportId' => $report->getId()]),
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/BalanceController.php
+++ b/client/app/src/Controller/Report/BalanceController.php
@@ -4,7 +4,6 @@ namespace App\Controller\Report;
 
 use App\Controller\AbstractController;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -38,7 +37,6 @@ class BalanceController extends AbstractController
     public function __construct(
         private RestClient $restClient,
         private ReportApi $reportApi,
-        private ClientApi $clientApi,
     ) {
     }
 

--- a/client/app/src/Controller/Report/BankAccountController.php
+++ b/client/app/src/Controller/Report/BankAccountController.php
@@ -41,10 +41,6 @@ class BankAccountController extends AbstractController
      */
     public function startAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (EntityDir\Report\Status::STATE_NOT_STARTED != $report->getStatus()->getBankAccountsState()['state']) {
             return $this->redirectToRoute('bank_accounts_summary', ['reportId' => $reportId]);
@@ -52,7 +48,6 @@ class BankAccountController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -208,10 +203,6 @@ class BankAccountController extends AbstractController
      */
     public function summaryAction($reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (EntityDir\Report\Status::STATE_NOT_STARTED == $report->getStatus()->getBankAccountsState()['state']) {
             return $this->redirectToRoute('bank_accounts', ['reportId' => $reportId]);
@@ -219,7 +210,6 @@ class BankAccountController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/BankAccountController.php
+++ b/client/app/src/Controller/Report/BankAccountController.php
@@ -4,9 +4,7 @@ namespace App\Controller\Report;
 
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
-use App\Entity\User;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\Service\StepRedirector;
@@ -28,7 +26,6 @@ class BankAccountController extends AbstractController
         private RestClient $restClient,
         private ReportApi $reportApi,
         private StepRedirector $stepRedirector,
-        private ClientApi $clientApi,
     ) {
     }
 

--- a/client/app/src/Controller/Report/ClientBenefitsCheckController.php
+++ b/client/app/src/Controller/Report/ClientBenefitsCheckController.php
@@ -10,7 +10,6 @@ use App\Entity\Ndr\MoneyReceivedOnClientsBehalf as NdrMoneyReceivedOnClientsBeha
 use App\Entity\Report\ClientBenefitsCheck;
 use App\Entity\Report\MoneyReceivedOnClientsBehalf;
 use App\Entity\Report\Status;
-use App\Entity\User;
 use App\Form\ConfirmDeleteType;
 use App\Form\Report\ClientBenefitsCheckType;
 use App\Service\Client\Internal\ClientApi;
@@ -40,7 +39,7 @@ class ClientBenefitsCheckController extends AbstractController
         private StepRedirector $stepRedirector,
         private MoneyReceivedOnClientsBehalfApi $moneyTypeApi,
         private NdrApi $ndrApi,
-        private ClientApi $clientApi
+        private ClientApi $clientApi,
     ) {
     }
 
@@ -55,10 +54,6 @@ class ClientBenefitsCheckController extends AbstractController
      */
     public function start(int $reportId, string $reportOrNdr)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = ('ndr' === $reportOrNdr) ? $this->ndrApi->getNdr($reportId, array_merge(self::$jmsGroups, ['ndr-client', 'client-id'])) :
             $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
@@ -75,7 +70,6 @@ class ClientBenefitsCheckController extends AbstractController
         return [
             'report' => $report,
             'reportOrNdr' => $reportOrNdr,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -194,10 +188,6 @@ class ClientBenefitsCheckController extends AbstractController
      */
     public function summary(int $reportId, string $reportOrNdr)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = ('ndr' === $reportOrNdr) ? $this->ndrApi->getNdr($reportId, array_merge(self::$jmsGroups, ['ndr-client', 'client-id'])) :
             $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
@@ -205,7 +195,6 @@ class ClientBenefitsCheckController extends AbstractController
             'report' => $report,
             'reportOrNdr' => $reportOrNdr,
             'showActions' => true,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/ClientBenefitsCheckController.php
+++ b/client/app/src/Controller/Report/ClientBenefitsCheckController.php
@@ -12,7 +12,6 @@ use App\Entity\Report\MoneyReceivedOnClientsBehalf;
 use App\Entity\Report\Status;
 use App\Form\ConfirmDeleteType;
 use App\Form\Report\ClientBenefitsCheckType;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ClientBenefitsCheckApi;
 use App\Service\Client\Internal\MoneyReceivedOnClientsBehalfApi;
 use App\Service\Client\Internal\NdrApi;
@@ -39,7 +38,6 @@ class ClientBenefitsCheckController extends AbstractController
         private StepRedirector $stepRedirector,
         private MoneyReceivedOnClientsBehalfApi $moneyTypeApi,
         private NdrApi $ndrApi,
-        private ClientApi $clientApi,
     ) {
     }
 

--- a/client/app/src/Controller/Report/ContactController.php
+++ b/client/app/src/Controller/Report/ContactController.php
@@ -5,7 +5,6 @@ namespace App\Controller\Report;
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -24,7 +23,6 @@ class ContactController extends AbstractController
     public function __construct(
         private RestClient $restClient,
         private ReportApi $reportApi,
-        private ClientApi $clientApi,
     ) {
     }
 

--- a/client/app/src/Controller/Report/ContactController.php
+++ b/client/app/src/Controller/Report/ContactController.php
@@ -4,7 +4,6 @@ namespace App\Controller\Report;
 
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
-use App\Entity\User;
 use App\Form as FormDir;
 use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
@@ -25,7 +24,7 @@ class ContactController extends AbstractController
     public function __construct(
         private RestClient $restClient,
         private ReportApi $reportApi,
-        private ClientApi $clientApi
+        private ClientApi $clientApi,
     ) {
     }
 
@@ -38,10 +37,6 @@ class ContactController extends AbstractController
      */
     public function startAction($reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
         if (EntityDir\Report\Status::STATE_NOT_STARTED != $report->getStatus()->getContactsState()['state']) {
@@ -50,7 +45,6 @@ class ContactController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -208,10 +202,6 @@ class ContactController extends AbstractController
      */
     public function summaryAction($reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
         if (EntityDir\Report\Status::STATE_NOT_STARTED == $report->getStatus()->getContactsState()['state']) {
@@ -220,7 +210,6 @@ class ContactController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/DebtController.php
+++ b/client/app/src/Controller/Report/DebtController.php
@@ -4,7 +4,6 @@ namespace App\Controller\Report;
 
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
-use App\Entity\User;
 use App\Form as FormDir;
 use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
@@ -25,7 +24,7 @@ class DebtController extends AbstractController
     public function __construct(
         private RestClient $restClient,
         private ReportApi $reportApi,
-        private ClientApi $clientApi
+        private ClientApi $clientApi,
     ) {
     }
 
@@ -38,11 +37,6 @@ class DebtController extends AbstractController
      */
     public function startAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (EntityDir\Report\Status::STATE_NOT_STARTED != $report->getStatus()->getDebtsState()['state']) {
             return $this->redirectToRoute('debts_summary', ['reportId' => $reportId]);
@@ -50,7 +44,6 @@ class DebtController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -189,10 +182,6 @@ class DebtController extends AbstractController
      */
     public function summaryAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $fromPage = $request->get('from');
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (EntityDir\Report\Status::STATE_NOT_STARTED == $report->getStatus()->getDebtsState()['state'] && 'skip-step' != $fromPage) {
@@ -203,7 +192,6 @@ class DebtController extends AbstractController
             'comingFromLastStep' => 'skip-step' == $fromPage || 'last-step' == $fromPage,
             'report' => $report,
             'status' => $report->getStatus(),
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/DebtController.php
+++ b/client/app/src/Controller/Report/DebtController.php
@@ -5,7 +5,6 @@ namespace App\Controller\Report;
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -24,7 +23,6 @@ class DebtController extends AbstractController
     public function __construct(
         private RestClient $restClient,
         private ReportApi $reportApi,
-        private ClientApi $clientApi,
     ) {
     }
 

--- a/client/app/src/Controller/Report/DecisionController.php
+++ b/client/app/src/Controller/Report/DecisionController.php
@@ -4,7 +4,6 @@ namespace App\Controller\Report;
 
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
-use App\Entity\User;
 use App\Form as FormDir;
 use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
@@ -27,7 +26,7 @@ class DecisionController extends AbstractController
     public function __construct(
         private RestClient $restClient,
         private ReportApi $reportApi,
-        private ClientApi $clientApi
+        private ClientApi $clientApi,
     ) {
     }
 
@@ -40,10 +39,6 @@ class DecisionController extends AbstractController
      */
     public function startAction($reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
         if (EntityDir\Report\Status::STATE_NOT_STARTED != $report->getStatus()->getDecisionsState()['state']) {
@@ -52,7 +47,6 @@ class DecisionController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -303,10 +297,6 @@ class DecisionController extends AbstractController
      */
     public function summaryAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $fromPage = $request->get('from');
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
@@ -321,7 +311,6 @@ class DecisionController extends AbstractController
             'report' => $report,
             'status' => $report->getStatus(),
             'numOfDecisions' => $numberOfDecisions,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/DecisionController.php
+++ b/client/app/src/Controller/Report/DecisionController.php
@@ -5,7 +5,6 @@ namespace App\Controller\Report;
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -26,7 +25,6 @@ class DecisionController extends AbstractController
     public function __construct(
         private RestClient $restClient,
         private ReportApi $reportApi,
-        private ClientApi $clientApi,
     ) {
     }
 

--- a/client/app/src/Controller/Report/DeputyExpenseController.php
+++ b/client/app/src/Controller/Report/DeputyExpenseController.php
@@ -5,7 +5,6 @@ namespace App\Controller\Report;
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -25,7 +24,6 @@ class DeputyExpenseController extends AbstractController
     public function __construct(
         private RestClient $restClient,
         private ReportApi $reportApi,
-        private ClientApi $clientApi,
     ) {
     }
 

--- a/client/app/src/Controller/Report/DeputyExpenseController.php
+++ b/client/app/src/Controller/Report/DeputyExpenseController.php
@@ -4,7 +4,6 @@ namespace App\Controller\Report;
 
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
-use App\Entity\User;
 use App\Form as FormDir;
 use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
@@ -26,7 +25,7 @@ class DeputyExpenseController extends AbstractController
     public function __construct(
         private RestClient $restClient,
         private ReportApi $reportApi,
-        private ClientApi $clientApi
+        private ClientApi $clientApi,
     ) {
     }
 
@@ -39,10 +38,6 @@ class DeputyExpenseController extends AbstractController
      */
     public function startAction($reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
         if (EntityDir\Report\Status::STATE_NOT_STARTED != $report->getStatus()->getExpensesState()['state']) {
@@ -51,7 +46,6 @@ class DeputyExpenseController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -241,10 +235,6 @@ class DeputyExpenseController extends AbstractController
      */
     public function summaryAction($reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (EntityDir\Report\Status::STATE_NOT_STARTED == $report->getStatus()->getExpensesState()['state']) {
             return $this->redirect($this->generateUrl('deputy_expenses', ['reportId' => $reportId]));
@@ -252,7 +242,6 @@ class DeputyExpenseController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/DocumentController.php
+++ b/client/app/src/Controller/Report/DocumentController.php
@@ -61,10 +61,6 @@ class DocumentController extends AbstractController
      */
     public function startAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
         if (EntityDir\Report\Status::STATE_NOT_STARTED !== $report->getStatus()->getDocumentsState()['state']) {
@@ -79,7 +75,6 @@ class DocumentController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -155,7 +150,7 @@ class DocumentController extends AbstractController
         Request $request,
         MultiFileFormUploadVerifier $multiFileVerifier,
         string $reportId,
-        LoggerInterface $logger
+        LoggerInterface $logger,
     ) {
         $report = $this->reportApi->refreshReportStatusCache($reportId, ['documents'], self::$jmsGroups);
         list($nextLink, $backLink) = $this->buildNavigationLinks($report);
@@ -354,10 +349,6 @@ class DocumentController extends AbstractController
      */
     public function summaryAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (EntityDir\Report\Status::STATE_NOT_STARTED == $report->getStatus()->getDocumentsState()['state']) {
             return $this->redirectToRoute('documents', ['reportId' => $report->getId()]);
@@ -370,7 +361,6 @@ class DocumentController extends AbstractController
             'report' => $report,
             'backLink' => $this->generateUrl('report_documents', ['reportId' => $report->getId()]),
             'status' => $report->getStatus(),
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/GiftController.php
+++ b/client/app/src/Controller/Report/GiftController.php
@@ -4,7 +4,6 @@ namespace App\Controller\Report;
 
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
-use App\Entity\User;
 use App\Form as FormDir;
 use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
@@ -26,7 +25,7 @@ class GiftController extends AbstractController
     public function __construct(
         private RestClient $restClient,
         private ReportApi $reportApi,
-        private ClientApi $clientApi
+        private ClientApi $clientApi,
     ) {
     }
 
@@ -39,10 +38,6 @@ class GiftController extends AbstractController
      */
     public function startAction($reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
         if (EntityDir\Report\Status::STATE_NOT_STARTED != $report->getStatus()->getGiftsState()['state']) {
@@ -51,7 +46,6 @@ class GiftController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -212,10 +206,6 @@ class GiftController extends AbstractController
      */
     public function summaryAction($reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (EntityDir\Report\Status::STATE_NOT_STARTED == $report->getStatus()->getGiftsState()['state']) {
             return $this->redirect($this->generateUrl('gifts', ['reportId' => $reportId]));
@@ -223,7 +213,6 @@ class GiftController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/GiftController.php
+++ b/client/app/src/Controller/Report/GiftController.php
@@ -5,7 +5,6 @@ namespace App\Controller\Report;
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -25,7 +24,6 @@ class GiftController extends AbstractController
     public function __construct(
         private RestClient $restClient,
         private ReportApi $reportApi,
-        private ClientApi $clientApi,
     ) {
     }
 

--- a/client/app/src/Controller/Report/LifestyleController.php
+++ b/client/app/src/Controller/Report/LifestyleController.php
@@ -5,7 +5,6 @@ namespace App\Controller\Report;
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\Service\StepRedirector;
@@ -25,7 +24,6 @@ class LifestyleController extends AbstractController
         private RestClient $restClient,
         private ReportApi $reportApi,
         private StepRedirector $stepRedirector,
-        private ClientApi $clientApi,
     ) {
     }
 

--- a/client/app/src/Controller/Report/LifestyleController.php
+++ b/client/app/src/Controller/Report/LifestyleController.php
@@ -4,7 +4,6 @@ namespace App\Controller\Report;
 
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
-use App\Entity\User;
 use App\Form as FormDir;
 use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
@@ -26,7 +25,7 @@ class LifestyleController extends AbstractController
         private RestClient $restClient,
         private ReportApi $reportApi,
         private StepRedirector $stepRedirector,
-        private ClientApi $clientApi
+        private ClientApi $clientApi,
     ) {
     }
 
@@ -39,10 +38,6 @@ class LifestyleController extends AbstractController
      */
     public function startAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (EntityDir\Report\Status::STATE_NOT_STARTED != $report->getStatus()->getLifestyleState()['state']) {
             return $this->redirectToRoute('lifestyle_summary', ['reportId' => $reportId]);
@@ -50,7 +45,6 @@ class LifestyleController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -123,10 +117,6 @@ class LifestyleController extends AbstractController
      */
     public function summaryAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $fromPage = $request->get('from');
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (EntityDir\Report\Status::STATE_NOT_STARTED == $report->getStatus()->getLifestyleState()['state'] && 'skip-step' != $fromPage) {
@@ -141,7 +131,6 @@ class LifestyleController extends AbstractController
             'comingFromLastStep' => 'skip-step' == $fromPage || 'last-step' == $fromPage,
             'report' => $report,
             'status' => $report->getStatus(),
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/MoneyInController.php
+++ b/client/app/src/Controller/Report/MoneyInController.php
@@ -6,7 +6,6 @@ use App\Controller\AbstractController;
 use App\Entity\Report\BankAccount;
 use App\Entity\Report\MoneyTransaction;
 use App\Entity\Report\Status;
-use App\Entity\User;
 use App\Form as FormDir;
 use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
@@ -32,7 +31,7 @@ class MoneyInController extends AbstractController
         private RestClient $restClient,
         private ReportApi $reportApi,
         private StepRedirector $stepRedirector,
-        private ClientApi $clientApi
+        private ClientApi $clientApi,
     ) {
     }
 
@@ -45,10 +44,6 @@ class MoneyInController extends AbstractController
      */
     public function startAction($reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (Status::STATE_NOT_STARTED != $report->getStatus()->getMoneyInState()['state']) {
             return $this->redirectToRoute('money_in_summary', ['reportId' => $reportId]);
@@ -56,7 +51,6 @@ class MoneyInController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -328,10 +322,6 @@ class MoneyInController extends AbstractController
      */
     public function summaryAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $fromPage = $request->get('from');
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (Status::STATE_NOT_STARTED == $report->getStatus()->getMoneyInState()['state'] && 'skip-step' != $fromPage) {
@@ -342,7 +332,6 @@ class MoneyInController extends AbstractController
             'comingFromLastStep' => 'skip-step' == $fromPage || 'last-step' == $fromPage,
             'report' => $report,
             'status' => $report->getStatus(),
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/MoneyInController.php
+++ b/client/app/src/Controller/Report/MoneyInController.php
@@ -7,7 +7,6 @@ use App\Entity\Report\BankAccount;
 use App\Entity\Report\MoneyTransaction;
 use App\Entity\Report\Status;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\Service\StepRedirector;
@@ -31,7 +30,6 @@ class MoneyInController extends AbstractController
         private RestClient $restClient,
         private ReportApi $reportApi,
         private StepRedirector $stepRedirector,
-        private ClientApi $clientApi,
     ) {
     }
 

--- a/client/app/src/Controller/Report/MoneyInShortController.php
+++ b/client/app/src/Controller/Report/MoneyInShortController.php
@@ -7,7 +7,6 @@ use App\Entity as EntityDir;
 use App\Entity\Report\MoneyTransactionShort;
 use App\Entity\Report\Status;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -26,7 +25,6 @@ class MoneyInShortController extends AbstractController
     public function __construct(
         private RestClient $restClient,
         private ReportApi $reportApi,
-        private ClientApi $clientApi,
     ) {
     }
 

--- a/client/app/src/Controller/Report/MoneyInShortController.php
+++ b/client/app/src/Controller/Report/MoneyInShortController.php
@@ -6,7 +6,6 @@ use App\Controller\AbstractController;
 use App\Entity as EntityDir;
 use App\Entity\Report\MoneyTransactionShort;
 use App\Entity\Report\Status;
-use App\Entity\User;
 use App\Form as FormDir;
 use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
@@ -27,7 +26,7 @@ class MoneyInShortController extends AbstractController
     public function __construct(
         private RestClient $restClient,
         private ReportApi $reportApi,
-        private ClientApi $clientApi
+        private ClientApi $clientApi,
     ) {
     }
 
@@ -40,10 +39,6 @@ class MoneyInShortController extends AbstractController
      */
     public function startAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
         if (Status::STATE_NOT_STARTED != $report->getStatus()->getMoneyInShortState()['state']) {
@@ -52,7 +47,6 @@ class MoneyInShortController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -393,10 +387,6 @@ class MoneyInShortController extends AbstractController
      */
     public function summaryAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $fromPage = $request->get('from');
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
@@ -408,7 +398,6 @@ class MoneyInShortController extends AbstractController
             'comingFromLastStep' => 'skip-step' == $fromPage || 'last-step' == $fromPage,
             'report' => $report,
             'status' => $report->getStatus(),
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/MoneyOutController.php
+++ b/client/app/src/Controller/Report/MoneyOutController.php
@@ -6,7 +6,6 @@ use App\Controller\AbstractController;
 use App\Entity\Report\BankAccount;
 use App\Entity\Report\MoneyTransaction;
 use App\Entity\Report\Status;
-use App\Entity\User;
 use App\Form as FormDir;
 use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
@@ -32,7 +31,7 @@ class MoneyOutController extends AbstractController
         private RestClient $restClient,
         private ReportApi $reportApi,
         private StepRedirector $stepRedirector,
-        private ClientApi $clientApi
+        private ClientApi $clientApi,
     ) {
     }
 
@@ -45,10 +44,6 @@ class MoneyOutController extends AbstractController
      */
     public function startAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (Status::STATE_NOT_STARTED != $report->getStatus()->getMoneyOutState()['state']) {
             return $this->redirectToRoute('money_out_summary', ['reportId' => $reportId]);
@@ -56,7 +51,6 @@ class MoneyOutController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -328,10 +322,6 @@ class MoneyOutController extends AbstractController
      */
     public function summaryAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $fromPage = $request->get('from');
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (Status::STATE_NOT_STARTED == $report->getStatus()->getMoneyOutState()['state'] && 'skip-step' != $fromPage) {
@@ -342,7 +332,6 @@ class MoneyOutController extends AbstractController
             'comingFromLastStep' => 'skip-step' == $fromPage || 'last-step' == $fromPage,
             'report' => $report,
             'status' => $report->getStatus(),
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/MoneyOutController.php
+++ b/client/app/src/Controller/Report/MoneyOutController.php
@@ -7,7 +7,6 @@ use App\Entity\Report\BankAccount;
 use App\Entity\Report\MoneyTransaction;
 use App\Entity\Report\Status;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\Service\StepRedirector;
@@ -31,7 +30,6 @@ class MoneyOutController extends AbstractController
         private RestClient $restClient,
         private ReportApi $reportApi,
         private StepRedirector $stepRedirector,
-        private ClientApi $clientApi,
     ) {
     }
 

--- a/client/app/src/Controller/Report/MoneyOutShortController.php
+++ b/client/app/src/Controller/Report/MoneyOutShortController.php
@@ -6,7 +6,6 @@ use App\Controller\AbstractController;
 use App\Entity as EntityDir;
 use App\Entity\Report\MoneyTransactionShort;
 use App\Entity\Report\Status;
-use App\Entity\User;
 use App\Form as FormDir;
 use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
@@ -27,7 +26,7 @@ class MoneyOutShortController extends AbstractController
     public function __construct(
         private RestClient $restClient,
         private ReportApi $reportApi,
-        private ClientApi $clientApi
+        private ClientApi $clientApi,
     ) {
     }
 
@@ -40,10 +39,6 @@ class MoneyOutShortController extends AbstractController
      */
     public function startAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
 
         if (Status::STATE_NOT_STARTED != $report->getStatus()->getMoneyOutShortState()['state']) {
@@ -52,7 +47,6 @@ class MoneyOutShortController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -396,10 +390,6 @@ class MoneyOutShortController extends AbstractController
      */
     public function summaryAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $fromPage = $request->get('from');
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (Status::STATE_NOT_STARTED == $report->getStatus()->getMoneyOutShortState()['state'] && 'skip-step' != $fromPage) {
@@ -410,7 +400,6 @@ class MoneyOutShortController extends AbstractController
             'comingFromLastStep' => 'skip-step' == $fromPage || 'last-step' == $fromPage,
             'report' => $report,
             'status' => $report->getStatus(),
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/MoneyOutShortController.php
+++ b/client/app/src/Controller/Report/MoneyOutShortController.php
@@ -7,7 +7,6 @@ use App\Entity as EntityDir;
 use App\Entity\Report\MoneyTransactionShort;
 use App\Entity\Report\Status;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -26,7 +25,6 @@ class MoneyOutShortController extends AbstractController
     public function __construct(
         private RestClient $restClient,
         private ReportApi $reportApi,
-        private ClientApi $clientApi,
     ) {
     }
 

--- a/client/app/src/Controller/Report/MoneyTransferController.php
+++ b/client/app/src/Controller/Report/MoneyTransferController.php
@@ -4,7 +4,6 @@ namespace App\Controller\Report;
 
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
-use App\Entity\User;
 use App\Form as FormDir;
 use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
@@ -29,7 +28,7 @@ class MoneyTransferController extends AbstractController
         private RestClient $restClient,
         private ReportApi $reportApi,
         private StepRedirector $stepRedirector,
-        private ClientApi $clientApi
+        private ClientApi $clientApi,
     ) {
     }
 
@@ -42,16 +41,11 @@ class MoneyTransferController extends AbstractController
      */
     public function startAction($reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (!$report->enoughBankAccountForTransfers()) {
             return $this->render('@App/Report/MoneyTransfer/error.html.twig', [
                 'error' => 'atLeastTwoBankAccounts',
                 'report' => $report,
-                'isMultiClientDeputy' => $isMultiClientDeputy,
             ]);
         }
 
@@ -61,7 +55,6 @@ class MoneyTransferController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -234,10 +227,6 @@ class MoneyTransferController extends AbstractController
      */
     public function summaryAction($reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (EntityDir\Report\Status::STATE_NOT_STARTED == $report->getStatus()->getMoneyTransferState()['state']) {
             return $this->redirect($this->generateUrl('money_transfers', ['reportId' => $reportId]));
@@ -245,7 +234,6 @@ class MoneyTransferController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/MoneyTransferController.php
+++ b/client/app/src/Controller/Report/MoneyTransferController.php
@@ -5,7 +5,6 @@ namespace App\Controller\Report;
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\Service\StepRedirector;
@@ -28,7 +27,6 @@ class MoneyTransferController extends AbstractController
         private RestClient $restClient,
         private ReportApi $reportApi,
         private StepRedirector $stepRedirector,
-        private ClientApi $clientApi,
     ) {
     }
 

--- a/client/app/src/Controller/Report/OtherInfoController.php
+++ b/client/app/src/Controller/Report/OtherInfoController.php
@@ -4,7 +4,6 @@ namespace App\Controller\Report;
 
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
-use App\Entity\User;
 use App\Form as FormDir;
 use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
@@ -26,7 +25,7 @@ class OtherInfoController extends AbstractController
         private RestClient $restClient,
         private ReportApi $reportApi,
         private StepRedirector $stepRedirector,
-        private ClientApi $clientApi
+        private ClientApi $clientApi,
     ) {
     }
 
@@ -39,10 +38,6 @@ class OtherInfoController extends AbstractController
      */
     public function startAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (EntityDir\Report\Status::STATE_NOT_STARTED != $report->getStatus()->getOtherInfoState()['state']) {
             return $this->redirectToRoute('other_info_summary', ['reportId' => $reportId]);
@@ -50,7 +45,6 @@ class OtherInfoController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -110,10 +104,6 @@ class OtherInfoController extends AbstractController
      */
     public function summaryAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $fromPage = $request->get('from');
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (EntityDir\Report\Status::STATE_NOT_STARTED == $report->getStatus()->getOtherInfoState()['state'] && 'skip-step' != $fromPage) {
@@ -123,7 +113,6 @@ class OtherInfoController extends AbstractController
         return [
             'comingFromLastStep' => 'skip-step' == $fromPage || 'last-step' == $fromPage,
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/OtherInfoController.php
+++ b/client/app/src/Controller/Report/OtherInfoController.php
@@ -5,7 +5,6 @@ namespace App\Controller\Report;
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\Service\StepRedirector;
@@ -25,7 +24,6 @@ class OtherInfoController extends AbstractController
         private RestClient $restClient,
         private ReportApi $reportApi,
         private StepRedirector $stepRedirector,
-        private ClientApi $clientApi,
     ) {
     }
 

--- a/client/app/src/Controller/Report/ReportController.php
+++ b/client/app/src/Controller/Report/ReportController.php
@@ -270,7 +270,11 @@ class ReportController extends AbstractController
         }
 
         $groups = ['client', 'client-name', 'client-case-number', 'client-reports', 'client-ndr', 'ndr', 'report', 'status'];
-        $clients = $this->clientApi->getAllClientsByDeputyUid($user->getDeputyUid(), $groups);
+        $clients = [];
+        $deputyUid = $user->getDeputyUid();
+        if (!is_null($deputyUid)) {
+            $clients = $this->clientApi->getAllClientsByDeputyUid($deputyUid, $groups);
+        }
 
         if (empty($clients)) {
             throw $this->createNotFoundException('Client not added');

--- a/client/app/src/Controller/Report/ReportController.php
+++ b/client/app/src/Controller/Report/ReportController.php
@@ -194,8 +194,6 @@ class ReportController extends AbstractController
             return $this->redirectToRoute('app_logout', ['notPrimaryAccount' => true]);
         }
 
-        $deputyHasMultiClients = $this->clientApi->checkDeputyHasMultiClients($user);
-
         // redirect if user has missing details or is on wrong page
         $route = $redirector->getCorrectRouteIfDifferent($user, 'lay_home');
         if (is_string($route)) {
@@ -208,7 +206,6 @@ class ReportController extends AbstractController
         $resultsArray = [
             'coDeputies' => $coDeputies,
             'clientHasCoDeputies' => $this->preRegistrationApi->clientHasCoDeputies($clientWithCoDeputies->getCaseNumber()),
-            'deputyHasMultiClients' => $deputyHasMultiClients,
         ];
 
         if ($ndrEnabled) {
@@ -431,15 +428,12 @@ class ReportController extends AbstractController
 
         $activeReport = $activeReportId ? $this->reportApi->getReportIfNotSubmitted($activeReportId, $reportJmsGroup) : null;
 
-        $deputyHasMultiClients = !$user->isDeputyOrg() && count($this->clientApi->getAllClientsByDeputyUid($user->getDeputyUid())) > 1;
-
         return $this->render($template, [
             'user' => $user,
             'client' => $client,
             'deputy' => $deputy,
             'report' => $report,
             'activeReport' => $activeReport,
-            'deputyHasMultiClients' => $deputyHasMultiClients,
         ]);
     }
 
@@ -535,14 +529,11 @@ class ReportController extends AbstractController
             return $this->redirect($this->generateUrl('report_submit_confirmation', ['reportId' => $report->getId()]));
         }
 
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($currentUser);
-
         return [
             'report' => $report,
             'client' => $report->getClient(),
             'contactDetails' => $this->getAssociatedContactDetails($deputy, $report),
             'form' => $form->createView(),
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -589,7 +580,7 @@ class ReportController extends AbstractController
      *
      * @Template("@App/Report/Report/review.html.twig")
      *
-     * @return RedirectResponse
+     * @return RedirectResponse|array
      *
      * @throws \Exception
      */
@@ -618,15 +609,12 @@ class ReportController extends AbstractController
             }
         }
 
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         return [
             'user' => $this->getUser(),
             'report' => $report,
             'reportStatus' => $status,
             'backLink' => $backLink,
             'feeTotals' => $report->getFeeTotals(),
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/Report/VisitsCareController.php
+++ b/client/app/src/Controller/Report/VisitsCareController.php
@@ -5,7 +5,6 @@ namespace App\Controller\Report;
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
 use App\Form as FormDir;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
 use App\Service\Client\RestClient;
 use App\Service\StepRedirector;
@@ -26,7 +25,6 @@ class VisitsCareController extends AbstractController
         private RestClient $restClient,
         private ReportApi $reportApi,
         private StepRedirector $stepRedirector,
-        private ClientApi $clientApi,
     ) {
     }
 

--- a/client/app/src/Controller/Report/VisitsCareController.php
+++ b/client/app/src/Controller/Report/VisitsCareController.php
@@ -4,7 +4,6 @@ namespace App\Controller\Report;
 
 use App\Controller\AbstractController;
 use App\Entity as EntityDir;
-use App\Entity\User;
 use App\Form as FormDir;
 use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\ReportApi;
@@ -27,7 +26,7 @@ class VisitsCareController extends AbstractController
         private RestClient $restClient,
         private ReportApi $reportApi,
         private StepRedirector $stepRedirector,
-        private ClientApi $clientApi
+        private ClientApi $clientApi,
     ) {
     }
 
@@ -40,10 +39,6 @@ class VisitsCareController extends AbstractController
      */
     public function startAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (EntityDir\Report\Status::STATE_NOT_STARTED != $report->getStatus()->getVisitsCareState()['state']) {
             return $this->redirectToRoute('visits_care_summary', ['reportId' => $reportId]);
@@ -51,7 +46,6 @@ class VisitsCareController extends AbstractController
 
         return [
             'report' => $report,
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 
@@ -132,10 +126,6 @@ class VisitsCareController extends AbstractController
      */
     public function summaryAction(Request $request, $reportId)
     {
-        /** @var User $user */
-        $user = $this->getUser();
-        $isMultiClientDeputy = $this->clientApi->checkDeputyHasMultiClients($user);
-
         $fromPage = $request->get('from');
         $report = $this->reportApi->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         if (EntityDir\Report\Status::STATE_NOT_STARTED == $report->getStatus()->getVisitsCareState()['state'] && 'skip-step' != $fromPage) {
@@ -150,7 +140,6 @@ class VisitsCareController extends AbstractController
             'comingFromLastStep' => 'skip-step' == $fromPage || 'last-step' == $fromPage,
             'report' => $report,
             'status' => $report->getStatus(),
-            'isMultiClientDeputy' => $isMultiClientDeputy,
         ];
     }
 

--- a/client/app/src/Controller/SettingsController.php
+++ b/client/app/src/Controller/SettingsController.php
@@ -5,7 +5,6 @@ namespace App\Controller;
 use App\Entity as EntityDir;
 use App\Form as FormDir;
 use App\Service\Audit\AuditEvents;
-use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\UserApi;
 use App\Service\Client\RestClient;
 use App\Service\Redirector;
@@ -21,7 +20,6 @@ class SettingsController extends AbstractController
     public function __construct(
         private readonly TranslatorInterface $translator,
         private readonly UserApi $userApi,
-        private readonly ClientApi $clientApi,
         private readonly RestClient $restClient,
     ) {
     }

--- a/client/app/src/Service/Client/Internal/ClientApi.php
+++ b/client/app/src/Service/Client/Internal/ClientApi.php
@@ -6,7 +6,6 @@ namespace App\Service\Client\Internal;
 
 use App\Entity\Client;
 use App\Entity\Report\Report;
-use App\Entity\User;
 use App\Event\ClientDeletedEvent;
 use App\Event\ClientUpdatedEvent;
 use App\EventDispatcher\ObservableEventDispatcher;
@@ -198,23 +197,5 @@ class ClientApi
             sprintf(self::GET_ALL_CLIENTS_BY_DEPUTY_UID, $deputyUid),
             'Client[]', $groups
         );
-    }
-
-    public function checkDeputyHasMultiClients(User $user): bool
-    {
-        // if we can't find the user's deputy UID, we can't look up their clients by UID using
-        // getAllClientsByDeputyUid, so we don't know if they are a single or multi client deputy, and default to
-        // single; this will disable the "choose a client" breadcrumb link
-        $deputyUid = $user->getDeputyUid();
-        if (is_null($deputyUid)) {
-            $this->logger->error(
-                "Deputy with ID {$user->getId()} has null deputy UID; ".
-                'returning false from checkDeputyHasMultiClients() (unsure if they are a multi-client deputy)'
-            );
-
-            return false;
-        }
-
-        return 'ROLE_LAY_DEPUTY' == $user->getRoleName() && count($this->getAllClientsByDeputyUid($deputyUid)) > 1;
     }
 }

--- a/client/app/src/Service/Client/Internal/ClientApi.php
+++ b/client/app/src/Service/Client/Internal/ClientApi.php
@@ -10,8 +10,6 @@ use App\Event\ClientDeletedEvent;
 use App\Event\ClientUpdatedEvent;
 use App\EventDispatcher\ObservableEventDispatcher;
 use App\Service\Client\RestClientInterface;
-use App\Service\Time\DateTimeProvider;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
@@ -27,30 +25,13 @@ class ClientApi
     private const UPDATE_CLIENT_DEPUTY = 'client/%d/update-deputy/%d';
     private const GET_ALL_CLIENTS_BY_DEPUTY_UID = 'client/get-all-clients-by-deputy-uid/%s';
 
-    private RestClientInterface $restClient;
-    private RouterInterface $router;
-    private LoggerInterface $logger;
-    private UserApi $userApi;
-    private DateTimeProvider $dateTimeProvider;
-    private TokenStorageInterface $tokenStorage;
-    private ObservableEventDispatcher $eventDispatcher;
-
     public function __construct(
-        RestClientInterface $restClient,
-        RouterInterface $router,
-        LoggerInterface $logger,
-        UserApi $userApi,
-        DateTimeProvider $dateTimeProvider,
-        TokenStorageInterface $tokenStorage,
-        ObservableEventDispatcher $eventDispatcher,
+        private readonly RestClientInterface $restClient,
+        private readonly RouterInterface $router,
+        private readonly UserApi $userApi,
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly ObservableEventDispatcher $eventDispatcher,
     ) {
-        $this->restClient = $restClient;
-        $this->router = $router;
-        $this->logger = $logger;
-        $this->userApi = $userApi;
-        $this->dateTimeProvider = $dateTimeProvider;
-        $this->tokenStorage = $tokenStorage;
-        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**

--- a/client/app/templates/Client/edit.html.twig
+++ b/client/app/templates/Client/edit.html.twig
@@ -12,7 +12,7 @@
 
 {% block breadcrumbs %}
     {{ macros.breadcrumbsArray([
-        { href: url('deputyship_details_clients'), text: 'Client details' },
+        { href: url('deputyship_details_clients'), text: 'Your reports' },
         { href: url('lay_home', {clientId: client.id}), text: client.firstname ~ '\'s reports' },
         { href: url('client_show', {clientId: client.id}), text: client.firstname ~ '\'s details' }
     ]) }}

--- a/client/app/templates/Client/edit.html.twig
+++ b/client/app/templates/Client/edit.html.twig
@@ -12,8 +12,7 @@
 
 {% block breadcrumbs %}
     {{ macros.breadcrumbsArray([
-        { href: url('deputyship_details_clients'), text: 'Your reports' },
-        { href: url('lay_home', {clientId: client.id}), text: client.firstname ~ '\'s reports' },
+        { href: url('deputyship_details_clients'), text: 'Your clients' },
         { href: url('client_show', {clientId: client.id}), text: client.firstname ~ '\'s details' }
     ]) }}
 {% endblock %}

--- a/client/app/templates/Client/edit.html.twig
+++ b/client/app/templates/Client/edit.html.twig
@@ -11,15 +11,11 @@
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans({'%client%': client.firstname}) }}{% endblock %}
 
 {% block breadcrumbs %}
-    {% if deputyHasMultiClients %}
-        {{ macros.breadcrumbsArray([
-            { href: url('choose_a_client'), text: 'Choose a client' },
-            { href: url('lay_home', {clientId: client.id}), text: client.firstname ~ '\'s reports' },
-            { href: url('client_show', {clientId: client.id}), text: client.firstname ~ '\'s details' }
-        ]) }}
-    {% else %}
-        {{ macros.breadcrumbsSettings('settings-client') }}
-    {% endif %}
+    {{ macros.breadcrumbsArray([
+        { href: url('deputyship_details_clients'), text: 'Client details' },
+        { href: url('lay_home', {clientId: client.id}), text: client.firstname ~ '\'s reports' },
+        { href: url('client_show', {clientId: client.id}), text: client.firstname ~ '\'s details' }
+    ]) }}
 {% endblock %}
 
 {% block pageContent %}

--- a/client/app/templates/Client/edit.html.twig
+++ b/client/app/templates/Client/edit.html.twig
@@ -12,7 +12,7 @@
 
 {% block breadcrumbs %}
     {{ macros.breadcrumbsArray([
-        { href: url('deputyship_details_clients'), text: 'Your clients' },
+        { href: url('homepage'), text: 'Your reports' },
         { href: url('client_show', {clientId: client.id}), text: client.firstname ~ '\'s details' }
     ]) }}
 {% endblock %}

--- a/client/app/templates/Client/show.html.twig
+++ b/client/app/templates/Client/show.html.twig
@@ -11,7 +11,7 @@
 
 {% block breadcrumbs %}
     {{ macros.breadcrumbsArray([
-        { href: url('deputyship_details_clients'), text: 'Your clients' }
+        { href: url('homepage'), text: 'Your reports' }
     ]) }}
 {% endblock %}
 

--- a/client/app/templates/Client/show.html.twig
+++ b/client/app/templates/Client/show.html.twig
@@ -11,8 +11,7 @@
 
 {% block breadcrumbs %}
     {{ macros.breadcrumbsArray([
-        { href: url('deputyship_details_clients'), text: 'Your reports' },
-        { href: url('lay_home', {clientId: client.id}), text: client.firstname ~ '\'s reports' }
+        { href: url('deputyship_details_clients'), text: 'Your clients' }
     ]) }}
 {% endblock %}
 

--- a/client/app/templates/Client/show.html.twig
+++ b/client/app/templates/Client/show.html.twig
@@ -10,14 +10,10 @@
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans({'%client%': client.firstname}) }}{% endblock %}
 
 {% block breadcrumbs %}
-    {% if deputyHasMultiClients %}
-        {{ macros.breadcrumbsArray([
-            { href: url('choose_a_client'), text: 'Choose a client' },
-            { href: url('lay_home', {clientId: client.id}), text: client.firstname ~ '\'s reports' }
-        ]) }}
-    {% else %}
-        {{ macros.breadcrumbsSettings('settings-client') }}
-    {% endif %}
+    {{ macros.breadcrumbsArray([
+        { href: url('deputyship_details_clients'), text: 'Client details' },
+        { href: url('lay_home', {clientId: client.id}), text: client.firstname ~ '\'s reports' }
+    ]) }}
 {% endblock %}
 
 {% block pageContent %}

--- a/client/app/templates/Client/show.html.twig
+++ b/client/app/templates/Client/show.html.twig
@@ -11,7 +11,7 @@
 
 {% block breadcrumbs %}
     {{ macros.breadcrumbsArray([
-        { href: url('deputyship_details_clients'), text: 'Client details' },
+        { href: url('deputyship_details_clients'), text: 'Your reports' },
         { href: url('lay_home', {clientId: client.id}), text: client.firstname ~ '\'s reports' }
     ]) }}
 {% endblock %}

--- a/client/app/templates/Deputyship/client-list.html.twig
+++ b/client/app/templates/Deputyship/client-list.html.twig
@@ -1,8 +1,16 @@
 {% extends '@App/Layouts/application.html.twig'%}
 
+{% import '@App/Macros/macros.html.twig' as macros %}
+
 {% trans_default_domain 'deputyship' %}
 {% block htmlTitle %}{{ 'clients.title' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'clients.title' | trans }}{% endblock %}
+
+{% block breadcrumbs %}
+    {{ macros.breadcrumbsArray([
+        { href: url('homepage'), text: 'Your reports' }
+    ]) }}
+{% endblock %}
 
 {% block pageContent %}
     {% if clients|length == 0 %}

--- a/client/app/templates/Deputyship/client-list.html.twig
+++ b/client/app/templates/Deputyship/client-list.html.twig
@@ -16,7 +16,7 @@
                     </h2>
                     <ul class="govuk-summary-card__actions">
                         <li class="govuk-summary-card__action">
-                            <a class="govuk-link" href="{{ path('lay_home', {'clientId' : client.id}) }}">
+                            <a class="govuk-link" href="{{ path('client_show', {'clientId': client.id}) }}">
                                 {{ 'clients.manageLinkText' | trans }}
                             </a>
                         </li>

--- a/client/app/templates/Layouts/application.html.twig
+++ b/client/app/templates/Layouts/application.html.twig
@@ -43,22 +43,11 @@
                             {{ 'nav.userAccount' | trans }}
                         </a>
                     </li>
-                    {% if client is defined and client is not null %}
-                        {% set clientId = client.id %}
-                    {% elseif report is defined and report is not null %}
-                        {% set clientId = report.client.id %}
-                    {% elseif ndr is defined and ndr is not null %}
-                        {% set clientId = ndr.client.id %}
-                    {% endif %}
-
-                    {% if clientId is defined and clientId is not null %}
                     <li class="govuk-header__navigation-item">
-                        <a href="{{ path('client_show', {'clientId': clientId}) }}" class="govuk-header__link behat-link-user-account">
-                            {{ 'nav.clientAccount' | trans }}
+                        <a href="{{ path('deputyship_details_clients') }}" class="govuk-header__link behat-link-user-account">
+                            {{ 'nav.clients' | trans }}
                         </a>
                     </li>
-                    {% endif %}
-
                 {% endif %}
                 {% if app.user.isDeputyOrg() %}
                     <li class="govuk-header__navigation-item">

--- a/client/app/templates/Macros/macros.html.twig
+++ b/client/app/templates/Macros/macros.html.twig
@@ -83,7 +83,7 @@
             {% else %}
                 <li class="govuk-breadcrumbs__list-item">
                     <a href="{{ path('homepage') }}" class="govuk-breadcrumbs__link">
-                        Deputy reports
+                        Your reports
                     </a>
                 </li>
                 {% if 'settings' in section and section != 'settings' and section != 'settings-client'%}

--- a/client/app/templates/Macros/macros.html.twig
+++ b/client/app/templates/Macros/macros.html.twig
@@ -1,24 +1,13 @@
-{% macro breadcrumbs(report, isMultiClientDeputy) %}
+{% macro breadcrumbs(report) %}
     {% set isUserNdrEnabled = app.user.isNdrEnabled() %}
     {% set isOrgUser = app.user.isDeputyOrg() %}
 
     <div class="govuk-breadcrumbs">
         <ol class="govuk-breadcrumbs__list">
-            {% if isMultiClientDeputy %}
-                <li class="govuk-breadcrumbs__list-item">
-                    <a href="{{ path('choose_a_client') }}" class="govuk-breadcrumbs__link">
-                        {{ 'chooseAClient' | trans({}, 'common' ) }}
-                    </a>
-                </li>
-            {% endif %}
                 <li class="govuk-breadcrumbs__list-item">
                     {% if isOrgUser %}
                         <a href="{{ path('org_dashboard') }}" class="govuk-breadcrumbs__link">
                             {{ 'dashboard' | trans({}, 'common' ) }}
-                        </a>
-                    {% elseif isMultiClientDeputy  %}
-                        <a href="{{ path('lay_home', {clientId: report.client.id}) }}" class="govuk-breadcrumbs__link">
-                            {{ 'yourReports' | trans({'deputyFirstname': app.user.firstname, 'deputyLastname': app.user.lastname}, 'common' ) }}
                         </a>
                     {% else  %}
                         <a href="{{ path('homepage') }}" class="govuk-breadcrumbs__link">

--- a/client/app/templates/Ndr/Action/start.html.twig
+++ b/client/app/templates/Ndr/Action/start.html.twig
@@ -10,7 +10,7 @@
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(ndr, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(ndr) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Ndr/Asset/start.html.twig
+++ b/client/app/templates/Ndr/Asset/start.html.twig
@@ -10,7 +10,7 @@
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(ndr, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(ndr) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Ndr/BankAccount/start.html.twig
+++ b/client/app/templates/Ndr/BankAccount/start.html.twig
@@ -10,7 +10,7 @@
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans(transOptions) }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(ndr, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(ndr) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Ndr/Debt/start.html.twig
+++ b/client/app/templates/Ndr/Debt/start.html.twig
@@ -11,7 +11,7 @@
 
 
 {% block breadcrumbs %}
-    {{ macros.breadcrumbs(ndr, isMultiClientDeputy) }}
+    {{ macros.breadcrumbs(ndr) }}
 {% endblock %}
 
 {% block pageContent %}

--- a/client/app/templates/Ndr/DeputyExpense/start.html.twig
+++ b/client/app/templates/Ndr/DeputyExpense/start.html.twig
@@ -10,7 +10,7 @@
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(ndr, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(ndr) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Ndr/IncomeBenefit/start.html.twig
+++ b/client/app/templates/Ndr/IncomeBenefit/start.html.twig
@@ -10,7 +10,7 @@
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(ndr, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(ndr) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Ndr/Ndr/declaration.html.twig
+++ b/client/app/templates/Ndr/Ndr/declaration.html.twig
@@ -12,13 +12,6 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs hard--bottom">
         <ol class="group">
-            {% if isMultiClientDeputy %}
-                <li class="govuk-breadcrumbs__list-item">
-                    <a href="{{ path('choose_a_client') }}" class="govuk-breadcrumbs__link">
-                        {{ 'chooseAClient' | trans({}, 'common' ) }}
-                    </a>
-                </li>
-            {% endif %}
             <li>
                 <a href="{{ path('homepage') }}">{{ 'yourReports' | trans({'deputyFirstname': app.user.firstname, 'deputyLastname': app.user.lastname}, 'common' ) }}</a>
             </li>

--- a/client/app/templates/Ndr/Ndr/overview.html.twig
+++ b/client/app/templates/Ndr/Ndr/overview.html.twig
@@ -10,14 +10,10 @@
 {% block supportTitleTop %}{{ client.fullname }}{% endblock %}
 
 {% block breadcrumbs %}
-    {% if deputyHasMultiClients %}
-        {{ macros.breadcrumbsArray([
-            { href: url('choose_a_client'), text: 'Choose a client' },
-            { href: url('lay_home', {clientId: client.id}), text: client.firstname ~ '\'s reports' }
-        ]) }}
-    {% else %}
-        {{ macros.homepage }}
-    {% endif %}
+    {{ macros.breadcrumbsArray([
+        { href: url('deputyship_details_clients'), text: 'Client details' },
+        { href: url('lay_home', {clientId: client.id}), text: client.firstname ~ '\'s reports' }
+    ]) }}
 {% endblock %}
 
 {% block pageContent %}

--- a/client/app/templates/Ndr/Ndr/overview.html.twig
+++ b/client/app/templates/Ndr/Ndr/overview.html.twig
@@ -11,7 +11,7 @@
 
 {% block breadcrumbs %}
     {{ macros.breadcrumbsArray([
-        { href: url('deputyship_details_clients'), text: 'Client details' },
+        { href: url('deputyship_details_clients'), text: 'Your reports' },
         { href: url('lay_home', {clientId: client.id}), text: client.firstname ~ '\'s reports' }
     ]) }}
 {% endblock %}

--- a/client/app/templates/Ndr/Ndr/review.html.twig
+++ b/client/app/templates/Ndr/Ndr/review.html.twig
@@ -34,7 +34,7 @@
            class="govuk-link link-back behat-link-back-to-reports">{{ 'back' | trans({}, 'common' ) }}
         </a>
     {% else %}
-        {{ macros.breadcrumbs(ndr, isMultiClientDeputy) }}
+        {{ macros.breadcrumbs(ndr) }}
     {% endif %}
 {% endblock %}
 

--- a/client/app/templates/Ndr/OtherInfo/start.html.twig
+++ b/client/app/templates/Ndr/OtherInfo/start.html.twig
@@ -10,7 +10,7 @@
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(ndr, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(ndr) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Ndr/VisitsCare/start.html.twig
+++ b/client/app/templates/Ndr/VisitsCare/start.html.twig
@@ -10,7 +10,7 @@
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(ndr, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(ndr) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/Action/start.html.twig
+++ b/client/app/templates/Report/Action/start.html.twig
@@ -12,7 +12,7 @@
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/Action/summary.html.twig
+++ b/client/app/templates/Report/Action/summary.html.twig
@@ -14,7 +14,7 @@
 
 
 {# Breadcrumbs #}
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/Asset/start.html.twig
+++ b/client/app/templates/Report/Asset/start.html.twig
@@ -11,7 +11,7 @@
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/Asset/summary.html.twig
+++ b/client/app/templates/Report/Asset/summary.html.twig
@@ -13,7 +13,7 @@
 
 
 {# Breadcrumbs #}
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/Balance/balance.html.twig
+++ b/client/app/templates/Report/Balance/balance.html.twig
@@ -15,7 +15,7 @@
 {% block htmlTitle %}{{ 'htmlTitle' | trans }}{% endblock %}
 {% block pageTitle %}{{ 'pageTitle' | trans }}{% endblock %}
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
     {% if not readyToBalance %}

--- a/client/app/templates/Report/BankAccount/start.html.twig
+++ b/client/app/templates/Report/BankAccount/start.html.twig
@@ -13,7 +13,7 @@
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans(transOptions) }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/BankAccount/summary.html.twig
+++ b/client/app/templates/Report/BankAccount/summary.html.twig
@@ -12,7 +12,7 @@
 
 
 {# Breadcrumbs #}
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/ClientBenefitsCheck/start.html.twig
+++ b/client/app/templates/Report/ClientBenefitsCheck/start.html.twig
@@ -13,7 +13,7 @@
 {% block pageTitle %}{{ 'common.pageTitle' | trans(transOptions) }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/ClientBenefitsCheck/summary.html.twig
+++ b/client/app/templates/Report/ClientBenefitsCheck/summary.html.twig
@@ -12,7 +12,7 @@
 {% block htmlTitle %}{{ 'common.htmlTitle' | trans(transOptions, translationDomain) }}{% endblock %}
 {% block pageTitle %}{{ 'common.pageTitle' | trans(transOptions, translationDomain) }}{% endblock %}
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/Contact/start.html.twig
+++ b/client/app/templates/Report/Contact/start.html.twig
@@ -11,7 +11,7 @@
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/Contact/summary.html.twig
+++ b/client/app/templates/Report/Contact/summary.html.twig
@@ -12,7 +12,7 @@
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 
 {# Breadcrumbs #}
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/Debt/start.html.twig
+++ b/client/app/templates/Report/Debt/start.html.twig
@@ -11,7 +11,7 @@
 
 
 {% block breadcrumbs %}
-    {{ macros.breadcrumbs(report, isMultiClientDeputy) }}
+    {{ macros.breadcrumbs(report) }}
 {% endblock %}
 
 {% block pageContent %}

--- a/client/app/templates/Report/Debt/summary.html.twig
+++ b/client/app/templates/Report/Debt/summary.html.twig
@@ -14,7 +14,7 @@
 
 
 {# Breadcrumbs #}
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/Decision/start.html.twig
+++ b/client/app/templates/Report/Decision/start.html.twig
@@ -13,7 +13,7 @@
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
     <p class="govuk-body">{{ (page ~ '.description1') | trans(transOptions) }}</p>

--- a/client/app/templates/Report/Decision/summary.html.twig
+++ b/client/app/templates/Report/Decision/summary.html.twig
@@ -14,7 +14,7 @@
 
 
 {# Breadcrumbs #}
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
     <div class="govuk-grid-row">

--- a/client/app/templates/Report/DeputyExpense/start.html.twig
+++ b/client/app/templates/Report/DeputyExpense/start.html.twig
@@ -13,7 +13,7 @@
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/DeputyExpense/summary.html.twig
+++ b/client/app/templates/Report/DeputyExpense/summary.html.twig
@@ -12,7 +12,7 @@
 
 
 {# Breadcrumbs #}
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/Document/start.html.twig
+++ b/client/app/templates/Report/Document/start.html.twig
@@ -10,7 +10,7 @@
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/Document/summary.html.twig
+++ b/client/app/templates/Report/Document/summary.html.twig
@@ -14,7 +14,7 @@
 {% block pageTitle %}{{ 'summaryPage.pageTitle' | trans }}{% endblock %}
 
 {# Breadcrumbs #}
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/Gift/start.html.twig
+++ b/client/app/templates/Report/Gift/start.html.twig
@@ -13,7 +13,7 @@
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/Gift/summary.html.twig
+++ b/client/app/templates/Report/Gift/summary.html.twig
@@ -12,7 +12,7 @@
 
 
 {# Breadcrumbs #}
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/Lifestyle/start.html.twig
+++ b/client/app/templates/Report/Lifestyle/start.html.twig
@@ -10,7 +10,7 @@
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/Lifestyle/summary.html.twig
+++ b/client/app/templates/Report/Lifestyle/summary.html.twig
@@ -11,7 +11,7 @@
 {% block pageTitle %}{{ 'summaryPage.pageTitle' | trans }}{% endblock %}
 
 {# Breadcrumbs #}
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/MoneyIn/start.html.twig
+++ b/client/app/templates/Report/MoneyIn/start.html.twig
@@ -16,7 +16,7 @@
 {% block pageTitle %}{{ 'startPage.moneyIn.pageTitle' | trans(transOptions) }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/MoneyIn/summary.html.twig
+++ b/client/app/templates/Report/MoneyIn/summary.html.twig
@@ -19,7 +19,7 @@
 
 
 {# Breadcrumbs #}
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/MoneyInShort/start.html.twig
+++ b/client/app/templates/Report/MoneyInShort/start.html.twig
@@ -10,7 +10,7 @@
 {% block pageTitle %}{{ 'startPage.moneyIn.pageTitle' | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block notification %}
     {{ macros.notification('info', 'startPage.notification' | trans)}}

--- a/client/app/templates/Report/MoneyInShort/summary.html.twig
+++ b/client/app/templates/Report/MoneyInShort/summary.html.twig
@@ -12,7 +12,7 @@
 
 
 {# Breadcrumbs #}
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/MoneyOut/start.html.twig
+++ b/client/app/templates/Report/MoneyOut/start.html.twig
@@ -20,7 +20,7 @@
 {% block pageTitle %}{{ 'startPage.moneyOut.pageTitle' | trans(transOptions) }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/MoneyOut/summary.html.twig
+++ b/client/app/templates/Report/MoneyOut/summary.html.twig
@@ -21,7 +21,7 @@
 
 
 {# Breadcrumbs #}
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/MoneyOutShort/start.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/start.html.twig
@@ -10,7 +10,7 @@
 {% block pageTitle %}{{ 'startPage.moneyOut.pageTitle' | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block notification %}
     {{ macros.notification('info', 'startPage.notification' | trans)}}

--- a/client/app/templates/Report/MoneyOutShort/summary.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/summary.html.twig
@@ -12,7 +12,7 @@
 
 
 {# Breadcrumbs #}
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/MoneyTransfer/error.html.twig
+++ b/client/app/templates/Report/MoneyTransfer/error.html.twig
@@ -10,7 +10,7 @@
 {% block pageTitle %}{{ 'errorPage.pageTitle' | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/MoneyTransfer/start.html.twig
+++ b/client/app/templates/Report/MoneyTransfer/start.html.twig
@@ -10,7 +10,7 @@
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/MoneyTransfer/summary.html.twig
+++ b/client/app/templates/Report/MoneyTransfer/summary.html.twig
@@ -12,7 +12,7 @@
 
 
 {# Breadcrumbs #}
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/OtherInfo/start.html.twig
+++ b/client/app/templates/Report/OtherInfo/start.html.twig
@@ -11,7 +11,7 @@
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
     <p class="govuk-body">

--- a/client/app/templates/Report/OtherInfo/summary.html.twig
+++ b/client/app/templates/Report/OtherInfo/summary.html.twig
@@ -12,7 +12,7 @@
 
 
 {# Breadcrumbs #}
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/Report/declaration.html.twig
+++ b/client/app/templates/Report/Report/declaration.html.twig
@@ -12,20 +12,9 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs hard--bottom">
         <ol class="group">
-            {% if isMultiClientDeputy %}
-                <li class="govuk-breadcrumbs__list-item">
-                    <a href="{{ path('choose_a_client') }}" class="govuk-breadcrumbs__link">
-                        {{ 'chooseAClient' | trans({}, 'common' ) }}
-                    </a>
-                </li>
-            {% endif %}
             <li>
                 {% if app.user.isDeputyOrg() %}
                     <a href="{{ path('org_dashboard') }}">{{ 'dashboard' | trans({}, 'common' ) }}</a>
-                {% elseif isMultiClientDeputy  %}
-                    <a href="{{ path('lay_home', {clientId: report.client.id}) }}" class="govuk-breadcrumbs__link">
-                        {{ 'yourReports' | trans({'deputyFirstname': app.user.firstname, 'deputyLastname': app.user.lastname}, 'common' ) }}
-                    </a>
                 {% else %}
                     <a href="{{ path('homepage') }}">{{ 'yourReports' | trans({'deputyFirstname': app.user.firstname, 'deputyLastname': app.user.lastname}, 'common' ) }}</a>
                 {% endif %}

--- a/client/app/templates/Report/Report/index.html.twig
+++ b/client/app/templates/Report/Report/index.html.twig
@@ -10,14 +10,6 @@
 {% block pageTitle %}{{ (page ~ '.pageTitle') | trans }}{% endblock %}
 {% block supportTitleTop %}{{ client.fullname }}{% endblock %}
 
-{% block breadcrumbs %}
-    {% if deputyHasMultiClients %}
-        {{ macros.breadcrumbsArray([
-            { href: url('choose_a_client'), text: 'Choose a client' }
-        ]) }}
-    {% endif %}
-{% endblock %}
-
 {% block pageContent %}
 
     {% if ndrEnabled %}

--- a/client/app/templates/Report/Report/overview.html.twig
+++ b/client/app/templates/Report/Report/overview.html.twig
@@ -15,14 +15,11 @@
 {% block pageTitle %}{{ report.period }} {{ 'reportOverviewTitle' | trans() }}{% endblock %}
 
 {% block breadcrumbs %}
-    {% if deputyHasMultiClients %}
-        {{ macros.breadcrumbsArray([
-            { href: url('choose_a_client'), text: 'Choose a client' },
-            { href: url('lay_home', {clientId: client.id}), text: client.firstname ~ '\'s reports' }
-        ]) }}
-    {% else %}
-        {{ macros.homepage }}
-    {% endif %}
+    {{ macros.breadcrumbsArray([
+        { href: url('deputyship_details_clients'), text: 'Client details' },
+        { href: url('lay_home', {clientId: client.id}), text: client.firstname ~ '\'s reports' }
+    ]) }}
+
 {% endblock %}
 
 {% block pageContent %}

--- a/client/app/templates/Report/Report/overview.html.twig
+++ b/client/app/templates/Report/Report/overview.html.twig
@@ -16,7 +16,7 @@
 
 {% block breadcrumbs %}
     {{ macros.breadcrumbsArray([
-        { href: url('deputyship_details_clients'), text: 'Client details' },
+        { href: url('deputyship_details_clients'), text: 'Your reports' },
         { href: url('lay_home', {clientId: client.id}), text: client.firstname ~ '\'s reports' }
     ]) }}
 

--- a/client/app/templates/Report/Report/review.html.twig
+++ b/client/app/templates/Report/Report/review.html.twig
@@ -39,7 +39,7 @@
                class="govuk-link link-back behat-link-return-to-client-profile">{{ 'page.returnToClientProfile' | trans({}, 'report-submitted') }}</a>
         {% endif %}
     {% else %}
-        {{ macros.breadcrumbs(report, isMultiClientDeputy) }}
+        {{ macros.breadcrumbs(report) }}
     {% endif %}
 {% endblock %}
 

--- a/client/app/templates/Report/VisitsCare/start.html.twig
+++ b/client/app/templates/Report/VisitsCare/start.html.twig
@@ -10,7 +10,7 @@
 {% block pageTitle %}{{ 'startPage.pageTitle' | trans }}{% endblock %}
 
 
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Report/VisitsCare/summary.html.twig
+++ b/client/app/templates/Report/VisitsCare/summary.html.twig
@@ -12,7 +12,7 @@
 
 
 {# Breadcrumbs #}
-{% block breadcrumbs %}{{ macros.breadcrumbs(report, isMultiClientDeputy) }}{% endblock %}
+{% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block pageContent %}
 

--- a/client/app/templates/Settings/index.html.twig
+++ b/client/app/templates/Settings/index.html.twig
@@ -10,7 +10,7 @@
 
 {% block breadcrumbs %}
     {{ macros.breadcrumbsArray([
-        { href: url('deputyship_details_clients'), text: 'Client details' }
+        { href: url('deputyship_details_clients'), text: 'Your reports' }
     ]) }}
 {% endblock %}
 

--- a/client/app/templates/Settings/index.html.twig
+++ b/client/app/templates/Settings/index.html.twig
@@ -9,13 +9,9 @@
 {% block pageTitle %}{{ (app.user.isDeputyOrg() ? 'pageTitle.pa-settings-page' : 'pageTitle.settings-page') | trans }}{% endblock %}
 
 {% block breadcrumbs %}
-    {% if deputyHasMultiClients %}
-        {{ macros.breadcrumbsArray([
-            { href: url('choose_a_client'), text: 'Choose a client' }
-        ]) }}
-    {% else %}
-        {{ macros.breadcrumbsSettings('settings') }}
-    {% endif %}
+    {{ macros.breadcrumbsArray([
+        { href: url('deputyship_details_clients'), text: 'Client details' }
+    ]) }}
 {% endblock %}
 
 {% block pageContent %}

--- a/client/app/templates/Settings/index.html.twig
+++ b/client/app/templates/Settings/index.html.twig
@@ -9,9 +9,7 @@
 {% block pageTitle %}{{ (app.user.isDeputyOrg() ? 'pageTitle.pa-settings-page' : 'pageTitle.settings-page') | trans }}{% endblock %}
 
 {% block breadcrumbs %}
-    {{ macros.breadcrumbsArray([
-        { href: url('deputyship_details_clients'), text: 'Your reports' }
-    ]) }}
+    {{ macros.breadcrumbsSettings('settings') }}
 {% endblock %}
 
 {% block pageContent %}

--- a/client/app/templates/Settings/passwordEdit.html.twig
+++ b/client/app/templates/Settings/passwordEdit.html.twig
@@ -9,14 +9,10 @@
 {% block pageTitle %}{{ 'pageTitle.change-password' | trans }}{% endblock %}
 
 {% block breadcrumbs %}
-    {% if deputyHasMultiClients %}
-        {{ macros.breadcrumbsArray([
-            { href: url('choose_a_client'), text: 'Choose a client' },
-            { href: url('account_settings'), text: 'Deputyship details' }
-        ]) }}
-    {% else %}
-        {{ macros.breadcrumbsSettings("settings-profile-password-edit") }}
-    {% endif %}
+    {{ macros.breadcrumbsArray([
+        { href: url('deputyship_details_clients'), text: 'Client details' },
+        { href: url('account_settings'), text: 'Deputyship details' }
+    ]) }}
 {% endblock %}
 
 {% block pageContent %}

--- a/client/app/templates/Settings/passwordEdit.html.twig
+++ b/client/app/templates/Settings/passwordEdit.html.twig
@@ -9,10 +9,7 @@
 {% block pageTitle %}{{ 'pageTitle.change-password' | trans }}{% endblock %}
 
 {% block breadcrumbs %}
-    {{ macros.breadcrumbsArray([
-        { href: url('deputyship_details_clients'), text: 'Your reports' },
-        { href: url('account_settings'), text: 'Deputyship details' }
-    ]) }}
+    {{ macros.breadcrumbsSettings("settings-profile-password-edit") }}
 {% endblock %}
 
 {% block pageContent %}

--- a/client/app/templates/Settings/passwordEdit.html.twig
+++ b/client/app/templates/Settings/passwordEdit.html.twig
@@ -10,7 +10,7 @@
 
 {% block breadcrumbs %}
     {{ macros.breadcrumbsArray([
-        { href: url('deputyship_details_clients'), text: 'Client details' },
+        { href: url('deputyship_details_clients'), text: 'Your reports' },
         { href: url('account_settings'), text: 'Deputyship details' }
     ]) }}
 {% endblock %}

--- a/client/app/templates/Settings/profile.html.twig
+++ b/client/app/templates/Settings/profile.html.twig
@@ -9,10 +9,7 @@
 {% block pageTitle %}{{ 'pageTitle.deputy-edit' | trans({}, 'user-account') }}{% endblock %}
 
 {% block breadcrumbs %}
-    {{ macros.breadcrumbsArray([
-        { href: url('deputyship_details_clients'), text: 'Your reports' },
-        { href: url('account_settings'), text: 'Deputyship details' }
-    ]) }}
+    {{ macros.breadcrumbsSettings("settings-profile") }}
 {% endblock %}
 
 {% block pageContent %}

--- a/client/app/templates/Settings/profile.html.twig
+++ b/client/app/templates/Settings/profile.html.twig
@@ -9,14 +9,10 @@
 {% block pageTitle %}{{ 'pageTitle.deputy-edit' | trans({}, 'user-account') }}{% endblock %}
 
 {% block breadcrumbs %}
-    {% if deputyHasMultiClients %}
-        {{ macros.breadcrumbsArray([
-            { href: url('choose_a_client'), text: 'Choose a client' },
-            { href: url('account_settings'), text: 'Deputyship details' }
-        ]) }}
-    {% else %}
-        {{ macros.breadcrumbsSettings("settings-profile") }}
-    {% endif %}
+    {{ macros.breadcrumbsArray([
+        { href: url('deputyship_details_clients'), text: 'Client details' },
+        { href: url('account_settings'), text: 'Deputyship details' }
+    ]) }}
 {% endblock %}
 
 {% block pageContent %}

--- a/client/app/templates/Settings/profile.html.twig
+++ b/client/app/templates/Settings/profile.html.twig
@@ -10,7 +10,7 @@
 
 {% block breadcrumbs %}
     {{ macros.breadcrumbsArray([
-        { href: url('deputyship_details_clients'), text: 'Client details' },
+        { href: url('deputyship_details_clients'), text: 'Your reports' },
         { href: url('account_settings'), text: 'Deputyship details' }
     ]) }}
 {% endblock %}

--- a/client/app/templates/Settings/profileEdit.html.twig
+++ b/client/app/templates/Settings/profileEdit.html.twig
@@ -9,11 +9,7 @@
 {% block pageTitle %}{{ 'pageTitle.profile-edit' | trans }}{% endblock %}
 
 {% block breadcrumbs %}
-    {{ macros.breadcrumbsArray([
-        { href: url('deputyship_details_clients'), text: 'Your reports' },
-        { href: url('account_settings'), text: 'Deputyship details' },
-        { href: url('user_show'), text: 'Your details' }
-    ]) }}
+    {{ macros.breadcrumbsSettings("settings-profile-edit") }}
 {% endblock %}
 
 {% block pageContent %}

--- a/client/app/templates/Settings/profileEdit.html.twig
+++ b/client/app/templates/Settings/profileEdit.html.twig
@@ -10,7 +10,7 @@
 
 {% block breadcrumbs %}
     {{ macros.breadcrumbsArray([
-        { href: url('deputyship_details_clients'), text: 'Client details' },
+        { href: url('deputyship_details_clients'), text: 'Your reports' },
         { href: url('account_settings'), text: 'Deputyship details' },
         { href: url('user_show'), text: 'Your details' }
     ]) }}

--- a/client/app/templates/Settings/profileEdit.html.twig
+++ b/client/app/templates/Settings/profileEdit.html.twig
@@ -9,15 +9,11 @@
 {% block pageTitle %}{{ 'pageTitle.profile-edit' | trans }}{% endblock %}
 
 {% block breadcrumbs %}
-    {% if deputyHasMultiClients %}
-        {{ macros.breadcrumbsArray([
-            { href: url('choose_a_client'), text: 'Choose a client' },
-            { href: url('account_settings'), text: 'Deputyship details' },
-            { href: url('user_show'), text: 'Your details' }
-        ]) }}
-    {% else %}
-        {{ macros.breadcrumbsSettings("settings-profile-edit") }}
-    {% endif %}
+    {{ macros.breadcrumbsArray([
+        { href: url('deputyship_details_clients'), text: 'Client details' },
+        { href: url('account_settings'), text: 'Deputyship details' },
+        { href: url('user_show'), text: 'Your details' }
+    ]) }}
 {% endblock %}
 
 {% block pageContent %}

--- a/client/app/tests/phpunit/Service/Client/Internal/ClientApiTest.php
+++ b/client/app/tests/phpunit/Service/Client/Internal/ClientApiTest.php
@@ -10,11 +10,9 @@ use App\EventDispatcher\ObservableEventDispatcher;
 use App\Service\Client\Internal\ClientApi;
 use App\Service\Client\Internal\UserApi;
 use App\Service\Client\RestClient;
-use App\Service\Time\DateTimeProvider;
 use App\TestHelpers\ClientHelpers;
 use App\TestHelpers\UserHelpers;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -24,9 +22,7 @@ class ClientApiTest extends TestCase
 {
     private RestClient $restClient;
     private RouterInterface $router;
-    private LoggerInterface $logger;
     private UserApi $userApi;
-    private DateTimeProvider $dateTimeProvider;
     private TokenStorageInterface $tokenStorage;
     private ObservableEventDispatcher $eventDispatcher;
 
@@ -36,18 +32,14 @@ class ClientApiTest extends TestCase
     {
         $this->restClient = $this->createMock(RestClient::class);
         $this->router = $this->createMock(RouterInterface::class);
-        $this->logger = $this->createMock(LoggerInterface::class);
         $this->userApi = $this->createMock(UserApi::class);
-        $this->dateTimeProvider = $this->createMock(DateTimeProvider::class);
         $this->tokenStorage = $this->createMock(TokenStorageInterface::class);
         $this->eventDispatcher = $this->createMock(ObservableEventDispatcher::class);
 
         $this->sut = new ClientApi(
             $this->restClient,
             $this->router,
-            $this->logger,
             $this->userApi,
-            $this->dateTimeProvider,
             $this->tokenStorage,
             $this->eventDispatcher
         );

--- a/client/app/translations/deputyship.en.yml
+++ b/client/app/translations/deputyship.en.yml
@@ -1,5 +1,5 @@
 clients:
-  title: Your clients
+  title: Client details
   caseNumber: Case number
   manageLinkText: Manage
   noClientsMessage: No clients to show

--- a/client/app/translations/layout.en.yml
+++ b/client/app/translations/layout.en.yml
@@ -2,7 +2,7 @@ nav:
   adArea: Assisted Digital
   reports: Your reports
   userAccount: Your details
-  clients: Your clients
+  clients: Client details
   # only in case of exception, when it's not clear the user role not the page
   homepage: Homepage
   adminArea: Users

--- a/client/app/translations/layout.en.yml
+++ b/client/app/translations/layout.en.yml
@@ -2,7 +2,7 @@ nav:
   adArea: Assisted Digital
   reports: Your reports
   userAccount: Your details
-  clientAccount: Client details
+  clients: Your clients
   # only in case of exception, when it's not clear the user role not the page
   homepage: Homepage
   adminArea: Users


### PR DESCRIPTION
## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes DDLS-540 and DDLS-541

Though there are a lot of changes, they are all very similar: removing the `isMultiClientDeputy` variable from the template arguments, along with the API calls used to set it.

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [x] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
