### PR TITLE
Enable stacktraces for local logging

### DIFF
--- a/client/app/config/packages/local/monolog.yml
+++ b/client/app/config/packages/local/monolog.yml
@@ -8,6 +8,7 @@ monolog:
       formatter: opg_line_formatter
       channels: ["!translation", "!verbose"]
       bubble: false
+      include_stacktraces: true
     csv:
       type: stream
       path: php://stderr

--- a/client/app/templates/Layouts/moj_template.html.twig
+++ b/client/app/templates/Layouts/moj_template.html.twig
@@ -37,8 +37,8 @@
     <div id="gaCustomElements"
         data-ga-default="{{ ga.default }}"
         data-ga-gds="{{ ga.gds }}"
-        data-tracking-id="{{ app.user.gaTrackingId() }}"
-        data-ga-custom-url="{{ gaCustomUrl }}"></d>
+        {% if app.user is not null %}data-tracking-id="{{ app.user.gaTrackingId() }}"{% endif %}
+        {% if gaCustomUrl is defined %}data-ga-custom-url="{{ gaCustomUrl }}"{% endif %}></d>
     {% include '@App/Layouts/_google_analytics_events_gtag.html.twig' %}
 {% endif %}
 


### PR DESCRIPTION
## Purpose
See more information in some log messages locally to help with debugging

Also, add a couple of is null/defined checks to google analytics to remove some twig rendering errors

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
