### PR TITLE
DDLS-572 Stop getting arrays with InputBag->get

### DIFF
--- a/client/app/phpstan-baseline.neon
+++ b/client/app/phpstan-baseline.neon
@@ -891,11 +891,6 @@ parameters:
 			path: src/Controller/Admin/ReportSubmissionController.php
 
 		-
-			message: "#^Parameter \\#1 \\$array of function array_keys expects array, float\\|int\\<min, \\-1\\>\\|int\\<1, max\\>\\|string\\|true given\\.$#"
-			count: 1
-			path: src/Controller/Admin/ReportSubmissionController.php
-
-		-
 			message: "#^Parameter \\#1 \\$string of function strtolower expects string, bool\\|float\\|int\\|string given\\.$#"
 			count: 1
 			path: src/Controller/Admin/ReportSubmissionController.php
@@ -5197,11 +5192,6 @@ parameters:
 
 		-
 			message: "#^Cannot access offset 'new_email' on bool\\|float\\|int\\|string\\|null\\.$#"
-			count: 1
-			path: src/Controller/SettingsController.php
-
-		-
-			message: "#^Cannot access offset 'password' on bool\\|float\\|int\\|string\\|null\\.$#"
 			count: 1
 			path: src/Controller/SettingsController.php
 
@@ -13016,32 +13006,12 @@ parameters:
 			path: src/Security/ClientVoter.php
 
 		-
-			message: "#^Cannot access offset '_token' on bool\\|float\\|int\\|string\\|null\\.$#"
-			count: 1
-			path: src/Security/LoginFormAuthenticator.php
-
-		-
-			message: "#^Cannot access offset 'email' on mixed\\.$#"
-			count: 1
-			path: src/Security/LoginFormAuthenticator.php
-
-		-
-			message: "#^Cannot access offset 'password' on mixed\\.$#"
-			count: 1
-			path: src/Security/LoginFormAuthenticator.php
-
-		-
 			message: "#^Cannot use array destructuring on App\\\\Entity\\\\User\\.$#"
 			count: 1
 			path: src/Security/LoginFormAuthenticator.php
 
 		-
 			message: "#^Parameter \\#1 \\$string of function urldecode expects string, bool\\|float\\|int\\|string\\|null given\\.$#"
-			count: 1
-			path: src/Security/LoginFormAuthenticator.php
-
-		-
-			message: "#^Parameter \\#1 \\$userIdentifier of class Symfony\\\\Component\\\\Security\\\\Http\\\\Authenticator\\\\Passport\\\\Badge\\\\UserBadge constructor expects string, mixed given\\.$#"
 			count: 1
 			path: src/Security/LoginFormAuthenticator.php
 

--- a/client/app/src/Controller/Admin/Client/SearchController.php
+++ b/client/app/src/Controller/Admin/Client/SearchController.php
@@ -34,10 +34,10 @@ class SearchController extends AbstractController
      */
     public function searchAction(Request $request)
     {
-        $searchQuery = $request->query->get('search_clients');
+        $searchQuery = $request->query->all('search_clients');
         $form = $this->createForm(SearchClientType::class, null, ['method' => 'GET']);
 
-        if (null === $searchQuery) {
+        if (empty($searchQuery)) {
             return $this->buildViewParams($form);
         }
 

--- a/client/app/src/Controller/Admin/ReportSubmissionController.php
+++ b/client/app/src/Controller/Admin/ReportSubmissionController.php
@@ -207,13 +207,15 @@ class ReportSubmissionController extends AbstractController
      */
     private function processPost(Request $request)
     {
-        if (empty($request->request->get('checkboxes'))) {
+        $checkedBoxes = $request->request->all('checkboxes');
+
+        if (empty($checkedBoxes)) {
             $this->addFlash('error', 'Please select at least one report submission');
 
             return;
         }
 
-        $checkedBoxes = array_keys($request->request->get('checkboxes'));
+        $checkedBoxes = array_keys($checkedBoxes);
         $action = is_null($request->request->get('multiAction')) ? null : strtolower($request->request->get('multiAction'));
 
         if (in_array($action, [self::ACTION_DOWNLOAD, self::ACTION_ARCHIVE, self::ACTION_SYNCHRONISE])) {

--- a/client/app/src/Controller/SettingsController.php
+++ b/client/app/src/Controller/SettingsController.php
@@ -122,7 +122,7 @@ class SettingsController extends AbstractController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $plainPassword = $request->request->get('change_password')['password']['first'];
+            $plainPassword = $request->request->all('change_password')['password']['first'];
             $this->restClient->put('user/'.$user->getId().'/set-password', json_encode([
                 'password' => $plainPassword,
             ]));

--- a/client/app/src/Security/LoginFormAuthenticator.php
+++ b/client/app/src/Security/LoginFormAuthenticator.php
@@ -40,9 +40,11 @@ class LoginFormAuthenticator extends AbstractAuthenticator
 
     public function authenticate(Request $request): Passport
     {
-        $email = $request->get('login')['email'];
-        $password = $request->get('login')['password'];
-        $csrfToken = $request->request->get('login')['_token'];
+        $data = $request->request->all('login');
+
+        $email = $data['email'];
+        $password = $data['password'];
+        $csrfToken = $data['_token'];
 
         if ('' === $email || null === $email || '' === $password || null === $password) {
             throw new BadCredentialsException('Missing username or password');


### PR DESCRIPTION
## Purpose

Getting non scalar values (Objects, arrays, etc), using InputBag->get is deprecated and throws an exception in Symfony 6+

Contributes to DDLS-572

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
