### PR TITLE
DDLS-591 Replace ParameterBag->get for arrays in API

### DIFF
--- a/api/app/config/packages/local/monolog.yml
+++ b/api/app/config/packages/local/monolog.yml
@@ -8,6 +8,7 @@ monolog:
             formatter: opg_line_formatter
             channels: ["!translation", "!verbose"]
             bubble: false
+            include_stacktraces: true
         csv:
             type: stream
             path: php://stderr

--- a/api/app/phpstan-baseline.neon
+++ b/api/app/phpstan-baseline.neon
@@ -1036,11 +1036,6 @@ parameters:
 			path: src/Controller/Report/ClientBenefitsCheckController.php
 
 		-
-			message: "#^Parameter \\#1 \\$groups of method App\\\\Service\\\\Formatter\\\\RestFormatter\\:\\:setJmsSerialiserGroups\\(\\) expects array, mixed given\\.$#"
-			count: 1
-			path: src/Controller/Report/ClientBenefitsCheckController.php
-
-		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, resource\\|string given\\.$#"
 			count: 2
 			path: src/Controller/Report/ClientBenefitsCheckController.php
@@ -1562,11 +1557,6 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyReceivedOnClientsBehalfController\\:\\:delete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyReceivedOnClientsBehalfController.php
-
-		-
-			message: "#^Parameter \\#1 \\$groups of method App\\\\Service\\\\Formatter\\\\RestFormatter\\:\\:setJmsSerialiserGroups\\(\\) expects array, mixed given\\.$#"
 			count: 1
 			path: src/Controller/Report/MoneyReceivedOnClientsBehalfController.php
 
@@ -2936,11 +2926,6 @@ parameters:
 			path: src/Controller/UserController.php
 
 		-
-			message: "#^Parameter \\#1 \\$groups of method App\\\\Service\\\\Formatter\\\\RestFormatter\\:\\:setJmsSerialiserGroups\\(\\) expects array, array\\<int, string\\>\\|bool\\|float\\|int\\|string\\|null given\\.$#"
-			count: 2
-			path: src/Controller/UserController.php
-
-		-
 			message: "#^Parameter \\#1 \\$hashedPassword of method Symfony\\\\Component\\\\PasswordHasher\\\\PasswordHasherInterface\\:\\:verify\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Controller/UserController.php
@@ -2977,11 +2962,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$formData of method App\\\\Factory\\\\UserResearchResponseFactory\\:\\:generateFromFormData\\(\\) expects array, mixed given\\.$#"
-			count: 1
-			path: src/Controller/UserResearchController.php
-
-		-
-			message: "#^Parameter \\#1 \\$groups of method App\\\\Service\\\\Formatter\\\\RestFormatter\\:\\:setJmsSerialiserGroups\\(\\) expects array, mixed given\\.$#"
 			count: 1
 			path: src/Controller/UserResearchController.php
 

--- a/api/app/src/Controller/ClientContactController.php
+++ b/api/app/src/Controller/ClientContactController.php
@@ -95,7 +95,7 @@ class ClientContactController extends RestController
     public function getOneById(Request $request, $id)
     {
         $serialisedGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups')
+            ? $request->query->all('groups')
             : ['clientcontact', 'clientcontact-client', 'client', 'client-users', 'current-report', 'report-id', 'user'];
         $this->formatter->setJmsSerialiserGroups($serialisedGroups);
 

--- a/api/app/src/Controller/ClientController.php
+++ b/api/app/src/Controller/ClientController.php
@@ -114,7 +114,7 @@ class ClientController extends RestController
     public function findByIdAction(Request $request, int $id)
     {
         $serialisedGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['client'];
+            ? $request->query->all('groups') : ['client'];
         $this->formatter->setJmsSerialiserGroups($serialisedGroups);
 
         $client = $this->findEntityBy(EntityDir\Client::class, $id);
@@ -141,7 +141,7 @@ class ClientController extends RestController
     public function detailsAction(Request $request, int $id)
     {
         if ($request->query->has('groups')) {
-            $serialisedGroups = (array) $request->query->get('groups');
+            $serialisedGroups = $request->query->all('groups');
         } else {
             $serialisedGroups = [
                 'client',
@@ -277,7 +277,7 @@ class ClientController extends RestController
     public function getAllClientsByDeputyUid(Request $request, int $deputyUid)
     {
         $serialisedGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['client'];
+            ? $request->query->all('groups') : ['client'];
         $this->formatter->setJmsSerialiserGroups($serialisedGroups);
 
         return $this->repository->getAllClientsAndReportsByDeputyUid($deputyUid);

--- a/api/app/src/Controller/DeputyController.php
+++ b/api/app/src/Controller/DeputyController.php
@@ -83,7 +83,7 @@ class DeputyController extends RestController
     public function findByIdAction(Request $request, int $id)
     {
         $serialisedGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['deputy'];
+            ? $request->query->all('groups') : ['deputy'];
         $this->formatter->setJmsSerialiserGroups($serialisedGroups);
 
         $deputy = $this->findEntityBy(Deputy::class, $id);

--- a/api/app/src/Controller/Ndr/AccountController.php
+++ b/api/app/src/Controller/Ndr/AccountController.php
@@ -49,7 +49,7 @@ class AccountController extends RestController
     public function getOneById(Request $request, $id)
     {
         if ($request->query->has('groups')) {
-            $this->formatter->setJmsSerialiserGroups((array) $request->query->get('groups'));
+            $this->formatter->setJmsSerialiserGroups($request->query->all('groups'));
         }
 
         $account = $this->findEntityBy(EntityDir\Ndr\BankAccount::class, $id, 'Account not found');

--- a/api/app/src/Controller/Ndr/NdrController.php
+++ b/api/app/src/Controller/Ndr/NdrController.php
@@ -26,7 +26,7 @@ class NdrController extends RestController
      */
     public function getById(Request $request, $id)
     {
-        $groups = $request->query->has('groups') ? (array) $request->query->get('groups') : ['ndr'];
+        $groups = $request->query->has('groups') ? $request->query->all('groups') : ['ndr'];
         $this->formatter->setJmsSerialiserGroups($groups);
 
         /* @var $report EntityDir\Ndr\Ndr */

--- a/api/app/src/Controller/Ndr/VisitsCareController.php
+++ b/api/app/src/Controller/Ndr/VisitsCareController.php
@@ -84,7 +84,7 @@ class VisitsCareController extends RestController
      */
     public function getOneById(Request $request, $id)
     {
-        $serialiseGroups = $request->query->has('groups') ? (array) $request->query->get('groups') : ['visits-care'];
+        $serialiseGroups = $request->query->has('groups') ? $request->query->all('groups') : ['visits-care'];
         $this->formatter->setJmsSerialiserGroups($serialiseGroups);
 
         $visitsCare = $this->findEntityBy(EntityDir\Ndr\VisitsCare::class, $id, 'VisitsCare with id:'.$id.' not found');

--- a/api/app/src/Controller/NoteController.php
+++ b/api/app/src/Controller/NoteController.php
@@ -58,7 +58,7 @@ class NoteController extends RestController
     public function getOneById(Request $request, $id)
     {
         $serialisedGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['notes', 'user'];
+            ? $request->query->all('groups') : ['notes', 'user'];
         $this->formatter->setJmsSerialiserGroups($serialisedGroups);
 
         $note = $this->findEntityBy(EntityDir\Note::class, $id); /* @var $note EntityDir\Note */

--- a/api/app/src/Controller/Report/AccountController.php
+++ b/api/app/src/Controller/Report/AccountController.php
@@ -59,7 +59,7 @@ class AccountController extends RestController
         $this->denyAccessIfReportDoesNotBelongToUser($account->getReport());
 
         $serialisedGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['account'];
+            ? $request->query->all('groups') : ['account'];
         $this->formatter->setJmsSerialiserGroups($serialisedGroups);
 
         return $account;

--- a/api/app/src/Controller/Report/ActionController.php
+++ b/api/app/src/Controller/Report/ActionController.php
@@ -58,7 +58,7 @@ class ActionController extends RestController
         $this->denyAccessIfReportDoesNotBelongToUser($action->getReport());
 
         $serialisedGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['action'];
+            ? $request->query->all('groups') : ['action'];
         $this->formatter->setJmsSerialiserGroups($serialisedGroups);
 
         return $action;

--- a/api/app/src/Controller/Report/AssetController.php
+++ b/api/app/src/Controller/Report/AssetController.php
@@ -33,7 +33,7 @@ class AssetController extends RestController
         $this->denyAccessIfReportDoesNotBelongToUser($asset->getReport());
 
         $serialisedGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['asset'];
+            ? $request->query->all('groups') : ['asset'];
         $this->formatter->setJmsSerialiserGroups($serialisedGroups);
 
         return $asset;

--- a/api/app/src/Controller/Report/ClientBenefitsCheckController.php
+++ b/api/app/src/Controller/Report/ClientBenefitsCheckController.php
@@ -94,7 +94,8 @@ class ClientBenefitsCheckController extends RestController
 
     private function setJmsGroups(Request $request)
     {
-        $groups = $request->get('groups') ? $request->get('groups') : ['client-benefits-check', 'report', 'ndr-client', 'ndr'];
+        $groups = $request->request->has('groups') ?
+            $request->request->all('groups') : ['client-benefits-check', 'report', 'ndr-client', 'ndr'];
         $this->formatter->setJmsSerialiserGroups($groups);
     }
 

--- a/api/app/src/Controller/Report/ContactController.php
+++ b/api/app/src/Controller/Report/ContactController.php
@@ -30,7 +30,7 @@ class ContactController extends RestController
     public function getOneById(Request $request, $id)
     {
         $serialisedGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['contact'];
+            ? $request->query->all('groups') : ['contact'];
         $this->formatter->setJmsSerialiserGroups($serialisedGroups);
 
         $contact = $this->findEntityBy(EntityDir\Report\Contact::class, $id);

--- a/api/app/src/Controller/Report/DecisionController.php
+++ b/api/app/src/Controller/Report/DecisionController.php
@@ -83,7 +83,7 @@ class DecisionController extends RestController
      */
     public function getOneById(Request $request, $id)
     {
-        $serialisedGroups = $request->query->has('groups') ? (array) $request->query->get('groups') : ['decision'];
+        $serialisedGroups = $request->query->has('groups') ? $request->query->all('groups') : ['decision'];
         $this->formatter->setJmsSerialiserGroups($serialisedGroups);
 
         $decision = $this->findEntityBy(EntityDir\Report\Decision::class, $id, 'Decision with id:'.$id.' not found');

--- a/api/app/src/Controller/Report/DocumentController.php
+++ b/api/app/src/Controller/Report/DocumentController.php
@@ -131,7 +131,7 @@ class DocumentController extends RestController
     public function getOneById(Request $request, $id)
     {
         $serialisedGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['documents'];
+            ? $request->query->all('groups') : ['documents'];
         $this->formatter->setJmsSerialiserGroups($serialisedGroups);
 
         /* @var $document EntityDir\Report\Document */
@@ -246,7 +246,7 @@ class DocumentController extends RestController
         $document = $documentRepository->find($id);
 
         $serialisedGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['synchronisation', 'document-id'];
+            ? $request->query->all('groups') : ['synchronisation', 'document-id'];
 
         $this->formatter->setJmsSerialiserGroups($serialisedGroups);
 

--- a/api/app/src/Controller/Report/ExpenseController.php
+++ b/api/app/src/Controller/Report/ExpenseController.php
@@ -33,7 +33,7 @@ class ExpenseController extends RestController
         $this->denyAccessIfReportDoesNotBelongToUser($expense->getReport());
 
         $serialisedGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['expenses', 'account'];
+            ? $request->query->all('groups') : ['expenses', 'account'];
         $this->formatter->setJmsSerialiserGroups($serialisedGroups);
 
         return $expense;

--- a/api/app/src/Controller/Report/GiftController.php
+++ b/api/app/src/Controller/Report/GiftController.php
@@ -33,7 +33,7 @@ class GiftController extends RestController
         $this->denyAccessIfReportDoesNotBelongToUser($gift->getReport());
 
         $serialisedGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['gifts'];
+            ? $request->query->all('groups') : ['gifts'];
         $this->formatter->setJmsSerialiserGroups($serialisedGroups);
 
         return $gift;

--- a/api/app/src/Controller/Report/LifestyleController.php
+++ b/api/app/src/Controller/Report/LifestyleController.php
@@ -95,7 +95,7 @@ class LifestyleController extends RestController
     public function getOneById(Request $request, $id)
     {
         $serialiseGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['lifestyle'];
+            ? $request->query->all('groups') : ['lifestyle'];
         $this->formatter->setJmsSerialiserGroups($serialiseGroups);
 
         $lifestyle = $this->findEntityBy(EntityDir\Report\Lifestyle::class, $id, 'Lifestyle with id:'.$id.' not found');

--- a/api/app/src/Controller/Report/MentalCapacityController.php
+++ b/api/app/src/Controller/Report/MentalCapacityController.php
@@ -58,7 +58,7 @@ class MentalCapacityController extends RestController
         $this->denyAccessIfReportDoesNotBelongToUser($mc->getReport());
 
         $serialisedGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['mental-capacity'];
+            ? $request->query->all('groups') : ['mental-capacity'];
         $this->formatter->setJmsSerialiserGroups($serialisedGroups);
 
         return $mc;

--- a/api/app/src/Controller/Report/MoneyReceivedOnClientsBehalfController.php
+++ b/api/app/src/Controller/Report/MoneyReceivedOnClientsBehalfController.php
@@ -31,7 +31,7 @@ class MoneyReceivedOnClientsBehalfController extends RestController
      */
     public function delete(Request $request, string $reportOrNdr, string $moneyTypeId)
     {
-        $groups = $request->get('groups') ? $request->get('groups') : ['client-benefits-check', 'report', 'ndr'];
+        $groups = $request->request->has('groups') ? $request->request->all('groups') : ['client-benefits-check', 'report', 'ndr'];
         $this->formatter->setJmsSerialiserGroups($groups);
         'ndr' === $reportOrNdr ? $this->ndrMoneyRepository->delete($moneyTypeId) : $this->reportMoneyRepository->delete($moneyTypeId);
 

--- a/api/app/src/Controller/Report/ProfDeputyPrevCostController.php
+++ b/api/app/src/Controller/Report/ProfDeputyPrevCostController.php
@@ -79,7 +79,7 @@ class ProfDeputyPrevCostController extends RestController
     public function getOneById(Request $request, $id)
     {
         $serialiseGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['prof-deputy-costs-prev'];
+            ? $request->query->all('groups') : ['prof-deputy-costs-prev'];
         $this->formatter->setJmsSerialiserGroups($serialiseGroups);
 
         $cost = $this->findEntityBy(EntityDir\Report\ProfDeputyPreviousCost::class, $id, 'Prof Service Fee with id:'.$id.' not found');

--- a/api/app/src/Controller/Report/ProfServiceFeeController.php
+++ b/api/app/src/Controller/Report/ProfServiceFeeController.php
@@ -78,7 +78,7 @@ class ProfServiceFeeController extends RestController
     public function getOneById(Request $request, $id)
     {
         $serialiseGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['prof_service_fee'];
+            ? $request->query->all('groups') : ['prof_service_fee'];
         $this->formatter->setJmsSerialiserGroups($serialiseGroups);
 
         $profServiceFee = $this->findEntityBy(EntityDir\Report\ProfServiceFee::class, $id, 'Prof Service Fee with id:'.$id.' not found');

--- a/api/app/src/Controller/Report/ReportController.php
+++ b/api/app/src/Controller/Report/ReportController.php
@@ -101,7 +101,7 @@ class ReportController extends RestController
     public function getById(Request $request, $id)
     {
         $groups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['report'];
+            ? $request->query->all('groups') : ['report'];
 
         $this->formatter->setJmsSerialiserGroups($groups);
 
@@ -959,7 +959,7 @@ class ReportController extends RestController
     public function refreshReportCache(Request $request, int $reportId)
     {
         $groups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['report', 'client', 'client-report'];
+            ? $request->query->all('groups') : ['report', 'client', 'client-report'];
 
         $this->formatter->setJmsSerialiserGroups($groups);
 

--- a/api/app/src/Controller/Report/VisitsCareController.php
+++ b/api/app/src/Controller/Report/VisitsCareController.php
@@ -97,7 +97,7 @@ class VisitsCareController extends RestController
     public function getOneById(Request $request, $id)
     {
         $serialiseGroups = $request->query->has('groups')
-            ? (array) $request->query->get('groups') : ['visits-care'];
+            ? $request->query->all('groups') : ['visits-care'];
         $this->formatter->setJmsSerialiserGroups($serialiseGroups);
 
         $visitsCare = $this->findEntityBy(EntityDir\Report\VisitsCare::class, $id, 'VisitsCare with id:'.$id.' not found');

--- a/api/app/src/Controller/StatsController.php
+++ b/api/app/src/Controller/StatsController.php
@@ -75,7 +75,7 @@ class StatsController extends RestController
      */
     public function getAdminUserAccountReportData(Request $request, RestFormatter $formatter): array
     {
-        $serialisedGroups = (array) $request->query->get('groups');
+        $serialisedGroups = $request->query->all('groups');
         $formatter->setJmsSerialiserGroups($serialisedGroups);
 
         $adminAccounts = $this->userRepository->getAllAdminAccounts();
@@ -109,7 +109,7 @@ class StatsController extends RestController
      */
     public function getInactiveAdminUserReportData(Request $request, Restformatter $formatter): array
     {
-        $serialisedGroups = (array) $request->query->get('groups');
+        $serialisedGroups = $request->query->all('groups');
         $formatter->setJmsSerialiserGroups($serialisedGroups);
 
         $numberOfMonthsInactive = $request->query->get('inactivityPeriod');

--- a/api/app/src/Controller/UserController.php
+++ b/api/app/src/Controller/UserController.php
@@ -68,7 +68,7 @@ class UserController extends RestController
         $this->userService->addUser($loggedInUser, $newUser, null);
 
         $groups = $request->query->has('groups') ?
-            $request->query->get('groups') : ['user', 'user-teams', 'team'];
+            $request->query->all('groups') : ['user', 'user-teams', 'team'];
         $this->formatter->setJmsSerialiserGroups($groups);
 
         return $newUser;
@@ -325,7 +325,7 @@ class UserController extends RestController
         $loggedInUser = $this->getUser();
 
         $groups = $request->query->has('groups') ?
-            $request->query->get('groups') : ['user'];
+            $request->query->all('groups') : ['user'];
 
         $this->formatter->setJmsSerialiserGroups($groups);
 
@@ -551,8 +551,7 @@ class UserController extends RestController
         }
 
         $groups = $request->query->has('groups') ?
-            (array) $request->query->get('groups') :
-            ['team', 'team-users', 'user'];
+            $request->query->all('groups') : ['team', 'team-users', 'user'];
 
         $this->formatter->setJmsSerialiserGroups($groups);
 

--- a/api/app/src/Controller/UserResearchController.php
+++ b/api/app/src/Controller/UserResearchController.php
@@ -43,7 +43,7 @@ class UserResearchController extends RestController
             $userResearchResponse = $this->factory->generateFromFormData($formData);
             $this->userResearchResponseRepository->create($userResearchResponse, $this->getUser());
 
-            $groups = $request->get('groups') ? $request->get('groups') : ['satisfaction', 'user-research', 'user'];
+            $groups = $request->request->has('groups') ? $request->request->all('groups') : ['satisfaction', 'user-research', 'user'];
             $this->formatter->setJmsSerialiserGroups($groups);
 
             return 'Created';

--- a/api/app/tests/Integration/ControllerReport/AccountControllerTest.php
+++ b/api/app/tests/Integration/ControllerReport/AccountControllerTest.php
@@ -109,13 +109,11 @@ class AccountControllerTest extends AbstractTestController
      */
     public function testgetAccounts()
     {
-        $url = '/report/'.self::$report1->getId();
-
-        // assert accounts
-        $data = $this->assertJsonRequest('GET', $url.'?groups=account', [
-            'mustSucceed' => true,
-            'AuthToken' => self::$tokenDeputy,
-        ])['data']['bank_accounts'];
+        $data = $this->assertJsonRequest(
+            'GET', 
+            sprintf('/report/%s?%s', self::$report1->getId(), http_build_query(['groups' => ['account']])),
+            ['mustSucceed' => true, 'AuthToken' => self::$tokenDeputy]
+        )['data']['bank_accounts'];
 
         $this->assertCount(2, $data);
         $this->assertTrue($data[0]['id'] != $data[1]['id']);

--- a/api/app/tests/Integration/ControllerReport/AssetControllerTest.php
+++ b/api/app/tests/Integration/ControllerReport/AssetControllerTest.php
@@ -55,13 +55,11 @@ class AssetControllerTest extends AbstractTestController
 
     public function testgetAssets()
     {
-        $url = '/report/'.self::$report1->getId().'?groups=asset';
-
-        // assert get
-        $data = $this->assertJsonRequest('GET', $url, [
-            'mustSucceed' => true,
-            'AuthToken' => self::$tokenDeputy,
-        ])['data']['assets'];
+        $data = $this->assertJsonRequest(
+            'GET',
+            sprintf('/report/%s?%s', self::$report1->getId(), http_build_query(['groups' => ['asset']])),
+            ['mustSucceed' => true, 'AuthToken' => self::$tokenDeputy]
+        )['data']['assets'];
 
         $this->assertCount(2, $data);
 

--- a/api/app/tests/Integration/ControllerReport/DecisionControllerTest.php
+++ b/api/app/tests/Integration/ControllerReport/DecisionControllerTest.php
@@ -88,13 +88,11 @@ class DecisionControllerTest extends AbstractTestController
 
     public function testgetDecisions()
     {
-        $url = '/report/'.self::$report1->getId().'?groups=decision';
-
-        // assert get
-        $data = $this->assertJsonRequest('GET', $url, [
-            'mustSucceed' => true,
-            'AuthToken' => self::$tokenDeputy,
-        ])['data']['decisions'];
+        $data = $this->assertJsonRequest(
+            'GET',
+            sprintf('/report/%s?%s', self::$report1->getId(), http_build_query(['groups' => ['decision']])),
+            ['mustSucceed' => true, 'AuthToken' => self::$tokenDeputy]
+        )['data']['decisions'];
 
         $this->assertCount(1, $data);
         $this->assertEquals(self::$decision1->getId(), $data[0]['id']);


### PR DESCRIPTION
## Purpose
Returning arrays from ParameterBag->get is deprecated, and in future will throw a BadRequestException. Replacing it with ParameterBag->all where appropriate.

Contributes to DDLS-591

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
