### PR TITLE
 DDLS-625 Move Client to PHP 8.2

### DIFF
--- a/api/app/tests/Unit/Service/File/Storage/S3StorageTest.php
+++ b/api/app/tests/Unit/Service/File/Storage/S3StorageTest.php
@@ -25,23 +25,6 @@ class S3StorageTest extends TestCase
     public function setUp(): void
     {
         $this->fileContent = 'FILE-CONTENT-'.microtime(1);
-
-        // check localstack connection. To test why failing on the infrastructure
-        if (!@fsockopen('localstack', '4572')) {
-//            $options = [
-//                'version' => 'latest',
-//                'region' => 'eu-west-1',
-//                'endpoint' => 'http://localstack:4572',
-//                'validate' => false,
-//                'credentials' => [
-//                    'key' => 'YOUR_ACCESS_KEY_ID',
-//                    'secret' => 'YOUR_SECRET_ACCESS_KEY',
-//                ],
-//            ];
-            
-//            $this->markTestSkipped('localstack not responding');
-//            echo "Can't connect to S3 ({$options['endpoint']})\n";
-        }
     }
 
     public function testUploadDownloadDeleteTextContent()
@@ -49,7 +32,6 @@ class S3StorageTest extends TestCase
         // create timestamped file and key to undo effects of potential previous executions
         $key = 'storagetest-upload-download-delete'.microtime(1);
 
-        /** @var S3ClientInterface */
         $awsClient = m::mock(S3ClientInterface::class);
 
         $awsClient->shouldReceive('putObject')

--- a/client/app/composer.json
+++ b/client/app/composer.json
@@ -6,7 +6,7 @@
     "config": {
         "sort-packages": true,
         "platform": {
-            "php": "8.1.27"
+            "php": "8.2.28"
         },
         "allow-plugins": {
             "php-http/discovery": true
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "alphagov/notifications-php-client": "^4.0.1",
         "aws/aws-sdk-php": "3.299.1",
         "doctrine/collections": "^2.0.0",

--- a/client/app/composer.lock
+++ b/client/app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ad55a25bcd592f0dd680a66e5642ede",
+    "content-hash": "61eb58d9c1e195e4199cf6fdee9414c8",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -13038,11 +13038,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.1"
+        "php": "^8.2"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.1.27"
+        "php": "8.2.28"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/client/app/src/Controller/Admin/ReportSubmissionController.php
+++ b/client/app/src/Controller/Admin/ReportSubmissionController.php
@@ -173,7 +173,7 @@ class ReportSubmissionController extends AbstractController
             $contents = $this->s3Storage->retrieve($document->getStorageReference());
         } catch (\Throwable $e) {
             $filename = $document->getFileName();
-            throw $this->createNotFoundException("Document '${$filename}' could not be retrieved");
+            throw $this->createNotFoundException("Document '$filename' could not be retrieved");
         }
 
         $response = new Response($contents);

--- a/client/app/tests/phpunit/Entity/Ndr/NdrTest.php
+++ b/client/app/tests/phpunit/Entity/Ndr/NdrTest.php
@@ -4,12 +4,15 @@ namespace App\Entity\Ndr;
 
 use App\Entity\Client;
 use Mockery as m;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class NdrTest extends TestCase
 {
-    /** @var Ndr */
-    private $ndr;
+    private Ndr $ndr;
+    private StateBenefit $incomeTicked;
+    private StateBenefit $incomeUnticked;
+    private Client&MockObject $client;
 
     protected function setUp(): void
     {

--- a/client/app/tests/phpunit/EventListener/SessionListenerTest.php
+++ b/client/app/tests/phpunit/EventListener/SessionListenerTest.php
@@ -3,7 +3,10 @@
 namespace App\EventListener;
 
 use Mockery as m;
+use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -12,11 +15,15 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  */
 class SessionListenerTest extends TestCase
 {
+    private RequestEvent&MockInterface $event;
+    private Router&MockInterface $router;
+    private LoggerInterface&MockInterface $logger;
+
     public function setUp(): void
     {
-        $this->event = m::mock('Symfony\Component\HttpKernel\Event\RequestEvent');
-        $this->router = m::mock('Symfony\Bundle\FrameworkBundle\Routing\Router');
-        $this->logger = m::mock('Psr\Log\LoggerInterface');
+        $this->event = m::mock(RequestEvent::class);
+        $this->router = m::mock(Router::class);
+        $this->logger = m::mock(LoggerInterface::class);
     }
 
     /**

--- a/client/app/tests/phpunit/Form/Report/Asset/AssetTypeTitleTest.php
+++ b/client/app/tests/phpunit/Form/Report/Asset/AssetTypeTitleTest.php
@@ -3,10 +3,14 @@
 namespace App\Form\Report\Asset;
 
 use Mockery as m;
+use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class AssetTypeTitleTest extends TestCase
 {
+    private TranslatorInterface|MockInterface $translator;
+
     public function setUp(): void
     {
         $this->translator = m::mock('Symfony\Contracts\Translation\TranslatorInterface');
@@ -29,9 +33,9 @@ class AssetTypeTitleTest extends TestCase
      */
     public function testgetTitleChoices($input, $expectedOutput)
     {
-        $this->object = new AssetTypeTitle($input, $this->translator, 'domain');
+        $object = new AssetTypeTitle($input, $this->translator, 'domain');
 
-        $this->assertEquals($expectedOutput, $this->object->getTitleChoices());
+        $this->assertEquals($expectedOutput, $object->getTitleChoices());
     }
 
     public function tearDown(): void

--- a/client/app/tests/phpunit/Service/Audit/AuditEventsTest.php
+++ b/client/app/tests/phpunit/Service/Audit/AuditEventsTest.php
@@ -20,6 +20,7 @@ class AuditEventsTest extends TestCase
 {
     use ProphecyTrait;
 
+    private DateTime $now;
     private ObjectProphecy|DateTimeProvider $dateTimeProvider;
 
     public function setUp(): void

--- a/client/app/tests/phpunit/Service/Client/TokenStorage/RedisStorageTest.php
+++ b/client/app/tests/phpunit/Service/Client/TokenStorage/RedisStorageTest.php
@@ -3,20 +3,16 @@
 namespace App\Service\Client\TokenStorage;
 
 use Mockery as m;
+use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use Predis\Client;
 
 class RedisStorageTest extends TestCase
 {
-    /**
-     * @var RedisStorage
-     */
-    private $object;
-
-    /**
-     * @var Client
-     */
-    private $redis;
+    private Client&MockInterface $redis;
+    private string $prefix;
+    private string $workspace;
+    private RedisStorage $object;
 
     public function setUp(): void
     {

--- a/client/app/tests/phpunit/Service/DocumentServiceTest.php
+++ b/client/app/tests/phpunit/Service/DocumentServiceTest.php
@@ -27,50 +27,15 @@ class DocumentServiceTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var DocumentService
-     */
-    protected $object;
-
-    /**
-     * @var ObjectProphecy|S3Storage
-     */
-    private $s3Storage;
-
-    /**
-     * @var ObjectProphecy|RestClient
-     */
-    private $restClient;
-
-    /**
-     * @var ObjectProphecy|Environment
-     */
-    private $twig;
-
-    /**
-     * @var ObjectProphecy|LoggerInterface
-     */
-    private $logger;
-
-    /**
-     * @var ObjectProphecy|Document
-     */
-    private $doc1;
-
-    /**
-     * @var ObjectProphecy|Document
-     */
-    private $doc2;
-
-    /**
-     * @var ObjectProphecy|Document
-     */
-    private $doc3;
-
-    /**
-     * @var ObjectProphecy|Document
-     */
-    private $doc4;
+    protected DocumentService $object;
+    private ObjectProphecy|S3Storage $s3Storage;
+    private ObjectProphecy|RestClient $restClient;
+    private ObjectProphecy|Environment $twig;
+    private ObjectProphecy|LoggerInterface $logger;
+    private ObjectProphecy|Document $doc1;
+    private ObjectProphecy|Document $doc2;
+    private ObjectProphecy|Document $doc3;
+    private ObjectProphecy|Document $doc4;
 
     public function setUp(): void
     {
@@ -345,7 +310,7 @@ class DocumentServiceTest extends TestCase
             $caseNumber = $missingDocumentCaseNumbers[$index];
             $fileName = $missingDocument->getFileName();
 
-            $expectedListItem = "<li>${caseNumber} - ${fileName}</li>";
+            $expectedListItem = "<li>{$caseNumber} - {$fileName}</li>";
             self::assertStringContainsString($expectedListItem, $renderedTwig);
         }
     }

--- a/client/app/tests/phpunit/Service/File/S3FileUploaderTest.php
+++ b/client/app/tests/phpunit/Service/File/S3FileUploaderTest.php
@@ -27,6 +27,7 @@ class S3FileUploaderTest extends KernelTestCase
     private ObjectProphecy $fileNameFixer;
     private ObjectProphecy $dateTimeProvider;
     private ObjectProphecy $mimeTypeAndExtensionChecker;
+    private ObjectProphecy|ImageConvertor $imageConvertor;
 
     public function setUp(): void
     {

--- a/client/app/tests/phpunit/Service/JWT/JWTServiceTest.php
+++ b/client/app/tests/phpunit/Service/JWT/JWTServiceTest.php
@@ -15,6 +15,26 @@ use PHPUnit\Framework\TestCase;
  */
 class JWTServiceTest extends TestCase
 {
+    /**
+     * @var string[]
+     */
+    private array $jwtHeaders;
+
+    /**
+     * @var string[]
+     */
+    private array $jwtClaims;
+
+    /**
+     * @var string[]
+     */
+    private array $jwtSignature;
+
+    private string $jwtHeadersClaim;
+    private string $jwtHeadersClaimSignature;
+
+    private array $jwks;
+
     public function setUp(): void
     {
         // The props below are all valid values based on a JWT (not used in prod)

--- a/client/app/tests/phpunit/Service/Mailer/MailSenderTest.php
+++ b/client/app/tests/phpunit/Service/Mailer/MailSenderTest.php
@@ -25,6 +25,7 @@ class MailSenderTest extends WebTestCase
     private ObjectProphecy|NotifyClient $notifyClient;
     private ObjectProphecy|DateTimeProvider $dateTimeProvider;
     private ObjectProphecy|TokenStorageInterface $tokenStorage;
+    private MailSender $sut;
 
     public function setup(): void
     {

--- a/client/app/tests/phpunit/Service/ReportSectionLinksServiceTest.php
+++ b/client/app/tests/phpunit/Service/ReportSectionLinksServiceTest.php
@@ -2,26 +2,21 @@
 
 namespace App\Service;
 
-use App\Entity\Report\Report;
 use App\Entity\ReportInterface;
+use Mockery\MockInterface;
 use MockeryStub as m;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\RouterInterface;
 
 class ReportSectionLinksServiceTest extends TestCase
 {
-    /**
-     * @var ReportSectionsLinkService
-     */
-    protected $sut;
+    protected ReportSectionsLinkService $sut;
+    private ReportInterface|MockInterface $report;
 
-    /**
-     * Set up the mockservies.
-     */
     public function setUp(): void
     {
-        $this->router = m::mock(RouterInterface::class);
-        $this->router->shouldReceive('generate')->withAnyArgs()->andReturnUsing(function ($a, $b) {
+        $router = m::mock(RouterInterface::class);
+        $router->shouldReceive('generate')->withAnyArgs()->andReturnUsing(function ($a, $b) {
             return $a.http_build_query($b);
         });
         $this->report = m::mock(ReportInterface::class);
@@ -47,9 +42,7 @@ class ReportSectionLinksServiceTest extends TestCase
             ->shouldReceive('hasSection')->with('debts')->andReturn(true)
             ->shouldReceive('hasSection')->with('documents')->andReturn(true);
 
-        //$this->report->shouldReceive('getType')->andReturn('irrelevant');
-
-        $this->sut = new ReportSectionsLinkService($this->router);
+        $this->sut = new ReportSectionsLinkService($router);
     }
 
     public function testgetSectionParamsLay()

--- a/client/app/tests/phpunit/Service/RequestIdLoggerProcessorTest.php
+++ b/client/app/tests/phpunit/Service/RequestIdLoggerProcessorTest.php
@@ -3,6 +3,7 @@
 namespace App\Service;
 
 use Mockery as m;
+use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -11,18 +12,15 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class RequestIdLoggerProcessorTest extends TestCase
 {
-    /**
-     * @var RequestIdLoggerProcessor
-     */
-    private $object;
-
-    private $record = ['key1' => 'abc', 'key2' => 2];
+    private array $record = ['key1' => 'abc', 'key2' => 2];
+    private Container|MockInterface $container;
+    private RequestStack|MockInterface $reqStack;
+    private RequestIdLoggerProcessor $object;
 
     public function setUp(): void
     {
         $this->container = m::mock(Container::class);
         $this->reqStack = m::mock(RequestStack::class);
-        $this->request = m::mock(Request::class);
 
         $this->object = new RequestIdLoggerProcessor($this->container);
     }

--- a/client/app/tests/phpunit/Twig/ComponentsExtensionTest.php
+++ b/client/app/tests/phpunit/Twig/ComponentsExtensionTest.php
@@ -3,11 +3,20 @@
 namespace App\Twig;
 
 use App\Entity\User;
+use App\Service\ReportSectionsLinkService;
 use Mockery as m;
+use Mockery\MockInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
 
 class ComponentsExtensionTest extends TestCase
 {
+    private TranslatorInterface|MockInterface $translator;
+    private ReportSectionsLinkService|MockInterface $reportSectionsLinkService;
+    private Environment|MockInterface $twigEnvironment;
+    private ComponentsExtension $object;
+
     public function setUp(): void
     {
         $this->translator = m::mock('Symfony\Contracts\Translation\TranslatorInterface');

--- a/client/docker/app/Dockerfile
+++ b/client/docker/app/Dockerfile
@@ -11,7 +11,7 @@ COPY client/app/config config
 COPY client/app/src src
 RUN composer dump-autoload --optimize
 
-FROM php:8.1.28-fpm-alpine3.19 AS base
+FROM php:8.2.28-fpm-alpine3.21 AS base
 ARG PLATFORM=${PLATFORM:-amd64}
 ARG TAG=${TAG:-latest}
 ARG ENVIRONMENT=${ENVIRONMENT:-production}
@@ -24,9 +24,9 @@ RUN apk add --no-cache \
     su-exec \
     libzip-dev \
     unzip \
-    php81-pecl-igbinary \
-    php81-pecl-redis \
-    php81-pecl-imagick  \
+    php82-pecl-igbinary \
+    php82-pecl-redis \
+    php82-pecl-imagick  \
     gmp \
     gmp-dev \
     libheif \


### PR DESCRIPTION
## Purpose
Move Client to PHP 8.2

Fixes DDLS-625

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
