### PR TITLE
DDLS-580 fix formatting bug in satisfaction score extract

### DIFF
--- a/api/app/src/Command/SatisfactionPerformanceStatsCommand.php
+++ b/api/app/src/Command/SatisfactionPerformanceStatsCommand.php
@@ -14,7 +14,7 @@ class SatisfactionPerformanceStatsCommand extends Command
 
     public function __construct(
         private readonly EntityManagerInterface $em,
-        private readonly S3SatisfactionDataStorage $s3SatisfactionDataStorage
+        private readonly S3SatisfactionDataStorage $s3SatisfactionDataStorage,
     ) {
         parent::__construct();
     }
@@ -60,7 +60,7 @@ class SatisfactionPerformanceStatsCommand extends Command
                     'service' => 'deputy-reporting',
                     'channel' => 'digital',
                     'count' => intval($satisfactionScoreRow),
-                    'dataType' => str_replace('-', '_', $satisfactionScoreKey),
+                    'dataType' => str_replace('_', '-', $satisfactionScoreKey),
                     'period' => 'month',
                 ];
             }


### PR DESCRIPTION
## Purpose
Wrong format. The scores have - instead of _. 
Fixes DDLS-580

## Approach
Looks like we were already trying to do this except the replace was the wrong way round! 

## Learning
NA

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
