### PR TITLE
DDLS-627 API Symfony Validator attributes

### DIFF
--- a/api/app/src/Entity/Organisation.php
+++ b/api/app/src/Entity/Organisation.php
@@ -39,12 +39,11 @@ class Organisation implements OrganisationInterface
     /**
      * @var string
      *
-     * @Assert\NotBlank()
-     *
      * @ORM\Column(name="name", type="string", length=256, nullable=false)
      *
      * @JMS\Groups({"organisation", "user-organisations", "client-organisations", "org-created-event"})
      */
+    #[Assert\NotBlank]
     private $name;
 
     /**
@@ -56,10 +55,9 @@ class Organisation implements OrganisationInterface
      *
      * @JMS\SerializedName("email_identifier")
      *
-     * @Assert\NotBlank()
-     *
      * @ORM\Column(name="email_identifier", type="string", length=256, nullable=false, unique=true)
      */
+    #[Assert\NotBlank]
     private $emailIdentifier;
 
     /**

--- a/api/app/src/Entity/PreRegistration.php
+++ b/api/app/src/Entity/PreRegistration.php
@@ -74,10 +74,9 @@ class PreRegistration
     /**
      * @JMS\Type("string")
      *
-     * @Assert\NotBlank()
-     *
      * @ORM\Column(name="client_case_number", type="string", length=20, nullable=false)
      */
+    #[Assert\NotBlank]
     private string $caseNumber;
 
     /**
@@ -90,10 +89,9 @@ class PreRegistration
     /**
      * @JMS\Type("string")
      *
-     * @Assert\NotBlank()
-     *
      * @ORM\Column(name="client_lastname", type="string", length=50, nullable=false)
      */
+    #[Assert\NotBlank]
     private string $clientLastname;
 
     /**
@@ -135,36 +133,31 @@ class PreRegistration
      * @JMS\Type("string")
      *
      * @ORM\Column(name="client_postcode", type="string", length=10, nullable=true)
-     *
-     * @Assert\Length(min=2, max=10, minMessage="postcode too short", maxMessage="postcode too long" )
      */
+    #[Assert\Length(min: 2, max: 10, minMessage: 'postcode too short', maxMessage: 'postcode too long')]
     private ?string $clientPostcode;
 
     /**
      * @JMS\Type("string")
      *
-     * @Assert\NotBlank()
-     *
      * @ORM\Column(name="deputy_uid", type="string", length=100, nullable=false)
      */
+    #[Assert\NotBlank]
     private string $deputyUid;
 
     /**
-     * @Assert\NotBlank()
-     *
      * @ORM\Column(name="deputy_firstname", type="string", length=100, nullable=true)
-     *
      * @JMS\Type("string")
      */
+    #[Assert\NotBlank]
     private string $deputyFirstname;
 
     /**
-     * @Assert\NotBlank()
-     *
      * @ORM\Column(name="deputy_lastname", type="string", length=100, nullable=true)
      *
      * @JMS\Type("string")
      */
+    #[Assert\NotBlank]
     private string $deputySurname;
 
     /**
@@ -206,9 +199,8 @@ class PreRegistration
      * @JMS\Type("string")
      *
      * @ORM\Column(name="deputy_postcode", type="string", length=10, nullable=true)
-     *
-     * @Assert\Length(min=2, max=10, minMessage="postcode too short", maxMessage="postcode too long" )
      */
+    #[Assert\Length(min: 2, max: 10, minMessage: 'postcode too short', maxMessage: 'postcode too long')]
     private ?string $deputyPostCode;
 
     /**

--- a/api/app/src/Model/SelfRegisterData.php
+++ b/api/app/src/Model/SelfRegisterData.php
@@ -14,77 +14,63 @@ class SelfRegisterData
      * @var string
      *
      * @JMS\Type("string")
-     *
-     * @Assert\NotBlank( message="user.firstname.notBlank", groups={"self_registration", "verify_codeputy"} )
-     *
-     * @Assert\Length(min=2, max=50, minMessage="user.firstname.minLength", maxMessage="user.firstname.maxLength", groups={"self_registration", "verify_codeputy"} )
      */
+    #[Assert\NotBlank(message: 'user.firstname.notBlank', groups: ['self_registration', 'verify_codeputy'])]
+    #[Assert\Length(min: 2, max: 50, minMessage: 'user.firstname.minLength', maxMessage: 'user.firstname.maxLength', groups: ['self_registration', 'verify_codeputy'])]
     private $firstname;
 
     /**
      * @var string lastname
      *
      * @JMS\Type("string")
-     *
-     * @Assert\NotBlank(message="user.lastname.notBlank", groups={"self_registration", "verify_codeputy"} )
-     *
-     * @Assert\Length(min=2, max=50, minMessage="user.lastname.minLength", maxMessage="user.lastname.maxLength", groups={"self_registration", "verify_codeputy"} )
      */
+    #[Assert\NotBlank(message: 'user.lastname.notBlank', groups: ['self_registration', 'verify_codeputy'])]
+    #[Assert\Length(min: 2, max: 50, minMessage: 'user.lastname.minLength', maxMessage: 'user.lastname.maxLength', groups: ['self_registration', 'verify_codeputy'])]
     private $lastname;
 
     /**
      * @var string email
      *
      * @JMS\Type("string")
-     *
-     * @Assert\NotBlank( message="user.email.notBlank", groups={"self_registration", "verify_codeputy"})
-     *
-     * @Assert\Email( message="user.email.invalid", groups={"self_registration", "verify_codeputy"} )
-     *
-     * @Assert\Length( max=60, maxMessage="user.email.maxLength", groups={"self_registration", "verify_codeputy"} )
      */
+    #[Assert\NotBlank(message: 'user.email.notBlank', groups: ['self_registration', 'verify_codeputy'])]
+    #[Assert\Email(message: 'user.email.invalid', groups: ['self_registration', 'verify_codeputy'])]
+    #[Assert\Length(max: 60, maxMessage: 'user.email.maxLength', groups: ['self_registration', 'verify_codeputy'])]
     private $email;
 
     /**
      * @var string email
      *
      * @JMS\Type("string")
-     *
-     * @Assert\Length( max=10, maxMessage="user.addressPostcode.maxLength", groups={"self_registration", "verify_codeputy"})
      */
+    #[Assert\Length(max: 10, maxMessage: 'user.addressPostcode.maxLength', groups: ['self_registration', 'verify_codeputy'])]
     private $postcode;
 
     /**
      * @var string
      *
      * @JMS\Type("string")
-     *
-     * @Assert\NotBlank( message="client.firstname.notBlank", groups={"self_registration"} )
-     *
-     * @Assert\Length(min = 2, minMessage= "client.firstname.minMessage", max=50, maxMessage= "client.firstname.maxMessage", groups={"self_registration"})
      */
+    #[Assert\NotBlank(message: 'client.firstname.notBlank', groups: ['self_registration'])]
+    #[Assert\Length(min: 2, minMessage: 'client.firstname.minMessage', max: 50, maxMessage: 'client.firstname.maxMessage', groups: ['self_registration'])]
     private $clientFirstname;
 
     /**
      * @var string clientLastName
      *
      * @JMS\Type("string")
-     *
-     * @Assert\NotBlank( message="client.lastname.notBlank", groups={"self_registration", "verify_codeputy"} )
-     *
-     * @Assert\Length(min = 2, minMessage= "client.lastname.minMessage", max=50, maxMessage= "client.lastname.maxMessage", groups={"self_registration", "verify_codeputy"})
      */
+    #[Assert\NotBlank(message: 'client.lastname.notBlank', groups: ['self_registration', 'verify_codeputy'])]
+    #[Assert\Length(min: 2, minMessage: 'client.lastname.minMessage', max: 50, maxMessage: 'client.lastname.maxMessage', groups: ['self_registration', 'verify_codeputy'])]
     private $clientLastname;
 
     /**
      * @var string caseNumber
      *
      * @JMS\Type("string")
-     *
-     * @Assert\NotBlank( message="client.caseNumber.notBlank", groups={"self_registration", "verify_codeputy"})
-     *
-     * @Assert\Length(min=8, max=8, groups={"self_registration", "verify_codeputy"})
      */
+    #[Assert\NotBlank(message: 'client.caseNumber.notBlank', groups: ['self_registration', 'verify_codeputy'])]
+    #[Assert\Length(min: 8, max: 8, groups: ['self_registration', 'verify_codeputy'])]
     private $caseNumber;
 
     /**


### PR DESCRIPTION
## Purpose
Convert API Symfony Validator annotations to attributes as they have various advantages

Fixes DDLS-627

## Approach
Use rector and then manually review

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
