### PR TITLE
Move API annotations to attributes in the Entity folder

### DIFF
--- a/api/app/phpstan-baseline.neon
+++ b/api/app/phpstan-baseline.neon
@@ -3586,16 +3586,6 @@ parameters:
 			path: src/Entity/Client.php
 
 		-
-			message: "#^PHPDoc tag @var above a method has no effect\\.$#"
-			count: 2
-			path: src/Entity/Client.php
-
-		-
-			message: "#^PHPDoc tag @var does not specify variable name\\.$#"
-			count: 2
-			path: src/Entity/Client.php
-
-		-
 			message: "#^Property App\\\\Entity\\\\Client\\:\\:\\$caseNumber \\(string\\) does not accept string\\|null\\.$#"
 			count: 1
 			path: src/Entity/Client.php

--- a/api/app/src/Entity/Client.php
+++ b/api/app/src/Entity/Client.php
@@ -41,10 +41,6 @@ class Client implements ClientInterface
     /**
      * @var int
      *
-     * @JMS\Groups({"related","basic", "client", "client-id"})
-     *
-     * @JMS\Type("integer")
-     *
      * @ORM\Column(name="id", type="integer", nullable=false)
      *
      * @ORM\Id
@@ -53,13 +49,11 @@ class Client implements ClientInterface
      *
      * @ORM\SequenceGenerator(sequenceName="client_id_seq", allocationSize=1, initialValue=1)
      */
+    #[JMS\Groups(['related', 'basic', 'client', 'client-id'])]
+    #[JMS\Type('integer')]
     private $id;
 
     /**
-     * @JMS\Groups({"client-users"})
-     *
-     * @JMS\Type("ArrayCollection<App\Entity\User>")
-     *
      * @ORM\ManyToMany(targetEntity="App\Entity\User", inversedBy="clients", fetch="EXTRA_LAZY")
      *
      * @ORM\JoinTable(name="deputy_case",
@@ -67,196 +61,162 @@ class Client implements ClientInterface
      *         inverseJoinColumns={@ORM\JoinColumn(name="user_id", referencedColumnName="id", onDelete="CASCADE")}
      *     )
      */
+    #[JMS\Groups(['client-users'])]
+    #[JMS\Type('ArrayCollection<App\Entity\User>')]
     private $users;
 
     /**
-     * @JMS\Groups({"client-reports"})
-     *
-     * @JMS\Type("ArrayCollection<App\Entity\Report\Report>")
-     *
      * @ORM\OneToMany(targetEntity="App\Entity\Report\Report", mappedBy="client", cascade={"persist", "remove"})
      *
      * @ORM\OrderBy({"submitDate"="DESC"})
      */
+    #[JMS\Groups(['client-reports'])]
+    #[JMS\Type('ArrayCollection<App\Entity\Report\Report>')]
     private $reports;
 
     /**
-     * @JMS\Groups({"basic", "client-ndr", "ndr_id"})
-     *
-     * @JMS\Type("App\Entity\Ndr\Ndr")
-     *
      * @ORM\OneToOne(targetEntity="App\Entity\Ndr\Ndr", mappedBy="client", cascade={"persist", "remove"})
      **/
+    #[JMS\Groups(['basic', 'client-ndr', 'ndr_id'])]
+    #[JMS\Type('App\Entity\Ndr\Ndr')]
     private $ndr;
 
     /**
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"client", "client-case-number"})
-     *
      * @var string
      *
      * @ORM\Column(name="case_number", type="string", length=20, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['client', 'client-case-number'])]
     private $caseNumber;
 
     /**
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"client", "client-email"})
-     *
      * @var string
      *
      * @ORM\Column(name="email", type="string", length=60, nullable=true, unique=false)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['client', 'client-email'])]
     private $email;
 
     /**
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"client"})
-     *
      * @var string
      *
      * @ORM\Column(name="phone", type="string", length=20, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['client'])]
     private $phone;
 
     /**
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"client"})
-     *
      * @ORM\Column(name="address", type="string", length=200, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['client'])]
     private ?string $address = null;
 
     /**
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"client"})
-     *
      * @ORM\Column(name="address2", type="string", length=200, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['client'])]
     private ?string $address2 = null;
 
     /**
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"client"})
-     *
      * @ORM\Column(name="address3", type="string", length=200, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['client'])]
     private ?string $address3 = null;
 
     /**
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"client"})
-     *
      * @ORM\Column(name="address4", type="string", length=200, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['client'])]
     private ?string $address4 = null;
 
     /**
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"client"})
-     *
      * @ORM\Column(name="address5", type="string", length=200, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['client'])]
     private ?string $address5 = null;
 
     /**
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"client"})
-     *
      * @var string
      *
      * @ORM\Column(name="postcode", type="string", length=10, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['client'])]
     private $postcode;
 
     /**
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"client"})
-     *
      * @var string
      *
      * @ORM\Column(name="country", type="string", length=10, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['client'])]
     private $country;
 
     /**
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"client", "client-name"})
-     *
      * @var string
      *
      * @ORM\Column(name="firstname", type="string", length=50, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['client', 'client-name'])]
     private $firstname;
 
     /**
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"client", "client-name"})
-     *
      * @var string
      *
      * @ORM\Column(name="lastname", type="string", length=50, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['client', 'client-name'])]
     private $lastname;
 
     /**
-     * @JMS\Type("DateTime<'Y-m-d'>")
-     *
-     * @JMS\Groups({"client", "client-court-date", "checklist-information"})
-     *
-     * @var \DateTime|null
+     * @var DateTime|null
      *
      * @ORM\Column(name="court_date", type="date", nullable=true)
      */
+    #[JMS\Type("DateTime<'Y-m-d'>")]
+    #[JMS\Groups(['client', 'client-court-date', 'checklist-information'])]
     private $courtDate;
 
     /**
-     * @JMS\Type("DateTime<'Y-m-d'>")
-     *
-     * @JMS\Groups({"client"})
-     *
-     * @var \DateTime|null
+     * @var DateTime|null
      *
      * @ORM\Column(name="date_of_birth", type="date", nullable=true)
      */
+    #[JMS\Type("DateTime<'Y-m-d'>")]
+    #[JMS\Groups(['client'])]
     private $dateOfBirth;
 
     /**
      * @var ArrayCollection
      *
-     * @JMS\Type("ArrayCollection<App\Entity\Note>")
-     *
-     * @JMS\Groups({"client-notes"})
-     *
      * @ORM\OneToMany(targetEntity="App\Entity\Note", mappedBy="client", cascade={"persist", "remove"})
      *
      * @ORM\OrderBy({"createdOn"="DESC"})
      */
+    #[JMS\Type('ArrayCollection<App\Entity\Note>')]
+    #[JMS\Groups(['client-notes'])]
     private $notes;
 
     /**
      * @var ArrayCollection
      *
-     * @JMS\Type("ArrayCollection<App\Entity\ClientContact>")
-     *
-     * @JMS\Groups({"client-clientcontacts"})
-     *
      * @ORM\OneToMany(targetEntity="App\Entity\ClientContact", mappedBy="client", cascade={"persist", "remove"})
      *
      * @ORM\OrderBy({"lastName"="ASC"})
      */
+    #[JMS\Type('ArrayCollection<App\Entity\ClientContact>')]
+    #[JMS\Groups(['client-clientcontacts'])]
     private $clientContacts;
 
     /**
@@ -265,52 +225,42 @@ class Client implements ClientInterface
      *
      * @var Deputy|null
      *
-     * @JMS\Groups({"report-submitted-by", "client-deputy"})
-     *
-     * @JMS\Type("App\Entity\Deputy")
-     *
      * @ORM\ManyToOne(targetEntity="App\Entity\Deputy", inversedBy="clients", fetch="EAGER")
      *
      * @ORM\JoinColumn(name="deputy_id", referencedColumnName="id", onDelete="SET NULL")
      */
+    #[JMS\Groups(['report-submitted-by', 'client-deputy'])]
+    #[JMS\Type('App\Entity\Deputy')]
     private $deputy;
 
     /**
      * @var ArrayCollection
      *
-     * @JMS\Type("ArrayCollection<App\Entity\CourtOrder>")
-     *
      * @ORM\OneToMany(targetEntity="App\Entity\CourtOrder", mappedBy="client", cascade={"persist", "remove"})
      *
      * @ORM\OrderBy({"createdAt"="DESC"})
      */
+    #[JMS\Type('ArrayCollection<App\Entity\CourtOrder>')]
     private $courtOrders;
 
     /**
-     * @var \DateTime|null
-     *
-     * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
-     *
-     * @JMS\Groups({"client"})
+     * @var DateTime|null
      *
      * @ORM\Column(name="archived_at", type="datetime", nullable=true)
      */
+    #[JMS\Type("DateTime<'Y-m-d H:i:s'>")]
+    #[JMS\Groups(['client'])]
     private $archivedAt;
 
     /**
      * @var Organisation|null
      *
-     * @JMS\Type("App\Entity\Organisation")
-     *
-     * @JMS\Groups({"client-organisations"})
-     *
      * @ORM\ManyToOne(targetEntity="Organisation", inversedBy="clients")
      */
+    #[JMS\Type('App\Entity\Organisation')]
+    #[JMS\Groups(['client-organisations'])]
     private $organisation;
 
-    /**
-     * Constructor.
-     */
     public function __construct()
     {
         $this->users = new ArrayCollection();
@@ -478,7 +428,7 @@ class Client implements ClientInterface
      *
      * @return Client
      */
-    public function setCourtDate(?\DateTime $courtDate = null)
+    public function setCourtDate(?DateTime $courtDate = null)
     {
         $this->courtDate = $courtDate;
 
@@ -488,7 +438,7 @@ class Client implements ClientInterface
     /**
      * Get courtDate.
      *
-     * @return \DateTime|null
+     * @return DateTime|null
      */
     public function getCourtDate()
     {
@@ -605,7 +555,7 @@ class Client implements ClientInterface
      *
      * @return Report|null
      */
-    public function getReportByEndDate(\DateTime $endDate)
+    public function getReportByEndDate(DateTime $endDate)
     {
         return $this->reports->filter(function ($report) use ($endDate) {
             return $endDate->format('Y-m-d') == $report->getEndDate()->format('Y-m-d');
@@ -637,16 +587,12 @@ class Client implements ClientInterface
      * get progress the user is currenty work on
      * That means the first one that is unsubmitted AND has an unsubmit date.
      *
-     * @JMS\VirtualProperty
-     *
-     * @JMS\Type("App\Entity\Report\Report")
-     *
-     * @JMS\SerializedName("current_report")
-     *
-     * @JMS\Groups({"current-report"})
-     *
      * @return Report|null
      */
+    #[JMS\VirtualProperty]
+    #[JMS\Type('App\Entity\Report\Report')]
+    #[JMS\SerializedName('current_report')]
+    #[JMS\Groups(['current-report'])]
     public function getCurrentReport()
     {
         foreach ($this->getReports() as $r) {
@@ -774,7 +720,7 @@ class Client implements ClientInterface
     }
 
     /**
-     * @return \DateTime|null $dateOfBirth
+     * @return DateTime|null $dateOfBirth
      */
     public function getDateOfBirth()
     {
@@ -784,7 +730,7 @@ class Client implements ClientInterface
     /**
      * @return $this
      */
-    public function setDateOfBirth(?\DateTime $dateOfBirth = null)
+    public function setDateOfBirth(?DateTime $dateOfBirth = null)
     {
         $this->dateOfBirth = $dateOfBirth;
 
@@ -853,40 +799,32 @@ class Client implements ClientInterface
     }
 
     /**
-     * @JMS\VirtualProperty
-     *
-     * @JMS\Type("integer")
-     *
-     * @JMS\SerializedName("total_report_count")
-     *
-     * @JMS\Groups({"total-report-count"})
-     *
      * @return int
      */
+    #[JMS\VirtualProperty]
+    #[JMS\Type('integer')]
+    #[JMS\SerializedName('total_report_count')]
+    #[JMS\Groups(['total-report-count'])]
     public function getTotalReportCount()
     {
         return count($this->getReports());
     }
 
     /**
-     * @JMS\VirtualProperty
-     *
-     * @JMS\Type("integer")
-     *
-     * @JMS\Groups({"unsubmitted-reports-count"})
-     *
      * @return int
      */
+    #[JMS\VirtualProperty]
+    #[JMS\Type('integer')]
+    #[JMS\Groups(['unsubmitted-reports-count'])]
     public function getUnsubmittedReportsCount()
     {
         return count($this->getUnsubmittedReports());
     }
 
     /**
-     * @JMS\Exclude()
-     *
      * @return Collection<Report>
      */
+    #[JMS\Exclude]
     public function getUnsubmittedReports()
     {
         return $this->getReports()->filter(function (Report $report) {
@@ -897,18 +835,12 @@ class Client implements ClientInterface
     /**
      * Generates the expected Report Start date based on the Court date.
      *
-     * @JMS\VirtualProperty
-     *
-     * @var \DateTime
-     *
-     * @JMS\Type("DateTime<'Y-m-d'>")
-     *
-     * @JMS\SerializedName("expected_report_start_date")
-     *
-     * @JMS\Groups({"checklist-information"})
-     *
-     * @return \DateTime|null
+     * @return DateTime|null
      */
+    #[JMS\VirtualProperty]
+    #[JMS\Type("DateTime<'Y-m-d'>")]
+    #[JMS\SerializedName('expected_report_start_date')]
+    #[JMS\Groups(['checklist-information'])]
     public function getExpectedReportStartDate($year = null)
     {
         if (is_null($this->getCourtDate())) {
@@ -936,21 +868,15 @@ class Client implements ClientInterface
     /**
      * Generates the expected Report End date based on the Court date.
      *
-     * @JMS\VirtualProperty
-     *
-     * @var \DateTime
-     *
-     * @JMS\Type("DateTime<'Y-m-d'>")
-     *
-     * @JMS\SerializedName("expected_report_end_date")
-     *
-     * @JMS\Groups({"checklist-information"})
-     *
-     * @return \DateTime|null
+     * @return DateTime|null
      */
+    #[JMS\VirtualProperty]
+    #[JMS\Type("DateTime<'Y-m-d'>")]
+    #[JMS\SerializedName('expected_report_end_date')]
+    #[JMS\Groups(['checklist-information'])]
     public function getExpectedReportEndDate($year = null)
     {
-        if (!($this->getExpectedReportStartDate($year) instanceof \DateTime)) {
+        if (!($this->getExpectedReportStartDate($year) instanceof DateTime)) {
             return null;
         }
         $expectedReportEndDate = clone $this->getExpectedReportStartDate($year);
@@ -958,13 +884,13 @@ class Client implements ClientInterface
         return $expectedReportEndDate->modify('+1year -1day');
     }
 
-    public function setArchivedAt(?\DateTime $archivedAt = null)
+    public function setArchivedAt(?DateTime $archivedAt = null)
     {
         $this->archivedAt = $archivedAt;
     }
 
     /**
-     * @return \DateTime|null
+     * @return DateTime|null
      */
     public function getArchivedAt()
     {
@@ -1000,20 +926,16 @@ class Client implements ClientInterface
     /**
      * Get Active From date == earliest report start date for this client.
      *
-     * @JMS\VirtualProperty
-     *
-     * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
-     *
-     * @JMS\SerializedName("active_from")
-     *
-     * @JMS\Groups({"active-period"})
-     *
-     * @return \DateTime
+     * @return DateTime
      */
+    #[JMS\VirtualProperty]
+    #[JMS\Type("DateTime<'Y-m-d H:i:s'>")]
+    #[JMS\SerializedName('active_from')]
+    #[JMS\Groups(['active-period'])]
     public function getActiveFrom()
     {
         $reports = $this->getReports();
-        $earliest = new \DateTime('now');
+        $earliest = new DateTime('now');
         foreach ($reports as $report) {
             if ($report->getStartDate() < $earliest) {
                 $earliest = $report->getStartDate();

--- a/api/app/src/Entity/ClientContact.php
+++ b/api/app/src/Entity/ClientContact.php
@@ -25,10 +25,6 @@ class ClientContact
     /**
      * @var int
      *
-     * @JMS\Type("integer")
-     *
-     * @JMS\Groups({"clientcontact"})
-     *
      * @ORM\Column(name="id", type="integer", nullable=false)
      *
      * @ORM\Id
@@ -37,89 +33,73 @@ class ClientContact
      *
      * @ORM\SequenceGenerator(sequenceName="user_id_seq", allocationSize=1, initialValue=1)
      */
+    #[JMS\Type('integer')]
+    #[JMS\Groups(['clientcontact'])]
     private $id;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"clientcontact"})
-     *
      * @ORM\Column(name="firstname", type="string", length=100, nullable=false)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['clientcontact'])]
     private $firstName;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"clientcontact"})
-     *
      * @ORM\Column(name="lastname", type="string", length=100, nullable=false)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['clientcontact'])]
     private $lastName;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"clientcontact"})
-     *
      * @ORM\Column(name="job_title", type="string", length=150, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['clientcontact'])]
     private $jobTitle;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"clientcontact"})
-     *
      * @ORM\Column(name="phone", type="string", length=20, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['clientcontact'])]
     private $phone;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"clientcontact"})
-     *
-     * The following is changed to unique=false, as the migration was missing,
-     * and prod data contains duplicate, making it impossible to add the
-     * migration now, unless the data is cleaned
-     *
      * @ORM\Column(name="email", type="string", length=60, nullable=true, unique=false)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['clientcontact'])] // The following is changed to unique=false, as the migration was missing,
     private $email;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"clientcontact"})
-     *
      * @ORM\Column(name="org_name", type="string", length=150, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['clientcontact'])]
     private $orgName;
 
     /**
      * @var Client
      *
-     * @JMS\Type("App\Entity\Client")
-     *
-     * @JMS\Groups({"clientcontact-client"})
-     *
      * @ORM\ManyToOne(targetEntity="App\Entity\Client", inversedBy="clientContacts")
      *
      * @ORM\JoinColumn(name="client_id", referencedColumnName="id", onDelete="CASCADE")
      */
+    #[JMS\Type('App\Entity\Client')]
+    #[JMS\Groups(['clientcontact-client'])]
     private $client;
 
     /**

--- a/api/app/src/Entity/CourtOrder.php
+++ b/api/app/src/Entity/CourtOrder.php
@@ -23,10 +23,6 @@ class CourtOrder
     use CreateUpdateTimestamps;
 
     /**
-     * @JMS\Type("integer")
-     *
-     * @JMS\Groups({"court-order-basic"})
-     *
      * @ORM\Column(name="id", type="integer", nullable=false)
      *
      * @ORM\Id
@@ -35,40 +31,31 @@ class CourtOrder
      *
      * @ORM\SequenceGenerator(sequenceName="court_order_id_seq", allocationSize=1, initialValue=1)
      */
+    #[JMS\Type('integer')]
     private int $id;
 
     /**
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"court-order-basic", "court-order-full"})
-     *
      * @ORM\Column(name="court_order_uid", type="string", length=36, nullable=false, unique=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['court-order-basic', 'court-order-full'])]
     private string $courtOrderUid;
 
     /**
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"court-order-basic", "court-order-full"})
-     *
      * @ORM\Column(name="type", type="string", length=10, nullable=false)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['court-order-basic', 'court-order-full'])]
     private string $type;
 
     /**
-     * @JMS\Type("boolean")
-     *
-     * @JMS\Groups({"court-order-basic", "court-order-full"})
-     *
      * @ORM\Column(name="active", type="boolean", options = { "default": true })
      */
+    #[JMS\Type('boolean')]
+    #[JMS\Groups(['court-order-basic', 'court-order-full'])]
     private bool $active;
 
     /**
-     * @JMS\Type("ArrayCollection<App\Entity\Report\Report>")
-     *
-     * @JMS\Groups({"court-order-full"})
-     *
      * @ORM\ManyToMany(targetEntity="App\Entity\Report\Report", inversedBy="courtOrders", fetch="EXTRA_LAZY", cascade={"persist"})
      *
      * @ORM\JoinTable(name="court_order_report",
@@ -78,6 +65,8 @@ class CourtOrder
      *
      * @var Collection<int, Report>
      */
+    #[JMS\Type('ArrayCollection<App\Entity\Report\Report>')]
+    #[JMS\Groups(['court-order-basic', 'court-order-full'])]
     private Collection $reports;
 
     /**
@@ -89,13 +78,14 @@ class CourtOrder
      *
      * @ORM\JoinColumn(name="client_id", referencedColumnName="id")
      */
+    #[JMS\Type(Client::class)]
+    #[JMS\Groups(['court-order-full'])]
     private Client $client;
 
     /**
-     * @JMS\Type("ArrayCollection<App\Entity\CourtOrderDeputy>")
-     *
      * @ORM\OneToMany(targetEntity="App\Entity\CourtOrderDeputy", mappedBy="courtOrder", cascade={"persist"})
      */
+    #[JMS\Type('ArrayCollection<App\Entity\CourtOrderDeputy>')]
     private Collection $courtOrderDeputyRelationships;
 
     public function __construct()

--- a/api/app/src/Entity/Deputy.php
+++ b/api/app/src/Entity/Deputy.php
@@ -25,8 +25,6 @@ class Deputy
     /**
      * @var int
      *
-     * @JMS\Type("integer")
-     *
      * @ORM\Column(name="id", type="integer", nullable=false)
      *
      * @ORM\Id
@@ -34,195 +32,163 @@ class Deputy
      * @ORM\GeneratedValue(strategy="IDENTITY")
      *
      * @ORM\SequenceGenerator(sequenceName="deputy_id_seq", allocationSize=1, initialValue=1)
-     *
-     * @JMS\Groups({"report-submitted-by", "deputy"})
      */
+    #[JMS\Type('integer')]
+    #[JMS\Groups(['report-submitted-by', 'deputy'])]
     private $id;
 
     /**
      * Holds the deputy the client belongs to
      * Loaded from the CSV upload.
      *
-     * @JMS\Exclude
-     *
      * @ORM\OneToMany(targetEntity="App\Entity\Client", mappedBy="deputy")
      *
      * @ORM\JoinColumn(name="id", referencedColumnName="deputy_id")
      */
+    #[JMS\Exclude]
     private $clients;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"report-submitted-by", "deputy"})
-     *
      * @ORM\Column(name="deputy_uid", type="string", length=20, nullable=false, unique=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['report-submitted-by', 'deputy'])]
     private $deputyUid;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"report-submitted-by", "deputy"})
-     *
      * @ORM\Column(name="firstname", type="string", length=100, nullable=false)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['report-submitted-by', 'deputy'])]
     private $firstname;
 
     /**
      * @var string
      *
      * @ORM\Column(name="lastname", type="string", length=100, nullable=false)
-     *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"report-submitted-by", "deputy"})
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['report-submitted-by', 'deputy'])]
     private $lastname;
 
     /**
      * @var string
      *
-     * @JMS\Groups({"report-submitted-by", "deputy"})
-     *
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="email1", type="string", length=60, nullable=false, unique=false)
      */
+    #[JMS\Groups(['report-submitted-by', 'deputy'])]
+    #[JMS\Type('string')]
     private $email1;
 
     /**
      * @var string
      *
-     * @JMS\Groups({"report-submitted-by", "deputy"})
-     *
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="email2", type="string", length=60, nullable=true, unique=false)
      */
+    #[JMS\Groups(['report-submitted-by', 'deputy'])]
+    #[JMS\Type('string')]
     private $email2;
 
     /**
      * @var string
      *
-     * @JMS\Groups({"report-submitted-by", "deputy"})
-     *
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="email3", type="string", length=60, nullable=true, unique=false)
      */
+    #[JMS\Groups(['report-submitted-by', 'deputy'])]
+    #[JMS\Type('string')]
     private $email3;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({ "report-submitted-by", "deputy"})
-     *
      * @ORM\Column(name="address1", type="string", length=200, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['report-submitted-by', 'deputy'])]
     private $address1;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({ "report-submitted-by", "deputy"})
-     *
      * @ORM\Column(name="address2", type="string", length=200, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['report-submitted-by', 'deputy'])]
     private $address2;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({ "report-submitted-by", "deputy"})
-     *
      * @ORM\Column(name="address3", type="string", length=200, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['report-submitted-by', 'deputy'])]
     private $address3;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({ "report-submitted-by", "deputy"})
-     *
      * @ORM\Column(name="address4", type="string", length=200, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['report-submitted-by', 'deputy'])]
     private $address4;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({ "report-submitted-by", "deputy"})
-     *
      * @ORM\Column(name="address5", type="string", length=200, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['report-submitted-by', 'deputy'])]
     private $address5;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({ "report-submitted-by", "deputy"})
-     *
      * @ORM\Column(name="address_postcode", type="string", length=10, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['report-submitted-by', 'deputy'])]
     private $addressPostcode;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"user", "team", "report-submitted-by", "deputy"})
-     *
      * @ORM\Column(name="address_country", type="string", length=10, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['user', 'team', 'report-submitted-by', 'deputy'])]
     private $addressCountry;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"report-submitted-by", "deputy"})
-     *
      * @ORM\Column(name="phone_main", type="string", length=20, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['report-submitted-by', 'deputy'])]
     private $phoneMain;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"report-submitted-by", "deputy"})
-     *
      * @ORM\Column(name="phone_alternative", type="string", length=20, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['report-submitted-by', 'deputy'])]
     private $phoneAlternative;
 
     /**
-     * @JMS\Type("App\Entity\User")
-     *
      * @ORM\OneToOne(targetEntity="App\Entity\User", inversedBy="deputy", cascade={"remove", "persist"})
      *
      * @ORM\JoinColumn(name="user_id", referencedColumnName="id", onDelete="cascade")
      */
+    #[JMS\Type('App\Entity\User')]
     private ?User $user;
 
     /**

--- a/api/app/src/Entity/Note.php
+++ b/api/app/src/Entity/Note.php
@@ -29,9 +29,8 @@ class Note
      * Keep in sync with API.
      *
      * Possible refactor would be moving some entities data into a shared library
-     *
-     * @JMS\Exclude
      */
+    #[JMS\Exclude]
     public static $categories = [
         // categoryId | categoryTranslationKey
         'Todo' => 'todo',
@@ -46,10 +45,6 @@ class Note
     /**
      * @var int
      *
-     * @JMS\Type("integer")
-     *
-     * @JMS\Groups({"notes"})
-     *
      * @ORM\Column(name="id", type="integer", nullable=false)
      *
      * @ORM\Id
@@ -58,52 +53,46 @@ class Note
      *
      * @ORM\SequenceGenerator(sequenceName="user_id_seq", allocationSize=1, initialValue=1)
      */
+    #[JMS\Type('integer')]
+    #[JMS\Groups(['notes'])]
     private $id;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"notes"})
-     *
      * @ORM\Column(name="category", type="string", length=100, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['notes'])]
     private $category;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"notes"})
-     *
      * @ORM\Column(name="title", type="string", length=150, nullable=false)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['notes'])]
     private $title;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"notes"})
-     *
      * @ORM\Column(name="content", type="text", nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['notes'])]
     private $content;
 
     /**
      * @var Client
      *
-     * @JMS\Groups({"note-client"})
-     *
-     * @JMS\Type("App\Entity\Client")
-     *
      * @ORM\ManyToOne(targetEntity="App\Entity\Client", inversedBy="notes")
      *
      * @ORM\JoinColumn(name="client_id", referencedColumnName="id", onDelete="CASCADE")
      */
+    #[JMS\Groups(['note-client'])]
+    #[JMS\Type('App\Entity\Client')]
     private $client;
 
     /**

--- a/api/app/src/Entity/Organisation.php
+++ b/api/app/src/Entity/Organisation.php
@@ -31,64 +31,54 @@ class Organisation implements OrganisationInterface
      * @ORM\GeneratedValue(strategy="IDENTITY")
      *
      * @ORM\SequenceGenerator(sequenceName="organisation_id_seq", allocationSize=1, initialValue=1)
-     *
-     * @JMS\Groups({"organisation", "user-organisations", "client-organisations", "org-created-event"})
      */
+    #[JMS\Groups(['organisation', 'user-organisations', 'client-organisations', 'org-created-event'])]
     private $id;
 
     /**
      * @var string
      *
      * @ORM\Column(name="name", type="string", length=256, nullable=false)
-     *
-     * @JMS\Groups({"organisation", "user-organisations", "client-organisations", "org-created-event"})
      */
     #[Assert\NotBlank]
+    #[JMS\Groups(['organisation', 'user-organisations', 'client-organisations', 'org-created-event'])]
     private $name;
 
     /**
      * @var string
      *
-     * @JMS\Groups({"user-organisations", "organisation", "org-created-event"})
-     *
-     * @JMS\Type("string")
-     *
-     * @JMS\SerializedName("email_identifier")
-     *
      * @ORM\Column(name="email_identifier", type="string", length=256, nullable=false, unique=true)
      */
     #[Assert\NotBlank]
+    #[JMS\Groups(['user-organisations', 'organisation', 'org-created-event'])]
+    #[JMS\Type('string')]
+    #[JMS\SerializedName('email_identifier')]
     private $emailIdentifier;
 
     /**
      * @var bool
      *
-     * @JMS\Groups({"organisation", "user-organisations", "client-organisations", "org-created-event"})
-     *
-     * @JMS\Type("boolean")
-     *
-     * @JMS\SerializedName("is_activated")
-     *
      * @ORM\Column(name="is_activated", type="boolean", options={ "default": false}, nullable=false)
      */
+    #[JMS\Groups(['organisation', 'user-organisations', 'client-organisations', 'org-created-event'])]
+    #[JMS\Type('boolean')]
+    #[JMS\SerializedName('is_activated')]
     private $isActivated;
 
     /**
      * @var ArrayCollection
      *
-     * @JMS\Type("ArrayCollection<App\Entity\User>")
-     *
      * @ORM\ManyToMany(targetEntity="User", inversedBy="organisations")
      */
+    #[JMS\Type('ArrayCollection<App\Entity\User>')]
     private $users;
 
     /**
      * @var ArrayCollection
      *
-     * @JMS\Type("ArrayCollection<App\Entity\Clients>")
-     *
      * @ORM\OneToMany(targetEntity="Client", mappedBy="organisation")
      */
+    #[JMS\Type('ArrayCollection<App\Entity\Clients>')]
     private $clients;
 
     public function __construct()
@@ -196,32 +186,24 @@ class Organisation implements OrganisationInterface
     }
 
     /**
-     * @JMS\VirtualProperty
-     *
-     * @JMS\Type("integer")
-     *
-     * @JMS\SerializedName("total-user-count")
-     *
-     * @JMS\Groups({"total-user-count"})
-     *
      * @return int
      */
+    #[JMS\VirtualProperty]
+    #[JMS\Type('integer')]
+    #[JMS\SerializedName('total-user-count')]
+    #[JMS\Groups(['total-user-count'])]
     public function getTotalUserCount()
     {
         return count($this->getUsers());
     }
 
     /**
-     * @JMS\VirtualProperty
-     *
-     * @JMS\Type("integer")
-     *
-     * @JMS\SerializedName("total-client-count")
-     *
-     * @JMS\Groups({"total-client-count"})
-     *
      * @return int
      */
+    #[JMS\VirtualProperty]
+    #[JMS\Type('integer')]
+    #[JMS\SerializedName('total-client-count')]
+    #[JMS\Groups(['total-client-count'])]
     public function getTotalClientCount()
     {
         return count($this->getClients());

--- a/api/app/src/Entity/PreRegistration.php
+++ b/api/app/src/Entity/PreRegistration.php
@@ -72,149 +72,130 @@ class PreRegistration
     private int $id;
 
     /**
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="client_case_number", type="string", length=20, nullable=false)
      */
     #[Assert\NotBlank]
+    #[JMS\Type('string')]
     private string $caseNumber;
 
     /**
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="client_firstname", type="string", length=100, nullable=true)
      */
+    #[JMS\Type('string')]
     private ?string $clientFirstname;
 
     /**
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="client_lastname", type="string", length=50, nullable=false)
      */
     #[Assert\NotBlank]
+    #[JMS\Type('string')]
     private string $clientLastname;
 
     /**
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="client_address_1", type="string", nullable=true)
      */
+    #[JMS\Type('string')]
     private ?string $clientAddress1;
 
     /**
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="client_address_2", type="string", nullable=true)
      */
+    #[JMS\Type('string')]
     private ?string $clientAddress2;
 
     /**
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="client_address_3", type="string", nullable=true)
      */
+    #[JMS\Type('string')]
     private ?string $clientAddress3;
 
     /**
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="client_address_4", type="string", nullable=true)
      */
+    #[JMS\Type('string')]
     private ?string $clientAddress4;
 
     /**
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="client_address_5", type="string", nullable=true)
      */
+    #[JMS\Type('string')]
     private ?string $clientAddress5;
 
     /**
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="client_postcode", type="string", length=10, nullable=true)
      */
     #[Assert\Length(min: 2, max: 10, minMessage: 'postcode too short', maxMessage: 'postcode too long')]
+    #[JMS\Type('string')]
     private ?string $clientPostcode;
 
     /**
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="deputy_uid", type="string", length=100, nullable=false)
      */
     #[Assert\NotBlank]
+    #[JMS\Type('string')]
     private string $deputyUid;
 
     /**
      * @ORM\Column(name="deputy_firstname", type="string", length=100, nullable=true)
-     * @JMS\Type("string")
      */
     #[Assert\NotBlank]
+    #[JMS\Type('string')]
     private string $deputyFirstname;
 
     /**
      * @ORM\Column(name="deputy_lastname", type="string", length=100, nullable=true)
-     *
-     * @JMS\Type("string")
      */
     #[Assert\NotBlank]
+    #[JMS\Type('string')]
     private string $deputySurname;
 
     /**
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="deputy_address_1", type="string", nullable=true)
      */
+    #[JMS\Type('string')]
     private ?string $deputyAddress1;
 
     /**
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="deputy_address_2", type="string", nullable=true)
      */
+    #[JMS\Type('string')]
     private ?string $deputyAddress2;
 
     /**
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="deputy_address_3", type="string", nullable=true)
      */
+    #[JMS\Type('string')]
     private ?string $deputyAddress3;
 
     /**
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="deputy_address_4", type="string", nullable=true)
      */
+    #[JMS\Type('string')]
     private ?string $deputyAddress4;
 
     /**
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="deputy_address_5", type="string", nullable=true)
      */
+    #[JMS\Type('string')]
     private ?string $deputyAddress5;
 
     /**
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="deputy_postcode", type="string", length=10, nullable=true)
      */
     #[Assert\Length(min: 2, max: 10, minMessage: 'postcode too short', maxMessage: 'postcode too long')]
+    #[JMS\Type('string')]
     private ?string $deputyPostCode;
 
     /**
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="type_of_report", type="string", length=10, nullable=true)
      */
+    #[JMS\Type('string')]
     private ?string $typeOfReport;
 
     /**
-     * @JMS\Type("bool")
-     *
      * @ORM\Column(name="ndr", type="boolean", nullable=true)
      */
+    #[JMS\Type('bool')]
     private ?bool $ndr;
 
     /**

--- a/api/app/src/Entity/Satisfaction.php
+++ b/api/app/src/Entity/Satisfaction.php
@@ -25,10 +25,6 @@ class Satisfaction
     /**
      * @var int
      *
-     * @JMS\Type("integer")
-     *
-     * @JMS\Groups({"satisfaction"})
-     *
      * @ORM\Column(name="id", type="integer", nullable=false)
      *
      * @ORM\Id
@@ -37,88 +33,74 @@ class Satisfaction
      *
      * @ORM\SequenceGenerator(sequenceName="satisfaction_id_seq", allocationSize=1, initialValue=1)
      */
+    #[JMS\Type('integer')]
+    #[JMS\Groups(['satisfaction'])]
     private $id;
 
     /**
      * @var int
      *
-     * @JMS\Type("integer")
-     *
-     * @JMS\Groups({"satisfaction"})
-     *
      * @ORM\Column(type="integer")
      */
+    #[JMS\Type('integer')]
+    #[JMS\Groups(['satisfaction'])]
     private $score;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"satisfaction"})
-     *
      * @ORM\Column(type="string", name="comments", length=1200, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['satisfaction'])]
     private $comments;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"satisfaction"})
-     *
      * @ORM\Column(type="string", name="deputy_role", length=50, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['satisfaction'])]
     private $deputyrole;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"satisfaction"})
-     *
      * @ORM\Column(type="string", name="report_type", length=9, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['satisfaction'])]
     private $reporttype;
 
     /**
-     * @JMS\Type("DateTime")
-     *
-     * @JMS\Groups({"satisfaction"})
-     *
      * @ORM\Column(name="created_at", type="datetime")
      *
      * @Gedmo\Timestampable(on="create")
      */
+    #[JMS\Type('DateTime')]
+    #[JMS\Groups(['satisfaction'])]
     private \DateTime $created;
 
     /**
      * @ORM\OneToOne(targetEntity="App\Entity\UserResearch\UserResearchResponse", mappedBy="satisfaction", cascade={"persist", "remove"})
-     *
-     * @JMS\Type("App\Entity\UserResearch\UserResearchResponse")
-     *
-     * @JMS\Groups({"user-research", "satisfaction"})
      */
+    #[JMS\Type('App\Entity\UserResearch\UserResearchResponse')]
+    #[JMS\Groups(['user-research', 'satisfaction'])]
     private UserResearchResponse $userResearchResponse;
 
     /**
-     * @JMS\Type("App\Entity\Report\Report")
-     *
-     * @JMS\Groups({"user-research", "satisfaction"})
-     *
      * @ORM\OneToOne(targetEntity="App\Entity\Report\Report", inversedBy="satisfaction", cascade={"persist"})
      */
+    #[JMS\Type('App\Entity\Report\Report')]
+    #[JMS\Groups(['user-research', 'satisfaction'])]
     private ?Report $report = null;
 
     /**
-     * @JMS\Type("App\Entity\Ndr\Ndr")
-     *
-     * @JMS\Groups({"user-research", "satisfaction"})
-     *
      * @ORM\OneToOne(targetEntity="App\Entity\Ndr\Ndr", inversedBy="satisfaction", cascade={"persist"})
      */
+    #[JMS\Type('App\Entity\Ndr\Ndr')]
+    #[JMS\Groups(['user-research', 'satisfaction'])]
     private ?Ndr $ndr = null;
 
     public function getId(): int

--- a/api/app/src/Entity/Setting.php
+++ b/api/app/src/Entity/Setting.php
@@ -15,36 +15,30 @@ class Setting
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"setting"})
-     *
      * @ORM\Column(name="id", type="string", length=64, nullable=false)
      *
      * @ORM\Id
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['setting'])]
     private $id;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"setting"})
-     *
      * @ORM\Column(name="content", type="text", nullable=false)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['setting'])]
     private $content;
 
     /**
      * @var bool
      *
-     * @JMS\Type("boolean")
-     *
-     * @JMS\Groups({"setting"})
-     *
      * @ORM\Column(name="enabled", type="boolean", nullable=false)
      */
+    #[JMS\Type('boolean')]
+    #[JMS\Groups(['setting'])]
     private $enabled;
 
     /**

--- a/api/app/src/Entity/SynchronisableTrait.php
+++ b/api/app/src/Entity/SynchronisableTrait.php
@@ -5,53 +5,46 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use DateTime;
+use JMS\Serializer\Annotation as JMS;
 
 trait SynchronisableTrait
 {
     /**
      * @var string|null
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"synchronisation"})
-     *
      * @ORM\Column(name="synchronisation_status", type="string", options={"default": null}, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['synchronisation'])]
     protected $synchronisationStatus;
 
     /**
-     * @var \DateTime|null
-     *
-     * @JMS\Type("DateTime")
-     *
-     * @JMS\Groups({"synchronisation"})
+     * @var DateTime|null
      *
      * @ORM\Column(name="synchronisation_time", type="datetime", options={"default": null}, nullable=true)
      */
+    #[JMS\Type('DateTime')]
+    #[JMS\Groups(['synchronisation'])]
     protected $synchronisationTime;
 
     /**
      * @var string|null
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"synchronisation"})
-     *
      * @ORM\Column(name="synchronisation_error", type="text", length=65535, options={"default": null}, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['synchronisation'])]
     protected $synchronisationError;
 
     /**
      * @var User|null
      *
-     * @JMS\Type("App\Entity\User")
-     *
-     * @JMS\Groups({"synchronisation"})
-     *
      * @ORM\ManyToOne(targetEntity="App\Entity\User")
      *
      * @ORM\JoinColumn(name="synchronised_by", referencedColumnName="id", onDelete="SET NULL")
      */
+    #[JMS\Type('App\Entity\User')]
+    #[JMS\Groups(['synchronisation'])]
     protected $synchronisedBy;
 
     public function getSynchronisationStatus(): ?string
@@ -60,8 +53,6 @@ trait SynchronisableTrait
     }
 
     /**
-     * @param string $status
-     *
      * @return $this
      */
     public function setSynchronisationStatus(?string $status)
@@ -83,17 +74,15 @@ trait SynchronisableTrait
         return $this;
     }
 
-    public function getSynchronisationTime(): ?\DateTime
+    public function getSynchronisationTime(): ?DateTime
     {
         return $this->synchronisationTime;
     }
 
     /**
-     * @param \DateTime $time
-     *
      * @return $this
      */
-    public function setSynchronisationTime(?\DateTime $time)
+    public function setSynchronisationTime(?DateTime $time)
     {
         $this->synchronisationTime = $time;
 
@@ -106,8 +95,6 @@ trait SynchronisableTrait
     }
 
     /**
-     * @param string $error
-     *
      * @return $this
      */
     public function setSynchronisationError(?string $error)
@@ -123,8 +110,6 @@ trait SynchronisableTrait
     }
 
     /**
-     * @param User $user
-     *
      * @return $this
      */
     public function setSynchronisedBy(?User $user)

--- a/api/app/src/Entity/User.php
+++ b/api/app/src/Entity/User.php
@@ -6,6 +6,7 @@ use App\Entity\Report\Report;
 use App\Entity\Traits\AddressTrait;
 use App\Entity\Traits\CreateUpdateTimestamps;
 use App\Entity\UserResearch\UserResearchResponse;
+use DateTime;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use JMS\Serializer\Annotation as JMS;
@@ -107,10 +108,6 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * @var int
      *
-     * @JMS\Type("integer")
-     *
-     * @JMS\Groups({"user", "report-submitted-by", "user-id", "user-list"})
-     *
      * @ORM\Column(name="id", type="integer", nullable=false)
      *
      * @ORM\Id
@@ -119,83 +116,70 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      *
      * @ORM\SequenceGenerator(sequenceName="user_id_seq", allocationSize=1, initialValue=1)
      */
+    #[JMS\Type('integer')]
+    #[JMS\Groups(['user', 'report-submitted-by', 'user-id', 'user-list'])]
     private $id;
 
     /**
-     * @JMS\Groups({"user-clients"})
-     *
-     * @JMS\Type("ArrayCollection<App\Entity\Client>")
-     *
      * @ORM\ManyToMany(targetEntity="App\Entity\Client", mappedBy="users", cascade={"persist"}, fetch="EXTRA_LAZY")
      */
+    #[JMS\Groups(['user-clients'])]
+    #[JMS\Type('ArrayCollection<App\Entity\Client>')]
     private $clients;
 
     /**
-     * @JMS\Type("ArrayCollection<App\Entity\Organisation>")
-     *
-     * @JMS\Groups({"user-organisations"})
-     *
-     * @JMS\Accessor(getter="getOrganisations")
-     *
      * @ORM\ManyToMany(targetEntity="App\Entity\Organisation", mappedBy="users", fetch="EXTRA_LAZY")
      *
      * @var ArrayCollection
      */
+    #[JMS\Type('ArrayCollection<App\Entity\Organisation>')]
+    #[JMS\Groups(['user-organisations'])]
+    #[JMS\Accessor(getter: 'getOrganisations')]
     private $organisations;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({ "user", "report-submitted-by", "user-name", "user-list"})
-     *
      * @ORM\Column(name="firstname", type="string", length=100, nullable=false)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['user', 'report-submitted-by', 'user-name', 'user-list'])]
     private $firstname;
 
     /**
      * @var string
      *
      * @ORM\Column(name="lastname", type="string", length=100, nullable=false)
-     *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({ "user", "report-submitted-by", "user-name", "user-list"})
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['user', 'report-submitted-by', 'user-name', 'user-list'])]
     private $lastname;
 
     /**
      * @var string
      *
      * @ORM\Column(name="password", type="string", length=100, nullable=false)
-     *
-     * @JMS\Groups({ "user-login"})
-     *
-     * @JMS\Exclude
      */
+    #[JMS\Groups(['user-login'])]
+    #[JMS\Exclude]
     private $password;
 
     /**
      * @var string
      *
-     * @JMS\Groups({"user", "report-submitted-by", "user-email", "user-list"})
-     *
-     * @JMS\Type("string")
-     *
      * @ORM\Column(name="email", type="string", length=60, nullable=false, unique=true)
      */
+    #[JMS\Groups(['user', 'report-submitted-by', 'user-email', 'user-list'])]
+    #[JMS\Type('string')]
     private $email;
 
     /**
      * @var bool
      *
-     * @JMS\Type("boolean")
-     *
-     * @JMS\Groups({"user", "user-list"})
-     *
      * @ORM\Column(name="active", type="boolean", nullable=true, options = { "default": false })
      */
+    #[JMS\Type('boolean')]
+    #[JMS\Groups(['user', 'user-list'])]
     private $active;
 
     /**
@@ -206,48 +190,40 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     private $salt;
 
     /**
-     * @var \DateTime
-     *
-     * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
-     *
-     * @JMS\Groups({"user"})
+     * @var DateTime
      *
      * @ORM\Column(name="registration_date", type="datetime", nullable=true)
      */
+    #[JMS\Type("DateTime<'Y-m-d H:i:s'>")]
+    #[JMS\Groups(['user'])]
     private $registrationDate;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"user"})
-     *
      * @ORM\Column(name="registration_token", type="string", length=100, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['user'])]
     private $registrationToken;
 
     /**
-     * @var \DateTime
-     *
-     * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
-     *
-     * @JMS\Groups({"user"})
+     * @var DateTime
      *
      * @ORM\Column(name="token_date", type="datetime", nullable=true)
      */
+    #[JMS\Type("DateTime<'Y-m-d H:i:s'>")]
+    #[JMS\Groups(['user'])]
     private $tokenDate;
 
     /**
      * @var string ROLE_
      *             see roles in Role class
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"user", "report-submitted-by", "user-rolename", "user-list", "team-users"})
-     *
      * @ORM\Column(name="role_name", type="string", length=50, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['user', 'report-submitted-by', 'user-rolename', 'user-list', 'team-users'])]
     private $roleName;
 
     /**
@@ -255,143 +231,117 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      * does not get stored in the database.
      *
      * @var string
-     *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"user"})
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['user'])]
     private $gaTrackingId;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"user", "report-submitted-by", "user-list", "user-phone-main"})
-     *
      * @ORM\Column(name="phone_main", type="string", length=20, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['user', 'report-submitted-by', 'user-list', 'user-phone-main'])]
     private $phoneMain;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"user", "report-submitted-by"})
-     *
      * @ORM\Column(name="phone_alternative", type="string", length=20, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['user', 'report-submitted-by'])]
     private $phoneAlternative;
 
     /**
-     * @var \DateTime
-     *
-     * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
-     *
-     * @JMS\Groups({"user"})
+     * @var DateTime
      *
      * @ORM\Column(name="last_logged_in", type="datetime", nullable=true)
      */
+    #[JMS\Type("DateTime<'Y-m-d H:i:s'>")]
+    #[JMS\Groups(['user'])]
     private $lastLoggedIn;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"user"})
-     *
      * @ORM\Column(name="deputy_no", type="string", length=100, nullable=true)
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['user'])]
     private $deputyNo;
 
     /**
      * @var int
      *
-     * @JMS\Type("integer")
-     *
-     * @JMS\Groups({"user"})
-     *
      * @ORM\Column(name="deputy_uid", type="bigint", nullable=true)
      */
+    #[JMS\Type('integer')]
+    #[JMS\Groups(['user'])]
     private $deputyUid;
 
     /**
      * @var bool
      *
-     * @JMS\Type("boolean")
-     *
-     * @JMS\Groups({"user", "user-login"})
-     *
      * @ORM\Column(name="odr_enabled", type="boolean", nullable=true, options = { "default": false })
      */
+    #[JMS\Type('boolean')]
+    #[JMS\Groups(['user', 'user-login'])]
     private $ndrEnabled;
 
     /**
      * @var bool
      *
-     * @JMS\Type("boolean")
-     *
-     * @JMS\Groups({"user"})
-     *
      * @ORM\Column(name="ad_managed", type="boolean", nullable=true, options = { "default": false })
      */
+    #[JMS\Type('boolean')]
+    #[JMS\Groups(['user'])]
     private $adManaged;
 
     /**
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"user", "user-list"})
-     *
      * @ORM\Column(name="job_title", type="string", length=150, nullable=true)
      *
      * @var string
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['user', 'user-list'])]
     private $jobTitle;
 
     /**
      * @var bool
      *
-     * @JMS\Type("boolean")
-     *
-     * @JMS\Groups({"user"})
-     *
      * @ORM\Column(name="agree_terms_use", type="boolean", nullable=true, options = { "default": false })
      */
+    #[JMS\Type('boolean')]
+    #[JMS\Groups(['user'])]
     private $agreeTermsUse;
 
     /**
-     * @var \DateTime
-     *
-     * @JMS\Type("DateTime<'Y-m-d'>")
-     *
-     * @JMS\Groups({"user"})
+     * @var DateTime
      *
      * @ORM\Column(name="agree_terms_use_date", type="datetime", nullable=true)
      */
+    #[JMS\Type("DateTime<'Y-m-d'>")]
+    #[JMS\Groups(['user'])]
     private $agreeTermsUseDate;
 
     /**
      * @var bool
      *
-     * @JMS\Type("boolean")
-     *
-     * @JMS\Groups({"user"})
-     *
      * @ORM\Column(name="codeputy_client_confirmed", type="boolean", nullable=false, options = { "default": false })
      */
+    #[JMS\Type('boolean')]
+    #[JMS\Groups(['user'])]
     private $coDeputyClientConfirmed;
 
     /**
      * @var UserResearchResponse|null
      *
-     * @JMS\Type("App\Entity\UserResearch\UserResearchResponse")
-     *
-     * @JMS\Groups({"user", "satisfaction", "user-research"})
-     *
      * @ORM\OneToMany(targetEntity="App\Entity\UserResearch\UserResearchResponse", mappedBy="user", cascade={"persist"})
      */
+    #[JMS\Type('App\Entity\UserResearch\UserResearchResponse')]
+    #[JMS\Groups(['user', 'satisfaction', 'user-research'])]
     private $userResearchResponse;
 
     /**
@@ -400,69 +350,54 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      * @ORM\ManyToOne(targetEntity="App\Entity\User", inversedBy="user")
      *
      * @ORM\JoinColumn(name="created_by_id", referencedColumnName="id", onDelete="SET NULL")
-     *
-     * @JMS\Type("App\Entity\User")
-     *
-     * @JMS\Groups({"user", "created-by"})
-     *
-     * @JMS\MaxDepth(3)
      */
+    #[JMS\Type('App\Entity\User')]
+    #[JMS\Groups(['user', 'created-by'])]
+    #[JMS\MaxDepth(3)]
     private $createdBy;
 
     /**
      * @var bool
      *
-     * @JMS\Type("boolean")
-     *
-     * @JMS\Groups({"user"})
-     *
      * @ORM\Column(name="deletion_protection", type="boolean", nullable=true, options = { "default": null })
      */
+    #[JMS\Type('boolean')]
+    #[JMS\Groups(['user'])]
     private $deletionProtection;
 
     /**
-     * @JMS\Type("App\Entity\Deputy")
-     *
      * @ORM\OneToOne(targetEntity="App\Entity\Deputy", mappedBy="user", cascade={"persist"})
      */
+    #[JMS\Type('App\Entity\Deputy')]
     private ?Deputy $deputy;
 
     /**
-     * @var \DateTime
-     *
-     * @JMS\Type("DateTime<'Y-m-d H:i:s'>")
-     *
-     * @JMS\Groups({"user"})
+     * @var DateTime
      *
      * @ORM\Column(name="pre_register_validated", type="datetime", nullable=true)
      */
+    #[JMS\Type("DateTime<'Y-m-d H:i:s'>")]
+    #[JMS\Groups(['user'])]
     private $preRegisterValidatedDate;
 
     /**
      * @var string
      *
-     * @JMS\Type("string")
-     *
-     * @JMS\Groups({"user"})
-     *
      * @ORM\Column(name="registration_route", type="string", length=30, nullable=false, options = { "default": "UNKNOWN" })
      */
+    #[JMS\Type('string')]
+    #[JMS\Groups(['user'])]
     private $registrationRoute = self::UNKNOWN_REGISTRATION_ROUTE;
 
     /**
      * @var bool
      *
-     * @JMS\Type("boolean")
-     *
-     * @JMS\Groups({"user"})
-     *
      * @ORM\Column(name="is_primary", type="boolean", nullable=false, options = { "default": false })
      */
+    #[JMS\Type('boolean')]
+    #[JMS\Groups(['user'])]
     private $isPrimary = false;
 
-    /**
-     * Constructor.
-     */
     public function __construct($coDeputyClientConfirmed = false)
     {
         $this->clients = new ArrayCollection();
@@ -594,7 +529,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * Set registrationDate.
      *
-     * @param \DateTime $registrationDate
+     * @param DateTime $registrationDate
      *
      * @return User
      */
@@ -608,7 +543,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * Get registrationDate.
      *
-     * @return \DateTime
+     * @return DateTime
      */
     public function getRegistrationDate()
     {
@@ -628,7 +563,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $token = bin2hex(random_bytes(16)).$userIdWithLeadingZeros;
 
         $this->setRegistrationToken($token);
-        $this->setTokenDate(new \DateTime());
+        $this->setTokenDate(new DateTime());
 
         return $this;
     }
@@ -684,7 +619,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * Set tokenDate.
      *
-     * @param \DateTime $tokenDate
+     * @param DateTime $tokenDate
      *
      * @return User
      */
@@ -698,7 +633,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * Get tokenDate.
      *
-     * @return \DateTime
+     * @return DateTime
      */
     public function getTokenDate()
     {
@@ -898,14 +833,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     }
 
     /**
-     * @return \DateTime
+     * @return DateTime
      */
     public function getLastLoggedIn()
     {
         return $this->lastLoggedIn;
     }
 
-    public function setLastLoggedIn(?\DateTime $lastLoggedIn = null)
+    public function setLastLoggedIn(?DateTime $lastLoggedIn = null)
     {
         $this->lastLoggedIn = $lastLoggedIn;
 
@@ -954,15 +889,11 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
 
     /**
      * Return Id of the client (if it has details).
-     *
-     * @JMS\VirtualProperty
-     *
-     * @JMS\SerializedName("id_of_client_with_details")
-     *
-     * @JMS\Groups({"user"})
-     *
-     * @JMS\Type("integer")
      */
+    #[JMS\VirtualProperty]
+    #[JMS\SerializedName('id_of_client_with_details')]
+    #[JMS\Groups(['user'])]
+    #[JMS\Type('integer')]
     public function getIdOfClientWithDetails()
     {
         return $this->getFirstClient() && $this->getFirstClient()->hasDetails()
@@ -970,15 +901,10 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
             : null;
     }
 
-    /**
-     * @JMS\VirtualProperty
-     *
-     * @JMS\Groups({"user-login"})
-     *
-     * @JMS\Type("integer")
-     *
-     * @JMS\SerializedName("active_report_id")
-     */
+    #[JMS\VirtualProperty]
+    #[JMS\Groups(['user-login'])]
+    #[JMS\Type('integer')]
+    #[JMS\SerializedName('active_report_id')]
     public function getActiveReportId()
     {
         $client = $this->getFirstClient() ? $this->getFirstClient() : null;
@@ -993,29 +919,19 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return;
     }
 
-    /**
-     * @JMS\VirtualProperty
-     *
-     * @JMS\Groups({"user"})
-     *
-     * @JMS\Type("integer")
-     *
-     * @JMS\SerializedName("number_of_reports")
-     */
+    #[JMS\VirtualProperty]
+    #[JMS\Groups(['user'])]
+    #[JMS\Type('integer')]
+    #[JMS\SerializedName('number_of_reports')]
     public function getNumberOfReports()
     {
         return $this->getFirstClient() ? count($this->getFirstClient()->getReports()) : 0;
     }
 
-    /**
-     * @JMS\VirtualProperty
-     *
-     * @JMS\Groups({"user"})
-     *
-     * @JMS\Type("integer")
-     *
-     * @JMS\SerializedName("number_of_submitted_reports")
-     */
+    #[JMS\VirtualProperty]
+    #[JMS\Groups(['user'])]
+    #[JMS\Type('integer')]
+    #[JMS\SerializedName('number_of_submitted_reports')]
     public function getNumberOfSubmittedReports()
     {
         if (!$this->getFirstClient()) {
@@ -1109,14 +1025,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         $this->agreeTermsUse = $agreeTermsUse;
 
         if ($agreeTermsUse) {
-            $this->agreeTermsUseDate = new \DateTime('now');
+            $this->agreeTermsUseDate = new DateTime('now');
         }
 
         return $this;
     }
 
     /**
-     * @return \DateTime
+     * @return DateTime
      */
     public function getAgreeTermsUseDate()
     {
@@ -1144,16 +1060,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * Return true if the client has other users.
      *
-     * @JMS\VirtualProperty
-     *
-     * @JMS\Type("boolean")
-     *
-     * @JMS\SerializedName("is_co_deputy")
-     *
-     * @JMS\Groups({"user"})
-     *
      * @return bool
      */
+    #[JMS\VirtualProperty]
+    #[JMS\Type('boolean')]
+    #[JMS\SerializedName('is_co_deputy')]
+    #[JMS\Groups(['user'])]
     public function isCoDeputy()
     {
         $isCoDeputy = false;
@@ -1410,7 +1322,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
      */
     public function regBeforeToday(User $user): bool
     {
-        return $user->getRegistrationDate() < (new \DateTime())->setTime(00, 00, 00);
+        return $user->getRegistrationDate() < (new DateTime())->setTime(00, 00, 00);
     }
 
     public function getCreatedBy(): ?User
@@ -1425,29 +1337,19 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
         return $this;
     }
 
-    /**
-     * @JMS\VirtualProperty
-     *
-     * @JMS\SerializedName("is_case_manager")
-     *
-     * @JMS\Groups({"user"})
-     *
-     * @JMS\Type("bool")
-     */
+    #[JMS\VirtualProperty]
+    #[JMS\SerializedName('is_case_manager')]
+    #[JMS\Groups(['user'])]
+    #[JMS\Type('bool')]
     public function isCaseManager(): bool
     {
         return in_array($this->getRoleName(), $this::$caseManagerRoles);
     }
 
-    /**
-     * @JMS\VirtualProperty
-     *
-     * @JMS\SerializedName("created_by_case_manager")
-     *
-     * @JMS\Groups({"user"})
-     *
-     * @JMS\Type("bool")
-     */
+    #[JMS\VirtualProperty]
+    #[JMS\SerializedName('created_by_case_manager')]
+    #[JMS\Groups(['user'])]
+    #[JMS\Type('bool')]
     public function createdByCaseManager(): bool
     {
         return $this->getCreatedBy() && $this->getCreatedBy()->isCaseManager();
@@ -1466,7 +1368,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * Set preRegisterValidatedDate.
      *
-     * @param \DateTime $preRegisterValidatedDate
+     * @param DateTime $preRegisterValidatedDate
      */
     public function setPreRegisterValidatedDate($preRegisterValidatedDate): User
     {
@@ -1478,7 +1380,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface
     /**
      * Get preRegisterValidatedDate.
      */
-    public function getPreRegisterValidatedDate(): ?\DateTime
+    public function getPreRegisterValidatedDate(): ?DateTime
     {
         return $this->preRegisterValidatedDate;
     }


### PR DESCRIPTION
## Purpose
Move API annotations to attributes in the Entity folder

Contributes to DDLS-633

## Approach
Use Rector then manually tidy and review

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
