### PR TITLE
Simplify RestClient->delete

### DIFF
--- a/client/app/phpstan-baseline.neon
+++ b/client/app/phpstan-baseline.neon
@@ -11986,11 +11986,6 @@ parameters:
 			path: src/Service/Client/Internal/PreRegistrationApi.php
 
 		-
-			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\PreRegistrationApi\\:\\:deleteAll\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Service/Client/Internal/PreRegistrationApi.php
-
-		-
 			message: "#^Method App\\\\Service\\\\Client\\\\Internal\\\\PreRegistrationApi\\:\\:verify\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Service/Client/Internal/PreRegistrationApi.php

--- a/client/app/src/Service/Client/Internal/PreRegistrationApi.php
+++ b/client/app/src/Service/Client/Internal/PreRegistrationApi.php
@@ -20,9 +20,9 @@ class PreRegistrationApi
         return $this->restClient->get(sprintf('/pre-registration/clientHasCoDeputies/%s', $caseNumber), 'array');
     }
 
-    public function deleteAll()
+    public function deleteAll(): void
     {
-        return $this->restClient->delete('/pre-registration/delete');
+        $this->restClient->delete('/pre-registration/delete');
     }
 
     public function count()

--- a/client/app/src/Service/Client/RestClient.php
+++ b/client/app/src/Service/Client/RestClient.php
@@ -255,16 +255,18 @@ class RestClient implements RestClientInterface
         return $this->apiCall('post', $endpoint, $mixed, $expectedResponseType, $options);
     }
 
-    /**
-     * @param string $endpoint e.g. /user
-     *
-     * @return string response body
-     */
-    public function delete($endpoint)
+    public function delete(string $endpoint): ?array
     {
-        return $this->apiCall('delete', $endpoint, null, 'array', [
+        $response = $this->rawSafeCall('delete', $endpoint, [
+            'addClientSecret' => false,
             'addAuthToken' => true,
         ]);
+
+        if (Response::HTTP_NO_CONTENT === $response->getStatusCode()) {
+            return null;
+        }
+
+        return $this->extractDataArray($response);
     }
 
     /**

--- a/client/app/tests/phpunit/Service/DocumentServiceTest.php
+++ b/client/app/tests/phpunit/Service/DocumentServiceTest.php
@@ -91,7 +91,7 @@ class DocumentServiceTest extends TestCase
         $this->restClient
             ->delete('document/'.$docId)
             ->shouldBeCalled()
-            ->willReturn(true);
+            ->willReturn(['id' => 1]);
 
         $this->object->removeDocumentFromS3($document);
     }


### PR DESCRIPTION
## Purpose
Simplify RestClient->delete

Using RestClient->apiCall isn't really needed, as it's always used in one way. So this should make the logic easier to read

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
