### PR TITLE
DDLS-623 do some cleanup on additional carriage returns on form entry

### DIFF
--- a/.github/workflows/_run-task.yml
+++ b/.github/workflows/_run-task.yml
@@ -98,7 +98,7 @@ jobs:
           terraform output -json > terraform.output.json
         working-directory: terraform/environment
 
-      - name: configure OIDC AWS credentials for terraform
+      - name: configure OIDC AWS credentials for gh run task
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
         with:
           role-to-assume: "arn:aws:iam::${{ inputs.account_id }}:role/digideps-gh-actions-run-task"

--- a/client/app/src/Form/Report/DecisionType.php
+++ b/client/app/src/Form/Report/DecisionType.php
@@ -2,17 +2,19 @@
 
 namespace App\Form\Report;
 
-use App\Entity\Report\Decision;
+use App\Service\StringUtils;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type as FormTypes;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DecisionType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder/*->add('title', FormTypes\TextType::class)*/
+        $builder/* ->add('title', FormTypes\TextType::class) */
         ->add('description', FormTypes\TextareaType::class)
             ->add('clientInvolvedBoolean', FormTypes\ChoiceType::class, [
                 'choices' => array_flip([1 => 'Yes', 0 => 'No']),
@@ -20,6 +22,20 @@ class DecisionType extends AbstractType
             ])
             ->add('clientInvolvedDetails', FormTypes\TextareaType::class)
             ->add('save', FormTypes\SubmitType::class);
+
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
+            $data = $event->getData();
+
+            if (is_array($data)) {
+                foreach (['description', 'clientInvolvedDetails'] as $field) {
+                    if (isset($data[$field]) && is_string($data[$field])) {
+                        $data[$field] = StringUtils::cleanText($data[$field]);
+                    }
+                }
+
+                $event->setData($data);
+            }
+        });
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/client/app/src/Service/StringUtils.php
+++ b/client/app/src/Service/StringUtils.php
@@ -16,39 +16,52 @@ class StringUtils
         $hours = intval(gmdate('H', $seconds));
         $minutes = intval(gmdate('i', $seconds));
 
-        $hoursString = $hours . ' ' . (($hours === 1) ? 'hour' : 'hours');
-        $minutesString = $minutes . ' ' . (($minutes === 1) ? 'minute' : 'minutes');
+        $hoursString = $hours.' '.((1 === $hours) ? 'hour' : 'hours');
+        $minutesString = $minutes.' '.((1 === $minutes) ? 'minute' : 'minutes');
 
         // less than a minute
-        if ($hours === 0 && $minutes === 0) {
+        if (0 === $hours && 0 === $minutes) {
             return 'less than a minute';
         }
 
         // X minutes
-        if ($hours === 0) {
+        if (0 === $hours) {
             return $minutesString;
         }
 
         // X hours
-        if ($minutes === 0) {
+        if (0 === $minutes) {
             return $hoursString;
         }
 
         // X hours and Y minutes
-        return $hoursString . ' and ' . $minutesString;
+        return $hoursString.' and '.$minutesString;
     }
 
     /**
-     * Implodes strings, but with a different joiner between the last two
+     * Implodes strings, but with a different joiner between the last two.
      */
     public static function implodeWithDifferentLast(array $strings, string $joiner, string $lastJoiner)
     {
         $last = array_pop($strings);
 
         if ($strings) {
-            return implode($joiner, $strings) . $lastJoiner . $last;
+            return implode($joiner, $strings).$lastJoiner.$last;
         }
 
         return $last;
+    }
+
+    /**
+     * Replaces all returns with standard \n, removes tabs and extra spaces and any excess new lines.
+     */
+    public static function cleanText(string $input): string
+    {
+        $input = trim($input);
+        $input = str_replace(["\r\n", "\r"], "\n", $input);
+        $input = preg_replace("/[ \t]+/", ' ', $input) ?? $input;
+        $input = preg_replace("/\n{2,}/", "\n", $input) ?? $input;
+
+        return $input;
     }
 }

--- a/client/app/tests/phpunit/Service/StringUtilsTest.php
+++ b/client/app/tests/phpunit/Service/StringUtilsTest.php
@@ -14,17 +14,17 @@ class StringUtilsTest extends TestCase
             [3600 * 2, '2 hours'],
             [60 * 2, '2 minutes'],
             [60, '1 minute'],
-            [60 + 59, '1 minute'], //ceil
+            [60 + 59, '1 minute'], // ceil
             [0, 'less than a minute'],
             [1, 'less than a minute'],
             [59, 'less than a minute'],
             [3600 * 2 + 60 * 6, '2 hours and 6 minutes'],
-
         ];
     }
 
     /**
      * @test
+     *
      * @dataProvider secondsToHoursMinutesProvider
      */
     public function secondsToHoursMinutes($input, $expected)
@@ -45,10 +45,19 @@ class StringUtilsTest extends TestCase
 
     /**
      * @test
+     *
      * @dataProvider implodeWithDifferentLastProvider
      */
     public function implodeWithDifferentLast($strings, $joiner, $lastJoiner, $expected)
     {
         $this->assertEquals($expected, StringUtils::implodeWithDifferentLast($strings, $joiner, $lastJoiner));
+    }
+
+    public function testCleanText()
+    {
+        $input = "  Some text\r\n\r\n\twith \rsome \tirregular   spacing\n\n\nand\n\n\nnewlines ";
+        $expected = "Some text\n with \nsome irregular spacing\nand\nnewlines";
+
+        $this->assertEquals($expected, StringUtils::cleanText($input));
     }
 }


### PR DESCRIPTION
## Purpose
Cleanup additional carriage returns

Fixes DDLS-623

## Approach
Decided that as under normal circumstances the report pdf seems to remove extra new line formatting anyway, I thought I would clean it up as input.

Decisions made:
- Use reuseable StringUtils service instead of doing it inline so that I can unit test it easily and so we can use it in other places
- Apply it as a listener to that specific form instead of globally. I don't know if there are parts of the app where we might want additional formatting and didn't want to break anything.
- Do it at the form level rather than pdf generator level or DB level. Stop bad data at source is better in most circumstances.


## Learning
Learnt about listeners on forms. Didn't know we had any of that :) 

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
