### PR TITLE
DDLS-566: Clean up summary pages to reflect bold headers and unbold user input

### DIFF
--- a/api/app/tests/Behat/bootstrap/v2/Reporting/Sections/ClientBenefitsCheckSectionTrait.php
+++ b/api/app/tests/Behat/bootstrap/v2/Reporting/Sections/ClientBenefitsCheckSectionTrait.php
@@ -259,7 +259,7 @@ trait ClientBenefitsCheckSectionTrait
         $moneyTypeAnswers = $this->getSectionAnswers('moneyType')[0];
         $moneyTypeDescription = $moneyTypeAnswers[array_key_first($moneyTypeAnswers)];
 
-        $moneyTypeRowXpath = sprintf('//dt[contains(.,"%s")]/..', $moneyTypeDescription);
+        $moneyTypeRowXpath = sprintf('//dd[contains(.,"%s")]/..', $moneyTypeDescription);
         $moneyTypeRow = $this->getSession()->getPage()->find('xpath', $moneyTypeRowXpath);
 
         if ('edit' === strtolower($action)) {

--- a/api/app/tests/Behat/bootstrap/v2/Reporting/Sections/DeputyExpensesSectionTrait.php
+++ b/api/app/tests/Behat/bootstrap/v2/Reporting/Sections/DeputyExpensesSectionTrait.php
@@ -200,7 +200,7 @@ trait DeputyExpensesSectionTrait
         if ('ndr' == $this->reportUrlPrefix) {
             $rowSelector = sprintf('//div[dt[normalize-space() ="%s"]]', $answers['expenses_single[explanation]']);
         } else {
-            $rowSelector = sprintf('//tr[th[normalize-space() ="%s"]]', $answers['expenses_single[explanation]']);
+            $rowSelector = sprintf('//tr[td[normalize-space() ="%s"]]', $answers['expenses_single[explanation]']);
         }
         $descriptionTableRow = $this->getSession()->getPage()->find('xpath', $rowSelector);
 

--- a/api/app/tests/Behat/bootstrap/v2/Reporting/Sections/GiftsSectionTrait.php
+++ b/api/app/tests/Behat/bootstrap/v2/Reporting/Sections/GiftsSectionTrait.php
@@ -61,7 +61,7 @@ trait GiftsSectionTrait
      */
     public function iEditGiftDescriptionAndAmount()
     {
-        $locator = "//th[normalize-space()='random-gift-1']/..";
+        $locator = "//td[normalize-space()='random-gift-1']/..";
         $giftRow = $this->getSession()->getPage()->find('xpath', $locator);
 
         $this->editFieldAnswerInSectionTrackTotal($giftRow, 'gifts_single[amount]', 'gifts1', false);

--- a/api/app/tests/Behat/bootstrap/v2/Reporting/Sections/MoneyInSectionTrait.php
+++ b/api/app/tests/Behat/bootstrap/v2/Reporting/Sections/MoneyInSectionTrait.php
@@ -259,7 +259,7 @@ trait MoneyInSectionTrait
      */
     public function iEditTheMoneyInValue()
     {
-        $xpath = sprintf('//tr[th[text()[contains(.,"%s")]]]', $this->currentMoneyTypeReportingOn);
+        $xpath = sprintf('//tr[td[text()[contains(.,"%s")]]]', $this->currentMoneyTypeReportingOn);
         $moneyTypeRow = $this->getSession()->getPage()->find(
             'xpath',
             $xpath

--- a/api/app/tests/Behat/bootstrap/v2/Reporting/Sections/MoneyOutSectionTrait.php
+++ b/api/app/tests/Behat/bootstrap/v2/Reporting/Sections/MoneyOutSectionTrait.php
@@ -157,7 +157,7 @@ trait MoneyOutSectionTrait
     {
         $this->iAmOnMoneyOutSummaryPage();
 
-        $this->getSession()->getPage()->find('xpath', '//th[contains(., "Care fees")]/..')->clickLink('Edit');
+        $this->getSession()->getPage()->find('xpath', '//td[contains(., "Care fees")]/..')->clickLink('Edit');
 
         $this->fillInPaymentDetails('Care fees', $this->faker->sentence(rand(5, 50)), mt_rand(1, 999));
     }
@@ -231,7 +231,7 @@ trait MoneyOutSectionTrait
         $this->moneyOutTransaction[] = [$this->paymentTypeDictionary['professional-fees-eg-solicitor-accountant'] => $paymentAmount];
     }
 
-    private function fillInPaymentDetails(string $translatedPaymentValue, string $paymentDescription = null, int $paymentAmount = null)
+    private function fillInPaymentDetails(string $translatedPaymentValue, ?string $paymentDescription = null, ?int $paymentAmount = null)
     {
         $this->iAmOnMoneyOutAddPaymentDetailsPage();
 

--- a/client/app/templates/Ndr/Asset/Other/_list_item.html.twig
+++ b/client/app/templates/Ndr/Asset/Other/_list_item.html.twig
@@ -21,7 +21,7 @@
 
     {% for asset in assetsInGroup.items %}
         <div class="govuk-summary-list__row behat-region-asset-{{ asset.description | behat_namify }}">
-            <dt class="govuk-summary-list__key">
+            <dt class="govuk-summary-list__value">
                 {{ asset.description | nl2br }}
             </dt>
             <dd class="govuk-summary-list__value">

--- a/client/app/templates/Ndr/BankAccount/_list.html.twig
+++ b/client/app/templates/Ndr/BankAccount/_list.html.twig
@@ -32,7 +32,7 @@
     <div class="govuk-summary-list__row behat-region-account-{{ account.accountNumber | behat_namify }}">
         <dt class="govuk-summary-list__key">
             {% if account.requiresBankName %}
-                <p class="govuk-!-font-weight-bold">{{ account.bank }}</p>
+                <p class="govuk-!-margin-bottom-1 govuk-!-font-size-18">{{ account.bank }}</p>
             {% endif %}
             <p class="govuk-!-margin-0 govuk-!-font-size-16">{{ account.accountTypeText }}</p>
                 {% if account.requiresSortCode %}

--- a/client/app/templates/Report/BankAccount/_list.html.twig
+++ b/client/app/templates/Report/BankAccount/_list.html.twig
@@ -37,7 +37,7 @@
         <tr class="govuk-table__row behat-region-account-{{ account.accountNumber | behat_namify }}">
             <th scope="row" class="govuk-table__header">
                 {% if account.requiresBankName %}
-                    <p class="govuk-!-font-weight-bold">{{ account.bank }}</p>
+                    <p class="govuk-!-font-size-18">{{ account.bank }}</p>
                 {% endif %}
 
                 <p class="govuk-!-margin-0 govuk-!-font-size-16">{{ account.accountTypeText }}</p>

--- a/client/app/templates/Report/ClientBenefitsCheck/_answers.html.twig
+++ b/client/app/templates/Report/ClientBenefitsCheck/_answers.html.twig
@@ -21,7 +21,7 @@
                 <dt class="govuk-summary-list__key">
                     {{ 'summaryPage.table.benefitsCheck.column1Title'|trans(transOptions, translationDomain) }}
                 </dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__key">
                     {{ 'summaryPage.table.benefitsCheck.column2Title'|trans(transOptions, translationDomain) }}
                 </dd>
                 {% if showActions %}
@@ -98,7 +98,7 @@
                 <dt class="govuk-summary-list__key">
                     {{ 'summaryPage.table.doOthersReceiveMoney.column1Title'|trans(transOptions, translationDomain) }}
                 </dt>
-                <dd class="govuk-summary-list__value">
+                <dd class="govuk-summary-list__key">
                     {{ 'summaryPage.table.doOthersReceiveMoney.column2Title'|trans(transOptions, translationDomain) }}
                 </dd>
                 {% if showActions %}
@@ -197,22 +197,22 @@
                     <dt class="govuk-summary-list__key">
                         {{ 'summaryPage.table.moneyOtherPeopleReceive.column1Title'|trans(transOptions, translationDomain) }}
                     </dt>
-                    <dd class="govuk-summary-list__value">
+                    <dd class="govuk-summary-list__key">
                         {{ 'summaryPage.table.moneyOtherPeopleReceive.column2Title'|trans(transOptions, translationDomain) }}
                     </dd>
-                    <dd class="govuk-summary-list__value">
+                    <dd class="govuk-summary-list__key">
                         {{ 'summaryPage.table.moneyOtherPeopleReceive.column3Title'|trans(transOptions, translationDomain) }}
                     </dd>
                     {% if showActions %}
-                        <dd class="govuk-summary-list__value">{# No title for actions column #}</dd>
+                        <dd class="govuk-summary-list__key">{# No title for actions column #}</dd>
                     {% endif %}
                 </div>
 
                 {% for money in report.clientBenefitsCheck.typesOfMoneyReceivedOnClientsBehalf %}
                     <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">
+                        <dd class="govuk-summary-list__value">
                             {{ money.moneyType }}
-                        </dt>
+                        </dd>
                         <dd class="govuk-summary-list__value">
                             {{ money.whoReceivedMoney }}
                         </dd>

--- a/client/app/templates/Report/Contact/_list.html.twig
+++ b/client/app/templates/Report/Contact/_list.html.twig
@@ -83,7 +83,7 @@
         {% for contact in report.contacts %}
             <tr class="govuk-table__row behat-region-contact-{{ contact.postcode | behat_namify }}">
                 <td class="govuk-table__cell">
-                    <p class="govuk-!-font-weight-bold">{{ contact.contactName }}</p>
+                    <p class="govuk-!-margin-0 govuk-!-font-size-18">{{ contact.contactName }}</p>
                     {% if contact.address %}
                         <p class="govuk-!-margin-0 govuk-!-font-size-16">{{ contact.address }}</p>
                     {% endif %}

--- a/client/app/templates/Report/Debt/_answers.html.twig
+++ b/client/app/templates/Report/Debt/_answers.html.twig
@@ -55,9 +55,9 @@
 
         {% for debt in report.debts %}
         <div class="govuk-summary-list__row behat-region-debt-{{ debt.debtTypeId | behat_namify }}">
-            <dt class="govuk-summary-list__key">
+            <dd class="govuk-summary-list__value">
                 {{ ('form.entries.' ~ debt.debtTypeId ~ '.label') | trans(transOptions) }}
-            </dt>
+            </dd>
             <dd class="govuk-summary-list__value">
                 £{{ debt.amount | money_format }}
             </dd>

--- a/client/app/templates/Report/Debt/_answers.html.twig
+++ b/client/app/templates/Report/Debt/_answers.html.twig
@@ -68,7 +68,7 @@
             <dt class="govuk-summary-list__key">
                 Total amount
             </dt>
-            <dd class="govuk-summary-list__value">
+            <dd class="govuk-summary-list__key">
                 £{{ report.debtsTotalAmount | money_format }}
             </dd>
         </div>

--- a/client/app/templates/Report/DeputyExpense/_list.html.twig
+++ b/client/app/templates/Report/DeputyExpense/_list.html.twig
@@ -68,9 +68,9 @@
         <tbody class="govuk-table__body">
             {% for expense in report.expenses %}
                 <tr class="govuk-table__row behat-region-expense-{{ expense.explanation | behat_namify }}">
-                    <th scope="row" class="govuk-table__header">
+                    <td class="govuk-table__cell">
                         {{ expense.explanation }}
-                    </th>
+                    </td>
                     {% if report.canLinkToBankAccounts %}
                         <td class="govuk-table__cell">
                             {{ (expense.bankAccount) ? expense.bankAccount.nameOneLine : '-' }}

--- a/client/app/templates/Report/Gift/_list.html.twig
+++ b/client/app/templates/Report/Gift/_list.html.twig
@@ -68,9 +68,9 @@
         <tbody>
         {% for gift in report.gifts %}
             <tr class="govuk-summary-list__row behat-region-gift-{{ gift.explanation | behat_namify }}">
-                <th scope="col" class="govuk-table__header">
+                <td class="govuk-table__cell">
                     {{ gift.explanation }}
-                </th>
+                </td>
                 {% if report.canLinkToBankAccounts %}
                     <td class="govuk-table__cell">
                         {{ (gift.bankAccount) ? gift.bankAccount.nameOneLine : '-' }}

--- a/client/app/templates/Report/MoneyIn/_list.html.twig
+++ b/client/app/templates/Report/MoneyIn/_list.html.twig
@@ -107,9 +107,9 @@
             <tbody class="govuk-table__body">
             {% for entry in groupData.entries %}
                 <tr class="govuk-table__row behat-region-transaction-{{ entry.description | behat_namify }}">
-                    <th scope="row" class="govuk-table__header">
+                    <td class="govuk-table__cell">
                         {{ ('form.category.entries.' ~ entry.category ~ '.label') | trans }}
-                    </th>
+                    </td>
                     <td class="govuk-table__cell">
                         {{ entry.description | nl2br }}
                     </td>

--- a/client/app/templates/Report/MoneyInShort/_answers.html.twig
+++ b/client/app/templates/Report/MoneyInShort/_answers.html.twig
@@ -158,9 +158,9 @@
             <tbody class="govuk-table__body">
             {% for tr in report.moneyTransactionsShortIn %}
                 <tr class="govuk-table__row behat-region-transaction-{{ tr.description | behat_namify }}">
-                    <th scope="row" class="govuk-table__header">
+                    <td class="govuk-table__cell">
                         {{ tr.description }}
-                    </th>
+                    </td>
                     <td class="govuk-table__cell">
                         {{ tr.date ? tr.date | date("j F Y")  : '-' }}
                     </td>

--- a/client/app/templates/Report/MoneyOut/_list.html.twig
+++ b/client/app/templates/Report/MoneyOut/_list.html.twig
@@ -107,9 +107,9 @@
             <tbody class="govuk-table__body">
             {% for entry in groupData.entries %}
                 <tr class="govuk-table__row behat-region-transaction-{{ entry.description | behat_namify }}">
-                    <th scope="row" class="govuk-table__header">
+                    <td class="govuk-table__cell">
                         {{ ('form.category.entries.' ~ entry.category ~ '.label') | trans(transOptions) }}
-                    </th>
+                    </td>
                     <td class="govuk-table__cell">
                         {{ entry.description | nl2br }}
                     </td>

--- a/client/app/templates/Report/MoneyOutShort/_answers.html.twig
+++ b/client/app/templates/Report/MoneyOutShort/_answers.html.twig
@@ -158,9 +158,9 @@
             <tbody class="govuk-table__body">
             {% for tr in report.moneyTransactionsShortOut %}
                 <tr class="govuk-table__row behat-region-transaction-{{ tr.description | behat_namify }}">
-                    <th scope="row" class="govuk-table__header">
+                    <td class="govuk-table__cell">
                         {{ tr.description }}<br/>
-                    </th>
+                    </td>
                     <td class="govuk-table__cell">
                         {{ tr.date ? tr.date | date("j F Y")  : '-' }}
                     </td>

--- a/client/app/templates/Report/MoneyTransfer/_list.html.twig
+++ b/client/app/templates/Report/MoneyTransfer/_list.html.twig
@@ -74,9 +74,9 @@
         <tbody class="govuk-table__body">
             {% for transfer in report.moneyTransfers|sort((a, b) => a.accountFrom.bank <=> b.accountFrom.bank) %}
                 <tr class="govuk-table__row behat-region-transfer-{{ transfer.accountFrom.accountNumber }}-{{ transfer.accountTo.accountNumber }}-{{ transfer.amount | behat_namify }}">
-                    <th scope="row" class="govuk-table__header">
+                    <td class="govuk-table__cell">
                         {{ _self.accountDetails(transfer.accountFrom) }}
-                    </th>
+                    </td>
                     <td class="govuk-table__cell">
                         {{ _self.accountDetails(transfer.accountTo) }}
                     </td>


### PR DESCRIPTION
## Purpose
Update summary pages to follow pattern of bold headers and non bold explanations.

Screenshots of summary pages that didn't follow this pattern are included in the ticket. 

Fixes DDLS-566

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [x] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
