### PR TITLE
DDLS-653 Fix out of memory errors during deputyships ingest

### DIFF
--- a/api/app/src/Repository/StagingDeputyshipRepository.php
+++ b/api/app/src/Repository/StagingDeputyshipRepository.php
@@ -6,6 +6,7 @@ namespace App\Repository;
 
 use App\Entity\StagingDeputyship;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -16,5 +17,32 @@ class StagingDeputyshipRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, StagingDeputyship::class);
+    }
+
+    public function findAllPaged(int $pageSize = 1000): iterable
+    {
+        $query = $this->getEntityManager()->createQuery("SELECT sd FROM App\Entity\StagingDeputyship sd");
+        $pagedQuery = $query->setFirstResult(0)->setMaxResults($pageSize);
+
+        // yield the deputyships from the first page
+        $page = new Paginator($pagedQuery, fetchJoinCollection: false);
+        foreach ($page as $deputyship) {
+            yield $deputyship;
+        }
+
+        // yield each of the other deputyships (if there is more than 1 page)
+        $numResults = count($page);
+        $numPages = ceil($numResults / $pageSize);
+
+        $currentPage = 2;
+        while ($numPages >= $currentPage) {
+            $pagedQuery = $query->setFirstResult(($currentPage - 1) * $pageSize)->setMaxResults($pageSize);
+            $page = new Paginator($pagedQuery, fetchJoinCollection: false);
+            foreach ($page as $deputyship) {
+                yield $deputyship;
+            }
+
+            ++$currentPage;
+        }
     }
 }

--- a/api/app/src/Repository/StagingDeputyshipRepository.php
+++ b/api/app/src/Repository/StagingDeputyshipRepository.php
@@ -6,7 +6,6 @@ namespace App\Repository;
 
 use App\Entity\StagingDeputyship;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\ORM\Query;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -20,15 +19,10 @@ class StagingDeputyshipRepository extends ServiceEntityRepository
         parent::__construct($registry, StagingDeputyship::class);
     }
 
-    public function findAllPaged(int $pageSize = 1000): \Generator
+    public function findAllPaged(int $pageSize = 1000): \Traversable
     {
         $query = $this->getEntityManager()->createQuery("SELECT sd FROM App\Entity\StagingDeputyship sd");
 
-        return $this->pagedQuery($query, $pageSize);
-    }
-
-    public function pagedQuery(Query $query, int $pageSize): \Generator
-    {
         // there will be at least one page, but we'll set this accurately when we've retrieved the first page
         $numPages = 1;
 

--- a/api/app/src/Repository/StagingSelectedCandidateRepository.php
+++ b/api/app/src/Repository/StagingSelectedCandidateRepository.php
@@ -21,9 +21,12 @@ class StagingSelectedCandidateRepository extends ServiceEntityRepository
     /**
      * @return StagingSelectedCandidate[]
      */
-    public function getDistinctCandidates(): iterable
+    public function getDistinctCandidates(): array
     {
-        /* @var StagingSelectedCandidate[] $result */
-        return $this->createQueryBuilder('sc')->select()->distinct()->getQuery()->getResult();
+        // TODO this only returns up to 100 candidates at the moment, for memory reasons; should return a Generator instead
+        /** @var StagingSelectedCandidate[] $result */
+        $result = $this->createQueryBuilder('sc')->select()->distinct()->setMaxResults(100)->getQuery()->getResult();
+
+        return $result;
     }
 }

--- a/api/app/src/Repository/StagingSelectedCandidateRepository.php
+++ b/api/app/src/Repository/StagingSelectedCandidateRepository.php
@@ -23,9 +23,7 @@ class StagingSelectedCandidateRepository extends ServiceEntityRepository
      */
     public function getDistinctCandidates(): iterable
     {
-        /** @var StagingSelectedCandidate[] $result */
-        $result = $this->createQueryBuilder('sc')->select()->distinct()->getQuery()->getResult();
-
-        return $result;
+        /* @var StagingSelectedCandidate[] $result */
+        return $this->createQueryBuilder('sc')->select()->distinct()->getQuery()->getResult();
     }
 }

--- a/api/app/src/v2/Registration/DeputyshipProcessing/DeputyshipCandidatesSelectorResult.php
+++ b/api/app/src/v2/Registration/DeputyshipProcessing/DeputyshipCandidatesSelectorResult.php
@@ -10,7 +10,7 @@ class DeputyshipCandidatesSelectorResult
 {
     public function __construct(
         /** @var StagingSelectedCandidate[] */
-        public readonly iterable $candidates,
+        public readonly array $candidates,
 
         public readonly int $numCandidates,
         public readonly ?\Exception $exception = null,

--- a/api/app/tests/Integration/v2/Registration/DeputyshipProcessing/CourtOrderReportCandidatesFactoryIntegrationTest.php
+++ b/api/app/tests/Integration/v2/Registration/DeputyshipProcessing/CourtOrderReportCandidatesFactoryIntegrationTest.php
@@ -144,7 +144,7 @@ class CourtOrderReportCandidatesFactoryIntegrationTest extends KernelTestCase
         $this->em->flush();
 
         // create compatible report candidates
-        $candidates = $this->sut->createCompatibleReportCandidates();
+        $candidates = iterator_to_array($this->sut->createCompatibleReportCandidates());
 
         // assertions
         self::assertCount(1, $candidates);
@@ -183,7 +183,7 @@ class CourtOrderReportCandidatesFactoryIntegrationTest extends KernelTestCase
         $this->em->flush();
 
         // create NDR candidates
-        $candidates = $this->sut->createCompatibleNdrCandidates();
+        $candidates = iterator_to_array($this->sut->createCompatibleNdrCandidates());
 
         // assertions
         self::assertCount(1, $candidates);

--- a/api/app/tests/Unit/v2/Registration/DeputyshipProcessing/CourtOrderReportCandidatesFactoryTest.php
+++ b/api/app/tests/Unit/v2/Registration/DeputyshipProcessing/CourtOrderReportCandidatesFactoryTest.php
@@ -35,10 +35,10 @@ class CourtOrderReportCandidatesFactoryTest extends TestCase
 
     public function testCreateCompatibleReportCandidates(): void
     {
-        $rows = [
+        $rows = new \ArrayIterator([
             ['court_order_uid' => '123', 'report_id' => '456'],
             ['court_order_uid' => '789', 'report_id' => '012'],
-        ];
+        ]);
 
         $expectedCandidates = [
             new StagingSelectedCandidate(),
@@ -46,7 +46,7 @@ class CourtOrderReportCandidatesFactoryTest extends TestCase
         ];
 
         $result = $this->createMock(Result::class);
-        $result->method('fetchAllAssociative')->willReturn($rows);
+        $result->method('iterateAssociative')->willReturn($rows);
         $this->connection->method('executeQuery')->willReturn($result);
 
         $this->candidateFactory->expects($this->exactly(2))
@@ -55,15 +55,15 @@ class CourtOrderReportCandidatesFactoryTest extends TestCase
 
         $candidates = $this->sut->createCompatibleReportCandidates();
 
-        $this->assertEquals($expectedCandidates, $candidates);
+        $this->assertEquals($expectedCandidates, iterator_to_array($candidates));
     }
 
     public function testCreateCompatibleNdrCandidates(): void
     {
-        $rows = [
+        $rows = new \ArrayIterator([
             ['court_order_uid' => '123', 'ndr_id' => '456'],
             ['court_order_uid' => '789', 'ndr_id' => '012'],
-        ];
+        ]);
 
         $expectedCandidates = [
             new StagingSelectedCandidate(),
@@ -71,7 +71,7 @@ class CourtOrderReportCandidatesFactoryTest extends TestCase
         ];
 
         $result = $this->createMock(Result::class);
-        $result->method('fetchAllAssociative')->willReturn($rows);
+        $result->method('iterateAssociative')->willReturn($rows);
         $this->connection->method('executeQuery')->willReturn($result);
 
         $this->candidateFactory->expects($this->exactly(2))
@@ -80,6 +80,6 @@ class CourtOrderReportCandidatesFactoryTest extends TestCase
 
         $candidates = $this->sut->createCompatibleNdrCandidates();
 
-        $this->assertEquals($expectedCandidates, $candidates);
+        $this->assertEquals($expectedCandidates, iterator_to_array($candidates));
     }
 }

--- a/api/app/tests/Unit/v2/Registration/DeputyshipProcessing/DeputyshipsCandidatesSelectorTest.php
+++ b/api/app/tests/Unit/v2/Registration/DeputyshipProcessing/DeputyshipsCandidatesSelectorTest.php
@@ -96,8 +96,11 @@ class DeputyshipsCandidatesSelectorTest extends TestCase
 
         $this->mockStagingDeputyshipRepository
             ->expects($this->once())
-            ->method('findAll')
-            ->willReturn([$mockStagingDeputyship1, $mockStagingDeputyship2]);
+            ->method('findAllPaged')
+            ->will($this->returnCallback(function () use ($mockStagingDeputyship1, $mockStagingDeputyship2) {
+                yield $mockStagingDeputyship1;
+                yield $mockStagingDeputyship2;
+            }));
 
         $this->mockCourtOrderAndDeputyCandidatesFactory
             ->expects($this->once())
@@ -117,12 +120,12 @@ class DeputyshipsCandidatesSelectorTest extends TestCase
         $this->mockCourtOrderReportCandidatesFactory
             ->expects($this->once())
             ->method('createCompatibleReportCandidates')
-            ->willReturn([$mockCandidate4]);
+            ->willReturn(new \ArrayIterator([$mockCandidate4]));
 
         $this->mockCourtOrderReportCandidatesFactory
             ->expects($this->once())
             ->method('createCompatibleNdrCandidates')
-            ->willReturn([$mockCandidate5]);
+            ->willReturn(new \ArrayIterator([$mockCandidate5]));
 
         $mockCandidates = [
             $mockCandidate1,

--- a/api/app/tests/Unit/v2/Registration/DeputyshipProcessing/DeputyshipsCandidatesSelectorTest.php
+++ b/api/app/tests/Unit/v2/Registration/DeputyshipProcessing/DeputyshipsCandidatesSelectorTest.php
@@ -97,10 +97,7 @@ class DeputyshipsCandidatesSelectorTest extends TestCase
         $this->mockStagingDeputyshipRepository
             ->expects($this->once())
             ->method('findAllPaged')
-            ->will($this->returnCallback(function () use ($mockStagingDeputyship1, $mockStagingDeputyship2) {
-                yield $mockStagingDeputyship1;
-                yield $mockStagingDeputyship2;
-            }));
+            ->willReturn(new \ArrayIterator([$mockStagingDeputyship1, $mockStagingDeputyship2]));
 
         $this->mockCourtOrderAndDeputyCandidatesFactory
             ->expects($this->once())


### PR DESCRIPTION
## Purpose

Fix the ingest process up to the point where it generates candidate objects.

Due to memory issues, the number of candidate objects returned to the builder (not yet implemented) is limited to 100. This is so that the rest of the process is able to run. The limit will be removed and made memory-efficient in the next ticket in this series (DDLS-552).

Fixes DDLS-653

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
