### PR TITLE
DDLS-647: Add new command to run individual api integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ api-integration-tests: reset-database-integration-tests ##@integration-tests Run
 INTEGRATION_SELECTION = selection-solo
 api-integration-test-solo: reset-database-integration-tests ##@integration-tests Run individual api integration tests
 #Example command: make api-integration-test-solo suite=Controller/AuthControllerTest.php
-	docker compose -f docker-compose.yml ${ADDITIONAL_CONFIG} run -e APP_ENV=test -e APP_DEBUG=0 --rm api-integration-tests sh scripts/api_integration_test.sh ${INTEGRATION_SELECTION} $(suite)
+	docker compose -f docker-compose.yml ${ADDITIONAL_CONFIG} run -e APP_ENV=test -e APP_DEBUG=0 --rm api-integration-tests sh scripts/api_integration_test.sh ${INTEGRATION_SELECTION} $(suite) $(test_case)
 
 reset-database-integration-tests: ##@database Resets the DB schema and runs migrations
 	docker compose -f docker-compose.yml ${ADDITIONAL_CONFIG} run --rm api-integration-tests sh scripts/reset_db_structure.sh local

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,11 @@ INTEGRATION_SELECTION = selection-all
 api-integration-tests: reset-database-integration-tests ##@integration-tests Run the api integration tests
 	docker compose -f docker-compose.yml ${ADDITIONAL_CONFIG} run -e APP_ENV=test -e APP_DEBUG=0 --rm api-integration-tests sh scripts/api_integration_test.sh ${INTEGRATION_SELECTION}
 
+INTEGRATION_SELECTION = selection-solo
+api-integration-test-solo: reset-database-integration-tests ##@integration-tests Run individual api integration tests
+#Example command: make api-integration-test-solo suite=Controller/AuthControllerTest.php
+	docker compose -f docker-compose.yml ${ADDITIONAL_CONFIG} run -e APP_ENV=test -e APP_DEBUG=0 --rm api-integration-tests sh scripts/api_integration_test.sh ${INTEGRATION_SELECTION} $(suite)
+
 reset-database-integration-tests: ##@database Resets the DB schema and runs migrations
 	docker compose -f docker-compose.yml ${ADDITIONAL_CONFIG} run --rm api-integration-tests sh scripts/reset_db_structure.sh local
 

--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,8 @@ api-integration-tests: reset-database-integration-tests ##@integration-tests Run
 	docker compose -f docker-compose.yml ${ADDITIONAL_CONFIG} run -e APP_ENV=test -e APP_DEBUG=0 --rm api-integration-tests sh scripts/api_integration_test.sh ${INTEGRATION_SELECTION}
 
 INTEGRATION_SELECTION = selection-solo
-api-integration-test-solo: reset-database-integration-tests ##@integration-tests Run individual api integration tests
-#Example command: make api-integration-test-solo suite=Controller/AuthControllerTest.php
+api-integration-test-solo: reset-database-integration-tests ##@integration-tests Run individual api integration test
+#Example command: make api-integration-test-solo suite=Controller/AuthControllerTest.php test_case=testLoginFailWrongPassword (test case argument is optional)
 	docker compose -f docker-compose.yml ${ADDITIONAL_CONFIG} run -e APP_ENV=test -e APP_DEBUG=0 --rm api-integration-tests sh scripts/api_integration_test.sh ${INTEGRATION_SELECTION} $(suite) $(test_case)
 
 reset-database-integration-tests: ##@database Resets the DB schema and runs migrations

--- a/api/app/scripts/api_integration_test.sh
+++ b/api/app/scripts/api_integration_test.sh
@@ -26,8 +26,11 @@ export PGDATABASE=digideps_unit_test
 export PGUSER=${DATABASE_USERNAME:=api}
 export SSL=${DATABASE_SSL:=allow}
 
+INTEGRATION_SELECTION=$1
+SUITE=$2
+
 # Check the argument provided and run the corresponding test suites
-case "$1" in
+case "$INTEGRATION_SELECTION" in
   selection-1)
     # API Run 1
     printf '\n Running Controller Suite \n\n'
@@ -84,8 +87,13 @@ case "$1" in
     # generate HTML coverage report
     php -d memory_limit=256M vendor/phpunit/phpcov/phpcov merge --html "./build/coverage-api" "./tests/coverage"
     ;;
+  selection-solo)
+    # Run specific test
+    printf "\n Running Solo Test Suite: %s \n\n" $SUITE
+    php vendor/bin/phpunit -c tests/Integration "tests/Integration/$SUITE"
+    ;;
   *)
-    echo "Invalid argument. Please provide one of the following arguments: selection-1, selection-2, selection-3, selection-all"
+    echo "Invalid argument. Please provide one of the following arguments: selection-1, selection-2, selection-3, selection-all, selection-solo"
     exit 1
     ;;
 esac

--- a/api/app/scripts/api_integration_test.sh
+++ b/api/app/scripts/api_integration_test.sh
@@ -28,6 +28,7 @@ export SSL=${DATABASE_SSL:=allow}
 
 INTEGRATION_SELECTION=$1
 SUITE=$2
+TEST_CASE=$3
 
 # Check the argument provided and run the corresponding test suites
 case "$INTEGRATION_SELECTION" in
@@ -88,9 +89,18 @@ case "$INTEGRATION_SELECTION" in
     php -d memory_limit=256M vendor/phpunit/phpcov/phpcov merge --html "./build/coverage-api" "./tests/coverage"
     ;;
   selection-solo)
-    # Run specific test
-    printf "\n Running Solo Test Suite: %s \n\n" $SUITE
-    php vendor/bin/phpunit -c tests/Integration "tests/Integration/$SUITE"
+    #Run solo test suite
+    if [[ -z "$TEST_CASE" ]]; then
+      TEST_FILTER=""
+    fi
+
+    #Run solo test case in test suite
+    if [[ -n "$TEST_CASE" ]]; then
+      TEST_FILTER="--filter $TEST_CASE"
+    fi
+
+    printf "\nRunning Solo Test: %s %s \n\n" $SUITE $TEST_CASE
+    php vendor/bin/phpunit -c tests/Integration $TEST_FILTER "tests/Integration/$SUITE"
     ;;
   *)
     echo "Invalid argument. Please provide one of the following arguments: selection-1, selection-2, selection-3, selection-all, selection-solo"


### PR DESCRIPTION
## Purpose
The Makefile now has a command that can run single test suite or single test case within a test suite.

Fixes DDLS-647

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
