### PR TITLE
Solo integration test changes make api-integration-tests target fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,14 +93,13 @@ client-unit-tests: ##@unit-tests Run the client unit tests
 api-unit-tests: ##@unit-tests Run the api unit tests
 	docker compose -f docker-compose.yml ${ADDITIONAL_CONFIG} run -e APP_ENV=test -e APP_DEBUG=0 --rm api-unit-tests sh scripts/api_unit_test.sh cov-html
 
-INTEGRATION_SELECTION = selection-all
+INTEGRATION_SELECTION := selection-all
 api-integration-tests: reset-database-integration-tests ##@integration-tests Run the api integration tests
 	docker compose -f docker-compose.yml ${ADDITIONAL_CONFIG} run -e APP_ENV=test -e APP_DEBUG=0 --rm api-integration-tests sh scripts/api_integration_test.sh ${INTEGRATION_SELECTION}
 
-INTEGRATION_SELECTION = selection-solo
-api-integration-test-solo: reset-database-integration-tests ##@integration-tests Run individual api integration test
+api-integration-tests-solo: reset-database-integration-tests ##@integration-tests Run individual api integration test
 #Example command: make api-integration-test-solo suite=Controller/AuthControllerTest.php test_case=testLoginFailWrongPassword (test case argument is optional)
-	docker compose -f docker-compose.yml ${ADDITIONAL_CONFIG} run -e APP_ENV=test -e APP_DEBUG=0 --rm api-integration-tests sh scripts/api_integration_test.sh ${INTEGRATION_SELECTION} $(suite) $(test_case)
+	docker compose -f docker-compose.yml ${ADDITIONAL_CONFIG} run -e APP_ENV=test -e APP_DEBUG=0 --rm api-integration-tests sh scripts/api_integration_test.sh selection-solo $(suite) $(test_case)
 
 reset-database-integration-tests: ##@database Resets the DB schema and runs migrations
 	docker compose -f docker-compose.yml ${ADDITIONAL_CONFIG} run --rm api-integration-tests sh scripts/reset_db_structure.sh local


### PR DESCRIPTION
* INTEGRATION_SELECTION appeared twice in Makefile, so second appearance overrode the first time it was set
* Should use ":=" so that the variable's value is only set if not set by user in make env
* Don't require INTEGRATION_SELECTION setting for solo integration test, as this value is always the same

These changes allow `make api-integration-tests` continue to work without requiring the user to specify `INTEGRATION_SELECTION=selection-all`.

## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes DDLS-####

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
