### PR TITLE
DDLS-631 Log where duplicate reports are potentially being created

### DIFF
--- a/api/app/phpstan-baseline.neon
+++ b/api/app/phpstan-baseline.neon
@@ -551,11 +551,6 @@ parameters:
 			path: src/Controller/Ndr/NdrController.php
 
 		-
-			message: "#^Parameter \\#2 \\$user of method App\\\\Service\\\\ReportService\\:\\:submit\\(\\) expects App\\\\Entity\\\\User, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
 			message: "#^Parameter \\#4 \\$ndrDocumentId of method App\\\\Service\\\\ReportService\\:\\:submit\\(\\) expects string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/Controller/Ndr/NdrController.php
@@ -2112,11 +2107,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#5 \\$status of method App\\\\Repository\\\\ReportRepository\\:\\:getAllByDeterminant\\(\\) expects string\\|null, bool\\|float\\|int\\|string\\|null given\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Property App\\\\Controller\\\\Report\\\\ReportController\\:\\:\\$parameterStoreService is never read, only written\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportController.php
 
@@ -6656,11 +6646,6 @@ parameters:
 			path: src/Entity/Report/Report.php
 
 		-
-			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setUnsubmittedSectionsList\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Entity/Report/Report.php
-
-		-
 			message: "#^Method App\\\\Entity\\\\Report\\\\Report\\:\\:setUpdatedAtAutomatically\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Entity/Report/Report.php
@@ -6912,11 +6897,6 @@ parameters:
 
 		-
 			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$unSubmitDate \\(DateTime\\) does not accept DateTime\\|null\\.$#"
-			count: 1
-			path: src/Entity/Report/Report.php
-
-		-
-			message: "#^Property App\\\\Entity\\\\Report\\\\Report\\:\\:\\$unsubmittedSectionsList \\(array\\) does not accept array\\|null\\.$#"
 			count: 1
 			path: src/Entity/Report/Report.php
 
@@ -8056,11 +8036,6 @@ parameters:
 			path: src/Repository/OrganisationRepository.php
 
 		-
-			message: "#^Class App\\\\Repository\\\\PreRegistrationRepository extends generic class Doctrine\\\\Bundle\\\\DoctrineBundle\\\\Repository\\\\ServiceEntityRepository but does not specify its types\\: T$#"
-			count: 1
-			path: src/Repository/PreRegistrationRepository.php
-
-		-
 			message: "#^Method App\\\\Repository\\\\PreRegistrationRepository\\:\\:deleteAll\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Repository/PreRegistrationRepository.php
@@ -9051,11 +9026,6 @@ parameters:
 			path: src/Service/PreRegistrationVerificationService.php
 
 		-
-			message: "#^Call to method findOneBy\\(\\) on an unknown class Doctrine\\\\Common\\\\Persistence\\\\ObjectRepository\\.$#"
-			count: 1
-			path: src/Service/ReportService.php
-
-		-
 			message: "#^Cannot call method getEndDate\\(\\) on mixed\\.$#"
 			count: 1
 			path: src/Service/ReportService.php
@@ -9111,57 +9081,7 @@ parameters:
 			path: src/Service/ReportService.php
 
 		-
-			message: "#^Parameter \\#1 \\$unsubmittedSectionsList of method App\\\\Entity\\\\Report\\\\Report\\:\\:setUnsubmittedSectionsList\\(\\) expects array\\|null, mixed given\\.$#"
-			count: 1
-			path: src/Service/ReportService.php
-
-		-
 			message: "#^Parameter \\#2 \\$orderType of static method App\\\\Entity\\\\PreRegistration\\:\\:getReportTypeByOrderType\\(\\) expects string, mixed given\\.$#"
-			count: 1
-			path: src/Service/ReportService.php
-
-		-
-			message: "#^Property App\\\\Service\\\\ReportService\\:\\:\\$assetRepository \\(Doctrine\\\\Common\\\\Persistence\\\\ObjectRepository\\) does not accept Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\Report\\\\Asset\\>\\.$#"
-			count: 1
-			path: src/Service/ReportService.php
-
-		-
-			message: "#^Property App\\\\Service\\\\ReportService\\:\\:\\$assetRepository has unknown class Doctrine\\\\Common\\\\Persistence\\\\ObjectRepository as its type\\.$#"
-			count: 1
-			path: src/Service/ReportService.php
-
-		-
-			message: "#^Property App\\\\Service\\\\ReportService\\:\\:\\$assetRepository is never read, only written\\.$#"
-			count: 1
-			path: src/Service/ReportService.php
-
-		-
-			message: "#^Property App\\\\Service\\\\ReportService\\:\\:\\$bankAccountRepository \\(Doctrine\\\\Common\\\\Persistence\\\\ObjectRepository\\) does not accept Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\Report\\\\BankAccount\\>\\.$#"
-			count: 1
-			path: src/Service/ReportService.php
-
-		-
-			message: "#^Property App\\\\Service\\\\ReportService\\:\\:\\$bankAccountRepository has unknown class Doctrine\\\\Common\\\\Persistence\\\\ObjectRepository as its type\\.$#"
-			count: 1
-			path: src/Service/ReportService.php
-
-		-
-			message: "#^Property App\\\\Service\\\\ReportService\\:\\:\\$bankAccountRepository is never read, only written\\.$#"
-			count: 1
-			path: src/Service/ReportService.php
-
-		-
-			message: "#^Property App\\\\Service\\\\ReportService\\:\\:\\$preRegistrationRepository \\(Doctrine\\\\Common\\\\Persistence\\\\ObjectRepository\\) does not accept Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\PreRegistration\\>\\.$#"
-			count: 1
-			path: src/Service/ReportService.php
-
-		-
-			message: "#^Property App\\\\Service\\\\ReportService\\:\\:\\$preRegistrationRepository has unknown class Doctrine\\\\Common\\\\Persistence\\\\ObjectRepository as its type\\.$#"
-			count: 1
-			path: src/Service/ReportService.php
-
-		-
-			message: "#^Property App\\\\Service\\\\ReportService\\:\\:\\$reportRepository is never read, only written\\.$#"
 			count: 1
 			path: src/Service/ReportService.php
 

--- a/api/app/src/Controller/Ndr/NdrController.php
+++ b/api/app/src/Controller/Ndr/NdrController.php
@@ -5,6 +5,7 @@ namespace App\Controller\Ndr;
 use App\Controller\RestController;
 use App\Entity as EntityDir;
 use App\Entity\Report\Document;
+use App\Entity\User;
 use App\Service\Formatter\RestFormatter;
 use App\Service\ReportService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -31,8 +32,8 @@ class NdrController extends RestController
         /* @var $report EntityDir\Ndr\Ndr */
         $report = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $id);
 
-        if (!$this->isGranted(EntityDir\User::ROLE_ADMIN)) {
-            $this->denyAccessUnlessGranted(EntityDir\User::ROLE_LAY_DEPUTY);
+        if (!$this->isGranted(User::ROLE_ADMIN)) {
+            $this->denyAccessUnlessGranted(User::ROLE_LAY_DEPUTY);
             $this->denyAccessIfNdrDoesNotBelongToUser($report);
         }
 
@@ -77,10 +78,12 @@ class NdrController extends RestController
         $ndr->setSubmitDate(new \DateTime($data['submit_date']));
 
         // submit and create new year's report
-        $nextYearReport = $reportService
-            ->submit($ndr, $this->getUser(), new \DateTime($data['submit_date']), $documentId);
+        /** @var User $user */
+        $user = $this->getUser();
 
-        return ['id' => $nextYearReport->getId()];
+        $nextYearReport = $reportService->submit($ndr, $user, new \DateTime($data['submit_date']), $documentId);
+
+        return ['id' => $nextYearReport?->getId()];
     }
 
     #[Route(path: '/ndr/{id}', methods: ['PUT'])]
@@ -89,8 +92,8 @@ class NdrController extends RestController
         /* @var $ndr EntityDir\Ndr\Ndr */
         $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $id, 'Ndr not found');
 
-        if (!$this->isGranted(EntityDir\User::ROLE_ADMIN)) {
-            $this->denyAccessUnlessGranted(EntityDir\User::ROLE_LAY_DEPUTY);
+        if (!$this->isGranted(User::ROLE_ADMIN)) {
+            $this->denyAccessUnlessGranted(User::ROLE_LAY_DEPUTY);
             $this->denyAccessIfNdrDoesNotBelongToUser($ndr);
         }
 

--- a/api/app/src/Controller/Report/ReportController.php
+++ b/api/app/src/Controller/Report/ReportController.php
@@ -154,7 +154,7 @@ class ReportController extends RestController
         /** @var Report|null $nextYearReport */
         $nextYearReport = $this->reportService->submit($currentReport, $user, new \DateTime($data['submit_date']));
 
-        return $nextYearReport ? $nextYearReport->getId() : null;
+        return $nextYearReport?->getId();
     }
 
     #[Route(path: '/{id}', requirements: ['id' => '\d+'], methods: ['PUT'])]

--- a/api/app/src/Controller/Report/ReportController.php
+++ b/api/app/src/Controller/Report/ReportController.php
@@ -11,7 +11,6 @@ use App\Exception\UnauthorisedException;
 use App\Repository\ReportRepository;
 use App\Service\Auth\AuthService;
 use App\Service\Formatter\RestFormatter;
-use App\Service\ParameterStoreService;
 use App\Service\ReportService;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
@@ -44,8 +43,14 @@ class ReportController extends RestController
         'report-submission-id',
     ];
 
-    public function __construct(private readonly array $updateHandlers, private readonly ReportRepository $repository, private readonly ReportService $reportService, private readonly EntityManagerInterface $em, private readonly AuthService $authService, private readonly RestFormatter $formatter, private readonly ParameterStoreService $parameterStoreService)
-    {
+    public function __construct(
+        private readonly array $updateHandlers,
+        private readonly ReportRepository $repository,
+        private readonly ReportService $reportService,
+        private readonly EntityManagerInterface $em,
+        private readonly AuthService $authService,
+        private readonly RestFormatter $formatter,
+    ) {
         parent::__construct($em);
     }
 

--- a/api/app/src/Entity/Client.php
+++ b/api/app/src/Entity/Client.php
@@ -180,7 +180,7 @@ class Client implements ClientInterface
     private $lastname;
 
     /**
-     * @var DateTime|null
+     * @var \DateTime|null
      *
      * @ORM\Column(name="court_date", type="date", nullable=true)
      */
@@ -189,7 +189,7 @@ class Client implements ClientInterface
     private $courtDate;
 
     /**
-     * @var DateTime|null
+     * @var \DateTime|null
      *
      * @ORM\Column(name="date_of_birth", type="date", nullable=true)
      */
@@ -244,7 +244,7 @@ class Client implements ClientInterface
     private $courtOrders;
 
     /**
-     * @var DateTime|null
+     * @var \DateTime|null
      *
      * @ORM\Column(name="archived_at", type="datetime", nullable=true)
      */
@@ -428,7 +428,7 @@ class Client implements ClientInterface
      *
      * @return Client
      */
-    public function setCourtDate(?DateTime $courtDate = null)
+    public function setCourtDate(?\DateTime $courtDate = null)
     {
         $this->courtDate = $courtDate;
 
@@ -438,7 +438,7 @@ class Client implements ClientInterface
     /**
      * Get courtDate.
      *
-     * @return DateTime|null
+     * @return \DateTime|null
      */
     public function getCourtDate()
     {
@@ -552,14 +552,18 @@ class Client implements ClientInterface
 
     /**
      * Get report by end date.
-     *
-     * @return Report|null
      */
-    public function getReportByEndDate(DateTime $endDate)
+    public function getReportByEndDate(\DateTime $endDate): ?Report
     {
-        return $this->reports->filter(function ($report) use ($endDate) {
+        $report = $this->reports->filter(function ($report) use ($endDate) {
             return $endDate->format('Y-m-d') == $report->getEndDate()->format('Y-m-d');
         })->first();
+
+        if (!$report) {
+            return null;
+        }
+
+        return $report;
     }
 
     /**
@@ -720,7 +724,7 @@ class Client implements ClientInterface
     }
 
     /**
-     * @return DateTime|null $dateOfBirth
+     * @return \DateTime|null $dateOfBirth
      */
     public function getDateOfBirth()
     {
@@ -730,7 +734,7 @@ class Client implements ClientInterface
     /**
      * @return $this
      */
-    public function setDateOfBirth(?DateTime $dateOfBirth = null)
+    public function setDateOfBirth(?\DateTime $dateOfBirth = null)
     {
         $this->dateOfBirth = $dateOfBirth;
 
@@ -835,7 +839,7 @@ class Client implements ClientInterface
     /**
      * Generates the expected Report Start date based on the Court date.
      *
-     * @return DateTime|null
+     * @return \DateTime|null
      */
     #[JMS\VirtualProperty]
     #[JMS\Type("DateTime<'Y-m-d'>")]
@@ -868,7 +872,7 @@ class Client implements ClientInterface
     /**
      * Generates the expected Report End date based on the Court date.
      *
-     * @return DateTime|null
+     * @return \DateTime|null
      */
     #[JMS\VirtualProperty]
     #[JMS\Type("DateTime<'Y-m-d'>")]
@@ -876,7 +880,7 @@ class Client implements ClientInterface
     #[JMS\Groups(['checklist-information'])]
     public function getExpectedReportEndDate($year = null)
     {
-        if (!($this->getExpectedReportStartDate($year) instanceof DateTime)) {
+        if (!($this->getExpectedReportStartDate($year) instanceof \DateTime)) {
             return null;
         }
         $expectedReportEndDate = clone $this->getExpectedReportStartDate($year);
@@ -884,13 +888,13 @@ class Client implements ClientInterface
         return $expectedReportEndDate->modify('+1year -1day');
     }
 
-    public function setArchivedAt(?DateTime $archivedAt = null)
+    public function setArchivedAt(?\DateTime $archivedAt = null)
     {
         $this->archivedAt = $archivedAt;
     }
 
     /**
-     * @return DateTime|null
+     * @return \DateTime|null
      */
     public function getArchivedAt()
     {
@@ -926,7 +930,7 @@ class Client implements ClientInterface
     /**
      * Get Active From date == earliest report start date for this client.
      *
-     * @return DateTime
+     * @return \DateTime
      */
     #[JMS\VirtualProperty]
     #[JMS\Type("DateTime<'Y-m-d H:i:s'>")]
@@ -935,7 +939,7 @@ class Client implements ClientInterface
     public function getActiveFrom()
     {
         $reports = $this->getReports();
-        $earliest = new DateTime('now');
+        $earliest = new \DateTime('now');
         foreach ($reports as $report) {
             if ($report->getStartDate() < $earliest) {
                 $earliest = $report->getStartDate();

--- a/api/app/src/Entity/Report/Report.php
+++ b/api/app/src/Entity/Report/Report.php
@@ -503,15 +503,13 @@ class Report implements ReportInterface
     private $significantDecisionsMade;
 
     /**
-     * @var array
-     *
      * @JMS\Groups({"report"})
      *
      * @ORM\Column(name="unsubmitted_sections_list", type="text", nullable=true)
      *
      * @JMS\Type("string")
      */
-    private $unsubmittedSectionsList;
+    private ?string $unsubmittedSectionsList;
 
     /**
      * @var Checklist
@@ -1266,18 +1264,12 @@ class Report implements ReportInterface
         return $this;
     }
 
-    /**
-     * @return array
-     */
-    public function getUnsubmittedSectionsList()
+    public function getUnsubmittedSectionsList(): ?string
     {
         return $this->unsubmittedSectionsList;
     }
 
-    /**
-     * @param array|null $unsubmittedSectionsList
-     */
-    public function setUnsubmittedSectionsList($unsubmittedSectionsList)
+    public function setUnsubmittedSectionsList(?string $unsubmittedSectionsList): void
     {
         $this->unsubmittedSectionsList = $unsubmittedSectionsList;
     }

--- a/api/app/src/Repository/PreRegistrationRepository.php
+++ b/api/app/src/Repository/PreRegistrationRepository.php
@@ -9,6 +9,9 @@ use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
+/**
+ * @extends ServiceEntityRepository<PreRegistration>
+ */
 class PreRegistrationRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)

--- a/api/app/src/Service/ReportService.php
+++ b/api/app/src/Service/ReportService.php
@@ -12,42 +12,24 @@ use App\Entity\PreRegistration;
 use App\Entity\Report\Asset;
 use App\Entity\Report\AssetOther as ReportAssetOther;
 use App\Entity\Report\AssetProperty as ReportAssetProperty;
-use App\Entity\Report\BankAccount as BankAccountEntity;
 use App\Entity\Report\BankAccount as ReportBankAccount;
 use App\Entity\Report\Document;
 use App\Entity\Report\Report;
 use App\Entity\Report\ReportSubmission;
 use App\Entity\ReportInterface;
 use App\Entity\User;
-use App\Repository\ReportRepository;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectRepository;
 
 class ReportService
 {
-    /**
-     * @var ObjectRepository
-     */
-    private $preRegistrationRepository;
-
-    /**
-     * @var ObjectRepository
-     */
-    private $assetRepository;
-
-    /**
-     * @var ObjectRepository
-     */
-    private $bankAccountRepository;
+    private ObjectRepository $preRegistrationRepository;
 
     public function __construct(
         private readonly EntityManagerInterface $em,
-        private readonly ReportRepository $reportRepository
     ) {
         $this->preRegistrationRepository = $em->getRepository(PreRegistration::class);
-        $this->assetRepository = $em->getRepository(Asset::class);
-        $this->bankAccountRepository = $em->getRepository(BankAccountEntity::class);
     }
 
     /**
@@ -340,9 +322,6 @@ class ReportService
         return null;
     }
 
-    /**
-     * @param mixed $sectionList
-     */
     public function unSubmit(Report $report, \DateTime $unsubmitDate, \DateTime $dueDate, \DateTime $startDate, \DateTime $endDate, $sectionList)
     {
         // reset report.submitted so that the deputy will set the report back into the dashboard
@@ -444,7 +423,7 @@ class ReportService
     /**
      * @return bool
      */
-    public static function isDue(\DateTime $endDate = null)
+    public static function isDue(?\DateTime $endDate = null)
     {
         if (!$endDate) {
             return false;

--- a/api/app/src/Service/ReportService.php
+++ b/api/app/src/Service/ReportService.php
@@ -18,20 +18,23 @@ use App\Entity\Report\Report;
 use App\Entity\Report\ReportSubmission;
 use App\Entity\ReportInterface;
 use App\Entity\User;
+use App\Repository\PreRegistrationRepository;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\Persistence\ObjectRepository;
 use Psr\Log\LoggerInterface;
 
 class ReportService
 {
-    private ObjectRepository $preRegistrationRepository;
+    private PreRegistrationRepository $preRegistrationRepository;
 
     public function __construct(
         private readonly EntityManagerInterface $em,
         private readonly LoggerInterface $logger,
     ) {
-        $this->preRegistrationRepository = $em->getRepository(PreRegistration::class);
+        /** @var PreRegistrationRepository $preRegistrationRepository */
+        $preRegistrationRepository = $em->getRepository(PreRegistration::class);
+
+        $this->preRegistrationRepository = $preRegistrationRepository;
     }
 
     /**
@@ -325,30 +328,28 @@ class ReportService
     /**
      * Set report type based on CasRec record (if existing).
      *
-     * @return string|null type
-     *
      * @throws \Exception
      */
-    public function getReportTypeBasedOnSirius(Client $client)
+    public function getReportTypeBasedOnSirius(Client $client): ?string
     {
         $preRegistration = $this->preRegistrationRepository->findOneBy(['caseNumber' => $client->getCaseNumber()]);
 
-        if ($preRegistration instanceof PreRegistration) {
-            if (count($client->getUsers())) {
-                if ($client->getUsers()->first()->isLayDeputy()) {
-                    return PreRegistration::getReportTypeByOrderType(
-                        $preRegistration->getTypeOfReport(),
-                        $preRegistration->getOrderType(),
-                        PreRegistration::REALM_LAY
-                    );
-                }
-            }
+        if (
+            !($preRegistration instanceof PreRegistration)
+            || count($client->getUsers()) < 1
+            || !$client->getUsers()->first()->isLayDeputy()
+        ) {
+            return null;
         }
 
-        return null;
+        return PreRegistration::getReportTypeByOrderType(
+            $preRegistration->getTypeOfReport(),
+            $preRegistration->getOrderType(),
+            PreRegistration::REALM_LAY
+        );
     }
 
-    public function unSubmit(Report $report, \DateTime $unsubmitDate, \DateTime $dueDate, \DateTime $startDate, \DateTime $endDate, $sectionList)
+    public function unSubmit(Report $report, \DateTime $unsubmitDate, \DateTime $dueDate, \DateTime $startDate, \DateTime $endDate, string $sectionList)
     {
         // reset report.submitted so that the deputy will set the report back into the dashboard
         $report->setSubmitted(false);

--- a/api/app/src/Service/ReportService.php
+++ b/api/app/src/Service/ReportService.php
@@ -21,6 +21,7 @@ use App\Entity\User;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectRepository;
+use Psr\Log\LoggerInterface;
 
 class ReportService
 {
@@ -28,6 +29,7 @@ class ReportService
 
     public function __construct(
         private readonly EntityManagerInterface $em,
+        private readonly LoggerInterface $logger,
     ) {
         $this->preRegistrationRepository = $em->getRepository(PreRegistration::class);
     }
@@ -35,11 +37,9 @@ class ReportService
     /**
      * Set report submitted and create a new year report.
      *
-     * @param string|null $ndrDocumentId
-     *
-     * @return Report
+     * @throws \Exception
      */
-    public function submit(ReportInterface $currentReport, User $user, \DateTime $submitDate, $ndrDocumentId = null)
+    public function submit(ReportInterface $currentReport, User $user, \DateTime $submitDate, ?string $ndrDocumentId = null): ?Report
     {
         if (!$currentReport->getAgreedBehalfDeputy()) {
             throw new \RuntimeException('Report must be agreed for submission');
@@ -72,23 +72,34 @@ class ReportService
 
         $this->em->persist($submission);
 
-        //      Set user to active once they have submitted a report
+        $client = $currentReport->getClient();
+        $clientId = $client->getId();
+        $now = (new \DateTime())->format('Y-m-d H:i:s');
+        $this->logger->notice("Report submitted for client ID $clientId at $now");
+
+        // Set user to active once they have submitted a report
         $user->setActive(true);
 
-        $newYearReport = [];
+        $newYearReport = null;
 
         if ($currentReport instanceof Ndr) {
             // Find the first report and clone assets/accounts across
-            $reports = $currentReport->getClient()->getReports();
+            $reports = $client->getReports();
 
             if (1 === count($reports)) {
+                $this->logger->notice("Populating existing report for client $clientId (NDR submitted, existing report) at $now");
+
                 $newYearReport = $reports[0];
 
                 $this->clonePersistentResources($newYearReport, $currentReport);
             } elseif (0 === count($reports)) {
+                $this->logger->notice("Creating next year report for client $clientId (NDR submitted, NO existing report) at $now");
+
                 $newYearReport = $this->createNextYearReport($currentReport);
             }
         } elseif ($currentReport instanceof Report && $currentReport->getUnSubmitDate()) {
+            $this->logger->notice("Creating next year report for client $clientId (NO NDR, existing unsubmitted report) at $now");
+
             // unsubmitted report
             $currentReport->setUnSubmitDate(null);
             $currentReport->setUnsubmittedSectionsList(null);
@@ -96,13 +107,15 @@ class ReportService
             // Find the next report and clone assets/accounts across
             $calculatedEndDate = clone $currentReport->getEndDate();
             $calculatedEndDate->modify('+12 months');
-            $newYearReport = $currentReport->getClient()->getReportByEndDate($calculatedEndDate);
 
-            if ($newYearReport) {
+            $newYearReport = $client->getReportByEndDate($calculatedEndDate);
+            if (!is_null($newYearReport)) {
                 $this->clonePersistentResources($newYearReport, $currentReport);
             }
         } else {
             // first-time submission
+            $this->logger->notice("Creating next year report for client $clientId (NO NDR, NO existing report) at $now");
+
             $newYearReport = $this->createNextYearReport($currentReport);
         }
 
@@ -292,6 +305,19 @@ class ReportService
 
         $newReport->updateSectionsStatusCache($newReport->getAvailableSections());
         $this->em->persist($newReport);
+
+        $createdAtStr = 'unknown';
+        $createdAt = $newReport->getCreatedAt();
+        if (!is_null($createdAt)) {
+            $createdAtStr = $createdAt->format('Y-m-d H:i:s');
+        }
+
+        $this->logger->notice(
+            "Created next year report for client ID {$client->getId()} ".
+            "; created at = {$createdAtStr} ".
+            "; start date = {$startDate->format('Y-m-d')} ".
+            "; end date = {$endDate->format('Y-m-d')}"
+        );
 
         return $newReport;
     }

--- a/api/app/tests/Unit/Service/ReportServiceTest.php
+++ b/api/app/tests/Unit/Service/ReportServiceTest.php
@@ -11,11 +11,8 @@ use App\Entity\Report\BankAccount;
 use App\Entity\Report\Document;
 use App\Entity\Report\Report;
 use App\Entity\User;
-use App\Repository\AssetRepository;
-use App\Repository\BankAccountRepository;
 use App\Repository\DocumentRepository;
 use App\Repository\PreRegistrationRepository;
-use App\Repository\ReportRepository;
 use App\Service\ReportService;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -80,16 +77,10 @@ class ReportServiceTest extends TestCase
         $this->em->shouldReceive('getRepository')->andReturnUsing(function ($arg) use ($client) {
             switch ($arg) {
                 case PreRegistration::class:
-                    return m::mock(EntityRepository::class)->shouldReceive('findOneBy')
+                    return m::mock(PreRegistrationRepository::class)->shouldReceive('findOneBy')
                         ->with(['caseNumber' => $client->getCaseNumber()])
                         ->andReturn(null)
                         ->getMock();
-                case Report::class:
-                    return m::mock(ReportRepository::class);
-                case Asset::class:
-                    return m::mock(EntityRepository::class);
-                case BankAccount::class:
-                    return m::mock(BankAccount::class);
                 case Document::class:
                     return m::mock(DocumentRepository::class)
                         ->shouldReceive('find')
@@ -225,7 +216,6 @@ class ReportServiceTest extends TestCase
         $this->em->shouldReceive('persist');
         $this->em->shouldReceive('flush');
 
-        /** @var Report $newYearReport */
         $newYearReport = $reportService->submit($ndr, $this->user, $submitDate, 999);
 
         // assert current report
@@ -444,14 +434,8 @@ class ReportServiceTest extends TestCase
         $preRegistrationRepo = self::prophesize(PreRegistrationRepository::class);
         $preRegistrationRepo->findOneBy(['caseNumber' => '12345678'])->willReturn($preRegistration);
 
-        $reportRepository = self::prophesize(ReportRepository::class);
-        $assetRepository = self::prophesize(AssetRepository::class);
-        $bankAccountRepository = self::prophesize(BankAccountRepository::class);
-
         $em = self::prophesize(EntityManagerInterface::class);
         $em->getRepository(PreRegistration::class)->willReturn($preRegistrationRepo->reveal());
-        $em->getRepository(Asset::class)->willReturn($assetRepository->reveal());
-        $em->getRepository(BankAccount::class)->willReturn($bankAccountRepository->reveal());
 
         $sut = new ReportService($em->reveal(), $this->mockLogger);
 

--- a/api/app/tests/Unit/Service/ReportServiceTest.php
+++ b/api/app/tests/Unit/Service/ReportServiceTest.php
@@ -22,9 +22,11 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Mockery\MockInterface;
 use MockeryStub as m;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\LoggerInterface;
 
 class ReportServiceTest extends TestCase
 {
@@ -41,6 +43,7 @@ class ReportServiceTest extends TestCase
     private MockInterface $bankAccount;
     private MockInterface|EntityManager $em;
     private Document $mockNdrDocument;
+    private LoggerInterface&MockObject $mockLogger;
     private ReportService $sut;
 
     public function setUp(): void
@@ -97,7 +100,9 @@ class ReportServiceTest extends TestCase
             }
         });
 
-        $this->sut = new ReportService($this->em);
+        $this->mockLogger = $this->createMock(LoggerInterface::class);
+
+        $this->sut = new ReportService($this->em, $this->mockLogger);
     }
 
     public function testSubmitInvalid()
@@ -112,7 +117,7 @@ class ReportServiceTest extends TestCase
         $report = $this->report;
 
         // Create partial mock of ReportService
-        $reportService = \Mockery::mock(ReportService::class, [$this->em])->makePartial();
+        $reportService = \Mockery::mock(ReportService::class, [$this->em, $this->mockLogger])->makePartial();
 
         // mocks
         $this->em->shouldReceive('detach');
@@ -157,7 +162,7 @@ class ReportServiceTest extends TestCase
         $client->addReport($nextReport);
 
         // Create partial mock of ReportService
-        $reportService = \Mockery::mock(ReportService::class, [$this->em])->makePartial();
+        $reportService = \Mockery::mock(ReportService::class, [$this->em, $this->mockLogger])->makePartial();
 
         // mocks
         $this->em->shouldReceive('detach');
@@ -215,7 +220,7 @@ class ReportServiceTest extends TestCase
         $this->em->shouldReceive('flush')->with()->once(); // last in createNextYearReport
 
         // Create partial mock of ReportService
-        $reportService = \Mockery::mock(ReportService::class, [$this->em])->makePartial();
+        $reportService = \Mockery::mock(ReportService::class, [$this->em, $this->mockLogger])->makePartial();
         $this->em->shouldReceive('detach');
         $this->em->shouldReceive('persist');
         $this->em->shouldReceive('flush');
@@ -287,7 +292,7 @@ class ReportServiceTest extends TestCase
         $this->em->shouldReceive('flush')->with()->once(); // last in createNextYearReport
 
         // Create partial mock of ReportService
-        $reportService = \Mockery::mock(ReportService::class, [$this->em])->makePartial();
+        $reportService = \Mockery::mock(ReportService::class, [$this->em, $this->mockLogger])->makePartial();
         $this->em->shouldReceive('detach');
         $this->em->shouldReceive('persist');
         $this->em->shouldReceive('flush');
@@ -319,7 +324,7 @@ class ReportServiceTest extends TestCase
         $report->setAgreedBehalfDeputy(true);
 
         // Create partial mock of ReportService
-        $reportService = \Mockery::mock(ReportService::class, [$this->em])->makePartial();
+        $reportService = \Mockery::mock(ReportService::class, [$this->em, $this->mockLogger])->makePartial();
         $this->em->shouldReceive('detach');
         $this->em->shouldReceive('persist');
         $this->em->shouldReceive('flush');
@@ -448,7 +453,7 @@ class ReportServiceTest extends TestCase
         $em->getRepository(Asset::class)->willReturn($assetRepository->reveal());
         $em->getRepository(BankAccount::class)->willReturn($bankAccountRepository->reveal());
 
-        $sut = new ReportService($em->reveal());
+        $sut = new ReportService($em->reveal(), $this->mockLogger);
 
         self::assertEquals($isAString, is_string($sut->getReportTypeBasedOnSirius($client)));
     }
@@ -490,7 +495,7 @@ class ReportServiceTest extends TestCase
     {
         $user = $this->user->setActive(null);
 
-        $reportService = \Mockery::mock(ReportService::class, [$this->em])->makePartial();
+        $reportService = \Mockery::mock(ReportService::class, [$this->em, $this->mockLogger])->makePartial();
 
         $this->em->shouldReceive('detach');
         $this->em->shouldReceive('persist');


### PR DESCRIPTION
## Purpose

Provides evidence to help resolve DDLS-631 (and subsequent tickets)

The main change is to add a logger to the ReportService, but this highlighted numerous type hinting, linting, phpstan etc. errors which I also fixed.

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
