### PR TITLE
DDLS-583 Status lozenge broken on lay home page (/clients/<client ID>)

### DIFF
--- a/client/app/src/Controller/Report/ReportController.php
+++ b/client/app/src/Controller/Report/ReportController.php
@@ -246,7 +246,7 @@ class ReportController extends AbstractController
         } else {
             return array_merge([
                 'ndrEnabled' => false,
-                'client' => $clientWithCoDeputies,
+                'client' => $client,
             ],
                 $resultsArray
             );


### PR DESCRIPTION
## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes DDLS-583

## Approach
Change client to return client including report with status included.

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
