### PR TITLE
DDLS-815 Fix xdebug setup

### DIFF
--- a/api/docker/app/Dockerfile
+++ b/api/docker/app/Dockerfile
@@ -21,7 +21,6 @@ WORKDIR /var/www
 EXPOSE 80
 EXPOSE 443
 ENV TIMEOUT=20
-ENV PHP_EXT_DIR=/usr/local/lib/php/extensions/no-debug-non-zts-20210902/
 # Install required packages
 RUN apk --no-cache add \
     postgresql-dev \
@@ -39,16 +38,12 @@ RUN apk add --no-cache autoconf build-base
 RUN pecl install pcov && docker-php-ext-enable pcov
 # Install Xdebug if directed to with build arg from docker-compose.yml
 ARG REQUIRE_XDEBUG=0
-ARG XDEBUG_IDEKEY_API=PHPSTORM
 RUN if [[ $REQUIRE_XDEBUG = 1 ]] ; then \
-    pecl install xdebug-3.1.4  ;\
-    docker-php-ext-enable $PHP_EXT_DIR/xdebug.so ; \
-    echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    echo "xdebug.idekey = ${XDEBUG_IDEKEY_API}" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    fi ;
+    apk add --update linux-headers && \
+    pecl install xdebug && \
+    docker-php-ext-enable xdebug && \
+    apk del linux-headers; \
+fi ;
 
 # Create var directories
 RUN mkdir -p var/cache \
@@ -76,6 +71,7 @@ COPY --chown=www-data:www-data api/app/phpstan-baseline.neon .
 COPY --chown=www-data:www-data api/app/scripts/wait-for-db.sh wait-for-db.sh
 COPY --chown=www-data:www-data api/docker/app/config/www.conf /usr/local/etc/php-fpm.d/www.conf
 COPY --chown=www-data:www-data api/docker/app/config/generate_parameters_yml.sh generate_parameters_yml.sh
+COPY --chown=www-data:www-data api/docker/app/config/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 RUN ./generate_parameters_yml.sh && mv /var/www/parameters.yml /var/www/config/parameters.yml
 
 RUN chmod 544 /var/www/wait-for-db.sh

--- a/api/docker/app/config/xdebug.ini
+++ b/api/docker/app/config/xdebug.ini
@@ -1,0 +1,5 @@
+xdebug.client_port=9003
+xdebug.client_host=host.docker.internal
+xdebug.mode=develop,debug
+# This is useful for checking the IDE is connecting to the debugger, but will also cause the docker build to  connect and need you to continue
+# xdebug.start_with_request=yes

--- a/client/docker/app/Dockerfile
+++ b/client/docker/app/Dockerfile
@@ -17,7 +17,6 @@ ARG TAG=${TAG:-latest}
 ARG ENVIRONMENT=${ENVIRONMENT:-production}
 WORKDIR /var/www
 ENV TIMEOUT=60
-ENV PHP_EXT_DIR=/usr/local/lib/php/extensions/no-debug-non-zts-20210902/
 # Install core PHP extensions
 RUN apk update && apk upgrade
 RUN apk add --no-cache \
@@ -41,16 +40,12 @@ RUN apk add --no-cache autoconf build-base
 RUN pecl install pcov && docker-php-ext-enable pcov
 # Install Xdebug if directed to with build arg from docker-compose.yml
 ARG REQUIRE_XDEBUG=0
-ARG XDEBUG_IDEKEY_CLIENT=PHPSTORM
 RUN if [[ $REQUIRE_XDEBUG = 1 ]] ; then \
-        pecl install xdebug-3.1.4  ;\
-        docker-php-ext-enable $PHP_EXT_DIR/xdebug.so ; \
-        echo "xdebug.mode = develop,debug" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-        echo "xdebug.client_host = host.docker.internal" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-        echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-        echo "xdebug.log = /tmp/xdebug.log" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-        echo "xdebug.idekey = ${XDEBUG_IDEKEY_CLIENT}" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ; \
-    fi ;
+    apk add --update linux-headers && \
+    pecl install xdebug && \
+    docker-php-ext-enable xdebug && \
+    apk del linux-headers; \
+fi ;
 
 # Create var directories
 RUN mkdir -p var/cache \
@@ -85,6 +80,7 @@ COPY --chown=www-data:www-data client/app/admin.env admin.env
 COPY --chown=www-data:www-data client/docker/app/config/www.conf /usr/local/etc/php-fpm.d/www.conf
 COPY --chown=www-data:www-data client/docker/app/config/meta.json.tmpl /var/www/public/meta.json.tmpl
 COPY --chown=www-data:www-data client/docker/app/config/generate_parameters_yml.sh generate_parameters_yml.sh
+COPY --chown=www-data:www-data client/docker/app/config/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 RUN chown -R www-data:www-data scripts \
     && sed "s|TAG|${TAG}|" /var/www/public/meta.json.tmpl > /var/www/public/meta.json
 RUN ./generate_parameters_yml.sh && mv /var/www/parameters.yml /var/www/config/parameters.yml

--- a/client/docker/app/config/xdebug.ini
+++ b/client/docker/app/config/xdebug.ini
@@ -1,0 +1,5 @@
+xdebug.client_port=9003
+xdebug.client_host=host.docker.internal
+xdebug.mode=develop,debug
+# This is useful for checking the IDE is connecting to the debugger, but will also cause the docker build to  connect and need you to continue
+# xdebug.start_with_request=yes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -292,6 +292,7 @@ services:
       dockerfile: client/docker/app/Dockerfile
       context: .
       args:
+        REQUIRE_XDEBUG: ${REQUIRE_XDEBUG_CLIENT} # set REQUIRE_XDEBUG_CLIENT=1 in .env to install Xdebug
         ENVIRONMENT: local
     depends_on:
       pact-mock:


### PR DESCRIPTION
## Purpose
Fix the installation of xdebug in local development containers when REQUIRE_XDEBUG_API and/or REQUIRE_XDEBUG_CLIENT are set

Fixes DDLS-815

## Approach
- Structure the installation command so if it fails the container build will visibly fail
- Move the configuration to a file that is copied in, rather than constructing the config using echo commands

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
