### PR TITLE
DDLS-796 Prevent multiple submissions of the same report

### DIFF
--- a/client/app/templates/Report/Report/declaration.html.twig
+++ b/client/app/templates/Report/Report/declaration.html.twig
@@ -69,7 +69,7 @@
 
         </div>
 
-        {{ form_start(form, {attr: {novalidate: 'novalidate'}}) }}
+        {{ form_start(form, {attr: {novalidate: 'novalidate', 'data-single-submit-form': 'true'}}) }}
 
         {{ form_checkbox(form.agree, 'agree', { 'labelClass': 'required' }) }}
 

--- a/client/resources/assets/javascripts/common.js
+++ b/client/resources/assets/javascripts/common.js
@@ -18,6 +18,7 @@ import { GoogleAnalyticsEvents } from './modules_new/googleAnalyticsEvents'
 import GoogleAnalyticsObject from './modules_new/GoogleAnalyticsObject'
 import GoogleAnalyticsGtag from './modules_new/GoogleAnalyticsGtag'
 import EnableJavascript from './modules_new/EnableJavascript'
+import FormSingleSubmit from './modules_new/FormSingleSubmit'
 
 window.addEventListener('DOMContentLoaded', () => {
   // Session Timeout
@@ -63,6 +64,8 @@ window.addEventListener('DOMContentLoaded', () => {
   GoogleAnalyticsObject.init(document)
 
   GoogleAnalyticsGtag.init(document)
+
+  FormSingleSubmit.init(document)
 
   // Error summaries
   const errorSummaries = document.querySelector('#error-summary')

--- a/client/resources/assets/javascripts/modules_new/FormSingleSubmit.js
+++ b/client/resources/assets/javascripts/modules_new/FormSingleSubmit.js
@@ -1,0 +1,18 @@
+// restrict a form to only being submittable once
+const FormSingleSubmit = {
+  init: function () {
+    document.querySelectorAll('[data-single-submit-form="true"]').forEach((form) => {
+      form.addEventListener('submit', (e) => {
+        const isSubmitting = form.getAttribute('data-is-submitting')
+
+        if (isSubmitting === null) {
+          form.setAttribute('data-is-submitting', 'true')
+        } else {
+          e.preventDefault()
+        }
+      })
+    })
+  }
+}
+
+export default FormSingleSubmit


### PR DESCRIPTION
Add a function which prevents a form being submitted multiple times. This prevents multiple submissions of the same report from a single form.

## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes DDLS-796

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
