### PR TITLE
DDLS-689: Remove selected file from the current doc upload page

### DIFF
--- a/api/app/tests/Behat/bootstrap/v2/ReportSubmission/ReportSubmissionTrait.php
+++ b/api/app/tests/Behat/bootstrap/v2/ReportSubmission/ReportSubmissionTrait.php
@@ -103,14 +103,20 @@ trait ReportSubmissionTrait
     }
 
     /**
-     * @When I attach a "second" supporting document :imageName to the :submitted report
-     * @When I attach a supporting document :imageName to the :submitted report
+     * @When I attach a "second" supporting document :imageName to the submitted report
+     * @When I attach a supporting document :imageName to the submitted report
      */
-    public function attachSupportingDocumentToSubmittedReport(string $imageName, $reportStatus)
+    public function attachSupportingDocumentToSubmittedReport(string $imageName)
     {
         $this->iVisitTheDocumentsStep2Page();
         $this->attachDocument($imageName);
+    }
 
+    /**
+     * @Given /^I send the documents to complete the upload process on the "([^"]*)" report$/
+     */
+    public function iSendTheDocumentsToCompleteTheUploadProcess($reportStatus)
+    {
         if ('submitted' != $reportStatus) {
             $this->clickLink('Continue to send documents');
         }

--- a/api/app/tests/Behat/bootstrap/v2/Reporting/Sections/DocumentsSectionTrait.php
+++ b/api/app/tests/Behat/bootstrap/v2/Reporting/Sections/DocumentsSectionTrait.php
@@ -208,7 +208,7 @@ trait DocumentsSectionTrait
      *
      * @Given /^I remove the "([^"]*)" document I uploaded$/
      */
-    public function iRemoveOneDocumentIUploaded($fileName)
+    public function iRemoveOneDocumentIUploaded($fileName = null)
     {
         if ($fileName) {
             $documentToPop = $fileName;

--- a/api/app/tests/Behat/bootstrap/v2/Reporting/Sections/DocumentsSectionTrait.php
+++ b/api/app/tests/Behat/bootstrap/v2/Reporting/Sections/DocumentsSectionTrait.php
@@ -66,6 +66,7 @@ trait DocumentsSectionTrait
 
     /**
      * @Then the documents summary page should not contain any documents
+     * @Then the document upload page should not contain any documents
      */
     public function theDocumentsSummaryPageShouldNotContainDocuments()
     {
@@ -204,12 +205,18 @@ trait DocumentsSectionTrait
 
     /**
      * @When I remove one document I uploaded
+     *
+     * @Given /^I remove the "([^"]*)" document I uploaded$/
      */
-    public function iRemoveOneDocumentIUploaded()
+    public function iRemoveOneDocumentIUploaded($fileName)
     {
-        $filenames = $this->uploadedDocumentFilenames;
-        $documentToPop = $filenames[0];
-        unset($filenames[0]);
+        if ($fileName) {
+            $documentToPop = $fileName;
+        } else {
+            $filenames = $this->uploadedDocumentFilenames;
+            $documentToPop = $filenames[0];
+            unset($filenames[0]);
+        }
 
         $parentOfDtWithTextSelector = sprintf('//dt[contains(text(),"%s")]/..', $documentToPop);
         $documentRowDiv = $this->getSession()->getPage()->find('xpath', $parentOfDtWithTextSelector);
@@ -226,9 +233,11 @@ trait DocumentsSectionTrait
         }
 
         $removeLink->click();
-        $this->pressButton('confirm_delete_confirm');
 
-        $this->uploadedDocumentFilenames = $filenames;
+        if (!$fileName) {
+            $this->pressButton('confirm_delete_confirm');
+            $this->uploadedDocumentFilenames = $filenames;
+        }
     }
 
     /**
@@ -414,6 +423,27 @@ trait DocumentsSectionTrait
             $fileNameItem = $this->getSession()->getPage()->find('xpath', $xpathSelector)->getHtml();
 
             $this->assertStringEqualsString($fileName, $fileNameItem, 'File found');
+        }
+    }
+
+    /**
+     * @Then /^a flash message should be displayed to the user confirming the removal of "([^"]*)"$/
+     */
+    public function aFlashMessageShouldBeDisplayedToTheUserConfirmingTheDocumentHasBeenRemoved($fileName)
+    {
+        $alertMessage = sprintf('File named %s has been removed', $fileName);
+
+        $xpath = '//div[contains(@class, "moj-banner moj-banner--success")]';
+        $alertText = $this->getSession()->getPage()->find('xpath', $xpath)->getText();
+
+        if (is_null($alertText)) {
+            throw new BehatException('Could not find a div with class "moj-banner moj-banner--success"');
+        }
+
+        $alertMessageFound = str_contains($alertText, $alertMessage);
+
+        if (!$alertMessageFound) {
+            throw new BehatException(sprintf('The alert element did not contain the expected message. Expected: "%s", got (full HTML): %s', $alertMessage, $alertText));
         }
     }
 }

--- a/api/app/tests/Behat/features-v2/report-submission/attaching-further-documents.feature
+++ b/api/app/tests/Behat/features-v2/report-submission/attaching-further-documents.feature
@@ -4,7 +4,8 @@ Feature: Attaching Further Documents
     @lay-pfa-high-submitted @super-admin
     Scenario: A user attempts to send further documents
         Given a Lay Deputy has submitted a report
-        When I attach a supporting document "test-image.png" to the "submitted" report
+        When I attach a supporting document "test-image.png" to the submitted report
+        And I send the documents to complete the upload process on the "submitted" report
         Then I should be on the Lay homepage
         And a flash message should be displayed to the user confirming the document upload
         Given a super admin user accesses the admin app
@@ -15,12 +16,22 @@ Feature: Attaching Further Documents
     @lay-pfa-high-submitted @super-admin
     Scenario: A user attempts to send further documents in two attempts
         Given a Lay Deputy has submitted a report
-        When I attach a supporting document "test-image.png" to the "submitted" report
+        When I attach a supporting document "test-image.png" to the submitted report
+        And I send the documents to complete the upload process on the "submitted" report
         Then I should be on the Lay homepage
         And a flash message should be displayed to the user confirming the document upload
         When I visit the documents step 2 page
         Then I should see "testimage.png" listed as a previously submitted document
-        When I attach a "second" supporting document "good.pdf" to the "submitted" report
+        When I attach a "second" supporting document "good.pdf" to the submitted report
+        And I send the documents to complete the upload process on the "submitted" report
         Then I should be on the Lay homepage
         When I visit the documents step 2 page
         Then I should see "testimage.png" and "good.pdf" as previously submitted documents
+
+    @lay-pfa-high-submitted @super-admin
+    Scenario: A user attempts to remove a file after it has been selected
+        Given a Lay Deputy has submitted a report
+        When I attach a supporting document "test-image.png" to the submitted report
+        And I remove the "testimage.png" document I uploaded
+        Then a flash message should be displayed to the user confirming the removal of "testimage.png"
+        And the document upload page should not contain any documents

--- a/client/app/src/Controller/Report/DocumentController.php
+++ b/client/app/src/Controller/Report/DocumentController.php
@@ -536,7 +536,7 @@ class DocumentController extends AbstractController
     {
         $documentId = $request->query->getInt('documentId');
 
-        return $this->deleteDocument($request, $documentId);
+        return $this->deleteDocument($request, strval($documentId));
     }
 
     /**

--- a/client/app/src/Controller/Report/DocumentController.php
+++ b/client/app/src/Controller/Report/DocumentController.php
@@ -487,8 +487,11 @@ class DocumentController extends AbstractController
             try {
                 $result = $this->documentService->removeDocumentFromS3($document); // rethrows any exception
 
-                if ($result) {
+                if ($result && !$report->isSubmitted()) {
                     $this->addFlash('notice', 'Document has been removed');
+                } elseif ($result && $report->isSubmitted()) {
+                    $documentName = $document->getFileName();
+                    $this->addFlash('fileRemovalSuccess', sprintf('File named %s has been removed', $documentName));
                 }
             } catch (\Throwable $e) {
                 $this->logger->error($e->getMessage());
@@ -499,9 +502,9 @@ class DocumentController extends AbstractController
                 );
             }
         }
+
         if ($report->isSubmitted()) {
-            // if report is submitted, then this remove path has come from adding additional documents so return the user
-            // to the step 2 page.
+            // if report is submitted, then this remove path has come from adding additional documents so return the user to the step 2 page.
             $returnUrl = $this->generateUrl('report_documents', ['reportId' => $document->getReportId()]);
         } else {
             $reportDocumentStatus = $report->getStatus()->getDocumentsState();
@@ -524,6 +527,16 @@ class DocumentController extends AbstractController
     {
         $this->restClient->delete('/document/'.$documentId);
         $this->addFlash('notice', 'Document has been removed');
+    }
+
+    /**
+     * @Route("/report/documents/deleteFilePostSubmission", name="delete_report_documents_post_submission")
+     */
+    public function deleteSelectedFilePostReportSubmission(Request $request): RedirectResponse
+    {
+        $documentId = $request->query->getInt('documentId');
+
+        return $this->deleteDocument($request, $documentId);
     }
 
     /**

--- a/client/app/templates/Layouts/application.html.twig
+++ b/client/app/templates/Layouts/application.html.twig
@@ -104,6 +104,9 @@
         {% for flashMessage in app.session.flashbag.get('fileUploadSuccess') %}
             {{ macros.notification('fileUploadSuccess', flashMessage) }}
         {% endfor %}
+        {% for flashMessage in app.session.flashbag.get('fileRemovalSuccess') %}
+            {{ macros.notification('fileRemovalSuccess', flashMessage) }}
+        {% endfor %}
     {% endblock %}
 
     {% block errors %}

--- a/client/app/templates/Macros/macros.html.twig
+++ b/client/app/templates/Macros/macros.html.twig
@@ -355,11 +355,19 @@
             <div class="moj-banner moj-banner--success">
                 {{ _self.icon('success', 'moj-banner__icon') }}
                 <div class="moj-banner__message">
-                        <h2 class="govuk-heading-m">
-                            Files uploaded
-                        </h2>
+                    <h2 class="govuk-heading-m">
+                        Files uploaded
+                    </h2>
                     <span class="moj-banner__assistive">Success</span>
-                        {{ message }}
+                    {{ message }}
+                </div>
+            </div>
+        {% elseif alertType == 'fileRemovalSuccess' %}
+            <div class="moj-banner moj-banner--success">
+                {{ _self.icon('success', 'moj-banner__icon') }}
+                <div class="moj-banner__message">
+                    <span class="moj-banner__assistive">Success</span>
+                    {{ message }}
                 </div>
             </div>
         {% else %}

--- a/client/app/templates/Report/Document/_list_submitted.html.twig
+++ b/client/app/templates/Report/Document/_list_submitted.html.twig
@@ -34,7 +34,7 @@
                 <dd class="govuk-summary-list__actions">
                     <a
                         class="govuk-link behat-link-delete-documents-button"
-                        href="{{ path('delete_document', {'reportId':report.id, 'documentId': document.id, 'from': page}) }}">
+                        href="{{ path('delete_report_documents_post_submission', {'reportId':report.id, 'documentId': document.id, 'from': page}) }}">
                         {{ (page ~ '.deleteDocument') | trans }}
                     </a>
                 </dd>


### PR DESCRIPTION
## Purpose
Amends user flow when a user removes a selected file before submitting to OPG - this applies to post submission doc uploads only.

User now has a simplified one click action to remove the file, instead of a 2 step process.

Fixes DDLS-689

## Approach
- Redirect user back to document upload page when clicking the Remove link
- Utilised existing deletion logic but expanded on conditional to render updated flash message on the upload page

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
