### PR TITLE
fix for cycle db issue

### DIFF
--- a/terraform/environment/scripts/cycle_secrets/cycle_secrets.py
+++ b/terraform/environment/scripts/cycle_secrets/cycle_secrets.py
@@ -128,7 +128,7 @@ def modify_db_instances_password(session, workspaces, aws_config):
             exit(1)
 
 
-def restart_ecs_services(session, workspaces, aws_config):
+def restart_ecs_services(session, workspaces, aws_config, api_only=False):
     """
     Force new deployments for ECS services across given workspaces to get the new secrets.
     """
@@ -136,7 +136,11 @@ def restart_ecs_services(session, workspaces, aws_config):
 
     for workspace in workspaces:
         cluster = workspace
-        services = [f"api-{workspace}", f"admin-{workspace}", f"front-{workspace}"]
+        services = (
+            [f"api-{workspace}"]
+            if api_only
+            else [f"api-{workspace}", f"admin-{workspace}", f"front-{workspace}"]
+        )
 
         passed = True
         for service_name in services:
@@ -182,6 +186,7 @@ def main(environment, secret_type):
     elif secret_type == "database":
         cycle_secrets(session, workspaces, aws_config, db_secrets_list)
         modify_db_instances_password(session, workspaces, aws_config)
+        restart_ecs_services(session, workspaces, aws_config, True)
     else:
         print(f"Incorrect secret type of {secret_type}")
         sys.exit(1)


### PR DESCRIPTION
## Purpose
Fixes a issue that causes noise in our logs after the cycle process

## Approach
Refresh the containers so that the container pulls latest secret

## Learning
NA

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
