### PR TITLE
DDLS-846

### DIFF
--- a/client/app/src/Service/Redirector.php
+++ b/client/app/src/Service/Redirector.php
@@ -78,6 +78,8 @@ class Redirector
 
     public function getCorrectRouteIfDifferent(User $user, ?string $currentRoute = null): bool|string
     {
+        $coDeputySignupRoutes = [User::UNKNOWN_REGISTRATION_ROUTE, User::CO_DEPUTY_INVITE];
+
         // none of these corrections apply to admin
         if (!$user->hasAdminRole()) {
             if ($user->getIsCoDeputy()) {
@@ -89,7 +91,7 @@ class Redirector
                 }
 
                 // unverified codeputy invitation
-                if (!$coDeputyClientConfirmed && User::CO_DEPUTY_INVITE == $user->getRegistrationRoute()) {
+                if (!$coDeputyClientConfirmed && in_array($user->getRegistrationRoute(), $coDeputySignupRoutes)) {
                     $route = 'codep_verification';
                 }
             } elseif (!$user->isDeputyOrg()) {


### PR DESCRIPTION
## Purpose
During the co-deputy registration process if the co-deputy invitation is unverified then the next step is to redirect to the co-deputy verification screen to input the details for the deputy and client. However, the code expects the registration route to have been set to CO_DEPUTY_INVITE. This was not always the case in the past and there are co-deputy invitations where the registration route is set to UNKNOWN. Those co-deputy invitations that have UNKNOWN as the registration route will need to follow the co-deputy registration process. 

Fixes DDLS-846

## Approach
Add UNKNOWN registration route if statement when checking unverified codeputy invitations

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
