### PR TITLE
Create localstack log groups in correct region

### DIFF
--- a/local-resources/localstack/init/init.sh
+++ b/local-resources/localstack/init/init.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-groupExists=$( (awslocal logs describe-log-groups | jq '.logGroups[] | select(.logGroupName == "audit-local")') )
+groupExists=$( (awslocal logs describe-log-groups --region eu-west-1 | jq '.logGroups[] | select(.logGroupName == "audit-local")') )
 
 #Create log group if it does not exist (stops ResourceAlreadyExists errors)
 if [ -z "$groupExists" ]
 then
-    awslocal logs create-log-group --log-group-name audit-local
+    awslocal logs create-log-group --log-group-name audit-local --region eu-west-1
 fi
 
 awslocal s3 mb s3://pa-uploads-local


### PR DESCRIPTION
During init, localstack log groups are created in the default region (us-east-1). Then when we try to write to the audit-log log group, it fails (noticed while working on DDLS-852). This doesn't appear to get picked up by any end to end tests.

This is a consequence of upgrading localstack, which seems to use a different default region from the older version. It might be that there's a way to set the default region for all of localstack which is more efficient than piecemeal changes like this one.

## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes DDLS-####

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
