### PR TITLE
DDLS-862 Move Ndr controllers to Symfony core Security

### DIFF
--- a/api/app/phpstan-baseline.neon
+++ b/api/app/phpstan-baseline.neon
@@ -271,47 +271,7 @@ parameters:
 			path: src/Controller/JWTController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AccountController\\:\\:accountDelete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AccountController.php
-
-		-
 			message: "#^Method App\\\\Controller\\\\Ndr\\\\AccountController\\:\\:accountDelete\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AccountController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AccountController\\:\\:addAccountAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AccountController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AccountController\\:\\:addAccountAction\\(\\) has parameter \\$ndrId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AccountController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AccountController\\:\\:editAccountAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AccountController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AccountController\\:\\:editAccountAction\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AccountController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AccountController\\:\\:fillAccountData\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AccountController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AccountController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AccountController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AccountController\\:\\:getOneById\\(\\) has parameter \\$id with no type specified\\.$#"
 			count: 1
 			path: src/Controller/Ndr/AccountController.php
 
@@ -331,66 +291,6 @@ parameters:
 			path: src/Controller/Ndr/AccountController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:add\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:add\\(\\) has parameter \\$ndrId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:delete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:delete\\(\\) has parameter \\$assetId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:delete\\(\\) has parameter \\$ndrId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:edit\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:edit\\(\\) has parameter \\$assetId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:edit\\(\\) has parameter \\$ndrId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:getOneById\\(\\) has parameter \\$assetId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:getOneById\\(\\) has parameter \\$ndrId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:updateEntityWithData\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/AssetController.php
-
-		-
 			message: "#^Method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:flush\\(\\) invoked with 1 parameter, 0 required\\.$#"
 			count: 1
 			path: src/Controller/Ndr/AssetController.php
@@ -404,66 +304,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$data of method App\\\\Controller\\\\Ndr\\\\AssetController\\:\\:updateEntityWithData\\(\\) expects array, array\\|null given\\.$#"
 			count: 2
 			path: src/Controller/Ndr/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\ExpenseController\\:\\:add\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\ExpenseController\\:\\:add\\(\\) has parameter \\$ndrId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\ExpenseController\\:\\:delete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\ExpenseController\\:\\:delete\\(\\) has parameter \\$expenseId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\ExpenseController\\:\\:delete\\(\\) has parameter \\$ndrId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\ExpenseController\\:\\:edit\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\ExpenseController\\:\\:edit\\(\\) has parameter \\$expenseId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\ExpenseController\\:\\:edit\\(\\) has parameter \\$ndrId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\ExpenseController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\ExpenseController\\:\\:getOneById\\(\\) has parameter \\$expenseId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\ExpenseController\\:\\:getOneById\\(\\) has parameter \\$ndrId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\ExpenseController\\:\\:updateEntityWithData\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/ExpenseController.php
 
 		-
 			message: "#^Method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:flush\\(\\) invoked with 1 parameter, 0 required\\.$#"
@@ -496,22 +336,7 @@ parameters:
 			path: src/Controller/Ndr/NdrController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\NdrController\\:\\:getById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\NdrController\\:\\:submit\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
 			message: "#^Method App\\\\Controller\\\\Ndr\\\\NdrController\\:\\:submit\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/NdrController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\NdrController\\:\\:update\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Controller/Ndr/NdrController.php
 
@@ -561,37 +386,7 @@ parameters:
 			path: src/Controller/Ndr/VisitsCareController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\VisitsCareController\\:\\:addAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/VisitsCareController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\VisitsCareController\\:\\:deleteVisitsCare\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/VisitsCareController.php
-
-		-
 			message: "#^Method App\\\\Controller\\\\Ndr\\\\VisitsCareController\\:\\:deleteVisitsCare\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/VisitsCareController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\VisitsCareController\\:\\:findByNdrIdAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/VisitsCareController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\VisitsCareController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/VisitsCareController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\VisitsCareController\\:\\:updateAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Ndr/VisitsCareController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Ndr\\\\VisitsCareController\\:\\:updateAction\\(\\) has parameter \\$id with no type specified\\.$#"
 			count: 1
 			path: src/Controller/Ndr/VisitsCareController.php
 

--- a/api/app/src/Controller/Ndr/AccountController.php
+++ b/api/app/src/Controller/Ndr/AccountController.php
@@ -6,9 +6,9 @@ use App\Controller\RestController;
 use App\Entity as EntityDir;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class AccountController extends RestController
 {
@@ -18,8 +18,8 @@ class AccountController extends RestController
     }
 
     #[Route(path: '/ndr/{ndrId}/account', methods: ['POST'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function addAccountAction(Request $request, $ndrId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function addAccount(Request $request, int $ndrId): array
     {
         $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $ndrId);
         $this->denyAccessIfNdrDoesNotBelongToUser($ndr);
@@ -39,8 +39,8 @@ class AccountController extends RestController
     }
 
     #[Route(path: '/ndr/account/{id}', methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function getOneById(Request $request, $id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getOneById(Request $request, int $id): EntityDir\Ndr\BankAccount
     {
         if ($request->query->has('groups')) {
             $this->formatter->setJmsSerialiserGroups($request->query->all('groups'));
@@ -55,10 +55,10 @@ class AccountController extends RestController
     }
 
     #[Route(path: '/ndr/account/{id}', methods: ['PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function editAccountAction(Request $request, $id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function editAccount(Request $request, int $id): int
     {
-        $account = $this->findEntityBy(EntityDir\Ndr\BankAccount::class, $id, 'Account not found'); /* @var $account EntityDir\Ndr\BankAccount */
+        $account = $this->findEntityBy(EntityDir\Ndr\BankAccount::class, $id, 'Account not found');
         $this->denyAccessIfNdrDoesNotBelongToUser($account->getNdr());
 
         $data = $this->formatter->deserializeBodyContent($request);
@@ -71,8 +71,8 @@ class AccountController extends RestController
     }
 
     #[Route(path: '/ndr/account/{id}', methods: ['DELETE'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function accountDelete($id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function accountDelete($id): array
     {
         $account = $this->findEntityBy(EntityDir\Ndr\BankAccount::class, $id, 'Account not found'); /* @var $account EntityDir\Ndr\BankAccount */
         $this->denyAccessIfNdrDoesNotBelongToUser($account->getNdr());
@@ -83,7 +83,7 @@ class AccountController extends RestController
         return [];
     }
 
-    private function fillAccountData(EntityDir\Ndr\BankAccount $account, array $data)
+    private function fillAccountData(EntityDir\Ndr\BankAccount $account, array $data): void
     {
         if (array_key_exists('account_type', $data)) {
             $account->setAccountType($data['account_type']);

--- a/api/app/src/Controller/Ndr/AssetController.php
+++ b/api/app/src/Controller/Ndr/AssetController.php
@@ -6,9 +6,9 @@ use App\Controller\RestController;
 use App\Entity as EntityDir;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class AssetController extends RestController
 {
@@ -18,8 +18,8 @@ class AssetController extends RestController
     }
 
     #[Route(path: '/ndr/{ndrId}/asset/{assetId}', requirements: ['ndrId' => '\d+', 'assetId' => '\d+'], methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function getOneById($ndrId, $assetId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getOneById(int $ndrId, int $assetId): EntityDir\Ndr\Asset
     {
         $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $ndrId);
         $this->denyAccessIfNdrDoesNotBelongToUser($ndr);
@@ -33,8 +33,8 @@ class AssetController extends RestController
     }
 
     #[Route(path: '/ndr/{ndrId}/asset', requirements: ['ndrId' => '\d+'], methods: ['POST'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function add(Request $request, $ndrId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function add(Request $request, int $ndrId): array
     {
         $data = $this->formatter->deserializeBodyContent($request);
 
@@ -56,8 +56,8 @@ class AssetController extends RestController
     }
 
     #[Route(path: '/ndr/{ndrId}/asset/{assetId}', requirements: ['ndrId' => '\d+', 'assetId' => '\d+'], methods: ['PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function edit(Request $request, $ndrId, $assetId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function edit(Request $request, int $ndrId, int $assetId): array
     {
         $data = $this->formatter->deserializeBodyContent($request);
 
@@ -75,8 +75,8 @@ class AssetController extends RestController
     }
 
     #[Route(path: '/ndr/{ndrId}/asset/{assetId}', requirements: ['ndrId' => '\d+', 'assetId' => '\d+'], methods: ['DELETE'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function delete($ndrId, $assetId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function delete(int $ndrId, int $assetId): array
     {
         $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $ndrId);
         $this->denyAccessIfNdrDoesNotBelongToUser($ndr);
@@ -90,7 +90,7 @@ class AssetController extends RestController
         return [];
     }
 
-    private function updateEntityWithData(EntityDir\Ndr\Asset $asset, array $data)
+    private function updateEntityWithData(EntityDir\Ndr\Asset $asset, array $data): void
     {
         // common props
         $this->hydrateEntityWithArrayData($asset, $data, [

--- a/api/app/src/Controller/Ndr/ExpenseController.php
+++ b/api/app/src/Controller/Ndr/ExpenseController.php
@@ -6,9 +6,9 @@ use App\Controller\RestController;
 use App\Entity as EntityDir;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class ExpenseController extends RestController
 {
@@ -18,8 +18,8 @@ class ExpenseController extends RestController
     }
 
     #[Route(path: '/ndr/{ndrId}/expense/{expenseId}', requirements: ['ndrId' => '\d+', 'expenseId' => '\d+'], methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function getOneById($ndrId, $expenseId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getOneById(int $ndrId, int $expenseId): EntityDir\Ndr\Expense
     {
         $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $ndrId);
         $this->denyAccessIfNdrDoesNotBelongToUser($ndr);
@@ -33,12 +33,12 @@ class ExpenseController extends RestController
     }
 
     #[Route(path: '/ndr/{ndrId}/expense', requirements: ['ndrId' => '\d+'], methods: ['POST'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function add(Request $request, $ndrId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function add(Request $request, int $ndrId): array
     {
         $data = $this->formatter->deserializeBodyContent($request);
 
-        $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $ndrId); /* @var $ndr EntityDir\Ndr\Ndr */
+        $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $ndrId);
         $this->denyAccessIfNdrDoesNotBelongToUser($ndr);
         $this->formatter->validateArray($data, [
             'explanation' => 'mustExist',
@@ -57,8 +57,8 @@ class ExpenseController extends RestController
     }
 
     #[Route(path: '/ndr/{ndrId}/expense/{expenseId}', requirements: ['ndrId' => '\d+', 'expenseId' => '\d+'], methods: ['PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function edit(Request $request, $ndrId, $expenseId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function edit(Request $request, int $ndrId, int $expenseId): array
     {
         $data = $this->formatter->deserializeBodyContent($request);
 
@@ -76,10 +76,10 @@ class ExpenseController extends RestController
     }
 
     #[Route(path: '/ndr/{ndrId}/expense/{expenseId}', requirements: ['ndrId' => '\d+', 'expenseId' => '\d+'], methods: ['DELETE'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function delete($ndrId, $expenseId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function delete(int $ndrId, int $expenseId): array
     {
-        $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $ndrId); /* @var $ndr EntityDir\Ndr\Ndr */
+        $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $ndrId);
         $this->denyAccessIfNdrDoesNotBelongToUser($ndr);
 
         $expense = $this->findEntityBy(EntityDir\Ndr\Expense::class, $expenseId);
@@ -91,7 +91,7 @@ class ExpenseController extends RestController
         return [];
     }
 
-    private function updateEntityWithData(EntityDir\Ndr\Expense $expense, array $data)
+    private function updateEntityWithData(EntityDir\Ndr\Expense $expense, array $data): void
     {
         // common props
         $this->hydrateEntityWithArrayData($expense, $data, [

--- a/api/app/src/Controller/Ndr/NdrController.php
+++ b/api/app/src/Controller/Ndr/NdrController.php
@@ -9,9 +9,9 @@ use App\Entity\User;
 use App\Service\Formatter\RestFormatter;
 use App\Service\ReportService;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class NdrController extends RestController
 {
@@ -20,16 +20,12 @@ class NdrController extends RestController
         parent::__construct($em);
     }
 
-    /**
-     * @param int $id
-     */
     #[Route(path: '/ndr/{id}', methods: ['GET'])]
-    public function getById(Request $request, $id)
+    public function getById(Request $request, int $id): EntityDir\Ndr\Ndr
     {
         $groups = $request->query->has('groups') ? $request->query->all('groups') : ['ndr'];
         $this->formatter->setJmsSerialiserGroups($groups);
 
-        /* @var $report EntityDir\Ndr\Ndr */
         $report = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $id);
 
         if (!$this->isGranted(User::ROLE_ADMIN)) {
@@ -41,8 +37,8 @@ class NdrController extends RestController
     }
 
     #[Route(path: '/ndr/{id}/submit', methods: ['PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function submit(Request $request, $id, ReportService $reportService)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function submit(Request $request, $id, ReportService $reportService): array
     {
         $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $id, 'Ndr not found');
         /* @var $ndr EntityDir\Ndr\Ndr */
@@ -87,7 +83,7 @@ class NdrController extends RestController
     }
 
     #[Route(path: '/ndr/{id}', methods: ['PUT'])]
-    public function update(Request $request, $id)
+    public function update(Request $request, $id): array
     {
         /* @var $ndr EntityDir\Ndr\Ndr */
         $ndr = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $id, 'Ndr not found');

--- a/api/app/src/Controller/Ndr/VisitsCareController.php
+++ b/api/app/src/Controller/Ndr/VisitsCareController.php
@@ -6,9 +6,9 @@ use App\Controller\RestController;
 use App\Entity as EntityDir;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class VisitsCareController extends RestController
 {
@@ -18,8 +18,8 @@ class VisitsCareController extends RestController
     }
 
     #[Route(path: '/ndr/visits-care', methods: ['POST'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function addAction(Request $request)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function add(Request $request): array
     {
         $visitsCare = new EntityDir\Ndr\VisitsCare();
         $data = $this->formatter->deserializeBodyContent($request);
@@ -38,8 +38,8 @@ class VisitsCareController extends RestController
     }
 
     #[Route(path: '/ndr/visits-care/{id}', methods: ['PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function updateAction(Request $request, $id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function update(Request $request, int $id): array
     {
         $visitsCare = $this->findEntityBy(EntityDir\Ndr\VisitsCare::class, $id);
         $this->denyAccessIfNdrDoesNotBelongToUser($visitsCare->getNdr());
@@ -56,8 +56,8 @@ class VisitsCareController extends RestController
      * @param int $ndrId
      */
     #[Route(path: '/ndr/{ndrId}/visits-care', methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function findByNdrIdAction($ndrId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function findByNdrId($ndrId): EntityDir\Ndr\Ndr
     {
         $report = $this->findEntityBy(EntityDir\Ndr\Ndr::class, $ndrId);
         $this->denyAccessIfNdrDoesNotBelongToUser($report);
@@ -71,8 +71,8 @@ class VisitsCareController extends RestController
      * @param int $id
      */
     #[Route(path: '/ndr/visits-care/{id}', methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function getOneById(Request $request, $id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getOneById(Request $request, $id): EntityDir\Ndr\VisitsCare
     {
         $serialiseGroups = $request->query->has('groups') ? $request->query->all('groups') : ['visits-care'];
         $this->formatter->setJmsSerialiserGroups($serialiseGroups);
@@ -84,8 +84,8 @@ class VisitsCareController extends RestController
     }
 
     #[Route(path: '/ndr/visits-care/{id}', methods: ['DELETE'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function deleteVisitsCare($id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function deleteVisitsCare($id): array
     {
         $visitsCare = $this->findEntityBy(EntityDir\Ndr\VisitsCare::class, $id, 'VisitsCare not found'); /* @var $visitsCare EntityDir\Ndr\VisitsCare */
         $this->denyAccessIfNdrDoesNotBelongToUser($visitsCare->getNdr());
@@ -96,10 +96,7 @@ class VisitsCareController extends RestController
         return [];
     }
 
-    /**
-     * @return EntityDir\Ndr\VisitsCare $report
-     */
-    private function updateEntity(array $data, EntityDir\Ndr\VisitsCare $visitsCare)
+    private function updateEntity(array $data, EntityDir\Ndr\VisitsCare $visitsCare): EntityDir\Ndr\VisitsCare
     {
         if (array_key_exists('plan_move_new_residence', $data)) {
             $visitsCare->setPlanMoveNewResidence($data['plan_move_new_residence']);


### PR DESCRIPTION
## Purpose
Move Ndr controllers to Symfony core Security as Sensio is abandoned and will receive no further updates

Contributes to DDLS-862

## Approach
Apply Rector rules to automatically update the Symfony conventions and manually review the changes

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
