### PR TITLE
DDLS-862 Move Report controllers to Symfony core Security pt 1

### DIFF
--- a/api/app/phpstan-baseline.neon
+++ b/api/app/phpstan-baseline.neon
@@ -536,61 +536,6 @@ parameters:
 			path: src/Controller/Report/AccountController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AccountController\\:\\:accountDelete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AccountController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AccountController\\:\\:accountDelete\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AccountController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AccountController\\:\\:accountDependentRecords\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AccountController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AccountController\\:\\:accountDependentRecords\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AccountController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AccountController\\:\\:addAccountAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AccountController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AccountController\\:\\:addAccountAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AccountController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AccountController\\:\\:editAccountAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AccountController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AccountController\\:\\:editAccountAction\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AccountController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AccountController\\:\\:fillAccountData\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AccountController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AccountController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AccountController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AccountController\\:\\:getOneById\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AccountController.php
-
-		-
 			message: "#^Parameter \\#1 \\$bank of method App\\\\Entity\\\\Report\\\\BankAccount\\:\\:setBank\\(\\) expects string, null given\\.$#"
 			count: 1
 			path: src/Controller/Report/AccountController.php
@@ -606,31 +551,6 @@ parameters:
 			path: src/Controller/Report/AccountController.php
 
 		-
-			message: "#^Property App\\\\Controller\\\\Report\\\\AccountController\\:\\:\\$sectionIds has no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AccountController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ActionController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ActionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ActionController\\:\\:updateAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ActionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ActionController\\:\\:updateAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ActionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ActionController\\:\\:updateEntity\\(\\) should return App\\\\Entity\\\\Report\\\\Report but returns App\\\\Entity\\\\Report\\\\Action\\.$#"
-			count: 1
-			path: src/Controller/Report/ActionController.php
-
-		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: src/Controller/Report/ActionController.php
@@ -639,66 +559,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$data of method App\\\\Controller\\\\Report\\\\ActionController\\:\\:updateEntity\\(\\) expects array, array\\|null given\\.$#"
 			count: 1
 			path: src/Controller/Report/ActionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:add\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:add\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:delete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:delete\\(\\) has parameter \\$assetId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:delete\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:edit\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:edit\\(\\) has parameter \\$assetId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:edit\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:getOneById\\(\\) has parameter \\$assetId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:getOneById\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AssetController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\AssetController\\:\\:updateEntityWithData\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/AssetController.php
 
 		-
 			message: "#^Offset 'type' does not exist on array\\|null\\.$#"
@@ -711,87 +571,17 @@ parameters:
 			path: src/Controller/Report/AssetController.php
 
 		-
-			message: "#^Call to an undefined method App\\\\Entity\\\\ClientBenefitsCheckInterface\\:\\:getReport\\(\\)\\.$#"
-			count: 2
-			path: src/Controller/Report/ClientBenefitsCheckController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ClientBenefitsCheckController\\:\\:create\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ClientBenefitsCheckController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ClientBenefitsCheckController\\:\\:getCorrectRepository\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ClientBenefitsCheckController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ClientBenefitsCheckController\\:\\:processEntity\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ClientBenefitsCheckController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ClientBenefitsCheckController\\:\\:read\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ClientBenefitsCheckController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ClientBenefitsCheckController\\:\\:setJmsGroups\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ClientBenefitsCheckController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ClientBenefitsCheckController\\:\\:update\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ClientBenefitsCheckController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ClientBenefitsCheckController\\:\\:update\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ClientBenefitsCheckController.php
-
-		-
 			message: "#^Parameter \\#1 \\$formData of method App\\\\Factory\\\\ClientBenefitsCheckFactory\\:\\:createFromFormData\\(\\) expects array, mixed given\\.$#"
 			count: 2
 			path: src/Controller/Report/ClientBenefitsCheckController.php
 
 		-
+			message: "#^Parameter \\#3 \\$existingEntity of method App\\\\Factory\\\\ClientBenefitsCheckFactory\\:\\:createFromFormData\\(\\) expects App\\\\Entity\\\\ClientBenefitsCheckInterface\\|null, object\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Report/ClientBenefitsCheckController.php
+
+		-
 			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\Report\\\\Contact\\>\\:\\:findByReport\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/ContactController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ContactController\\:\\:deleteContact\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ContactController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ContactController\\:\\:deleteContact\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ContactController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ContactController\\:\\:getContacts\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ContactController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ContactController\\:\\:getContacts\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ContactController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ContactController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ContactController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ContactController\\:\\:getOneById\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ContactController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ContactController\\:\\:upsertContact\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Controller/Report/ContactController.php
 
@@ -851,26 +641,6 @@ parameters:
 			path: src/Controller/Report/ContactController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:deleteDecision\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/DecisionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:deleteDecision\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/DecisionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/DecisionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\DecisionController\\:\\:upsertDecision\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/DecisionController.php
-
-		-
 			message: "#^Offset 'id' does not exist on array\\|null\\.$#"
 			count: 1
 			path: src/Controller/Report/DecisionController.php
@@ -884,6 +654,11 @@ parameters:
 			message: "#^Parameter \\#2 \\$data of method App\\\\Controller\\\\RestController\\:\\:hydrateEntityWithArrayData\\(\\) expects array, array\\|null given\\.$#"
 			count: 1
 			path: src/Controller/Report/DecisionController.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Entity\\\\Ndr\\\\Ndr\\|App\\\\Entity\\\\Report\\\\Report\\:\\:setWishToProvideDocumentation\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Report/DocumentController.php
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\Report\\\\Document\\>\\:\\:getQueuedDocumentsAndSetToInProgress\\(\\)\\.$#"
@@ -941,47 +716,7 @@ parameters:
 			path: src/Controller/Report/DocumentController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:add\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/DocumentController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:add\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/DocumentController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:add\\(\\) has parameter \\$reportType with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/DocumentController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/DocumentController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:getOneById\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/DocumentController.php
-
-		-
 			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:getQueuedDocuments\\(\\) should return string but returns string\\|false\\.$#"
-			count: 1
-			path: src/Controller/Report/DocumentController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:overwriteReportPdf\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/DocumentController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:overwriteReportPdf\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/DocumentController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\DocumentController\\:\\:overwriteReportPdf\\(\\) has parameter \\$reportType with no type specified\\.$#"
 			count: 1
 			path: src/Controller/Report/DocumentController.php
 
@@ -1016,11 +751,6 @@ parameters:
 			path: src/Controller/Report/DocumentController.php
 
 		-
-			message: "#^PHPDoc tag @var has invalid value \\(\\$document EntityDir\\\\Report\\\\Document\\)\\: Unexpected token \"\\$document\", expected type at offset 9$#"
-			count: 1
-			path: src/Controller/Report/DocumentController.php
-
-		-
 			message: "#^Parameter \\#1 \\$createdBy of method App\\\\Entity\\\\Report\\\\Document\\:\\:setCreatedBy\\(\\) expects App\\\\Entity\\\\User, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
 			count: 2
 			path: src/Controller/Report/DocumentController.php
@@ -1041,129 +771,9 @@ parameters:
 			path: src/Controller/Report/DocumentController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ExpenseController\\:\\:add\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ExpenseController\\:\\:add\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ExpenseController\\:\\:delete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ExpenseController\\:\\:delete\\(\\) has parameter \\$expenseId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ExpenseController\\:\\:delete\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ExpenseController\\:\\:edit\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ExpenseController\\:\\:edit\\(\\) has parameter \\$expenseId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ExpenseController\\:\\:edit\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ExpenseController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ExpenseController\\:\\:getOneById\\(\\) has parameter \\$expenseId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ExpenseController\\:\\:getOneById\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ExpenseController\\:\\:updateEntityWithData\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ExpenseController.php
-
-		-
 			message: "#^Parameter \\#3 \\$data of method App\\\\Controller\\\\Report\\\\ExpenseController\\:\\:updateEntityWithData\\(\\) expects array, array\\|null given\\.$#"
 			count: 2
 			path: src/Controller/Report/ExpenseController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:add\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/GiftController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:add\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/GiftController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:delete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/GiftController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:delete\\(\\) has parameter \\$giftId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/GiftController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:delete\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/GiftController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:edit\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/GiftController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:edit\\(\\) has parameter \\$giftId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/GiftController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:edit\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/GiftController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/GiftController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:getOneById\\(\\) has parameter \\$giftId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/GiftController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:getOneById\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/GiftController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\GiftController\\:\\:updateEntityWithData\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/GiftController.php
 
 		-
 			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\|null given\\.$#"
@@ -1182,46 +792,6 @@ parameters:
 
 		-
 			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\Report\\\\Lifestyle\\>\\:\\:findByReport\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/LifestyleController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\LifestyleController\\:\\:addAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/LifestyleController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\LifestyleController\\:\\:deleteLifestyle\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/LifestyleController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\LifestyleController\\:\\:deleteLifestyle\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/LifestyleController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\LifestyleController\\:\\:findByReportIdAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/LifestyleController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\LifestyleController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/LifestyleController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\LifestyleController\\:\\:updateAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/LifestyleController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\LifestyleController\\:\\:updateAction\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/LifestyleController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\LifestyleController\\:\\:updateInfo\\(\\) should return App\\\\Entity\\\\Report\\\\Report but returns App\\\\Entity\\\\Report\\\\Lifestyle\\.$#"
 			count: 1
 			path: src/Controller/Report/LifestyleController.php
 

--- a/api/app/src/Controller/Report/AccountController.php
+++ b/api/app/src/Controller/Report/AccountController.php
@@ -7,13 +7,13 @@ use App\Entity as EntityDir;
 use App\Entity\Report\Report;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class AccountController extends RestController
 {
-    private $sectionIds = [Report::SECTION_BANK_ACCOUNTS];
+    private array $sectionIds = [Report::SECTION_BANK_ACCOUNTS];
 
     public function __construct(private readonly EntityManagerInterface $em, private readonly RestFormatter $formatter)
     {
@@ -21,8 +21,8 @@ class AccountController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/account', methods: ['POST'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function addAccountAction(Request $request, $reportId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function addAccount(Request $request, int $reportId): array
     {
         $report = $this->findEntityBy(Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -46,8 +46,8 @@ class AccountController extends RestController
     }
 
     #[Route(path: '/report/account/{id}', methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function getOneById(Request $request, $id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getOneById(Request $request, int $id): EntityDir\Report\BankAccount
     {
         $account = $this->findEntityBy(EntityDir\Report\BankAccount::class, $id, 'Account not found');
         $this->denyAccessIfReportDoesNotBelongToUser($account->getReport());
@@ -60,8 +60,8 @@ class AccountController extends RestController
     }
 
     #[Route(path: '/account/{id}', methods: ['PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function editAccountAction(Request $request, $id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function editAccount(Request $request, int $id): EntityDir\Report\BankAccount
     {
         $account = $this->findEntityBy(EntityDir\Report\BankAccount::class, $id, 'Account not found'); /* @var $account EntityDir\Report\BankAccount */
         $report = $account->getReport();
@@ -82,8 +82,8 @@ class AccountController extends RestController
     }
 
     #[Route(path: '/account/{id}/dependent-records', methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function accountDependentRecords($id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function accountDependentRecords(int $id): array
     {
         $account = $this->findEntityBy(EntityDir\Report\BankAccount::class, $id, 'Account not found'); /* @var $account EntityDir\Report\BankAccount */
         $this->denyAccessIfReportDoesNotBelongToUser($account->getReport());
@@ -124,8 +124,8 @@ class AccountController extends RestController
     }
 
     #[Route(path: '/account/{id}', methods: ['DELETE'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function accountDelete($id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function accountDelete(int $id): array
     {
         $account = $this->findEntityBy(EntityDir\Report\BankAccount::class, $id, 'Account not found'); /* @var $account EntityDir\Report\BankAccount */
         $report = $account->getReport();
@@ -139,7 +139,7 @@ class AccountController extends RestController
         return [];
     }
 
-    private function fillAccountData(EntityDir\Report\BankAccount $account, array $data)
+    private function fillAccountData(EntityDir\Report\BankAccount $account, array $data): void
     {
         // basicdata
         if (array_key_exists('account_type', $data)) {

--- a/api/app/src/Controller/Report/ActionController.php
+++ b/api/app/src/Controller/Report/ActionController.php
@@ -6,9 +6,9 @@ use App\Controller\RestController;
 use App\Entity as EntityDir;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class ActionController extends RestController
 {
@@ -20,8 +20,8 @@ class ActionController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/action', methods: ['PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function updateAction(Request $request, $reportId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function update(Request $request, int $reportId): array
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -42,12 +42,9 @@ class ActionController extends RestController
         return ['id' => $action->getId()];
     }
 
-    /**
-     * @param int $id
-     */
     #[Route(path: '/report/{reportId}/action', methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function getOneById(Request $request, $id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getOneById(Request $request, int $id): EntityDir\Report\Action
     {
         $action = $this->findEntityBy(EntityDir\Report\Action::class, $id, 'Action with id:'.$id.' not found');
         $this->denyAccessIfReportDoesNotBelongToUser($action->getReport());
@@ -59,10 +56,7 @@ class ActionController extends RestController
         return $action;
     }
 
-    /**
-     * @return \App\Entity\Report\Report $report
-     */
-    private function updateEntity(array $data, EntityDir\Report\Action $action)
+    private function updateEntity(array $data, EntityDir\Report\Action $action): void
     {
         if (array_key_exists('do_you_expect_financial_decisions', $data)) {
             $action->setDoYouExpectFinancialDecisions($data['do_you_expect_financial_decisions']);
@@ -81,7 +75,5 @@ class ActionController extends RestController
         }
 
         $action->cleanUpUnusedData();
-
-        return $action;
     }
 }

--- a/api/app/src/Controller/Report/AssetController.php
+++ b/api/app/src/Controller/Report/AssetController.php
@@ -6,9 +6,9 @@ use App\Controller\RestController;
 use App\Entity as EntityDir;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class AssetController extends RestController
 {
@@ -20,8 +20,8 @@ class AssetController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/asset/{assetId}', requirements: ['reportId' => '\d+', 'assetId' => '\d+'], methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function getOneById(Request $request, $reportId, $assetId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getOneById(Request $request, int $reportId, int $assetId): EntityDir\Report\Asset
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -37,8 +37,8 @@ class AssetController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/asset', requirements: ['reportId' => '\d+'], methods: ['POST'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function add(Request $request, $reportId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function add(Request $request, int $reportId): array
     {
         $data = $this->formatter->deserializeBodyContent($request);
 
@@ -63,8 +63,8 @@ class AssetController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/asset/{assetId}', requirements: ['reportId' => '\d+', 'assetId' => '\d+'], methods: ['PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function edit(Request $request, $reportId, $assetId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function edit(Request $request, int $reportId, int $assetId): array
     {
         $data = $this->formatter->deserializeBodyContent($request);
 
@@ -84,8 +84,8 @@ class AssetController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/asset/{assetId}', requirements: ['reportId' => '\d+', 'assetId' => '\d+'], methods: ['DELETE'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function delete($reportId, $assetId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function delete(int $reportId, int $assetId): array
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -102,7 +102,7 @@ class AssetController extends RestController
         return [];
     }
 
-    private function updateEntityWithData(EntityDir\Report\Asset $asset, array $data)
+    private function updateEntityWithData(EntityDir\Report\Asset $asset, array $data): void
     {
         // common propertie
         $this->hydrateEntityWithArrayData($asset, $data, [

--- a/api/app/src/Controller/Report/ClientBenefitsCheckController.php
+++ b/api/app/src/Controller/Report/ClientBenefitsCheckController.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace App\Controller\Report;
 
 use App\Controller\RestController;
-use App\Entity\ClientBenefitsCheckInterface;
+use App\Entity\Report\ClientBenefitsCheck as ReportClientBenefitsCheck;
+use App\Entity\Ndr\ClientBenefitsCheck as NdrClientBenefitsCheck;
 use App\Entity\Report\Report;
 use App\Factory\ClientBenefitsCheckFactory;
 use App\Repository\ClientBenefitsCheckRepository;
 use App\Repository\NdrClientBenefitsCheckRepository;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class ClientBenefitsCheckController extends RestController
 {
@@ -28,9 +29,9 @@ class ClientBenefitsCheckController extends RestController
         parent::__construct($em);
     }
 
-    #[Route(path: '/{reportOrNdr}/client-benefits-check', requirements: ['reportOrNdr' => '(report|ndr)'], methods: ['POST'], name: 'persist')]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function create(Request $request, string $reportOrNdr)
+    #[Route(path: '/{reportOrNdr}/client-benefits-check', name: 'persist', requirements: ['reportOrNdr' => '(report|ndr)'], methods: ['POST'])]
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function create(Request $request, string $reportOrNdr): ReportClientBenefitsCheck|NdrClientBenefitsCheck
     {
         $this->setJmsGroups($request);
 
@@ -39,9 +40,9 @@ class ClientBenefitsCheckController extends RestController
         return $this->processEntity($clientBenefitsCheck, $reportOrNdr);
     }
 
-    #[Route(path: '/{reportOrNdr}/client-benefits-check/{id}', methods: ['GET'], name: 'read', requirements: ['reportOrNdr' => '(report|ndr)'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function read(Request $request, string $id, string $reportOrNdr)
+    #[Route(path: '/{reportOrNdr}/client-benefits-check/{id}', name: 'read', requirements: ['reportOrNdr' => '(report|ndr)'], methods: ['GET'])]
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function read(Request $request, string $id, string $reportOrNdr): array
     {
         $this->setJmsGroups($request);
 
@@ -49,9 +50,9 @@ class ClientBenefitsCheckController extends RestController
             $this->clientBenefitsCheckRepository->findBy(['id' => $id], ['created' => 'ASC']);
     }
 
-    #[Route(path: '/{reportOrNdr}/client-benefits-check/{id}', methods: ['PUT'], name: 'update', requirements: ['reportOrNdr' => '(report|ndr)'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function update(Request $request, $id, string $reportOrNdr)
+    #[Route(path: '/{reportOrNdr}/client-benefits-check/{id}', name: 'update', requirements: ['reportOrNdr' => '(report|ndr)'], methods: ['PUT'])]
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function update(Request $request, string $id, string $reportOrNdr): ReportClientBenefitsCheck|NdrClientBenefitsCheck
     {
         $this->setJmsGroups($request);
 
@@ -65,26 +66,26 @@ class ClientBenefitsCheckController extends RestController
         return $this->processEntity($clientBenefitsCheck, $reportOrNdr);
     }
 
-    private function processEntity(ClientBenefitsCheckInterface $clientBenefitsCheck, string $reportOrNdr)
-    {
+    private function processEntity(
+        ReportClientBenefitsCheck|NdrClientBenefitsCheck $clientBenefitsCheck,
+        string $reportOrNdr
+    ): ReportClientBenefitsCheck|NdrClientBenefitsCheck {
         $this->getCorrectRepository($reportOrNdr)->persistAndFlush($clientBenefitsCheck);
 
-        if ($clientBenefitsCheck->getReport()) {
-            $clientBenefitsCheck->getReport()->updateSectionsStatusCache([Report::SECTION_CLIENT_BENEFITS_CHECK]);
-        }
+        $clientBenefitsCheck->getReport()?->updateSectionsStatusCache([Report::SECTION_CLIENT_BENEFITS_CHECK]);
         $this->getCorrectRepository($reportOrNdr)->persistAndFlush($clientBenefitsCheck);
 
         return $clientBenefitsCheck;
     }
 
-    private function setJmsGroups(Request $request)
+    private function setJmsGroups(Request $request): void
     {
         $groups = $request->request->has('groups') ?
             $request->request->all('groups') : ['client-benefits-check', 'report', 'ndr-client', 'ndr'];
         $this->formatter->setJmsSerialiserGroups($groups);
     }
 
-    private function getCorrectRepository(string $reportOrNdr)
+    private function getCorrectRepository(string $reportOrNdr): ClientBenefitsCheckRepository|NdrClientBenefitsCheckRepository
     {
         return 'ndr' === $reportOrNdr ? $this->ndrClientBenefitsCheckRepository : $this->clientBenefitsCheckRepository;
     }

--- a/api/app/src/Controller/Report/ContactController.php
+++ b/api/app/src/Controller/Report/ContactController.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route(path: '/report')]
 class ContactController extends RestController
@@ -21,8 +22,8 @@ class ContactController extends RestController
     }
 
     #[Route(path: '/contact/{id}', methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function getOneById(Request $request, $id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getOneById(Request $request, int $id): EntityDir\Report\Contact
     {
         $serialisedGroups = $request->query->has('groups')
             ? $request->query->all('groups') : ['contact'];
@@ -35,8 +36,8 @@ class ContactController extends RestController
     }
 
     #[Route(path: '/contact/{id}', methods: ['DELETE'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function deleteContact($id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function deleteContact(int $id): array
     {
         $contact = $this->findEntityBy(EntityDir\Report\Contact::class, $id, 'Contact not found');
         $report = $contact->getReport();
@@ -52,8 +53,8 @@ class ContactController extends RestController
     }
 
     #[Route(path: '/contact', methods: ['POST', 'PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function upsertContact(Request $request)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function upsertContact(Request $request): array
     {
         $contactData = $this->formatter->deserializeBodyContent($request);
 
@@ -107,8 +108,8 @@ class ContactController extends RestController
     }
 
     #[Route(path: '/{id}/contacts', methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function getContacts($id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getContacts(int $id): array
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $id);
         $this->denyAccessIfReportDoesNotBelongToUser($report);

--- a/api/app/src/Controller/Report/DecisionController.php
+++ b/api/app/src/Controller/Report/DecisionController.php
@@ -6,9 +6,9 @@ use App\Controller\RestController;
 use App\Entity as EntityDir;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route(path: '/report')]
 class DecisionController extends RestController
@@ -23,8 +23,8 @@ class DecisionController extends RestController
     }
 
     #[Route(path: '/decision', methods: ['POST', 'PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function upsertDecision(Request $request)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function upsertDecision(Request $request): array
     {
         $data = $this->formatter->deserializeBodyContent($request);
 
@@ -69,12 +69,9 @@ class DecisionController extends RestController
         return ['id' => $decision->getId()];
     }
 
-    /**
-     * @param int $id
-     */
     #[Route(path: '/decision/{id}', methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function getOneById(Request $request, $id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getOneById(Request $request, int $id): EntityDir\Report\Decision
     {
         $serialisedGroups = $request->query->has('groups') ? $request->query->all('groups') : ['decision'];
         $this->formatter->setJmsSerialiserGroups($serialisedGroups);
@@ -86,8 +83,8 @@ class DecisionController extends RestController
     }
 
     #[Route(path: '/decision/{id}', methods: ['DELETE'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function deleteDecision($id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function deleteDecision(int $id): array
     {
         $decision = $this->findEntityBy(EntityDir\Report\Decision::class, $id, 'Decision with id:'.$id.' not found');
         $report = $decision->getReport();

--- a/api/app/src/Controller/Report/ExpenseController.php
+++ b/api/app/src/Controller/Report/ExpenseController.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class ExpenseController extends RestController
 {
@@ -20,8 +21,8 @@ class ExpenseController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/expense/{expenseId}', requirements: ['reportId' => '\d+', 'expenseId' => '\d+'], methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function getOneById(Request $request, $reportId, $expenseId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getOneById(Request $request, int $reportId, int $expenseId): EntityDir\Report\Expense
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -37,8 +38,8 @@ class ExpenseController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/expense', requirements: ['reportId' => '\d+'], methods: ['POST'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function add(Request $request, $reportId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function add(Request $request, int $reportId): array
     {
         $data = $this->formatter->deserializeBodyContent($request);
 
@@ -65,8 +66,8 @@ class ExpenseController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/expense/{expenseId}', requirements: ['reportId' => '\d+', 'expenseId' => '\d+'], methods: ['PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function edit(Request $request, $reportId, $expenseId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function edit(Request $request, int $reportId, int $expenseId): array
     {
         $data = $this->formatter->deserializeBodyContent($request);
 
@@ -86,8 +87,8 @@ class ExpenseController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/expense/{expenseId}', requirements: ['reportId' => '\d+', 'expenseId' => '\d+'], methods: ['DELETE'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function delete($reportId, $expenseId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function delete(int $reportId, int $expenseId): array
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId); /* @var $report EntityDir\Report\Report */
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -103,8 +104,10 @@ class ExpenseController extends RestController
         return [];
     }
 
-    private function updateEntityWithData(EntityDir\Report\Report $report, EntityDir\Report\Expense $expense, array $data)
-    {
+    private function updateEntityWithData(
+        EntityDir\Report\Report $report,
+        EntityDir\Report\Expense $expense, array $data
+    ): void {
         // common props
         $this->hydrateEntityWithArrayData($expense, $data, [
             'amount' => 'setAmount',

--- a/api/app/src/Controller/Report/GiftController.php
+++ b/api/app/src/Controller/Report/GiftController.php
@@ -6,9 +6,9 @@ use App\Controller\RestController;
 use App\Entity as EntityDir;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class GiftController extends RestController
 {
@@ -20,8 +20,8 @@ class GiftController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/gift/{giftId}', requirements: ['reportId' => '\d+', 'giftId' => '\d+'], methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function getOneById(Request $request, $reportId, $giftId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getOneById(Request $request, int $reportId, int $giftId): EntityDir\Report\Gift
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -37,8 +37,8 @@ class GiftController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/gift', requirements: ['reportId' => '\d+'], methods: ['POST'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function add(Request $request, $reportId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function add(Request $request, int $reportId): array
     {
         $data = $this->formatter->deserializeBodyContent($request);
 
@@ -63,8 +63,8 @@ class GiftController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/gift/{giftId}', requirements: ['reportId' => '\d+', 'giftId' => '\d+'], methods: ['PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function edit(Request $request, $reportId, $giftId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function edit(Request $request, int $reportId, int $giftId): array
     {
         $data = $this->formatter->deserializeBodyContent($request);
 
@@ -93,8 +93,8 @@ class GiftController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/gift/{giftId}', requirements: ['reportId' => '\d+', 'giftId' => '\d+'], methods: ['DELETE'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function delete($reportId, $giftId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function delete(int $reportId, int $giftId): array
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId); /* @var $report EntityDir\Report\Report */
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -110,7 +110,7 @@ class GiftController extends RestController
         return [];
     }
 
-    private function updateEntityWithData(EntityDir\Report\Report $report, EntityDir\Report\Gift $gift, array $data)
+    private function updateEntityWithData(EntityDir\Report\Report $report, EntityDir\Report\Gift $gift, array $data): void
     {
         // common props
         $this->hydrateEntityWithArrayData($gift, $data, [

--- a/api/app/src/Controller/Report/LifestyleController.php
+++ b/api/app/src/Controller/Report/LifestyleController.php
@@ -6,9 +6,9 @@ use App\Controller\RestController;
 use App\Entity as EntityDir;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route(path: '/report')]
 class LifestyleController extends RestController
@@ -21,8 +21,8 @@ class LifestyleController extends RestController
     }
 
     #[Route(path: '/lifestyle', methods: ['POST'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function addAction(Request $request)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function add(Request $request): array
     {
         $lifestyle = new EntityDir\Report\Lifestyle();
         $data = $this->formatter->deserializeBodyContent($request);
@@ -43,8 +43,8 @@ class LifestyleController extends RestController
     }
 
     #[Route(path: '/lifestyle/{id}', methods: ['PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function updateAction(Request $request, $id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function update(Request $request, int $id): array
     {
         $lifestyle = $this->findEntityBy(EntityDir\Report\Lifestyle::class, $id);
         $report = $lifestyle->getReport();
@@ -60,27 +60,19 @@ class LifestyleController extends RestController
         return ['id' => $lifestyle->getId()];
     }
 
-    /**
-     * @param int $reportId
-     */
     #[Route(path: '/{reportId}/lifestyle', methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function findByReportIdAction($reportId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function findByReportId(int $reportId): array
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
 
-        $ret = $this->em->getRepository(EntityDir\Report\Lifestyle::class)->findByReport($report);
-
-        return $ret;
+        return $this->em->getRepository(EntityDir\Report\Lifestyle::class)->findByReport($report);
     }
 
-    /**
-     * @param int $id
-     */
     #[Route(path: '/lifestyle/{id}', methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function getOneById(Request $request, $id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getOneById(Request $request, int $id): EntityDir\Report\Lifestyle
     {
         $serialiseGroups = $request->query->has('groups')
             ? $request->query->all('groups') : ['lifestyle'];
@@ -93,8 +85,8 @@ class LifestyleController extends RestController
     }
 
     #[Route(path: '/lifestyle/{id}', methods: ['DELETE'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function deleteLifestyle($id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function deleteLifestyle(int $id): array
     {
         $lifestyle = $this->findEntityBy(EntityDir\Report\Lifestyle::class, $id, 'VisitsCare not found');
         $report = $lifestyle->getReport();
@@ -110,10 +102,7 @@ class LifestyleController extends RestController
         return [];
     }
 
-    /**
-     * @return \App\Entity\Report\Report $report
-     */
-    private function updateInfo(array $data, EntityDir\Report\Lifestyle $lifestyle)
+    private function updateInfo(array $data, EntityDir\Report\Lifestyle $lifestyle): void
     {
         if (array_key_exists('care_appointments', $data)) {
             $lifestyle->setCareAppointments($data['care_appointments']);
@@ -125,7 +114,5 @@ class LifestyleController extends RestController
             $lifestyle->setActivityDetailsYes('yes' === $yesNo ? $data['activity_details_yes'] : null);
             $lifestyle->setActivityDetailsNo('no' === $yesNo ? $data['activity_details_no'] : null);
         }
-
-        return $lifestyle;
     }
 }

--- a/api/app/tests/Integration/Entity/Repository/ReportRepositoryTest.php
+++ b/api/app/tests/Integration/Entity/Repository/ReportRepositoryTest.php
@@ -19,6 +19,7 @@ class ReportRepositoryTest extends ApiBaseTestCase
     private Checklist|array $queuedChecklists = [];
     public const QUERY_LIMIT = 2;
     private ReportRepository $sut;
+    private Fixtures $fixtures;
 
     public function setUp(): void
     {


### PR DESCRIPTION
## Purpose
Move the first half of the Report controllers to Symfony core Security as Sensio is abandoned and will receive no further updates

Contributes to [DDLS-862](https://opgtransform.atlassian.net/browse/DDLS-862)

## Approach
Apply Rector rules to automatically update the Symfony conventions and manually review the changes

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values


[DDLS-862]: https://opgtransform.atlassian.net/browse/DDLS-862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ