### PR TITLE
DDLS-862 Move Report controllers to Symfony core Security pt 2

### DIFF
--- a/api/app/phpstan-baseline.neon
+++ b/api/app/phpstan-baseline.neon
@@ -806,26 +806,6 @@ parameters:
 			path: src/Controller/Report/LifestyleController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MentalCapacityController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MentalCapacityController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MentalCapacityController\\:\\:updateAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MentalCapacityController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MentalCapacityController\\:\\:updateAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MentalCapacityController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MentalCapacityController\\:\\:updateEntity\\(\\) should return App\\\\Entity\\\\Report\\\\Report but returns App\\\\Entity\\\\Report\\\\MentalCapacity\\.$#"
-			count: 1
-			path: src/Controller/Report/MentalCapacityController.php
-
-		-
 			message: "#^Negated boolean expression is always false\\.$#"
 			count: 1
 			path: src/Controller/Report/MentalCapacityController.php
@@ -836,72 +816,7 @@ parameters:
 			path: src/Controller/Report/MentalCapacityController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyReceivedOnClientsBehalfController\\:\\:delete\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyReceivedOnClientsBehalfController.php
-
-		-
 			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\Query\\\\Filter\\\\SQLFilter\\:\\:disableForEntity\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionController\\:\\:addMoneyTransactionAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionController\\:\\:addMoneyTransactionAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionController\\:\\:deleteMoneyTransactionAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionController\\:\\:deleteMoneyTransactionAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionController\\:\\:deleteMoneyTransactionAction\\(\\) has parameter \\$transactionId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionController\\:\\:getSoftDeletedMoneyTransactionItems\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionController\\:\\:getSoftDeletedMoneyTransactionItems\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionController\\:\\:softDeleteMoneyTransactionAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionController\\:\\:softDeleteMoneyTransactionAction\\(\\) has parameter \\$transactionId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionController\\:\\:updateMoneyTransactionAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionController\\:\\:updateMoneyTransactionAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionController\\:\\:updateMoneyTransactionAction\\(\\) has parameter \\$transactionId with no type specified\\.$#"
 			count: 1
 			path: src/Controller/Report/MoneyTransactionController.php
 
@@ -936,86 +851,6 @@ parameters:
 			path: src/Controller/Report/MoneyTransactionShortController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:addMoneyTransactionAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:addMoneyTransactionAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:deleteMoneyTransactionAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:deleteMoneyTransactionAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:deleteMoneyTransactionAction\\(\\) has parameter \\$transactionId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:fillData\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:getOneById\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:getOneById\\(\\) has parameter \\$transactionId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:getSoftDeletedMoneyTransactionShortItems\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:getSoftDeletedMoneyTransactionShortItems\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:softDeleteMoneyTransactionShortAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:softDeleteMoneyTransactionShortAction\\(\\) has parameter \\$transactionId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:updateMoneyTransactionAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:updateMoneyTransactionAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransactionShortController\\:\\:updateMoneyTransactionAction\\(\\) has parameter \\$transactionId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransactionShortController.php
-
-		-
 			message: "#^Method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:flush\\(\\) invoked with 1 parameter, 0 required\\.$#"
 			count: 1
 			path: src/Controller/Report/MoneyTransactionShortController.php
@@ -1041,51 +876,6 @@ parameters:
 			path: src/Controller/Report/MoneyTransactionShortController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:addMoneyTransferAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransferController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:addMoneyTransferAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransferController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:deleteMoneyTransferAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransferController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:deleteMoneyTransferAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransferController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:deleteMoneyTransferAction\\(\\) has parameter \\$transferId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransferController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:editMoneyTransferAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransferController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:editMoneyTransferAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransferController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:editMoneyTransferAction\\(\\) has parameter \\$transferId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransferController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:fillEntity\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/MoneyTransferController.php
-
-		-
 			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\|null given\\.$#"
 			count: 2
 			path: src/Controller/Report/MoneyTransferController.php
@@ -1099,46 +889,6 @@ parameters:
 			message: "#^Property App\\\\Controller\\\\Report\\\\MoneyTransferController\\:\\:\\$sectionIds has no type specified\\.$#"
 			count: 1
 			path: src/Controller/Report/MoneyTransferController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyPrevCostController\\:\\:addAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfDeputyPrevCostController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyPrevCostController\\:\\:addAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfDeputyPrevCostController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyPrevCostController\\:\\:deleteProfDeputyPreviousCost\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfDeputyPrevCostController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyPrevCostController\\:\\:deleteProfDeputyPreviousCost\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfDeputyPrevCostController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyPrevCostController\\:\\:getOneById\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfDeputyPrevCostController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyPrevCostController\\:\\:updateAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfDeputyPrevCostController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyPrevCostController\\:\\:updateAction\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfDeputyPrevCostController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ProfDeputyPrevCostController\\:\\:updateEntity\\(\\) should return App\\\\Entity\\\\Report\\\\Report but returns App\\\\Entity\\\\Report\\\\ProfDeputyPreviousCost\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfDeputyPrevCostController.php
 
 		-
 			message: "#^Parameter \\#1 \\$data of method App\\\\Controller\\\\Report\\\\ProfDeputyPrevCostController\\:\\:updateEntity\\(\\) expects array, array\\|null given\\.$#"
@@ -1159,46 +909,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$array of function array_key_exists expects array, array\\|null given\\.$#"
 			count: 1
 			path: src/Controller/Report/ProfDeputyPrevCostController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ProfServiceFeeController\\:\\:addAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfServiceFeeController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ProfServiceFeeController\\:\\:addAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfServiceFeeController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ProfServiceFeeController\\:\\:deleteProfServiceFee\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfServiceFeeController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ProfServiceFeeController\\:\\:deleteProfServiceFee\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfServiceFeeController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ProfServiceFeeController\\:\\:getOneById\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfServiceFeeController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ProfServiceFeeController\\:\\:updateAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfServiceFeeController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ProfServiceFeeController\\:\\:updateAction\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfServiceFeeController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ProfServiceFeeController\\:\\:updateEntity\\(\\) should return App\\\\Entity\\\\Report\\\\Report but returns App\\\\Entity\\\\Report\\\\ProfServiceFee\\.$#"
-			count: 1
-			path: src/Controller/Report/ProfServiceFeeController.php
 
 		-
 			message: "#^Parameter \\#1 \\$amountReceived of method App\\\\Entity\\\\Report\\\\ProfServiceFee\\:\\:setAmountReceived\\(\\) expects App\\\\Entity\\\\Report\\\\decimal, null given\\.$#"
@@ -1241,17 +951,7 @@ parameters:
 			path: src/Controller/Report/ReportController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:addAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
 			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:getChecklist\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:getChecklist\\(\\) has parameter \\$report_id with no type specified\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportController.php
 
@@ -1262,16 +962,6 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:getResponseByDeterminant\\(\\) has parameter \\$orgIdsOrUserId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:insertChecklist\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:insertChecklist\\(\\) has parameter \\$report_id with no type specified\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportController.php
 
@@ -1296,42 +986,7 @@ parameters:
 			path: src/Controller/Report/ReportController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:submit\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:submit\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
 			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:submitDocuments\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:submitDocuments\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:unsubmit\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:unsubmit\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:update\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:update\\(\\) has parameter \\$id with no type specified\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportController.php
 
@@ -1341,22 +996,7 @@ parameters:
 			path: src/Controller/Report/ReportController.php
 
 		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:updateChecklist\\(\\) has parameter \\$report_id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:updateReportStatusCache\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
 			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:upsertChecklist\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportController\\:\\:upsertChecklist\\(\\) has parameter \\$report_id with no type specified\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportController.php
 
@@ -1501,67 +1141,7 @@ parameters:
 			path: src/Controller/Report/ReportSubmissionController.php
 
 		-
-			message: "#^Instantiated class App\\\\Controller\\\\Report\\\\UnauthorisedException not found\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportSubmissionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportSubmissionController\\:\\:getAll\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportSubmissionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportSubmissionController\\:\\:getOld\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportSubmissionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportSubmissionController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportSubmissionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportSubmissionController\\:\\:getOneById\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportSubmissionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportSubmissionController\\:\\:queueDocuments\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportSubmissionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportSubmissionController\\:\\:queueDocuments\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportSubmissionController.php
-
-		-
 			message: "#^Method App\\\\Controller\\\\Report\\\\ReportSubmissionController\\:\\:setUndownloadable\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportSubmissionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportSubmissionController\\:\\:setUndownloadable\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportSubmissionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportSubmissionController\\:\\:update\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportSubmissionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportSubmissionController\\:\\:update\\(\\) has parameter \\$reportSubmissionId with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportSubmissionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportSubmissionController\\:\\:updateUuid\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportSubmissionController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\ReportSubmissionController\\:\\:updateUuid\\(\\) has parameter \\$reportSubmissionId with no type specified\\.$#"
 			count: 1
 			path: src/Controller/Report/ReportSubmissionController.php
 
@@ -1621,52 +1201,7 @@ parameters:
 			path: src/Controller/Report/ReportSubmissionController.php
 
 		-
-			message: "#^Throwing object of an unknown class App\\\\Controller\\\\Report\\\\UnauthorisedException\\.$#"
-			count: 1
-			path: src/Controller/Report/ReportSubmissionController.php
-
-		-
 			message: "#^Call to an undefined method Doctrine\\\\ORM\\\\EntityRepository\\<App\\\\Entity\\\\Report\\\\VisitsCare\\>\\:\\:findByReport\\(\\)\\.$#"
-			count: 1
-			path: src/Controller/Report/VisitsCareController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\VisitsCareController\\:\\:addAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/VisitsCareController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\VisitsCareController\\:\\:deleteVisitsCare\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/VisitsCareController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\VisitsCareController\\:\\:deleteVisitsCare\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/VisitsCareController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\VisitsCareController\\:\\:findByReportIdAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/VisitsCareController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\VisitsCareController\\:\\:getOneById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/VisitsCareController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\VisitsCareController\\:\\:updateAction\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/VisitsCareController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\VisitsCareController\\:\\:updateAction\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/Controller/Report/VisitsCareController.php
-
-		-
-			message: "#^Method App\\\\Controller\\\\Report\\\\VisitsCareController\\:\\:updateInfo\\(\\) should return App\\\\Entity\\\\Report\\\\Report but returns App\\\\Entity\\\\Report\\\\VisitsCare\\.$#"
 			count: 1
 			path: src/Controller/Report/VisitsCareController.php
 

--- a/api/app/src/Controller/Report/MentalCapacityController.php
+++ b/api/app/src/Controller/Report/MentalCapacityController.php
@@ -6,9 +6,9 @@ use App\Controller\RestController;
 use App\Entity as EntityDir;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class MentalCapacityController extends RestController
 {
@@ -20,8 +20,8 @@ class MentalCapacityController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/mental-capacity', methods: ['PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function updateAction(Request $request, $reportId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function update(Request $request, int $reportId): array
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -42,12 +42,9 @@ class MentalCapacityController extends RestController
         return ['id' => $mc->getId()];
     }
 
-    /**
-     * @param int $id
-     */
     #[Route(path: '/report/{reportId}/mental-capacity', methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function getOneById(Request $request, $id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getOneById(Request $request, int $id): EntityDir\Report\MentalCapacity
     {
         $mc = $this->findEntityBy(EntityDir\Report\MentalCapacity::class, $id, 'MentalCapacity with id:'.$id.' not found');
         $this->denyAccessIfReportDoesNotBelongToUser($mc->getReport());
@@ -59,10 +56,7 @@ class MentalCapacityController extends RestController
         return $mc;
     }
 
-    /**
-     * @return \App\Entity\Report\Report $report
-     */
-    private function updateEntity(array $data, EntityDir\Report\MentalCapacity $mc)
+    private function updateEntity(array $data, EntityDir\Report\MentalCapacity $mc): EntityDir\Report\MentalCapacity
     {
         if (array_key_exists('has_capacity_changed', $data)) {
             $mc->setHasCapacityChanged($data['has_capacity_changed']);

--- a/api/app/src/Controller/Report/MoneyReceivedOnClientsBehalfController.php
+++ b/api/app/src/Controller/Report/MoneyReceivedOnClientsBehalfController.php
@@ -9,9 +9,9 @@ use App\Repository\MoneyReceivedOnClientsBehalfRepository;
 use App\Repository\NdrMoneyReceivedOnClientsBehalfRepository;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class MoneyReceivedOnClientsBehalfController extends RestController
 {
@@ -25,8 +25,8 @@ class MoneyReceivedOnClientsBehalfController extends RestController
     }
 
     #[Route(path: '{reportOrNdr}/money-type/delete/{moneyTypeId}', methods: ['DELETE'], name: 'delete_money_type')]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function delete(Request $request, string $reportOrNdr, string $moneyTypeId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function delete(Request $request, string $reportOrNdr, string $moneyTypeId): array
     {
         $groups = $request->request->has('groups') ? $request->request->all('groups') : ['client-benefits-check', 'report', 'ndr'];
         $this->formatter->setJmsSerialiserGroups($groups);

--- a/api/app/src/Controller/Report/MoneyTransactionController.php
+++ b/api/app/src/Controller/Report/MoneyTransactionController.php
@@ -8,9 +8,9 @@ use App\Repository\MoneyTransactionRepository;
 use App\Service\Formatter\RestFormatter;
 use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class MoneyTransactionController extends RestController
 {
@@ -28,8 +28,8 @@ class MoneyTransactionController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/money-transaction', methods: ['POST'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function addMoneyTransactionAction(Request $request, $reportId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function addMoneyTransaction(Request $request, int $reportId): int
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -72,8 +72,8 @@ class MoneyTransactionController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/money-transaction/{transactionId}', methods: ['PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function updateMoneyTransactionAction(Request $request, $reportId, $transactionId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function updateMoneyTransaction(Request $request, int $reportId, int $transactionId): int
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -106,8 +106,8 @@ class MoneyTransactionController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/money-transaction/{transactionId}', methods: ['DELETE'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function deleteMoneyTransactionAction($reportId, $transactionId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function deleteMoneyTransaction(int $reportId, int $transactionId): array
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -126,8 +126,8 @@ class MoneyTransactionController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/money-transaction/soft-delete/{transactionId}', methods: ['PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function softDeleteMoneyTransactionAction($transactionId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function softDeleteMoneyTransaction(int $transactionId): array
     {
         $filter = $this->em->getFilters()->getFilter('softdeleteable');
         $filter->disableForEntity(EntityDir\Report\MoneyTransaction::class);
@@ -146,8 +146,8 @@ class MoneyTransactionController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/money-transaction/get-soft-delete', methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function getSoftDeletedMoneyTransactionItems($reportId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getSoftDeletedMoneyTransactionItems(int $reportId): array
     {
         $this->formatter->setJmsSerialiserGroups(['transaction']);
 

--- a/api/app/src/Controller/Report/MoneyTransactionShortController.php
+++ b/api/app/src/Controller/Report/MoneyTransactionShortController.php
@@ -7,9 +7,9 @@ use App\Entity as EntityDir;
 use App\Repository\MoneyTransactionShortRepository;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class MoneyTransactionShortController extends RestController
 {
@@ -27,8 +27,8 @@ class MoneyTransactionShortController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/money-transaction-short', methods: ['POST'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function addMoneyTransactionAction(Request $request, $reportId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function addMoneyTransaction(Request $request, int $reportId): int
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId); /* @var $report EntityDir\Report\Report */
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -55,8 +55,8 @@ class MoneyTransactionShortController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/money-transaction-short/{transactionId}', methods: ['PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function updateMoneyTransactionAction(Request $request, $reportId, $transactionId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function updateMoneyTransaction(Request $request, int $reportId, int $transactionId): int
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -76,8 +76,8 @@ class MoneyTransactionShortController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/money-transaction-short/{transactionId}', methods: ['DELETE'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function deleteMoneyTransactionAction(Request $request, $reportId, $transactionId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function deleteMoneyTransaction(int $reportId, int $transactionId): array
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -98,8 +98,8 @@ class MoneyTransactionShortController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/money-transaction-short/{transactionId}', requirements: ['reportId' => '\d+', 'transactionId' => '\d+'], methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function getOneById($reportId, $transactionId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getOneById(int $reportId, int $transactionId): EntityDir\Report\MoneyTransactionShort
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -112,7 +112,7 @@ class MoneyTransactionShortController extends RestController
         return $record;
     }
 
-    private function fillData(EntityDir\Report\MoneyTransactionShort $t, array $data)
+    private function fillData(EntityDir\Report\MoneyTransactionShort $t, array $data): void
     {
         $t->setDescription($data['description']);
         $t->setAmount($data['amount']);
@@ -123,8 +123,8 @@ class MoneyTransactionShortController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/money-transaction-short/soft-delete/{transactionId}', methods: ['PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function softDeleteMoneyTransactionShortAction($transactionId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function softDeleteMoneyTransactionShort(int $transactionId): array
     {
         $filter = $this->em->getFilters()->getFilter('softdeleteable');
         $filter->disableForEntity(EntityDir\Report\MoneyTransactionShort::class);
@@ -143,8 +143,8 @@ class MoneyTransactionShortController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/money-transaction-short/get-soft-delete', methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function getSoftDeletedMoneyTransactionShortItems($reportId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getSoftDeletedMoneyTransactionShortItems(int $reportId): array
     {
         return $this->moneyTransactionShortRepository->retrieveSoftDeleted($reportId);
     }

--- a/api/app/src/Controller/Report/MoneyTransferController.php
+++ b/api/app/src/Controller/Report/MoneyTransferController.php
@@ -6,9 +6,9 @@ use App\Controller\RestController;
 use App\Entity as EntityDir;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class MoneyTransferController extends RestController
 {
@@ -20,8 +20,8 @@ class MoneyTransferController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/money-transfers', methods: ['POST'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function addMoneyTransferAction(Request $request, $reportId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function addMoneyTransfer(Request $request, int $reportId): int
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -55,8 +55,8 @@ class MoneyTransferController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/money-transfers/{transferId}', methods: ['PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function editMoneyTransferAction(Request $request, $reportId, $transferId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function editMoneyTransfer(Request $request, int $reportId, int $transferId): int
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -85,8 +85,8 @@ class MoneyTransferController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/money-transfers/{transferId}', methods: ['DELETE'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function deleteMoneyTransferAction(Request $request, $reportId, $transferId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function deleteMoneyTransfer(int $reportId, int $transferId): array
     {
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
@@ -102,7 +102,7 @@ class MoneyTransferController extends RestController
         return [];
     }
 
-    private function fillEntity(EntityDir\Report\MoneyTransfer $transfer, array $data)
+    private function fillEntity(EntityDir\Report\MoneyTransfer $transfer, array $data): void
     {
         $amountCleaned = preg_replace('/[^\d\.]+/', '', $data['amount']); // 123,123.34 -> 123123.34
 

--- a/api/app/src/Controller/Report/ProfDeputyPrevCostController.php
+++ b/api/app/src/Controller/Report/ProfDeputyPrevCostController.php
@@ -6,9 +6,9 @@ use App\Controller\RestController;
 use App\Entity as EntityDir;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class ProfDeputyPrevCostController extends RestController
 {
@@ -20,12 +20,11 @@ class ProfDeputyPrevCostController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/prof-deputy-previous-cost', methods: ['POST'])]
-    #[Security("is_granted('ROLE_PROF')")]
-    public function addAction(Request $request, $reportId)
+    #[IsGranted(attribute: 'ROLE_PROF')]
+    public function add(Request $request, int $reportId): array
     {
         $data = $this->formatter->deserializeBodyContent($request);
 
-        /* @var $report EntityDir\Report\Report */
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
         if (!array_key_exists('amount', $data)) {
@@ -45,10 +44,9 @@ class ProfDeputyPrevCostController extends RestController
     }
 
     #[Route(path: '/prof-deputy-previous-cost/{id}', methods: ['PUT'])]
-    #[Security("is_granted('ROLE_PROF')")]
-    public function updateAction(Request $request, $id)
+    #[IsGranted(attribute: 'ROLE_PROF')]
+    public function update(Request $request, int $id): array
     {
-        /** @var EntityDir\Report\ProfDeputyPreviousCost $cost */
         $cost = $this->findEntityBy(EntityDir\Report\ProfDeputyPreviousCost::class, $id);
         $report = $cost->getReport();
         $this->denyAccessIfReportDoesNotBelongToUser($cost->getReport());
@@ -63,12 +61,9 @@ class ProfDeputyPrevCostController extends RestController
         return ['id' => $cost->getId()];
     }
 
-    /**
-     * @return object|null
-     */
     #[Route(path: '/prof-deputy-previous-cost/{id}', methods: ['GET'])]
-    #[Security("is_granted('ROLE_PROF')")]
-    public function getOneById(Request $request, $id)
+    #[IsGranted(attribute: 'ROLE_PROF')]
+    public function getOneById(Request $request, int $id): EntityDir\Report\ProfDeputyPreviousCost
     {
         $serialiseGroups = $request->query->has('groups')
             ? $request->query->all('groups') : ['prof-deputy-costs-prev'];
@@ -81,8 +76,8 @@ class ProfDeputyPrevCostController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/prof-deputy-previous-cost/{id}', methods: ['DELETE'])]
-    #[Security("is_granted('ROLE_PROF')")]
-    public function deleteProfDeputyPreviousCost($id)
+    #[IsGranted(attribute: 'ROLE_PROF')]
+    public function deleteProfDeputyPreviousCost(int $id): array
     {
         $cost = $this->findEntityBy(EntityDir\Report\ProfDeputyPreviousCost::class, $id, 'Prof Service fee not found');
         $report = $cost->getReport(); /* @var $report EntityDir\Report\Report */
@@ -103,10 +98,7 @@ class ProfDeputyPrevCostController extends RestController
         return [];
     }
 
-    /**
-     * @return \App\Entity\Report\Report $report
-     */
-    private function updateEntity(array $data, EntityDir\Report\ProfDeputyPreviousCost $cost)
+    private function updateEntity(array $data, EntityDir\Report\ProfDeputyPreviousCost $cost): EntityDir\Report\ProfDeputyPreviousCost
     {
         if (array_key_exists('start_date', $data)) {
             $cost->setStartDate(new \DateTime($data['start_date']));

--- a/api/app/src/Controller/Report/ProfServiceFeeController.php
+++ b/api/app/src/Controller/Report/ProfServiceFeeController.php
@@ -6,9 +6,9 @@ use App\Controller\RestController;
 use App\Entity as EntityDir;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class ProfServiceFeeController extends RestController
 {
@@ -20,12 +20,11 @@ class ProfServiceFeeController extends RestController
     }
 
     #[Route(path: '/report/{reportId}/prof-service-fee', methods: ['POST'])]
-    #[Security("is_granted('ROLE_PROF')")]
-    public function addAction(Request $request, $reportId)
+    #[IsGranted(attribute: 'ROLE_PROF')]
+    public function add(Request $request, int $reportId): array
     {
         $data = $this->formatter->deserializeBodyContent($request);
 
-        /* @var $report EntityDir\Report\Report */
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
         $profServiceFee = new EntityDir\Report\ProfServiceFeeCurrent($report);
@@ -44,10 +43,9 @@ class ProfServiceFeeController extends RestController
     }
 
     #[Route(path: '/prof-service-fee/{id}', methods: ['PUT'])]
-    #[Security("is_granted('ROLE_PROF')")]
-    public function updateAction(Request $request, $id)
+    #[IsGranted(attribute: 'ROLE_PROF')]
+    public function update(Request $request, int $id): array
     {
-        /** @var EntityDir\Report\ProfServiceFee $profServiceFee */
         $profServiceFee = $this->findEntityBy(EntityDir\Report\ProfServiceFee::class, $id);
         $report = $profServiceFee->getReport();
         $this->denyAccessIfReportDoesNotBelongToUser($profServiceFee->getReport());
@@ -62,12 +60,9 @@ class ProfServiceFeeController extends RestController
         return ['id' => $profServiceFee->getId()];
     }
 
-    /**
-     * @return object|null
-     */
     #[Route(path: '/prof-service-fee/{id}', methods: ['GET'])]
-    #[Security("is_granted('ROLE_PROF')")]
-    public function getOneById(Request $request, $id)
+    #[IsGranted(attribute: 'ROLE_PROF')]
+    public function getOneById(Request $request, int $id): EntityDir\Report\ProfServiceFee
     {
         $serialiseGroups = $request->query->has('groups')
             ? $request->query->all('groups') : ['prof_service_fee'];
@@ -80,8 +75,8 @@ class ProfServiceFeeController extends RestController
     }
 
     #[Route(path: '/prof-service-fee/{id}', methods: ['DELETE'])]
-    #[Security("is_granted('ROLE_PROF')")]
-    public function deleteProfServiceFee($id)
+    #[IsGranted(attribute: 'ROLE_PROF')]
+    public function deleteProfServiceFee(int $id): array
     {
         $profServiceFee = $this->findEntityBy(EntityDir\Report\ProfServiceFee::class, $id, 'Prof Service fee not found');
         $report = $profServiceFee->getReport();
@@ -96,10 +91,7 @@ class ProfServiceFeeController extends RestController
         return [];
     }
 
-    /**
-     * @return \App\Entity\Report\Report $report
-     */
-    private function updateEntity(array $data, EntityDir\Report\ProfServiceFee $profServiceFee)
+    private function updateEntity(array $data, EntityDir\Report\ProfServiceFee $profServiceFee): void
     {
         if (array_key_exists('assessed_or_fixed', $data)) {
             $profServiceFee->setAssessedOrFixed($data['assessed_or_fixed']);
@@ -132,7 +124,5 @@ class ProfServiceFeeController extends RestController
                 }
             }
         }
-
-        return $profServiceFee;
     }
 }

--- a/api/app/src/Controller/Report/VisitsCareController.php
+++ b/api/app/src/Controller/Report/VisitsCareController.php
@@ -6,9 +6,9 @@ use App\Controller\RestController;
 use App\Entity as EntityDir;
 use App\Service\Formatter\RestFormatter;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route(path: '/report')]
 class VisitsCareController extends RestController
@@ -21,8 +21,8 @@ class VisitsCareController extends RestController
     }
 
     #[Route(path: '/visits-care', methods: ['POST'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function addAction(Request $request)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function add(Request $request): array
     {
         $visitsCare = new EntityDir\Report\VisitsCare();
         $data = $this->formatter->deserializeBodyContent($request);
@@ -43,8 +43,8 @@ class VisitsCareController extends RestController
     }
 
     #[Route(path: '/visits-care/{id}', methods: ['PUT'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function updateAction(Request $request, $id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function update(Request $request, int $id): array
     {
         $visitsCare = $this->findEntityBy(EntityDir\Report\VisitsCare::class, $id);
         $report = $visitsCare->getReport();
@@ -60,29 +60,21 @@ class VisitsCareController extends RestController
         return ['id' => $visitsCare->getId()];
     }
 
-    /**
-     * @param int $reportId
-     */
     #[Route(path: '/{reportId}/visits-care', methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function findByReportIdAction($reportId)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function findByReportId(int $reportId): array
     {
         $this->formatter->setJmsSerialiserGroups(['visits-care']);
 
         $report = $this->findEntityBy(EntityDir\Report\Report::class, $reportId);
         $this->denyAccessIfReportDoesNotBelongToUser($report);
 
-        $ret = $this->em->getRepository(EntityDir\Report\VisitsCare::class)->findByReport($report);
-
-        return $ret;
+        return $this->em->getRepository(EntityDir\Report\VisitsCare::class)->findByReport($report);
     }
 
-    /**
-     * @param int $id
-     */
     #[Route(path: '/visits-care/{id}', methods: ['GET'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function getOneById(Request $request, $id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getOneById(Request $request, int $id): EntityDir\Report\VisitsCare
     {
         $serialiseGroups = $request->query->has('groups')
             ? $request->query->all('groups') : ['visits-care'];
@@ -95,8 +87,8 @@ class VisitsCareController extends RestController
     }
 
     #[Route(path: '/visits-care/{id}', methods: ['DELETE'])]
-    #[Security("is_granted('ROLE_DEPUTY')")]
-    public function deleteVisitsCare($id)
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function deleteVisitsCare(int $id): array
     {
         $visitsCare = $this->findEntityBy(EntityDir\Report\VisitsCare::class, $id, 'VisitsCare not found');
         $report = $visitsCare->getReport();
@@ -110,10 +102,7 @@ class VisitsCareController extends RestController
         return [];
     }
 
-    /**
-     * @return \App\Entity\Report\Report $report
-     */
-    private function updateInfo(array $data, EntityDir\Report\VisitsCare $visitsCare)
+    private function updateInfo(array $data, EntityDir\Report\VisitsCare $visitsCare): void
     {
         if (array_key_exists('do_you_live_with_client', $data)) {
             $visitsCare->setDoYouLiveWithClient($data['do_you_live_with_client']);
@@ -146,7 +135,5 @@ class VisitsCareController extends RestController
                 $visitsCare->setWhenWasCarePlanLastReviewed(null);
             }
         }
-
-        return $visitsCare;
     }
 }

--- a/api/app/tests/Integration/Controller-Ndr/AssetControllerTest.php
+++ b/api/app/tests/Integration/Controller-Ndr/AssetControllerTest.php
@@ -193,19 +193,16 @@ class AssetControllerTest extends AbstractTestController
         $this->assertEndpointNotAllowedFor('DELETE', $url3, self::$tokenDeputy);
     }
 
-    /**
-     * Run this last to avoid corrupting the data.
-     *
-     * @depends testgetAssets
-     */
     public function testDelete()
     {
-        $url = '/ndr/'.self::$ndr1->getId().'/asset/'.self::$asset1->getId();
+        $asset = self::fixtures()->createNdrAsset('other', self::$ndr1, ['setTitle' => 'asset1']);
+
+        $url = '/ndr/'.self::$ndr1->getId().'/asset/'.$asset->getId();
         $this->assertJsonRequest('DELETE', $url, [
             'mustSucceed' => true,
             'AuthToken' => self::$tokenDeputy,
         ]);
 
-        $this->assertTrue(null === self::fixtures()->getRepo('Ndr\Asset')->find(self::$asset1->getId()));
+        $this->assertTrue(null === self::fixtures()->getRepo('Ndr\Asset')->find($asset->getId()));
     }
 }

--- a/api/app/tests/Integration/ControllerReport/ReportControllerTest.php
+++ b/api/app/tests/Integration/ControllerReport/ReportControllerTest.php
@@ -209,6 +209,8 @@ class ReportControllerTest extends AbstractTestController
     {
         $url = '/report/'.self::$report1->getId();
         $this->assertEndpointNeedsAuth('GET', $url);
+        $this->assertEndpointAllowedFor('GET', $url, self::$tokenAdmin);
+        $this->assertEndpointAllowedFor('GET', $url, self::$tokenDeputy);
     }
 
     public function testGetByIdAuthPa()


### PR DESCRIPTION
## Purpose
Move the second half of the Report controllers to Symfony core Security as Sensio is abandoned and will receive no further updates

Contributes to [DDLS-862](https://opgtransform.atlassian.net/browse/DDLS-862)

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
