### PR TITLE
DDLS-862 Remove sensio/framework-extra-bundle from the API

### DIFF
--- a/api/app/composer.json
+++ b/api/app/composer.json
@@ -27,6 +27,7 @@
     "require": {
         "php": "^8.3",
         "aws/aws-sdk-php": "^3.343.18",
+        "doctrine/annotations": "^2.0",
         "doctrine/doctrine-bundle": "^2.14.0",
         "doctrine/doctrine-migrations-bundle": "^3.0",
         "doctrine/orm": "^2.20.2",
@@ -38,7 +39,6 @@
         "predis/predis": "^1.1.1",
         "ramsey/uuid": "^4.2",
         "ramsey/uuid-doctrine": "^1.6",
-        "sensio/framework-extra-bundle": "^6.2",
         "snc/redis-bundle": "^3.5.2",
         "stof/doctrine-extensions-bundle": "^1.7.1",
         "symfony/cache": "^6.4",

--- a/api/app/composer.lock
+++ b/api/app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b8eb499ee6367a39e2ee59bb0cf86cc",
+    "content-hash": "af44b371bd9e0a87c70b46b0a45a48d7",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -3590,84 +3590,6 @@
                 }
             ],
             "time": "2022-11-03T19:30:26+00:00"
-        },
-        {
-            "name": "sensio/framework-extra-bundle",
-            "version": "v6.2.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sensiolabs/SensioFrameworkExtraBundle.git",
-                "reference": "2f886f4b31f23c76496901acaedfedb6936ba61f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/2f886f4b31f23c76496901acaedfedb6936ba61f",
-                "reference": "2f886f4b31f23c76496901acaedfedb6936ba61f",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/annotations": "^1.0|^2.0",
-                "php": ">=7.2.5",
-                "symfony/config": "^4.4|^5.0|^6.0",
-                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-                "symfony/framework-bundle": "^4.4|^5.0|^6.0",
-                "symfony/http-kernel": "^4.4|^5.0|^6.0"
-            },
-            "conflict": {
-                "doctrine/doctrine-cache-bundle": "<1.3.1",
-                "doctrine/persistence": "<1.3"
-            },
-            "require-dev": {
-                "doctrine/dbal": "^2.10|^3.0",
-                "doctrine/doctrine-bundle": "^1.11|^2.0",
-                "doctrine/orm": "^2.5",
-                "symfony/browser-kit": "^4.4|^5.0|^6.0",
-                "symfony/doctrine-bridge": "^4.4|^5.0|^6.0",
-                "symfony/dom-crawler": "^4.4|^5.0|^6.0",
-                "symfony/expression-language": "^4.4|^5.0|^6.0",
-                "symfony/finder": "^4.4|^5.0|^6.0",
-                "symfony/monolog-bridge": "^4.0|^5.0|^6.0",
-                "symfony/monolog-bundle": "^3.2",
-                "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0",
-                "symfony/security-bundle": "^4.4|^5.0|^6.0",
-                "symfony/twig-bundle": "^4.4|^5.0|^6.0",
-                "symfony/yaml": "^4.4|^5.0|^6.0",
-                "twig/twig": "^1.34|^2.4|^3.0"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "6.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Sensio\\Bundle\\FrameworkExtraBundle\\": "src/"
-                },
-                "exclude-from-classmap": [
-                    "/tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                }
-            ],
-            "description": "This bundle provides a way to configure your controllers with annotations",
-            "keywords": [
-                "annotations",
-                "controllers"
-            ],
-            "support": {
-                "source": "https://github.com/sensiolabs/SensioFrameworkExtraBundle/tree/v6.2.10"
-            },
-            "abandoned": "Symfony",
-            "time": "2023-02-24T14:57:12+00:00"
         },
         {
             "name": "snc/redis-bundle",

--- a/api/app/config/bundles.php
+++ b/api/app/config/bundles.php
@@ -7,7 +7,6 @@ return [
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
     FriendsOfBehat\SymfonyExtension\Bundle\FriendsOfBehatSymfonyExtensionBundle::class => ['dev' => true, 'test' => true, 'local' => true],
     JMS\SerializerBundle\JMSSerializerBundle::class => ['all' => true],
-    Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle::class => ['all' => true],
     Snc\RedisBundle\SncRedisBundle::class => ['all' => true],
     Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle::class => ['all' => true],
     Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],

--- a/api/app/config/packages/sensio_framework_extra.yml
+++ b/api/app/config/packages/sensio_framework_extra.yml
@@ -1,3 +1,0 @@
-sensio_framework_extra:
-    router:
-        annotations: false

--- a/api/app/phpstan-baseline.neon
+++ b/api/app/phpstan-baseline.neon
@@ -341,16 +341,6 @@ parameters:
 			path: src/Controller/Ndr/VisitsCareController.php
 
 		-
-			message: "#^Parameter \\#1 \\$whenWasCarePlanLastReviewed of method App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:setWhenWasCarePlanLastReviewed\\(\\) expects App\\\\Entity\\\\Ndr\\\\date, DateTime given\\.$#"
-			count: 1
-			path: src/Controller/Ndr/VisitsCareController.php
-
-		-
-			message: "#^Parameter \\#1 \\$whenWasCarePlanLastReviewed of method App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:setWhenWasCarePlanLastReviewed\\(\\) expects App\\\\Entity\\\\Ndr\\\\date, null given\\.$#"
-			count: 1
-			path: src/Controller/Ndr/VisitsCareController.php
-
-		-
 			message: "#^Method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:flush\\(\\) invoked with 1 parameter, 0 required\\.$#"
 			count: 2
 			path: src/Controller/NoteController.php
@@ -1322,16 +1312,6 @@ parameters:
 
 		-
 			message: "#^Call to function is_null\\(\\) with App\\\\Entity\\\\User will always evaluate to false\\.$#"
-			count: 1
-			path: src/Controller/UserController.php
-
-		-
-			message: "#^Cannot call method getClients\\(\\) on object\\|null\\.$#"
-			count: 1
-			path: src/Controller/UserController.php
-
-		-
-			message: "#^Cannot call method getFirstClient\\(\\) on object\\|null\\.$#"
 			count: 1
 			path: src/Controller/UserController.php
 
@@ -2956,11 +2936,6 @@ parameters:
 			path: src/Entity/Ndr/VisitsCare.php
 
 		-
-			message: "#^Method App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:getWhenWasCarePlanLastReviewed\\(\\) has invalid return type App\\\\Entity\\\\Ndr\\\\date\\.$#"
-			count: 1
-			path: src/Entity/Ndr/VisitsCare.php
-
-		-
 			message: "#^Method App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:getWhoIsDoingTheCaring\\(\\) has invalid return type App\\\\Entity\\\\Ndr\\\\type\\.$#"
 			count: 1
 			path: src/Entity/Ndr/VisitsCare.php
@@ -2991,11 +2966,6 @@ parameters:
 			path: src/Entity/Ndr/VisitsCare.php
 
 		-
-			message: "#^Parameter \\$whenWasCarePlanLastReviewed of method App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:setWhenWasCarePlanLastReviewed\\(\\) has invalid type App\\\\Entity\\\\Ndr\\\\date\\.$#"
-			count: 1
-			path: src/Entity/Ndr/VisitsCare.php
-
-		-
 			message: "#^Property App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:\\$doesClientHaveACarePlan \\(App\\\\Entity\\\\Ndr\\\\type\\) does not accept string\\.$#"
 			count: 1
 			path: src/Entity/Ndr/VisitsCare.php
@@ -3007,11 +2977,6 @@ parameters:
 
 		-
 			message: "#^Property App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:\\$id is never written, only read\\.$#"
-			count: 1
-			path: src/Entity/Ndr/VisitsCare.php
-
-		-
-			message: "#^Property App\\\\Entity\\\\Ndr\\\\VisitsCare\\:\\:\\$whenWasCarePlanLastReviewed has unknown class App\\\\Entity\\\\Ndr\\\\date as its type\\.$#"
 			count: 1
 			path: src/Entity/Ndr/VisitsCare.php
 
@@ -8301,33 +8266,8 @@ parameters:
 			path: src/v2/Assembler/UserAssembler.php
 
 		-
-			message: "#^Method App\\\\v2\\\\Controller\\\\DeputyController\\:\\:getByIdAction\\(\\) has parameter \\$id with no type specified\\.$#"
-			count: 1
-			path: src/v2/Controller/DeputyController.php
-
-		-
 			message: "#^Cannot call method getOrganisations\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null\\.$#"
 			count: 2
-			path: src/v2/Controller/OrganisationController.php
-
-		-
-			message: "#^Method App\\\\v2\\\\Controller\\\\OrganisationController\\:\\:getClients\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/v2/Controller/OrganisationController.php
-
-		-
-			message: "#^Method App\\\\v2\\\\Controller\\\\OrganisationController\\:\\:getMemberById\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/v2/Controller/OrganisationController.php
-
-		-
-			message: "#^Method App\\\\v2\\\\Controller\\\\OrganisationController\\:\\:getMembers\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/v2/Controller/OrganisationController.php
-
-		-
-			message: "#^Method App\\\\v2\\\\Controller\\\\OrganisationController\\:\\:getUsers\\(\\) has no return type specified\\.$#"
-			count: 1
 			path: src/v2/Controller/OrganisationController.php
 
 		-
@@ -8342,11 +8282,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$string of function strtolower expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/v2/Controller/OrganisationController.php
-
-		-
-			message: "#^Property App\\\\v2\\\\Controller\\\\OrganisationController\\:\\:\\$verboseLogger is never read, only written\\.$#"
 			count: 1
 			path: src/v2/Controller/OrganisationController.php
 
@@ -8571,32 +8506,7 @@ parameters:
 			path: src/v2/Fixture/Controller/FixtureController.php
 
 		-
-			message: "#^Method App\\\\v2\\\\Fixture\\\\Controller\\\\FixtureController\\:\\:activateOrg\\(\\) should return Symfony\\\\Component\\\\HttpFoundation\\\\JsonResponse but return statement is missing\\.$#"
-			count: 1
-			path: src/v2/Fixture/Controller/FixtureController.php
-
-		-
-			message: "#^Method App\\\\v2\\\\Fixture\\\\Controller\\\\FixtureController\\:\\:completeReportSectionsAction\\(\\) has parameter \\$reportId with no type specified\\.$#"
-			count: 1
-			path: src/v2/Fixture/Controller/FixtureController.php
-
-		-
-			message: "#^Method App\\\\v2\\\\Fixture\\\\Controller\\\\FixtureController\\:\\:createAdmin\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/v2/Fixture/Controller/FixtureController.php
-
-		-
 			message: "#^Method App\\\\v2\\\\Fixture\\\\Controller\\\\FixtureController\\:\\:createClient\\(\\) has parameter \\$fromRequest with no type specified\\.$#"
-			count: 1
-			path: src/v2/Fixture/Controller/FixtureController.php
-
-		-
-			message: "#^Method App\\\\v2\\\\Fixture\\\\Controller\\\\FixtureController\\:\\:createClientAndAttachToDeputy\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/v2/Fixture/Controller/FixtureController.php
-
-		-
-			message: "#^Method App\\\\v2\\\\Fixture\\\\Controller\\\\FixtureController\\:\\:createClientAndAttachToOrgs\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/v2/Fixture/Controller/FixtureController.php
 
@@ -8621,37 +8531,12 @@ parameters:
 			path: src/v2/Fixture/Controller/FixtureController.php
 
 		-
-			message: "#^Method App\\\\v2\\\\Fixture\\\\Controller\\\\FixtureController\\:\\:createNdr\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/v2/Fixture/Controller/FixtureController.php
-
-		-
 			message: "#^Method App\\\\v2\\\\Fixture\\\\Controller\\\\FixtureController\\:\\:createOrgAndAttachParticipants\\(\\) has parameter \\$fromRequest with no type specified\\.$#"
 			count: 1
 			path: src/v2/Fixture/Controller/FixtureController.php
 
 		-
-			message: "#^Method App\\\\v2\\\\Fixture\\\\Controller\\\\FixtureController\\:\\:createPreRegistration\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/v2/Fixture/Controller/FixtureController.php
-
-		-
 			message: "#^Method App\\\\v2\\\\Fixture\\\\Controller\\\\FixtureController\\:\\:createReport\\(\\) has parameter \\$fromRequest with no type specified\\.$#"
-			count: 1
-			path: src/v2/Fixture/Controller/FixtureController.php
-
-		-
-			message: "#^Method App\\\\v2\\\\Fixture\\\\Controller\\\\FixtureController\\:\\:createUser\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/v2/Fixture/Controller/FixtureController.php
-
-		-
-			message: "#^Method App\\\\v2\\\\Fixture\\\\Controller\\\\FixtureController\\:\\:deleteUser\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/v2/Fixture/Controller/FixtureController.php
-
-		-
-			message: "#^Method App\\\\v2\\\\Fixture\\\\Controller\\\\FixtureController\\:\\:getUserIDByEmail\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/v2/Fixture/Controller/FixtureController.php
 
@@ -9036,11 +8921,6 @@ parameters:
 			path: src/v2/Registration/Controller/LayDeputyshipUploadController.php
 
 		-
-			message: "#^Method App\\\\v2\\\\Registration\\\\Controller\\\\OrgDeputyshipController\\:\\:create\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/v2/Registration/Controller/OrgDeputyshipController.php
-
-		-
 			message: "#^Parameter \\#1 \\$data of method App\\\\v2\\\\Registration\\\\DeputyshipProcessing\\\\CSVDeputyshipProcessing\\:\\:orgProcessing\\(\\) expects array, mixed given\\.$#"
 			count: 1
 			path: src/v2/Registration/Controller/OrgDeputyshipController.php
@@ -9373,26 +9253,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$value of function intval expects array\\|bool\\|float\\|int\\|resource\\|string\\|null, mixed given\\.$#"
 			count: 2
-			path: src/v2/Tools/Controller/ToolsController.php
-
-		-
-			message: "#^Property App\\\\v2\\\\Tools\\\\Controller\\\\ToolsController\\:\\:\\$reportRepository is never read, only written\\.$#"
-			count: 1
-			path: src/v2/Tools/Controller/ToolsController.php
-
-		-
-			message: "#^Property App\\\\v2\\\\Tools\\\\Controller\\\\ToolsController\\:\\:\\$userRepository is never read, only written\\.$#"
-			count: 1
-			path: src/v2/Tools/Controller/ToolsController.php
-
-		-
-			message: "#^Variable \\$firstClient in PHPDoc tag @var does not exist\\.$#"
-			count: 1
-			path: src/v2/Tools/Controller/ToolsController.php
-
-		-
-			message: "#^Variable \\$secondClient in PHPDoc tag @var does not exist\\.$#"
-			count: 1
 			path: src/v2/Tools/Controller/ToolsController.php
 
 		-

--- a/api/app/src/Entity/Ndr/VisitsCare.php
+++ b/api/app/src/Entity/Ndr/VisitsCare.php
@@ -129,7 +129,7 @@ class VisitsCare
     private $doesClientHaveACarePlan;
 
     /**
-     * @var date
+     * @var \DateTime|null
      *
      * @JMS\Type("DateTime<'Y-m-d'>")
      *
@@ -317,18 +317,12 @@ class VisitsCare
         return $this;
     }
 
-    /**
-     * @return date
-     */
-    public function getWhenWasCarePlanLastReviewed()
+    public function getWhenWasCarePlanLastReviewed(): ?\DateTime
     {
         return $this->whenWasCarePlanLastReviewed;
     }
 
-    /**
-     * @param date $whenWasCarePlanLastReviewed
-     */
-    public function setWhenWasCarePlanLastReviewed($whenWasCarePlanLastReviewed)
+    public function setWhenWasCarePlanLastReviewed(?\DateTime $whenWasCarePlanLastReviewed)
     {
         $this->whenWasCarePlanLastReviewed = $whenWasCarePlanLastReviewed;
     }

--- a/api/app/src/v2/Controller/ClientController.php
+++ b/api/app/src/v2/Controller/ClientController.php
@@ -4,19 +4,17 @@ namespace App\v2\Controller;
 
 use App\Controller\RestController;
 use App\Entity\Client;
-use App\Entity\User;
 use App\Repository\ClientRepository;
 use App\v2\Assembler\ClientAssembler;
 use App\v2\Assembler\OrganisationAssembler;
 use App\v2\Transformer\ClientTransformer;
 use App\v2\Transformer\OrganisationTransformer;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route(path: '/client')]
 class ClientController extends RestController
@@ -35,8 +33,8 @@ class ClientController extends RestController
     }
 
     #[Route(path: '/{id}', requirements: ['id' => '\d+'], methods: ['GET'])]
-    #[Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD') or is_granted('ROLE_DEPUTY')")]
-    public function getByIdAction(int $id): JsonResponse
+    #[IsGranted(attribute: new Expression("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD') or is_granted('ROLE_DEPUTY')"))]
+    public function getById(int $id): JsonResponse
     {
         if (null === ($data = $this->repository->getArrayById($id))) {
             throw new NotFoundHttpException(sprintf('Client id %s not found', $id));
@@ -44,7 +42,6 @@ class ClientController extends RestController
 
         $dto = $this->clientAssembler->assembleFromArray($data);
 
-        $orgDto = null;
         $transformedOrg = null;
 
         if (isset($data['organisation'])) {
@@ -67,7 +64,7 @@ class ClientController extends RestController
     }
 
     #[Route(path: '/case-number/{caseNumber}', methods: ['GET'])]
-    #[Security("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD') or is_granted('ROLE_DEPUTY')")]
+    #[IsGranted(attribute: new Expression("is_granted('ROLE_ADMIN') or is_granted('ROLE_AD') or is_granted('ROLE_DEPUTY')"))]
     public function getByCaseNumber(string $caseNumber): JsonResponse
     {
         if (null === ($data = $this->repository->getArrayByCaseNumber($caseNumber))) {

--- a/api/app/src/v2/Controller/CourtOrderController.php
+++ b/api/app/src/v2/Controller/CourtOrderController.php
@@ -7,10 +7,10 @@ namespace App\v2\Controller;
 use App\v2\Service\CourtOrderService;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
  * Show court order data to deputies.
@@ -35,8 +35,8 @@ class CourtOrderController extends AbstractController
      * path on API = /v2/courtorder/<UID>.
      */
     #[Route('/{uid}', requirements: ['uid' => '\w+'], methods: ['GET'])]
-    #[Security('is_granted("ROLE_DEPUTY")')]
-    public function getByUidAction(string $uid): JsonResponse
+    #[IsGranted(attribute: 'ROLE_DEPUTY')]
+    public function getByUid(string $uid): JsonResponse
     {
         $user = $this->getUser();
 

--- a/api/app/src/v2/Controller/DeputyController.php
+++ b/api/app/src/v2/Controller/DeputyController.php
@@ -28,7 +28,7 @@ class DeputyController extends AbstractController
     }
 
     #[Route(path: '/{id}', requirements:['id' => '\d+'], methods: ['GET'])]
-    public function getByIdAction($id): JsonResponse
+    public function getById(int $id): JsonResponse
     {
         if (null === ($data = $this->repository->findUserArrayById($id))) {
             $this->buildNotFoundResponse(sprintf('Deputy id %s not found', $id));

--- a/api/app/src/v2/Controller/OrganisationController.php
+++ b/api/app/src/v2/Controller/OrganisationController.php
@@ -13,14 +13,12 @@ use App\v2\Assembler\OrganisationAssembler;
 use App\v2\Transformer\OrganisationTransformer;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMException;
-use Psr\Log\LoggerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route(path: '/organisation')]
 class OrganisationController extends AbstractController
@@ -28,14 +26,13 @@ class OrganisationController extends AbstractController
     use ControllerTrait;
 
     public function __construct(
-        private OrganisationRestHandler $restHandler,
-        private OrganisationRepository $organisationRepository,
-        private UserRepository $userRepository,
-        private ClientRepository $clientRepository,
-        private OrganisationAssembler $assembler,
-        private OrganisationTransformer $transformer,
-        private RestFormatter $formatter,
-        private LoggerInterface $verboseLogger
+        private readonly OrganisationRestHandler $restHandler,
+        private readonly OrganisationRepository $organisationRepository,
+        private readonly UserRepository $userRepository,
+        private readonly ClientRepository $clientRepository,
+        private readonly OrganisationAssembler $assembler,
+        private readonly OrganisationTransformer $transformer,
+        private readonly RestFormatter $formatter
     ) {
     }
 
@@ -48,8 +45,8 @@ class OrganisationController extends AbstractController
     ];
 
     #[Route(path: '/list', methods: ['GET'])]
-    #[Security("is_granted('ROLE_ADMIN')")]
-    public function getAllAction(): JsonResponse
+    #[IsGranted(attribute: 'ROLE_ADMIN')]
+    public function getAll(): JsonResponse
     {
         // Fetch all data from db
         $data = $this->organisationRepository->getNonDeletedArray();
@@ -87,12 +84,9 @@ class OrganisationController extends AbstractController
         return $result;
     }
 
-    /**
-     * @Entity("organisation", expr="repository.find(id)")
-     */
     #[Route(path: '/{id}', requirements: ['id' => '\d+'], methods: ['GET'])]
-    #[Security("is_granted('view', organisation)")]
-    public function getByIdAction(Organisation $organisation): JsonResponse
+    #[IsGranted(attribute: 'view', subject: 'organisation')]
+    public function getById(Organisation $organisation): JsonResponse
     {
         $dto = $this->assembler->assembleFromEntity($organisation);
         $transformedDto = $this->transformer->transform($dto);
@@ -100,12 +94,9 @@ class OrganisationController extends AbstractController
         return $this->buildSuccessResponse($transformedDto);
     }
 
-    /**
-     * @Entity("organisation", expr="repository.find(id)")
-     */
     #[Route(path: '/{id}/users', requirements: ['id' => '\d+'], methods: ['GET'])]
-    #[Security("is_granted('view', organisation)")]
-    public function getUsers(Organisation $organisation, Request $request)
+    #[IsGranted(attribute: 'view', subject: 'organisation')]
+    public function getUsers(Organisation $organisation, Request $request): array
     {
         $ret = $this->userRepository->findByFiltersWithCounts(
             $request->get('q'),
@@ -119,12 +110,9 @@ class OrganisationController extends AbstractController
         return $ret;
     }
 
-    /**
-     * @Entity("organisation", expr="repository.find(id)")
-     */
     #[Route(path: '/{id}/clients', requirements: ['id' => '\d+'], methods: ['GET'])]
-    #[Security("is_granted('view', organisation)")]
-    public function getClients(Organisation $organisation, Request $request)
+    #[IsGranted(attribute: 'view', subject: 'organisation')]
+    public function getClients(Organisation $organisation, Request $request): array
     {
         $ret = $this->clientRepository->findByFiltersWithCounts(
             $request->get('q'),
@@ -143,8 +131,8 @@ class OrganisationController extends AbstractController
      * @throws OptimisticLockException
      */
     #[Route(path: '', methods: ['POST'])]
-    #[Security("is_granted('ROLE_ADMIN')")]
-    public function createAction(Request $request): JsonResponse
+    #[IsGranted(attribute: 'ROLE_ADMIN')]
+    public function create(Request $request): JsonResponse
     {
         $data = json_decode($request->getContent(), true);
         $entity = $this->restHandler->create($data);
@@ -153,8 +141,8 @@ class OrganisationController extends AbstractController
     }
 
     #[Route(path: '/{id}', requirements: ['id' => '\d+'], methods: ['PUT'])]
-    #[Security("is_granted('ROLE_ADMIN')")]
-    public function updateAction(Request $request, int $id): JsonResponse
+    #[IsGranted(attribute: 'ROLE_ADMIN')]
+    public function update(Request $request, int $id): JsonResponse
     {
         $data = json_decode($request->getContent(), true);
         $this->restHandler->update($data, $id);
@@ -167,8 +155,8 @@ class OrganisationController extends AbstractController
      * @throws OptimisticLockException
      */
     #[Route(path: '/{id}', requirements: ['id' => '\d+'], methods: ['DELETE'])]
-    #[Security("is_granted('ROLE_SUPER_ADMIN')")]
-    public function deleteAction(int $id): JsonResponse
+    #[IsGranted(attribute: 'ROLE_SUPER_ADMIN')]
+    public function delete(int $id): JsonResponse
     {
         $deleted = $this->restHandler->delete($id);
         $message = $deleted ? 'Organisation deleted' : 'Organisation not found. Nothing deleted';
@@ -177,14 +165,12 @@ class OrganisationController extends AbstractController
     }
 
     /**
-     * @Entity("organisation", expr="repository.find(orgId)")
-     *
      * @throws ORMException
      * @throws OptimisticLockException
      */
-    #[Route(path: '/{orgId}/user/{userId}', requirements: ['orgId' => '\d+', 'userId' => '\d+'], methods: ['PUT'])]
-    #[Security("is_granted('edit', organisation)")]
-    public function addUserAction(Request $request, Organisation $organisation, int $userId): JsonResponse
+    #[Route(path: '/{id}/user/{userId}', requirements: ['id' => '\d+', 'userId' => '\d+'], methods: ['PUT'])]
+    #[IsGranted(attribute: 'edit', subject: 'organisation')]
+    public function addUser(Organisation $organisation, int $userId): JsonResponse
     {
         $orgId = $organisation->getId();
         $this->restHandler->addUser($orgId, $userId);
@@ -193,14 +179,12 @@ class OrganisationController extends AbstractController
     }
 
     /**
-     * @Entity("organisation", expr="repository.find(orgId)")
-     *
      * @throws ORMException
      * @throws OptimisticLockException
      */
-    #[Route(path: '/{orgId}/user/{userId}', requirements: ['orgId' => '\d+', 'userId' => '\d+'], methods: ['DELETE'])]
-    #[Security("is_granted('edit', organisation)")]
-    public function removeUserAction(Organisation $organisation, int $userId): JsonResponse
+    #[Route(path: '/{id}/user/{userId}', requirements: ['id' => '\d+', 'userId' => '\d+'], methods: ['DELETE'])]
+    #[IsGranted(attribute: 'edit', subject: 'organisation')]
+    public function removeUser(Organisation $organisation, int $userId): JsonResponse
     {
         $orgId = $organisation->getId();
         $this->restHandler->removeUser($orgId, $userId);
@@ -209,15 +193,15 @@ class OrganisationController extends AbstractController
     }
 
     #[Route(path: '/members', methods: ['GET'])]
-    #[Security("is_granted('ROLE_ORG')")]
-    public function getMembers(Request $request)
+    #[IsGranted(attribute: 'ROLE_ORG')]
+    public function getMembers(): array
     {
         return $this->getUser()->getOrganisations()[0]->getUsers();
     }
 
     #[Route(path: '/member/{id}', requirements: ['id' => '\d+'], methods: ['GET'])]
-    #[Security("is_granted('ROLE_ORG')")]
-    public function getMemberById(string $id)
+    #[IsGranted(attribute: 'ROLE_ORG')]
+    public function getMemberById(string $id): ?User
     {
         return $this->getUser()->getOrganisations()[0]->getUsers()->get($id);
     }

--- a/api/app/src/v2/Registration/Controller/LayDeputyshipUploadController.php
+++ b/api/app/src/v2/Registration/Controller/LayDeputyshipUploadController.php
@@ -5,9 +5,9 @@ namespace App\v2\Registration\Controller;
 use App\Service\DataCompression;
 use App\v2\Registration\DeputyshipProcessing\CSVDeputyshipProcessing;
 use Psr\Log\LoggerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route(path: '/lay-deputyship')]
 class LayDeputyshipUploadController
@@ -19,17 +19,14 @@ class LayDeputyshipUploadController
     ) {
     }
 
-    /**
-     * @return array
-     */
     #[Route(path: '/upload', methods: ['POST'])]
-    #[Security("is_granted('ROLE_ADMIN')")]
-    public function upload(Request $request)
+    #[IsGranted(attribute: 'ROLE_ADMIN')]
+    public function upload(Request $request): array
     {
         ini_set('memory_limit', '1024M');
 
         $this->logger->notice(
-            sprintf('Uploading chunk with Id: %s', 
+            sprintf('Uploading chunk with Id: %s',
             $request->headers->get('chunkId')
             )
         );

--- a/api/app/src/v2/Registration/Controller/OrgDeputyshipController.php
+++ b/api/app/src/v2/Registration/Controller/OrgDeputyshipController.php
@@ -9,24 +9,24 @@ use App\Service\Formatter\RestFormatter;
 use App\v2\Controller\ControllerTrait;
 use App\v2\Registration\DeputyshipProcessing\CSVDeputyshipProcessing;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 class OrgDeputyshipController extends AbstractController
 {
     use ControllerTrait;
 
     public function __construct(
-        private DataCompression $dataCompression,
-        private CSVDeputyshipProcessing $csvProcessing,
-        private RestFormatter $restFormatter
+        private readonly DataCompression $dataCompression,
+        private readonly CSVDeputyshipProcessing $csvProcessing,
+        private readonly RestFormatter $restFormatter
     ) {
     }
 
     #[Route(path: '/org-deputyships', methods: ['POST'])]
-    #[Security("is_granted('ROLE_ADMIN')")]
-    public function create(Request $request)
+    #[IsGranted(attribute: 'ROLE_ADMIN')]
+    public function create(Request $request): array
     {
         $decompressedData = $this->dataCompression->decompress($request->getContent());
 

--- a/api/app/src/v2/Tools/Controller/ToolsController.php
+++ b/api/app/src/v2/Tools/Controller/ToolsController.php
@@ -4,17 +4,14 @@ declare(strict_types=1);
 
 namespace App\v2\Tools\Controller;
 
-use App\Entity\Client;
 use App\Repository\ClientRepository;
-use App\Repository\ReportRepository;
-use App\Repository\UserRepository;
 use App\v2\Controller\ControllerTrait;
 use Doctrine\ORM\EntityManagerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[Route(path: '/tools')]
 class ToolsController extends AbstractController
@@ -22,21 +19,17 @@ class ToolsController extends AbstractController
     use ControllerTrait;
 
     public function __construct(
-        private EntityManagerInterface $em,
-        private ReportRepository $reportRepository,
-        private UserRepository $userRepository,
-        private ClientRepository $clientRepository,
+        private readonly EntityManagerInterface $em,
+        private readonly ClientRepository $clientRepository,
     ) {
     }
 
     /**
-     * @return JsonResponse
-     *
      * @throws \Exception
      */
     #[Route(path: '/reassign-reports', methods: ['POST'])]
-    #[Security("is_granted('ROLE_SUPER_ADMIN')")]
-    public function reassignReports(Request $request)
+    #[IsGranted(attribute: 'ROLE_SUPER_ADMIN')]
+    public function reassignReports(Request $request): JsonResponse
     {
         $fromRequest = json_decode($request->getContent(), true);
 
@@ -51,12 +44,10 @@ class ToolsController extends AbstractController
             return $this->buildErrorResponse('The client ids provided are the same!');
         }
 
-        /** @var Client $firstClient */
         if (null === $firstClient = $this->clientRepository->findByIdIncludingDischarged($firstClientId)) {
             return $this->buildErrorResponse(sprintf('First Client with id %s not found', $firstClientId));
         }
 
-        /** @var Client $secondClient */
         if (null === $secondClient = $this->clientRepository->findByIdIncludingDischarged($secondClientId)) {
             return $this->buildErrorResponse(sprintf('Second Client with id %s not found', $secondClientId));
         }

--- a/api/app/tests/Integration/v2/Controller/OrganisationControllerTest.php
+++ b/api/app/tests/Integration/v2/Controller/OrganisationControllerTest.php
@@ -384,7 +384,7 @@ class OrganisationControllerTest extends AbstractTestController
 
         $response = self::$frameworkBundleClient->getResponse();
 
-        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode(), $response->getContent());
 
         $organisation = self::$em
             ->getRepository(Organisation::class)


### PR DESCRIPTION
## Purpose
Remove sensio/framework-extra-bundle from the API as it is no longer supported and features were moved to core symfony

Fixes DDLS-862

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
