### PR TITLE
DDLS-905 Set the reporting year to the current year and ensure the dates are within the reporting year

### DIFF
--- a/api/app/src/Controller/Report/ReportController.php
+++ b/api/app/src/Controller/Report/ReportController.php
@@ -84,6 +84,7 @@ class ReportController extends RestController
         }
 
         $today = new \DateTime();
+        // Day and month from order made date combined with current year
         $amendedOrderStartDate = new \DateTime(date('d M ', $orderStartDate->getTimestamp()).date('Y'));
         if ($today < $amendedOrderStartDate) {
             $amendedOrderStartDate->modify('-1 year');


### PR DESCRIPTION
## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes DDLS-905

## Approach
1. Create new variable where I amended the order made date to current year
2. Compare the amended order date to today
3. If today is before amended order date , subtract 1 year from amended order date (i.e report will be for previous reporting year)
4. End date to be + 12 months minus 1 day from amended order date
5. Automatically set start and end date depending on current year for test but not sure if should have used Carbon or Greg suggested Clock.

## Learning
Should i use Carbon or Clock for consistent test results?

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [X] I have added tests to prove my work
- [X] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
