### PR TITLE
Move integration test fixture setup to setUpBeforeClass

### DIFF
--- a/api/app/tests/Integration/Controller-Ndr/AssetControllerTest.php
+++ b/api/app/tests/Integration/Controller-Ndr/AssetControllerTest.php
@@ -20,9 +20,11 @@ class AssetControllerTest extends AbstractTestController
     private static $tokenAdmin;
     private static $tokenDeputy;
 
-    /**
-     * clear fixtures.
-     */
+    public static function setUpBeforeClass(): void
+    {
+        // This is here to prevent the default setup until tests that fail with it are altered
+    }
+
     public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();
@@ -33,6 +35,8 @@ class AssetControllerTest extends AbstractTestController
     public function setUp(): void
     {
         parent::setUp();
+
+        self::setupFixtures();
 
         if (null === self::$tokenAdmin) {
             self::$tokenAdmin = $this->loginAsAdmin();

--- a/api/app/tests/Integration/Controller-Ndr/ExpenseControllerTest.php
+++ b/api/app/tests/Integration/Controller-Ndr/ExpenseControllerTest.php
@@ -25,9 +25,16 @@ class ExpenseControllerTest extends AbstractTestController
     private static $tokenAdmin;
     private static $tokenDeputy;
 
+    public static function setUpBeforeClass(): void
+    {
+        // This is here to prevent the default setup until tests that fail with it are altered
+    }
+
     public function setUp(): void
     {
         parent::setUp();
+
+        self::setupFixtures();
 
         if (null === self::$tokenAdmin) {
             self::$tokenAdmin = $this->loginAsAdmin();

--- a/api/app/tests/Integration/Controller/AbstractTestController.php
+++ b/api/app/tests/Integration/Controller/AbstractTestController.php
@@ -20,37 +20,32 @@ abstract class AbstractTestController extends WebTestCase
     protected static KernelBrowser $frameworkBundleClient;
     protected static string|false $deputySecret;
     protected static string|false $adminSecret;
-    protected ?JWTService $jwtService;
+    protected static ?JWTService $jwtService;
     protected ?int $loggedInUserId = null;
     private ?ValidatorInterface $openapiValidator = null;
 
-    /**
-     * Create static client and fixtures.
-     */
-    public function setUp(): void
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        self::setupFixtures();
+    }
+
+    public static function setupFixtures(): void
     {
         // each test restores the db before launching the entire suite,
         // help to cleanup records created from previously-executed tests
-        // TODO consider moving into setUpBeforeClass of each method. might not be needed for some tests
         Fixtures::deleteReportsData();
 
         self::$frameworkBundleClient = static::createClient(['environment' => 'test', 'debug' => false]);
 
-        /** @var EntityManager $em */
-        $em = static::getContainer()->get('em');
-        self::$em = $em;
-        self::$fixtures = new Fixtures($em);
+        self::$em = static::getContainer()->get('em');
+        self::$fixtures = new Fixtures(self::$em);
+        self::$em->clear();
 
-        /** @var JWTService $jwtService */
-        $jwtService = static::getContainer()->get('App\Service\JWT\JWTService');
-        $this->jwtService = $jwtService;
-
-        $em->clear();
-
+        self::$jwtService = static::getContainer()->get(JWTService::class);
         self::$deputySecret = getenv('SECRETS_FRONT_KEY');
         self::$adminSecret = getenv('SECRETS_ADMIN_KEY');
-
-        unset($em);
     }
 
     public static function fixtures(): Fixtures
@@ -72,7 +67,7 @@ abstract class AbstractTestController extends WebTestCase
         }
 
         if ($withValidJwt) {
-            $headers['HTTP_JWT'] = $this->jwtService->createNewJWT();
+            $headers['HTTP_JWT'] = self::$jwtService->createNewJWT();
         }
 
         $rawData = null;

--- a/api/app/tests/Integration/Controller/ChecklistControllerTest.php
+++ b/api/app/tests/Integration/Controller/ChecklistControllerTest.php
@@ -13,15 +13,22 @@ class ChecklistControllerTest extends AbstractTestController
     private static $report;
     private static $checklist;
 
-    public function setUp(): void
+    public static function setUpBeforeClass(): void
     {
-        parent::setUp();
+        parent::setUpBeforeClass();
 
         self::$deputy = self::fixtures()->getRepo('User')->findOneByEmail('deputy@example.org');
         self::$client = self::fixtures()->createClient(self::$deputy, ['setFirstname' => 'CL']);
         self::$report = self::fixtures()->createReport(self::$client);
         self::$checklist = self::fixtures()->createChecklist(self::$report);
         self::fixtures()->flush();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+
+        self::fixtures()->clear();
     }
 
     /**
@@ -88,12 +95,5 @@ class ChecklistControllerTest extends AbstractTestController
 
         self::assertEquals(self::$checklist->getId(), $response['data']['id']);
         self::assertEquals('1234-456789-0123', $response['data']['uuid']);
-    }
-
-    public static function tearDownAfterClass(): void
-    {
-        parent::tearDownAfterClass();
-
-        self::fixtures()->clear();
     }
 }

--- a/api/app/tests/Integration/Controller/ClientControllerTest.php
+++ b/api/app/tests/Integration/Controller/ClientControllerTest.php
@@ -10,14 +10,11 @@ class ClientControllerTest extends AbstractTestController
 {
     private static $deputy1;
     private static $client1;
-    private static $report1;
     private static $deputy2;
     private static $client2;
-    private static $report2;
     private static $deputy3;
     private static $deputy4;
     private static $coDeputy;
-    private static $coDeputyClient;
     private static $primaryUserAccount;
     private static $nonPrimaryUserAccount;
     private static $primaryAccountClient;
@@ -25,7 +22,6 @@ class ClientControllerTest extends AbstractTestController
     private static $primaryAccountDischargedClient;
     private static $tokenAdmin;
     private static $tokenDeputy;
-    private static $tokenMainDeputy;
     private static $tokenCoDeputy;
     private static $tokenMultiClientPrimaryDeputy;
     private static $tokenMultiClientNonPrimaryDeputy;
@@ -34,7 +30,6 @@ class ClientControllerTest extends AbstractTestController
 
     // pa
     private static $pa1;
-    private static $prof1;
     private static $pa1Client1;
     private static $pa1Client1Report1;
 
@@ -68,9 +63,16 @@ class ClientControllerTest extends AbstractTestController
         'date_of_birth' => '1947-1-31',
     ];
 
+    public static function setUpBeforeClass(): void
+    {
+        // This is here to prevent the default setup until tests that fail with it are altered
+    }
+
     public function setUp(): void
     {
         parent::setUp();
+
+        self::setupFixtures();
 
         self::$fixtures::deleteReportsData(['client']);
 
@@ -79,7 +81,6 @@ class ClientControllerTest extends AbstractTestController
             self::$tokenDeputy = $this->loginAsDeputy();
             self::$tokenMultiClientPrimaryDeputy = $this->loginAsMultiClientPrimaryDeputy();
             self::$tokenMultiClientNonPrimaryDeputy = $this->loginAsMultiClientNonPrimaryDeputy();
-            self::$tokenMainDeputy = $this->loginAsMainDeputy();
             self::$tokenCoDeputy = $this->loginAsCoDeputy();
             self::$tokenPa = $this->loginAsPa();
             self::$tokenProf = $this->loginAsProf();
@@ -88,12 +89,11 @@ class ClientControllerTest extends AbstractTestController
         // deputy 1
         self::$deputy1 = self::fixtures()->getRepo('User')->findOneByEmail('deputy@example.org');
         self::$client1 = self::fixtures()->createClient(self::$deputy1, ['setFirstname' => 'deputy1Client1']);
-        self::$report1 = self::fixtures()->createReport(self::$client1);
+        self::fixtures()->createReport(self::$client1);
 
         // deputy 2
         self::$deputy2 = self::fixtures()->createUser();
         self::$client2 = self::fixtures()->createClient(self::$deputy2, ['setFirstname' => 'deputy2Client1']);
-        self::$report2 = self::fixtures()->createReport(self::$client2);
 
         // deputy 3
         self::$deputy3 = self::fixtures()->createDeputy();
@@ -101,7 +101,7 @@ class ClientControllerTest extends AbstractTestController
         // deputy 4 w/ Co-deputy (Deputy 5)
         self::$deputy4 = self::fixtures()->getRepo('User')->findOneByEmail('main-deputy@example.org');
         self::$coDeputy = self::fixtures()->getRepo('User')->findOneByEmail('co-deputy@example.org');
-        self::$coDeputyClient = self::fixtures()->createCoDeputyClient([self::$deputy4, self::$coDeputy], ['setFirstname' => 'coDeputyClient1']);
+        self::fixtures()->createCoDeputyClient([self::$deputy4, self::$coDeputy], ['setFirstname' => 'coDeputyClient1']);
 
         // multi-client deputy
         self::$primaryUserAccount = self::fixtures()->getRepo('User')->findOneByEmail('multi-client-primary-deputy@example.org');
@@ -115,9 +115,6 @@ class ClientControllerTest extends AbstractTestController
         self::$pa1 = self::fixtures()->getRepo('User')->findOneByEmail('pa@example.org');
         self::$pa1Client1 = self::fixtures()->createClient(self::$pa1, ['setFirstname' => 'pa1Client1', 'setCaseNumber' => 'pa000001']);
         self::$pa1Client1Report1 = self::fixtures()->createReport(self::$pa1Client1);
-
-        // prof
-        self::$prof1 = self::fixtures()->getRepo('User')->findOneByEmail('prof@example.org');
 
         $org = self::fixtures()->createOrganisation('Example', ''.Uuid::uuid4().'example.org', true);
         self::fixtures()->flush();

--- a/api/app/tests/Integration/Controller/CoDeputyControllerTest.php
+++ b/api/app/tests/Integration/Controller/CoDeputyControllerTest.php
@@ -11,6 +11,16 @@ class CoDeputyControllerTest extends AbstractTestController
     private static $coDeputy;
     private static $coDeputyClient;
 
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        self::$coDeputy = self::fixtures()->getRepo('User')->findOneByEmail('deputy@example.org');
+        self::$coDeputyClient = self::fixtures()->createCoDeputyClient([self::$coDeputy], ['setFirstname' => 'coDeputyClient']);
+
+        self::fixtures()->flush()->clear();
+    }
+
     public function setUp(): void
     {
         parent::setUp();
@@ -19,11 +29,6 @@ class CoDeputyControllerTest extends AbstractTestController
             self::$tokenAdmin = $this->loginAsAdmin();
             self::$tokenCoDeputy = $this->loginAsCoDeputy();
         }
-
-        self::$coDeputy = self::fixtures()->getRepo('User')->findOneByEmail('deputy@example.org');
-        self::$coDeputyClient = self::fixtures()->createCoDeputyClient([self::$coDeputy], ['setFirstname' => 'coDeputyClient']);
-
-        self::fixtures()->flush()->clear();
     }
 
     /**

--- a/api/app/tests/Integration/Controller/DeputyControllerTest.php
+++ b/api/app/tests/Integration/Controller/DeputyControllerTest.php
@@ -7,29 +7,25 @@ use App\TestHelpers\CourtOrderTestHelper;
 use App\TestHelpers\DeputyTestHelper;
 use App\TestHelpers\ReportTestHelper;
 use App\Tests\Behat\v2\Helpers\FixtureHelper;
-use App\Tests\Integration\Fixtures;
 
 class DeputyControllerTest extends AbstractTestController
 {
     private static JsonHttpTestClient $client;
     private static FixtureHelper $fixtureHelper;
 
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        self::$client = new JsonHttpTestClient(self::$frameworkBundleClient, self::$jwtService);
+        self::$fixtureHelper = static::getContainer()->get(FixtureHelper::class);;
+    }
+
     public function setUp(): void
     {
         parent::setup();
-
-        $container = static::getContainer();
-
-        self::$client = new JsonHttpTestClient(self::$frameworkBundleClient, $this->jwtService);
-
-        /** @var FixtureHelper $fixtureHelper */
-        $fixtureHelper = $container->get(FixtureHelper::class);
-        self::$fixtureHelper = $fixtureHelper;
     }
 
-    /**
-     * clear fixtures.
-     */
     public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();

--- a/api/app/tests/Integration/Controller/DocumentControllerTest.php
+++ b/api/app/tests/Integration/Controller/DocumentControllerTest.php
@@ -38,24 +38,17 @@ class DocumentControllerTest extends AbstractTestController
     private static $reportSubmission1;
     private static $reportSubmission2;
 
+
     public static function setUpBeforeClass(): void
     {
-        parent::setUpBeforeClass();
-    }
-
-    /**
-     * clear fixtures.
-     */
-    public static function tearDownAfterClass(): void
-    {
-        parent::tearDownAfterClass();
-
-        self::fixtures()->clear();
+        // This is here to prevent the default setup until tests that fail with it are altered
     }
 
     public function setUp(): void
     {
         parent::setUp();
+
+        self::setupFixtures();
 
         self::$deputy1 = self::fixtures()->getRepo('User')->findOneByEmail('deputy@example.org');
         self::$client1 = self::fixtures()->createClient(self::$deputy1, ['setFirstname' => 'c1']);
@@ -80,6 +73,13 @@ class DocumentControllerTest extends AbstractTestController
 
         $this->repo = self::fixtures()->getRepo('Report\Document');
         self::$tokenDeputy = $this->loginAsDeputy();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+
+        self::fixtures()->clear();
     }
 
     /** @test */

--- a/api/app/tests/Integration/Controller/HealthControllerTest.php
+++ b/api/app/tests/Integration/Controller/HealthControllerTest.php
@@ -9,6 +9,18 @@ use ReflectionObject;
 
 class HealthControllerTest extends AbstractTestController
 {
+    public static function setUpBeforeClass(): void
+    {
+        // This is here to override to prevent the default setup until tests that fail with it are altered
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        self::setupFixtures();
+    }
+
     public function testContainerHealthOk()
     {
         $ret = $this->assertJsonRequest('GET', '/health-check', [

--- a/api/app/tests/Integration/Controller/NoteControllerTest.php
+++ b/api/app/tests/Integration/Controller/NoteControllerTest.php
@@ -28,17 +28,9 @@ class NoteControllerTest extends AbstractTestController
     private static $pa3;
     private static $pa3Client1;
 
-    public function setUp(): void
+    public static function setUpBeforeClass(): void
     {
-        parent::setUp();
-
-        if (null === self::$tokenAdmin) {
-            self::$tokenDeputy = $this->loginAsDeputy();
-            self::$tokenAdmin = $this->loginAsAdmin();
-            self::$tokenPa = $this->loginAsPa();
-            self::$tokenPa2 = $this->loginAsPaAdmin();
-            self::$tokenPa3 = $this->loginAsPaTeamMember();
-        }
+        parent::setUpBeforeClass();
 
         // deputy1
         self::$deputy1 = self::fixtures()->getRepo('User')->findOneByEmail('deputy@example.org');
@@ -63,6 +55,19 @@ class NoteControllerTest extends AbstractTestController
         self::fixtures()->addUserToOrganisation(self::$pa2->getId(), $org->getId());
 
         self::fixtures()->flush()->clear();
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if (null === self::$tokenAdmin) {
+            self::$tokenDeputy = $this->loginAsDeputy();
+            self::$tokenAdmin = $this->loginAsAdmin();
+            self::$tokenPa = $this->loginAsPa();
+            self::$tokenPa2 = $this->loginAsPaAdmin();
+            self::$tokenPa3 = $this->loginAsPaTeamMember();
+        }
     }
 
     /**

--- a/api/app/tests/Integration/Controller/PreRegistrationControllerTest.php
+++ b/api/app/tests/Integration/Controller/PreRegistrationControllerTest.php
@@ -14,19 +14,16 @@ class PreRegistrationControllerTest extends AbstractTestController
     private static string $tokenPa;
     private ?PreRegistration $c1;
 
-    /**
-     * clear fixtures.
-     */
-    public static function tearDownAfterClass(): void
+    public static function setUpBeforeClass(): void
     {
-        parent::tearDownAfterClass();
-
-        self::fixtures()->clear();
+        // This is here to override to prevent the default setup until tests that fail with it are altered
     }
 
     public function setUp(): void
     {
         parent::setUp();
+
+        self::setupFixtures();
 
         if (null === self::$tokenAdmin) {
             self::$tokenAdmin = $this->loginAsAdmin();
@@ -49,6 +46,13 @@ class PreRegistrationControllerTest extends AbstractTestController
         ];
 
         $this->c1 = new PreRegistration($data);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+
+        self::fixtures()->clear();
     }
 
     public function testDeleteHasRoleProtections()

--- a/api/app/tests/Integration/Controller/SelfRegisterControllerTest.php
+++ b/api/app/tests/Integration/Controller/SelfRegisterControllerTest.php
@@ -8,6 +8,16 @@ use App\Entity\User;
 
 class SelfRegisterControllerTest extends AbstractTestController
 {
+    public static function setUpBeforeClass(): void
+    {
+        // This is here to override to prevent the default setup until tests that fail with it are altered
+    }
+
+    public function setUp(): void
+    {
+        self::setupFixtures();
+    }
+
     public static function tearDownAfterClass(): void
     {
         parent::tearDownAfterClass();

--- a/api/app/tests/Integration/Controller/ToolsControllerTest.php
+++ b/api/app/tests/Integration/Controller/ToolsControllerTest.php
@@ -28,9 +28,16 @@ class ToolsControllerTest extends AbstractTestController
     private ?array $headersSuperAdmin = [];
     private ?array $headersDeputy = [];
 
+    public static function setUpBeforeClass(): void
+    {
+        // This is here to prevent the default setup until tests that fail with it are altered
+    }
+
     public function setUp(): void
     {
         parent::setUp();
+
+        self::setupFixtures();
 
         if (null === self::$tokenAdmin) {
             self::$tokenAdmin = $this->loginAsAdmin();

--- a/api/app/tests/Integration/phpunit.xml
+++ b/api/app/tests/Integration/phpunit.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" convertErrorsToExceptions="false" convertNoticesToExceptions="false" convertWarningsToExceptions="false" stopOnError="true" stopOnFailure="true" stopOnRisky="false" stopOnWarning="false" backupGlobals="false" colors="true" bootstrap="./bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         convertErrorsToExceptions="false"
+         convertNoticesToExceptions="false"
+         convertWarningsToExceptions="false"
+         stopOnError="true"
+         stopOnFailure="false"
+         stopOnRisky="false"
+         stopOnWarning="false"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="./bootstrap.php"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage processUncoveredFiles="true">
     <include>
       <directory suffix=".php">../../src</directory>

--- a/api/app/tests/Integration/v2/Controller/CourtOrderControllerTest.php
+++ b/api/app/tests/Integration/v2/Controller/CourtOrderControllerTest.php
@@ -18,19 +18,15 @@ class CourtOrderControllerTest extends AbstractTestController
     private static FixtureHelper $fixtureHelper;
     private static ReportTestHelper $reportTestHelper;
 
-    public function setUp(): void
+    public static function setUpBeforeClass(): void
     {
-        parent::setUp();
+        parent::setUpBeforeClass();
 
         $container = static::getContainer();
 
-        /** @var FixtureHelper $fixtureHelper */
-        $fixtureHelper = $container->get(FixtureHelper::class);
-        self::$fixtureHelper = $fixtureHelper;
-
+        self::$fixtureHelper = $container->get(FixtureHelper::class);
         self::$reportTestHelper = new ReportTestHelper();
-
-        self::$client = new JsonHttpTestClient(self::$frameworkBundleClient, $this->jwtService);
+        self::$client = new JsonHttpTestClient(self::$frameworkBundleClient, self::$jwtService);
     }
 
     private function createDeputyForUser(User $user): Deputy

--- a/api/app/tests/Integration/v2/Controller/OrganisationControllerTest.php
+++ b/api/app/tests/Integration/v2/Controller/OrganisationControllerTest.php
@@ -34,9 +34,17 @@ class OrganisationControllerTest extends AbstractTestController
     /** @var string|null */
     private static $tokenDeputyInOrg;
 
+    public static function setUpBeforeClass(): void
+    {
+        // This is here to prevent the default setup until tests that fail with it are altered
+    }
+
     public function setUp(): void
     {
         parent::setUp();
+
+        self::setupFixtures();
+
         self::$fixtures::deleteReportsData(['organisation']);
 
         self::$orgs = self::fixtures()->createOrganisations(4);


### PR DESCRIPTION
## Purpose
Reduces the repeated calls to setup code in the controller integration tests by moving the setup code in AbstractControllerTest from `setUp` to `setUpBeforeClass` in the majority of cases

Fixes DDLS-921

## Approach
Make the default to run the common setup in setUpBeforeClass.
Where this causes failures in a test class, prevent this running by overriding `setUpBeforeClass`, and call it explicitly in the `setUp` method.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
