### PR TITLE
Added new Application User Secret

### DIFF
--- a/local-resources/localstack/init/init.sh
+++ b/local-resources/localstack/init/init.sh
@@ -38,6 +38,7 @@ awslocal ssm put-parameter --name "/local/parameter/document-sync-row-limit" --v
 
 awslocal secretsmanager create-secret --name "local/opg-response-slack-token" --secret-string "IAMAFAKETOKEN" --region eu-west-1
 awslocal secretsmanager create-secret --name "local/database-password" --secret-string "api" --region eu-west-1
+awslocal secretsmanager create-secret --name "local/application-db-password" --secret-string "apiapp" --region eu-west-1
 # 64444001 is client for Lay-OPG102-4 Client 1.
 awslocal secretsmanager create-secret --name "local/smoke-test-variables" --secret-string "{\"admin_user\":\"smoketestddadmin@smoketest.com\",\"admin_password\":\"DigidepsPass1234\",\"client\":\"64444001\",\"deputy_user\":\"lay-opg102-user-1@publicguardian.gov.uk\",\"deputy_password\":\"DigidepsPass1234\"}" --region eu-west-1
 

--- a/terraform/account/region/secrets.tf
+++ b/terraform/account/region/secrets.tf
@@ -15,7 +15,8 @@ module "environment_secrets" {
     "private-jwt-key-base64",
     "smoke-test-variables",
     "custom-sql-db-password",
-    "custom-sql-users"
+    "custom-sql-users",
+    "application-db-password"
   ]
   kms_key = module.secret_kms.eu_west_1_target_key_arn
   tags    = var.default_tags

--- a/terraform/environment/region/ecs_cluster.tf
+++ b/terraform/environment/region/ecs_cluster.tf
@@ -70,6 +70,10 @@ locals {
     {
       name  = "SESSION_PREFIX",
       value = "dd_api"
+    },
+    {
+      name  = "APP_DB_USERNAME",
+      value = "application"
     }
   ]
 

--- a/terraform/environment/region/ecs_iam_api.tf
+++ b/terraform/environment/region/ecs_iam_api.tf
@@ -40,7 +40,8 @@ data "aws_iam_policy_document" "api_permissions" {
     resources = [
       data.aws_secretsmanager_secret.private_jwt_key_base64.arn,
       data.aws_secretsmanager_secret.public_jwt_key_base64.arn,
-      data.aws_secretsmanager_secret.database_password.arn
+      data.aws_secretsmanager_secret.database_password.arn,
+      data.aws_secretsmanager_secret.application_db_password.arn
     ]
   }
 

--- a/terraform/environment/region/ecs_iam_execution.tf
+++ b/terraform/environment/region/ecs_iam_execution.tf
@@ -147,7 +147,8 @@ data "aws_iam_policy_document" "execution_role_secrets_db" {
     resources = [
       data.aws_secretsmanager_secret.database_password.arn,
       data.aws_secretsmanager_secret.api_secret.arn,
-      data.aws_secretsmanager_secret.custom_sql_db_password.arn
+      data.aws_secretsmanager_secret.custom_sql_db_password.arn,
+      data.aws_secretsmanager_secret.application_db_password.arn
     ]
     actions = ["secretsmanager:GetSecretValue"]
   }

--- a/terraform/environment/region/ecs_service_api.tf
+++ b/terraform/environment/region/ecs_service_api.tf
@@ -135,6 +135,10 @@ locals {
         {
           name      = "SECRETS_FRONT_KEY",
           valueFrom = data.aws_secretsmanager_secret.front_api_client_secret.arn
+        },
+        {
+          name      = "APP_DB_PASSWORD",
+          valueFrom = data.aws_secretsmanager_secret.application_db_password.arn
         }
       ],
       environment = concat(local.api_base_variables, local.api_service_variables, local.api_service_app_variables)

--- a/terraform/environment/region/ecs_task_integration_tests.tf
+++ b/terraform/environment/region/ecs_task_integration_tests.tf
@@ -95,6 +95,10 @@ locals {
         {
           name      = "SECRETS_FRONT_KEY",
           valueFrom = data.aws_secretsmanager_secret.front_api_client_secret.arn
+        },
+        {
+          name      = "APP_DB_PASSWORD",
+          valueFrom = data.aws_secretsmanager_secret.application_db_password.arn
         }
       ],
       environment = concat(local.api_base_variables, local.api_service_variables, local.api_integration_test_variables, local.api_testing_app_variables)

--- a/terraform/environment/region/ecs_task_performance_data.tf
+++ b/terraform/environment/region/ecs_task_performance_data.tf
@@ -36,6 +36,10 @@ locals {
         {
           name      = "SECRET",
           valueFrom = data.aws_secretsmanager_secret.api_secret.arn
+        },
+        {
+          name      = "APP_DB_PASSWORD",
+          valueFrom = data.aws_secretsmanager_secret.application_db_password.arn
         }
       ],
       environment = concat(local.api_base_variables, local.api_service_variables, local.api_testing_app_variables)

--- a/terraform/environment/region/ecs_task_reset_database.tf
+++ b/terraform/environment/region/ecs_task_reset_database.tf
@@ -40,6 +40,10 @@ locals {
         {
           name      = "SECRET",
           valueFrom = data.aws_secretsmanager_secret.api_secret.arn
+        },
+        {
+          name      = "APP_DB_PASSWORD",
+          valueFrom = data.aws_secretsmanager_secret.application_db_password.arn
         }
       ],
       environment = concat(local.api_base_variables, local.api_service_variables, local.api_testing_app_variables)

--- a/terraform/environment/region/secrets.tf
+++ b/terraform/environment/region/secrets.tf
@@ -6,6 +6,10 @@ data "aws_secretsmanager_secret" "database_password" {
   name = join("/", compact([var.secrets_prefix, "database-password"]))
 }
 
+data "aws_secretsmanager_secret" "application_db_password" {
+  name = join("/", compact([var.secrets_prefix, "application-db-password"]))
+}
+
 data "aws_secretsmanager_secret_version" "database_password" {
   secret_id = data.aws_secretsmanager_secret.database_password.id
 }


### PR DESCRIPTION
This is to get ready for the next PR where we enable the application to use the Application User instead. This work has been done, but we require this gets done first.