### PR TITLE
DDLS-909 Case pulls closed court order into the CO view

### DIFF
--- a/api/app/src/Repository/DeputyRepository.php
+++ b/api/app/src/Repository/DeputyRepository.php
@@ -58,6 +58,7 @@ class DeputyRepository extends ServiceEntityRepository
             INNER JOIN report re ON cr.report_id = re.id
             WHERE d.deputy_uid = :deputyUid
             AND r.id = re.id
+            AND co.status = 'ACTIVE'
         ) AS "courtOrderUid",
         r.type AS "type"
         FROM report r

--- a/api/app/tests/Integration/Entity/Repository/DeputyRepositoryTest.php
+++ b/api/app/tests/Integration/Entity/Repository/DeputyRepositoryTest.php
@@ -76,6 +76,35 @@ class DeputyRepositoryTest extends ApiBaseTestCase
         self::assertEquals($report->getType(), $results[0]['report']['type']);
     }
 
+    public function testFindReportsInfoByUidWithClosedCourtOrder()
+    {
+        $deputyUid = 7000000022;
+        $courtOrderUid = '7100000081';
+
+        $deputy = DeputyTestHelper::generateDeputy(deputyUid: "$deputyUid");
+        $client = ClientTestHelper::generateClient(em: $this->entityManager);
+        $user = UserTestHelper::createAndPersistUser(em: $this->entityManager, client: $client, deputyUid: $deputyUid);
+        $report = ReportTestHelper::generateReport(em: $this->entityManager, client: $client);
+        $courtOrder = CourtOrderTestHelper::generateCourtOrder(
+            em: $this->entityManager,
+            client: $client,
+            courtOrderUid: $courtOrderUid,
+            status: 'CLOSED',
+            report: $report,
+            deputy: $deputy,
+        );
+
+        $deputy->setUser(user: $user);
+        $client->setDeputy(deputy: $deputy);
+
+        self::$fixtures->persist($deputy, $client);
+        self::$fixtures->flush();
+
+        $results = self::$sut->findReportsInfoByUid(uid: $deputyUid);
+
+        self::assertCount(0, $results);
+    }
+
     public function testFindReportsInfoByUidIsNull()
     {
         $deputyUid = 70000022;


### PR DESCRIPTION
## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes DDLS-909

## Approach
Add active court order status when returning court order uids

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [X] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
