### PR TITLE
DDLS-910 Digideps stores co-deputy as submitting data but sends pdf with the 1st deputy named

### DIFF
--- a/client/app/src/Controller/Ndr/NdrController.php
+++ b/client/app/src/Controller/Ndr/NdrController.php
@@ -122,7 +122,7 @@ class NdrController extends AbstractController
      */
     public function reviewAction(int $ndrId)
     {
-        $ndr = $this->ndrApi->getNdr($ndrId, array_merge(self::$ndrGroupsForValidation, ['ndr-client', 'client-id']));
+        $ndr = $this->ndrApi->getNdr($ndrId, array_merge(self::$ndrGroupsForValidation, ['ndr-client', 'client-id', 'report-submitted-by']));
 
         $clientId = $ndr->getClient()->getId();
         $client = $this->clientApi->getById($clientId);

--- a/client/app/src/Entity/Ndr/Ndr.php
+++ b/client/app/src/Entity/Ndr/Ndr.php
@@ -5,6 +5,7 @@ namespace App\Entity\Ndr;
 use App\Entity\Client;
 use App\Entity\Ndr\Traits as NdrTraits;
 use App\Entity\ReportInterface;
+use App\Entity\User;
 use App\Service\NdrStatusService;
 use DateTime;
 use JMS\Serializer\Annotation as JMS;
@@ -39,6 +40,15 @@ class Ndr implements ReportInterface
      * @var bool
      */
     private $submitted;
+
+    /**
+     * @JMS\Type("App\Entity\User")
+     *
+     * @JMS\Groups({"report-submitted-by"})
+     *
+     * @var User
+     */
+    private $submittedBy;
 
     /**
      * @var \DateTime
@@ -295,6 +305,18 @@ class Ndr implements ReportInterface
     public function setSubmitted($submitted)
     {
         $this->submitted = $submitted;
+
+        return $this;
+    }
+
+    public function getSubmittedBy(): ?User
+    {
+        return $this->submittedBy;
+    }
+
+    public function setSubmittedBy(?User $submittedBy): static
+    {
+        $this->submittedBy = $submittedBy;
 
         return $this;
     }

--- a/client/app/templates/Ndr/Formatted/_client_information.html.twig
+++ b/client/app/templates/Ndr/Formatted/_client_information.html.twig
@@ -18,6 +18,6 @@
 
     <p class="govuk-body">{{ adLoggedAsDeputy}}</p>
 
-    {{ macros.deputyClientInfo(true,app.user,client,adLoggedAsDeputy) }}
+    {{ macros.deputyClientInfo(true,submittedBy,client,adLoggedAsDeputy) }}
 
 </div>

--- a/client/app/templates/Ndr/Formatted/_submission_declaration.html.twig
+++ b/client/app/templates/Ndr/Formatted/_submission_declaration.html.twig
@@ -27,7 +27,7 @@
             <dt class="label">{{ 'declarationTime' | trans }}</dt>
             <dd class="value">{{ndr.submitDate | date("H:i") }}&nbsp;&nbsp;&nbsp;{{ndr.submitDate | date("d/m/Y") }}</dd>
             <dt class="label">{{ 'submittedBy' | trans }}</dt>
-            <dd class="value" id="statusDeputyName">{{ app.user.fullname }}</dd>
+            <dd class="value" id="statusDeputyName">{{ submittedBy.fullname }}</dd>
         </dl>
     </div>
 </div>

--- a/client/app/templates/Ndr/Formatted/formatted_body.html.twig
+++ b/client/app/templates/Ndr/Formatted/formatted_body.html.twig
@@ -1,6 +1,7 @@
 {% set client = ndr.client %}
 {% set isEmailAttachment = true %}
 {% set transOptions = {'%client%': ndr.client.firstname | striptags } %}
+{% set submittedBy = ndr.submittedBy | default(app.user) %}
 
 <div id="wrapper">
     <div class="formatted-report content">


### PR DESCRIPTION
## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes DDLS-910

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
