### PR TITLE
DDLS-948 [Medium] Email address field positioned after Save button on Edit User Account page - org admin users

### DIFF
--- a/client/app/templates/Org/Organisation/edit.html.twig
+++ b/client/app/templates/Org/Organisation/edit.html.twig
@@ -29,6 +29,9 @@
     {{ form_input(form.lastname,'form.lastname') }}
     {{ form_input(form.jobTitle, 'form.jobTitle') }}
     {{ form_input(form.phoneMain,'form.phoneMain') }}
+    {% if form.email is defined %}
+        {{ form_input(form.email,'form.email') }}
+    {% endif %}
     {{ form_checkbox_group(form.roleName, 'form.roleName', {}) }}
 
     {{ form_submit(form.save,'form.save', {'buttonClass': 'behat-link-save'}) }}


### PR DESCRIPTION
## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes DDLS-948

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
