### PR TITLE
DDLS-941 Address form fields missing accessible labels

### DIFF
--- a/client/app/templates/Macros/macros.html.twig
+++ b/client/app/templates/Macros/macros.html.twig
@@ -617,9 +617,8 @@ C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.
             <div class="govuk-form-group">
                 {% set formAddressLabel = translationPrefix ~ 'address.label' %}
                 {% set formAddressContext = translationPrefix ~ 'address.context' %}
-                {{ formAddressLabel | trans({}, transDomain) }}<span
-                    class="govuk-visually-hidden">{{ formAddressContext | trans({}, transDomain) }}</span>
-                {{ form_input(formObject.address, '') }}
+                <span class="govuk-visually-hidden">{{ formAddressContext | trans({}, transDomain) }}</span>
+                {{ form_input(formObject.address, '' ,{'labelText': formAddressLabel | trans({}, transDomain)}) }}
             </div>
         {% endif %}
 
@@ -627,9 +626,8 @@ C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.
             <div class="govuk-form-group">
                 {% set formAddress1Label = translationPrefix ~ 'address1.label' %}
                 {% set formAddress1Context = translationPrefix ~ 'address1.context' %}
-                {{ formAddress1Label | trans({}, transDomain) }}<span
-                    class="govuk-visually-hidden">{{ formAddress1Context | trans({}, transDomain) }}</span>
-                {{ form_input(formObject.address1, '') }}
+                <span class="govuk-visually-hidden">{{ formAddress1Context | trans({}, transDomain) }}</span>
+                {{ form_input(formObject.address1, '',{'labelText': formAddress1Label | trans({}, transDomain)}) }}
             </div>
         {% endif %}
 
@@ -637,17 +635,15 @@ C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.
             <div class="govuk-form-group">
                 {% set formAddress2Label = translationPrefix ~ 'address2.label' %}
                 {% set formAddress2Context = translationPrefix ~ 'address2.context' %}
-                {{ formAddress2Label | trans({}, transDomain) }}<span
-                    class="govuk-visually-hidden">{{ formAddress2Context | trans({}, transDomain) }}</span>
-                {{ form_input(formObject.address2, '') }}
+                <span class="govuk-visually-hidden">{{ formAddress2Context | trans({}, transDomain) }}</span>
+                {{ form_input(formObject.address2, '',{'labelText': formAddress2Label | trans({}, transDomain)}) }}
             </div>
         {% endif %}
 
         {% if formObject.county is defined %}
             <div class="govuk-form-group">
                 {% set formCountyLabel = translationPrefix ~ 'county.label' %}
-                {{ formCountyLabel | trans({}, transDomain) }}
-                {{ form_input(formObject.county, '') }}
+                {{ form_input(formObject.county, '',{'labelText': formCountyLabel | trans({}, transDomain)}) }}
             </div>
         {% endif %}
 
@@ -655,9 +651,8 @@ C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.
             <div class="govuk-form-group">
                 {% set formAddress3Label = translationPrefix ~ 'address3.label' %}
                 {% set formAddress3Context = translationPrefix ~ 'address3.context' %}
-                {{ formAddress3Label | trans({}, transDomain) }}<span
-                    class="govuk-visually-hidden">{{ formAddress3Context | trans({}, transDomain) }}</span>
-                {{ form_input(formObject.address3, '') }}
+                <span class="govuk-visually-hidden">{{ formAddress3Context | trans({}, transDomain) }}</span>
+                {{ form_input(formObject.address3, '',{'labelText': formAddress3Label | trans({}, transDomain) }) }}
             </div>
         {% endif %}
 
@@ -665,9 +660,8 @@ C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.
             <div class="govuk-form-group">
                 {% set formAddress4Label = translationPrefix ~ 'address4.label' %}
                 {% set formAddress4Context = translationPrefix ~ 'address4.context' %}
-                {{ formAddress4Label | trans({}, transDomain) }}<span
-                    class="govuk-visually-hidden">{{ formAddress4Context | trans({}, transDomain) }}</span>
-                {{ form_input(formObject.address4, '') }}
+                <span class="govuk-visually-hidden">{{ formAddress4Context | trans({}, transDomain) }}</span>
+                {{ form_input(formObject.address4, '',{'labelText': formAddress4Label | trans({}, transDomain) }) }}
             </div>
         {% endif %}
 
@@ -675,41 +669,36 @@ C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.
             <div class="govuk-form-group">
                 {% set formAddress5Label = translationPrefix ~ 'address5.label' %}
                 {% set formAddress5Context = translationPrefix ~ 'address5.context' %}
-                {{ formAddress5Label | trans({}, transDomain) }}<span
-                    class="govuk-visually-hidden">{{ formAddress5Context | trans({}, transDomain) }}</span>
-                {{ form_input(formObject.address5, '') }}
+                <span class="govuk-visually-hidden">{{ formAddress5Context | trans({}, transDomain) }}</span>
+                {{ form_input(formObject.address5, '',{'labelText': formAddress5Label | trans({}, transDomain) }) }}
             </div>
         {% endif %}
 
         {% if formObject.postcode is defined %}
             <div class="govuk-form-group">
                 {% set formPostcodeLabel = translationPrefix ~ 'postcode.label' %}
-                {{ formPostcodeLabel | trans({}, transDomain) }}
-                {{ form_input(formObject.postcode, '') }}
+                {{ form_input(formObject.postcode, '',{'labelText': formPostcodeLabel | trans({}, transDomain) }) }}
             </div>
         {% endif %}
 
         {% if formObject.addressPostcode is defined %}
             <div class="govuk-form-group">
                 {% set formaddressPostcodeLabel = translationPrefix ~ 'addressPostcode.label' %}
-                {{ formaddressPostcodeLabel | trans({}, transDomain) }}
-                {{ form_input(formObject.addressPostcode, '') }}
+                {{ form_input(formObject.addressPostcode, '',{'labelText':  formaddressPostcodeLabel | trans({}, transDomain) }) }}
             </div>
         {% endif %}
 
         {% if formObject.country is defined %}
             <div class="govuk-form-group">
                 {% set formCountryLabel = translationPrefix ~ 'country.label' %}
-                {{ formCountryLabel | trans({}, transDomain) }}
-                {{ form_input(formObject.country, '') }}
+                {{ form_input(formObject.country, '',{'labelText':  formCountryLabel | trans({}, transDomain) }) }}
             </div>
         {% endif %}
 
         {% if formObject.addressCountry is defined %}
             <div class="govuk-form-group">
                 {% set formaddressCountryLabel = translationPrefix ~ 'addressCountry.label' %}
-                {{ formaddressCountryLabel | trans({}, transDomain) }}
-                {{ form_input(formObject.addressCountry, '') }}
+                {{ form_input(formObject.addressCountry, '',{'labelText': formaddressCountryLabel | trans({}, transDomain) }) }}
             </div>
         {% endif %}
 

--- a/client/app/translations/client.en.yml
+++ b/client/app/translations/client.en.yml
@@ -4,22 +4,22 @@ editClient:
   pageSectionDescription: "You can update %client%'s details and your court order date below."
   lastLoggedIn: "Last signed in:"
   address:
-    label: Address
+    label: Address line 1
     context: line 1 of 5
   address2:
-    label: " "
+    label: Address line 2
     context: Address line 2 of 5
     hint: ""
   address3:
-    label: " "
+    label: Address line 3
     context: Address line 3 of 5
     hint: ""
   address4:
-    label: " "
+    label: Address line 4
     context: Address line 4 of 5
     hint: ""
   address5:
-    label: " "
+    label: Address line 5
     context: Address line 5 of 5
     hint: ""
   postcode:

--- a/client/app/translations/co-deputy.en.yml
+++ b/client/app/translations/co-deputy.en.yml
@@ -43,19 +43,19 @@ form:
       lastname:
         label: Last name
       address1:
-        label: Address
+        label: Address line 1
         context: line 1 of 5
       address2:
-        label: " "
+        label: Address line 2
         context: Address line 2 of 5
       address3:
-        label: " "
+        label: Address line 3
         context: Address line 3 of 5
       address4:
-        label: " "
+        label: Address line 4
         context: Address line 4 of 5
       address5:
-        label: " "
+        label: Address line 5
         context: Address line 5 of 5
       addressPostcode:
         label: Postcode

--- a/client/app/translations/ndr-assets.en.yml
+++ b/client/app/translations/ndr-assets.en.yml
@@ -106,8 +106,10 @@ form:
   property:
     address:
       label: Address line 1
+      context: ""
     address2:
       label: Address line 2
+      context: ""
     county:
       label: County
     postcode:

--- a/client/app/translations/org-client-edit.en.yml
+++ b/client/app/translations/org-client-edit.en.yml
@@ -10,22 +10,22 @@ form:
   lastname:
     label: Last name
   address:
-    label: Address
+    label: Address line 1
     context: line 1 of 5
   address2:
-    label: " "
+    label: Address line 2
     context: Address line 2 of 5
     hint: ""
   address3:
-    label: " "
+    label: Address line 3
     context: Address line 3 of 5
     hint: ""
   address4:
-    label: " "
+    label: Address line 4
     context: Address line 4 of 5
     hint: ""
   address5:
-    label: " "
+    label: Address line 5
     context: Address line 5 of 5
     hint: ""
   postcode:

--- a/client/app/translations/registration.en.yml
+++ b/client/app/translations/registration.en.yml
@@ -14,22 +14,22 @@ caseNumber:
   label: Case number
   hint: This is 8 or 10 characters long and can be found on your court order
 address:
-  label: Address
+  label: Address line 1
   context: line 1 of 5
 address2:
-  label: " "
+  label: Address line 2
   context: Address line 2 of 5
   hint: ""
 address3:
-  label: " "
+  label: Address line 3
   context: Address line 3 of 5
   hint: ""
 address4:
-  label: " "
+  label: Address line 4
   context: Address line 4 of 5
   hint: ""
 address5:
-  label: " "
+  label: Address line 5
   context: Address line 5 of 5
   hint: ""
 postcode:

--- a/client/app/translations/report-contacts.en.yml
+++ b/client/app/translations/report-contacts.en.yml
@@ -76,10 +76,10 @@ form:
     label: Why did you ask this person to help you?
     hint: ""
   address:
-    label: Address (optional)
+    label: Address line 1 (optional)
     context: line 1 of 2
   address2:
-    label: " "
+    label: Address line 2 (optional)
     context: Address line 2 of 2 (optional)
     hint: ""
   county:

--- a/client/app/translations/settings.en.yml
+++ b/client/app/translations/settings.en.yml
@@ -70,19 +70,19 @@ form:
       lastname:
         label: Last name
       address1:
-        label: Address
+        label: Address line 1
         context: 1 of 5
       address2:
-        label: " "
+        label: Address line 2
         context: Address 2 of 5
       address3:
-        label: " "
+        label: Address line 3
         context: Address 3 of 5
       address4:
-        label: " "
+        label: Address line 4
         context: Address 4 of 5
       address5:
-        label: " "
+        label: Address line 5
         context: Address 5 of 5
       addressPostcode:
         label: Postcode


### PR DESCRIPTION
## Purpose
Form fields are missing programmatic associations between the visible label and the input field. Although labels are visually present, these are presented within <div> elements while the actual <label> is left blank

Fixes DDLS-941

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
Address form fields are implemented using a macro that is used in various parts of the app

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
- [ ] If adding GA events, I have updated or [checked](docs/runbooks/GOOGLE-ANALYTICS.md) the existing category or label values
