### PR TITLE
DDLS-1406b improve renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,128 +1,85 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "enabled": false,
+
+  "enabled": true,
+  "timezone": "Europe/London",
+
   "extends": [
     "config:recommended",
-    "schedule:earlyMondays",
-    "helpers:pinGitHubActionDigests",
-    "docker:pinDigests"
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigests"
   ],
-  "branchPrefix": "renovate-",
-  "commitMessageAction": "Renovate Update",
-  "labels": ["Dependencies", "Renovate"],
+
+  "branchPrefix": "renovate/",
+  "labels": ["dependencies", "renovate"],
+
+  "dependencyDashboard": true,
   "branchConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+
   "minimumReleaseAge": "7 days",
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^Dockerfile.*$/"],
-      "matchStrings": ["FROM node:(?<currentValue>.*?)-alpine.*\\n"],
-      "depNameTemplate": "node",
-      "datasourceTemplate": "node",
-      "versioningTemplate": "node"
-    }
-  ],
+
   "packageRules": [
     {
-      "groupName": "Minor and Patch Updates PHP",
-      "groupSlug": "all-patch-updates-php",
-      "labels": ["Dependencies", "Renovate", "PHP"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "prPriority": 0,
-      "schedule": ["after 6am and before 9am on Monday"],
-      "prCreation": "immediate",
-      "matchCategories": ["php"],
-      "matchPackageNames": ["*", "!php"]
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true,
+      "labels": ["dependencies", "renovate", "major"]
     },
     {
-      "groupName": "Minor and Patch Updates Node",
-      "groupSlug": "all-patch-updates-node",
-      "labels": ["Dependencies", "Renovate", "Node"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "prPriority": 0,
-      "schedule": ["after 6am and before 9am on Monday"],
-      "prCreation": "immediate",
-      "matchCategories": ["node"],
-      "matchPackageNames": ["*"]
+      "matchPackagePatterns": ["*"],
+      "isVulnerabilityAlert": true,
+      "labels": ["dependencies", "renovate", "security"],
+      "prPriority": 10,
+      "prCreation": "immediate"
     },
     {
-      "groupName": "Minor and Patch Updates Docker",
-      "groupSlug": "all-patch-updates-docker",
-      "labels": ["Dependencies", "Renovate", "Docker"],
+      "groupName": "Docker base image updates",
+      "matchManagers": ["dockerfile"],
       "matchUpdateTypes": ["minor", "patch"],
-      "prPriority": 0,
-      "schedule": ["after 6am and before 9am on Monday"],
-      "prCreation": "immediate",
-      "matchCategories": ["docker"],
-      "matchPackageNames": ["*"]
+      "labels": ["dependencies", "docker"],
+      "schedule": ["before 9am on Monday"]
     },
     {
-      "groupName": "Minor and Patch Updates Python",
-      "groupSlug": "all-patch-updates-python",
-      "labels": ["Dependencies", "Renovate", "Python"],
+      "groupName": "Terraform dependency updates",
+      "matchManagers": ["terraform"],
       "matchUpdateTypes": ["minor", "patch"],
-      "prPriority": 0,
-      "schedule": ["after 6am and before 9am on Monday"],
-      "prCreation": "immediate",
-      "matchCategories": ["python"],
-      "matchPackageNames": ["*"]
-    },
-    {
-      "groupName": "Minor and Patch Updates Golang",
-      "groupSlug": "all-patch-updates-golang",
-      "labels": ["Dependencies", "Renovate", "Golang"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "prPriority": 0,
-      "schedule": ["after 6am and before 9am on Monday"],
-      "prCreation": "immediate",
-      "matchCategories": ["golang"],
-      "matchPackageNames": ["*"]
+      "labels": ["dependencies", "terraform"],
+      "schedule": ["before 9am on Monday"]
     },
     {
       "groupName": "GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "labels": ["dependencies", "github-actions"],
       "automerge": true,
-      "dependencyDashboardApproval": true,
-      "prPriority": 0,
-      "labels": ["Dependencies", "Renovate", "Actions"],
-      "prBody": "Updates the following GitHub Actions dependencies:\n\n{{#each dependencies}}- {{this.name}}\n{{/each}}",
-      "schedule": ["after 6am and before 9am on Monday"],
-      "prCreation": "immediate",
-      "matchPackageNames": ["/actions/*/"]
+      "schedule": ["before 9am on Monday"]
     },
     {
-      "groupName": "Disable node updates for dockerfiles",
-      "matchPackageNames": ["node"],
-      "matchManagers": ["dockerfile"],
-      "enabled": false
+      "groupName": "Node.js dependency updates",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "labels": ["dependencies", "node"],
+      "schedule": ["before 9am on Monday"]
     },
     {
-      "groupName": "Minor Updates",
-      "groupSlug": "all-minor-updates",
-      "labels": ["Dependencies", "Renovate", "All-Minor"],
-      "matchUpdateTypes": ["minor"],
-      "prPriority": -1,
-      "schedule": ["after 6am and before 9am on Monday"],
-      "prCreation": "immediate",
-      "matchPackageNames": ["*", "!php"]
+      "groupName": "PHP dependency updates",
+      "matchManagers": ["composer"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "labels": ["dependencies", "php"],
+      "schedule": ["before 9am on Monday"]
+    },
+    {
+      "groupName": "Python dependency updates",
+      "matchManagers": ["pip_requirements", "pip-compile"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "labels": ["dependencies", "python"],
+      "schedule": ["before 9am on Monday"]
+    },
+    {
+      "groupName": "Golang dependency updates",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "labels": ["dependencies", "golang"],
+      "schedule": ["before 9am on Monday"]
     }
-  ],
-  "major": {
-    "labels": ["Dependencies", "Renovate", "Major"],
-    "prCreation": "status-success",
-    "rangeStrategy": "pin",
-    "prPriority": 1,
-    "schedule": ["after 6am and before 9am on Monday"]
-  },
-  "vulnerabilityAlerts": {
-    "groupName": "Security Alerts",
-    "labels": ["Dependencies", "Renovate", "Vulnerability"],
-    "schedule": ["after 6am and before 9am every weekday"],
-    "dependencyDashboardApproval": false,
-    "minimumReleaseAge": null,
-    "rangeStrategy": "pin",
-    "commitMessagePrefix": "[SECURITY]",
-    "branchTopic": "{{{datasource}}}-{{{depName}}}-vulnerability",
-    "prCreation": "immediate",
-    "prPriority": 5
-  }
+  ]
 }


### PR DESCRIPTION
Simplify and expand the renovate config. 

This should mean we get grouped minor/patch updates per category and we don't get auto major updates but that they are available on the dashboard to create (given that I understand the documentation properly)