### PR TITLE
DDLS-1411 put pre into serveless and set min acu to 0 for dev envs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,9 +33,9 @@
       "prCreation": "immediate"
     },
     {
-      "groupName": "Docker base image updates",
-      "matchManagers": ["dockerfile"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Docker image updates",
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
       "labels": ["dependencies", "docker"],
       "schedule": ["before 9am on Monday"]
     },

--- a/terraform/environment/moved.tf
+++ b/terraform/environment/moved.tf
@@ -2,6 +2,7 @@ moved {
   from = aws_acm_certificate.wildcard
   to   = aws_acm_certificate.wildcard[0]
 }
+
 moved {
   from = aws_acm_certificate_validation.wildcard
   to   = aws_acm_certificate_validation.wildcard[0]

--- a/terraform/environment/region/modules/aurora/main.tf
+++ b/terraform/environment/region/modules/aurora/main.tf
@@ -84,8 +84,8 @@ resource "aws_rds_cluster" "cluster_serverless" {
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
 
   serverlessv2_scaling_configuration {
-    min_capacity = 0.5
-    max_capacity = 4
+    min_capacity = var.min_acu
+    max_capacity = var.max_acu
   }
   depends_on = [var.log_group]
 }
@@ -114,4 +114,19 @@ resource "aws_rds_cluster_instance" "serverless_instances" {
     update = var.timeout_update
     delete = var.timeout_delete
   }
+}
+
+moved {
+  from = aws_rds_cluster.cluster[0]
+  to   = aws_rds_cluster.cluster_serverless[0]
+}
+
+moved {
+  from = aws_rds_cluster_instance.cluster_instances[0]
+  to   = aws_rds_cluster_instance.serverless_instances[0]
+}
+
+moved {
+  from = aws_rds_cluster_instance.cluster_instances[1]
+  to   = aws_rds_cluster_instance.serverless_instances[1]
 }

--- a/terraform/environment/region/modules/aurora/variables.tf
+++ b/terraform/environment/region/modules/aurora/variables.tf
@@ -161,3 +161,13 @@ variable "log_group" {
   description = "The name of the CloudWatch Logs log group."
   type        = string
 }
+
+variable "min_acu" {
+  description = "The minimum acu value."
+  type        = number
+}
+
+variable "max_acu" {
+  description = "The maximum acu value."
+  type        = number
+}

--- a/terraform/environment/region/rds.tf
+++ b/terraform/environment/region/rds.tf
@@ -21,6 +21,8 @@ module "api_aurora" {
   tags                                = local.environment == "preproduction" ? merge(var.default_tags, { backup_to_vault = "true" }, ) : merge(var.default_tags, { backup_to_vault = "false" }, )
   log_group                           = aws_cloudwatch_log_group.api_cluster.name
   iam_database_authentication_enabled = true
+  min_acu                             = var.account.db.min_acu
+  max_acu                             = var.account.db.max_acu
 }
 
 locals {

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -38,7 +38,9 @@
         "dr_backup": true,
         "backup_retention_period": 14,
         "deletion_protection": true,
-        "psql_engine_version": "14.18"
+        "psql_engine_version": "14.18",
+        "min_acu": 1,
+        "max_acu": 8
       },
       "s3": {
         "backup_kms_arn": "8d42ba9a-321c-43ac-a911-5f452d336da5",
@@ -84,11 +86,13 @@
       },
       "db": {
         "aurora_instance_count": 2,
-        "aurora_serverless": false,
+        "aurora_serverless": true,
         "dr_backup": false,
         "backup_retention_period": 1,
         "deletion_protection": true,
-        "psql_engine_version": "14.18"
+        "psql_engine_version": "14.18",
+        "min_acu": 0.5,
+        "max_acu": 4
       },
       "s3": {
         "backup_kms_arn": "5875b77a-043c-41e3-a3c6-84bdd865fedf",
@@ -138,7 +142,9 @@
         "dr_backup": false,
         "backup_retention_period": 1,
         "deletion_protection": true,
-        "psql_engine_version": "14.18"
+        "psql_engine_version": "14.18",
+        "min_acu": 0,
+        "max_acu": 4
       },
       "s3": {
         "backup_kms_arn": "5875b77a-043c-41e3-a3c6-84bdd865fedf",
@@ -188,7 +194,9 @@
         "dr_backup": true,
         "backup_retention_period": 1,
         "deletion_protection": false,
-        "psql_engine_version": "14.18"
+        "psql_engine_version": "14.18",
+        "min_acu": 0,
+        "max_acu": 4
       },
       "s3": {
         "backup_kms_arn": "5875b77a-043c-41e3-a3c6-84bdd865fedf",
@@ -238,7 +246,9 @@
         "dr_backup": false,
         "backup_retention_period": 1,
         "deletion_protection": false,
-        "psql_engine_version": "14.18"
+        "psql_engine_version": "14.18",
+        "min_acu": 0,
+        "max_acu": 4
       },
       "s3": {
         "backup_kms_arn": "f4dd7602-251f-48f8-accb-6d1bec57436f",
@@ -288,7 +298,9 @@
         "dr_backup": true,
         "backup_retention_period": 1,
         "deletion_protection": false,
-        "psql_engine_version": "14.18"
+        "psql_engine_version": "14.18",
+        "min_acu": 0,
+        "max_acu": 4
       },
       "s3": {
         "backup_kms_arn": "f4dd7602-251f-48f8-accb-6d1bec57436f",
@@ -338,7 +350,9 @@
         "dr_backup": false,
         "backup_retention_period": 1,
         "deletion_protection": false,
-        "psql_engine_version": "14.18"
+        "psql_engine_version": "14.18",
+        "min_acu": 0,
+        "max_acu": 4
       },
       "s3": {
         "backup_kms_arn": "f4dd7602-251f-48f8-accb-6d1bec57436f",

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -56,6 +56,8 @@ variable "accounts" {
         backup_retention_period = number
         deletion_protection     = bool
         psql_engine_version     = string
+        min_acu                 = number
+        max_acu                 = number
       })
       s3 = object({
         backup_kms_arn       = string


### PR DESCRIPTION
## Purpose
Save money
Have scaleable DB
Make config consistent across environments
Make non prod envs scale down to 0

Fixes DDLS-1411

## Approach
Trialled with preprod initially. 

Was incredibly simple. It does remove connectivity as it upgrades the instances but it keeps the same data and the process is very straight forward.

Moved blocks will need to be expanded for the prod change.

I also added a small change to renovate config that should hopefully group the digest docker changes as we're getting a lot of them currently!

## Learning
NA

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
