### PR TITLE
renovate improvement, filter out php itself

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,8 @@
     {
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": true,
-      "labels": ["dependencies", "renovate", "major"]
+      "labels": ["dependencies", "renovate", "major"],
+      "minimumReleaseAge": "7 days"
     },
     {
       "matchPackagePatterns": ["*"],
@@ -37,49 +38,61 @@
       "matchManagers": ["dockerfile", "docker-compose"],
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "labels": ["dependencies", "docker"],
-      "schedule": ["before 9am on Monday"]
+      "schedule": ["before 9am on Monday"],
+      "minimumReleaseAge": "7 days"
     },
     {
       "groupName": "Terraform dependency updates",
       "matchManagers": ["terraform"],
       "matchUpdateTypes": ["minor", "patch"],
       "labels": ["dependencies", "terraform"],
-      "schedule": ["before 9am on Monday"]
+      "schedule": ["before 9am on Monday"],
+      "minimumReleaseAge": "7 days"
     },
     {
       "groupName": "GitHub Actions",
       "matchManagers": ["github-actions"],
       "labels": ["dependencies", "github-actions"],
       "automerge": true,
-      "schedule": ["before 9am on Monday"]
+      "schedule": ["before 9am on Monday"],
+      "minimumReleaseAge": "7 days"
     },
     {
       "groupName": "Node.js dependency updates",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"],
       "labels": ["dependencies", "node"],
-      "schedule": ["before 9am on Monday"]
+      "schedule": ["before 9am on Monday"],
+      "minimumReleaseAge": "7 days"
     },
     {
       "groupName": "PHP dependency updates",
       "matchManagers": ["composer"],
       "matchUpdateTypes": ["minor", "patch"],
       "labels": ["dependencies", "php"],
-      "schedule": ["before 9am on Monday"]
+      "schedule": ["before 9am on Monday"],
+      "minimumReleaseAge": "7 days"
     },
     {
       "groupName": "Python dependency updates",
       "matchManagers": ["pip_requirements", "pip-compile"],
       "matchUpdateTypes": ["minor", "patch"],
       "labels": ["dependencies", "python"],
-      "schedule": ["before 9am on Monday"]
+      "schedule": ["before 9am on Monday"],
+      "minimumReleaseAge": "7 days"
     },
     {
       "groupName": "Golang dependency updates",
       "matchManagers": ["gomod"],
       "matchUpdateTypes": ["minor", "patch"],
       "labels": ["dependencies", "golang"],
-      "schedule": ["before 9am on Monday"]
+      "schedule": ["before 9am on Monday"],
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "matchManagers": ["composer"],
+      "matchPackageNames": ["php"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Filter out php itself from the renovate composer updates.

Also added top release age to all the package managers. Previously I thought it would be better to apply it at top level so it wasn't missed but the docs actually advise adding it to both levels: https://docs.renovatebot.com/key-concepts/minimum-release-age/