### PR TITLE
DDLS-1442 Fix the report update step in the ingest so it doesn't fail on indeterminate or "dangerous" changes

### DIFF
--- a/api/app/scripts/api_integration_test.sh
+++ b/api/app/scripts/api_integration_test.sh
@@ -61,6 +61,8 @@ case "$INTEGRATION_SELECTION" in
     php vendor/bin/phpunit -c tests/Integration tests/Integration/Model/ --coverage-php tests/coverage/Model.cov
     printf '\n Running Service Suite \n\n'
     php vendor/bin/phpunit -c tests/Integration tests/Integration/Service/ --coverage-php tests/coverage/Service.cov
+    printf '\n Running Factory Suite \n\n'
+    php vendor/bin/phpunit -c tests/Integration tests/Integration/Factory/ --coverage-php tests/coverage/Factory.cov
     ;;
   selection-all)
     # selection-1
@@ -88,6 +90,9 @@ case "$INTEGRATION_SELECTION" in
     php vendor/bin/phpunit -c tests/Integration tests/Integration/Model/ --coverage-php tests/coverage/Model.cov
     printf '\n Running Service Suite \n\n'
     php vendor/bin/phpunit -c tests/Integration tests/Integration/Service/ --coverage-php tests/coverage/Service.cov
+    printf '\n Running Factory Suite \n\n'
+    php vendor/bin/phpunit -c tests/Integration tests/Integration/Factory/ --coverage-php tests/coverage/Factory.cov
+
     # generate HTML coverage report
     php -d memory_limit=256M vendor/phpunit/phpcov/phpcov merge --html "./build/coverage-api" "./tests/coverage"
     ;;

--- a/api/app/src/Factory/ReportTypeUpdateFactory.php
+++ b/api/app/src/Factory/ReportTypeUpdateFactory.php
@@ -105,6 +105,11 @@ readonly class ReportTypeUpdateFactory implements DataFactoryInterface
                 $report->setType((string) $possibleReportType);
                 $this->entityManager->persist($report);
                 ++$count;
+
+                // batch flushes in 10s
+                if ($count % 10 === 0) {
+                    $this->entityManager->flush();
+                }
             } else {
                 $this->logger->info(
                     "DRYRUN[{$this->getName()}]: Report with ID: $reportId; report type change from $currentReportType to $possibleReportType"
@@ -112,22 +117,26 @@ readonly class ReportTypeUpdateFactory implements DataFactoryInterface
             }
         }
 
-        $numIndeterminate = count($indeterminate);
-        $numDangerous = count($dangerous);
+        $this->entityManager->flush();
 
-        $errors = [];
+        $messages = ['success' => ["Updated $count report types"]];
+
+        // don't treat indeterminate or dangerous report type transitions as errors which will stop the ingest;
+        // just warn about them
+        $numIndeterminate = count($indeterminate);
         if ($numIndeterminate > 0) {
-            $errors[] = "Unable to determine report type for $numIndeterminate report IDs: " . implode(', ', $indeterminate);
+            $messages['indeterminate'] = "Unable to determine report type for $numIndeterminate report IDs: " . implode(', ', $indeterminate);
         }
 
-        // while we log this as an error, we apply the change to/from hybrid anyway
+        // while we log this as a warning, we apply the change to/from hybrid anyway
+        $numDangerous = count($dangerous);
         if ($numDangerous > 0) {
-            $errors[] = "Possible dangerous change of report type to/from hybrid for $numDangerous report IDs: " . implode(', ', $dangerous);
+            $messages['dangerous'] = "Possible dangerous change of report type to/from hybrid for $numDangerous report IDs: " . implode(', ', $dangerous);
         }
 
         return new DataFactoryResult(
-            messages: ['success' => ["Updated $count report types"]],
-            errorMessages: ['errors' => $errors]
+            messages: $messages,
+            errorMessages: ['errors' => []]
         );
     }
 }

--- a/api/app/src/Factory/ReportTypeUpdateFactory.php
+++ b/api/app/src/Factory/ReportTypeUpdateFactory.php
@@ -82,12 +82,12 @@ readonly class ReportTypeUpdateFactory implements DataFactoryInterface
             $currentReportType = ReportType::tryFrom($report->getType());
             $possibleReportType = ReportTypeService::determineReportType($courtOrders);
 
-            if ($possibleReportType === null) {
-                $indeterminate[] = $reportId;
+            if ((string) $currentReportType === (string) $possibleReportType) {
                 continue;
             }
 
-            if ((string) $currentReportType === (string) $possibleReportType) {
+            if ($possibleReportType === null) {
+                $indeterminate[] = $reportId;
                 continue;
             }
 
@@ -99,6 +99,7 @@ readonly class ReportTypeUpdateFactory implements DataFactoryInterface
                 )
             ) {
                 $dangerous[] = $reportId;
+                continue;
             }
 
             if (!$dryRun) {
@@ -106,8 +107,7 @@ readonly class ReportTypeUpdateFactory implements DataFactoryInterface
                 $this->entityManager->persist($report);
                 ++$count;
 
-                // batch flushes in 10s
-                if ($count % 10 === 0) {
+                if ($count % 128 === 0) {
                     $this->entityManager->flush();
                 }
             } else {
@@ -125,13 +125,13 @@ readonly class ReportTypeUpdateFactory implements DataFactoryInterface
         // just warn about them
         $numIndeterminate = count($indeterminate);
         if ($numIndeterminate > 0) {
-            $messages['indeterminate'] = "Unable to determine report type for $numIndeterminate report IDs: " . implode(', ', $indeterminate);
+            $messages['indeterminate'] = ["Unable to determine report type for $numIndeterminate report IDs: " . implode(', ', $indeterminate)];
         }
 
         // while we log this as a warning, we apply the change to/from hybrid anyway
         $numDangerous = count($dangerous);
         if ($numDangerous > 0) {
-            $messages['dangerous'] = "Possible dangerous change of report type to/from hybrid for $numDangerous report IDs: " . implode(', ', $dangerous);
+            $messages['dangerous'] = ["Possible dangerous change of report type to/from hybrid for $numDangerous report IDs: " . implode(', ', $dangerous)];
         }
 
         return new DataFactoryResult(

--- a/api/app/tests/Integration/Factory/ClientIdFixDataFactoryIntegrationTest.php
+++ b/api/app/tests/Integration/Factory/ClientIdFixDataFactoryIntegrationTest.php
@@ -104,7 +104,7 @@ class ClientIdFixDataFactoryIntegrationTest extends ApiIntegrationTestCase
     {
         $sut = new ClientIdFixDataFactory(self::$entityManager);
 
-        $oldClientFields['setCaseNumber'] = $caseNumber;
+        $oldClientFields['setCaseNumber'] = $caseNumber . '1';
 
         $user = self::$fixtures->createUser();
 
@@ -124,7 +124,7 @@ class ClientIdFixDataFactoryIntegrationTest extends ApiIntegrationTestCase
         self::$entityManager->flush();
 
         // court order associated with old inactive client
-        $courtOrder = self::$fixtures->createCourtOrder($courtOrderUid, CourtOrderType::PFA, CourtOrderKind::Single, 'ACTIVE');
+        $courtOrder = self::$fixtures->createCourtOrder($courtOrderUid . '2', CourtOrderType::PFA, CourtOrderKind::Single, 'ACTIVE');
         $courtOrder->setClient($oldClient);
 
         // report also associated with old inactive client

--- a/api/app/tests/Integration/Factory/ReportTypeUpdateDataFactoryIntegrationTest.php
+++ b/api/app/tests/Integration/Factory/ReportTypeUpdateDataFactoryIntegrationTest.php
@@ -81,9 +81,9 @@ class ReportTypeUpdateDataFactoryIntegrationTest extends ApiIntegrationTestCase
                 'action' => DeputyshipCandidateAction::InsertOrderReport,
                 'deputyType' => DeputyType::LAY,
                 'existingReportType' => Report::LAY_PFA_HIGH_ASSETS_TYPE,
-                'expectedReportType' => Report::LAY_COMBINED_HIGH_ASSETS_TYPE,
-                'updatedCount' => 1,
-                'errorCount' => 1,
+                'expectedReportType' => Report::LAY_PFA_HIGH_ASSETS_TYPE,
+                'updatedCount' => 0,
+                'errorCount' => 0,
             ]],
             'Hybrid to PFA - changedFromHybrid' =>  [[
                 'orderType' => CourtOrderType::PFA,
@@ -92,9 +92,9 @@ class ReportTypeUpdateDataFactoryIntegrationTest extends ApiIntegrationTestCase
                 'action' => DeputyshipCandidateAction::InsertOrderReport,
                 'deputyType' => DeputyType::LAY,
                 'existingReportType' => Report::LAY_COMBINED_HIGH_ASSETS_TYPE,
-                'expectedReportType' => Report::LAY_PFA_HIGH_ASSETS_TYPE,
-                'updatedCount' => 1,
-                'errorCount' => 1,
+                'expectedReportType' => Report::LAY_COMBINED_HIGH_ASSETS_TYPE,
+                'updatedCount' => 0,
+                'errorCount' => 0,
             ]],
             'No-change' => [[
                 'orderType' => CourtOrderType::PFA,
@@ -184,8 +184,16 @@ class ReportTypeUpdateDataFactoryIntegrationTest extends ApiIntegrationTestCase
             )
         );
 
-        $this->assertStringContainsString($updatedCount, $dataFactoryResult->getMessages()['success'][0], 'Updated report types count');
-        $this->assertCount($errorCount, $dataFactoryResult->getErrorMessages()['errors'], 'Expected error count did not match actual error count');
+        $this->assertStringContainsString(
+            "Updated $updatedCount report types",
+            $dataFactoryResult->getMessages()['success'][0],
+            'Number of report types updated did not match expectation'
+        );
+        $this->assertCount(
+            $errorCount,
+            $dataFactoryResult->getErrorMessages()['errors'],
+            'Expected error count did not match actual error count'
+        );
     }
 
     #[DataProvider('reportTypeChanges')]
@@ -196,7 +204,7 @@ class ReportTypeUpdateDataFactoryIntegrationTest extends ApiIntegrationTestCase
         $dataFactoryResult = self::$sut->run(true);
 
         /** @var string $expectedReportType */
-        $expectedReportType = $data['expectedReportType'];
+        $expectedReportType = $data['existingReportType'];
 
         /** @var string $existingReportType */
         $existingReportType = $data['existingReportType'];


### PR DESCRIPTION
## Purpose

hybrid <-> dual changes are "dangerous" at the moment as we don't split/merge the reports when it happens, so could cause some data to be hidden from users unexpectedly.

Fixes DDLS-1442

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
