### PR TITLE
DDLS-1468 add a retry for build and test stages

### DIFF
--- a/.github/workflows/_integration-tests-api.yml
+++ b/.github/workflows/_integration-tests-api.yml
@@ -36,14 +36,26 @@ jobs:
 
       - name: build docker images
         run: |
-          docker buildx build \
-          -f api/docker/app/Dockerfile \
-          --cache-from=type=local,src=/tmp/.buildx-cache \
-          --cache-to=type=local,dest=/tmp/.buildx-cache-new \
-          --build-arg LOCAL_RESOURCES=true \
-          --tag api-integration-tests:latest \
-          --target devtools-admin \
-          --output type=docker .
+          success=0
+          for i in 1 2; do
+            echo "Starting attempt $i"
+
+            if docker buildx build \
+              -f api/docker/app/Dockerfile \
+              --cache-from=type=local,src=/tmp/.buildx-cache \
+              --cache-to=type=local,dest=/tmp/.buildx-cache-new \
+              --build-arg LOCAL_RESOURCES=true \
+              --tag api-integration-tests:latest \
+              --target devtools-admin \
+              --output type=docker .; then
+              success=1
+              break
+            fi
+
+            sleep 1
+          done
+
+          [ "$success" -eq 1 ] || exit 1
 
       - name: Move cache
         run: |
@@ -54,7 +66,18 @@ jobs:
         env:
           SELECTION: ${{ inputs.selection }}
         id: integration-tests
-        run: make api-integration-tests ADDITIONAL_CONFIG="" INTEGRATION_SELECTION=${{ inputs.selection }}
+        run: |
+          success=0
+          for i in 1 2; do
+            echo "Starting attempt $i"
+
+            if make api-integration-tests ADDITIONAL_CONFIG="" INTEGRATION_SELECTION=${{ inputs.selection }}; then
+              success=1
+              break
+            fi
+
+            sleep 1
+          done
 
       - name: archive test results
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.github/workflows/workflow-pull-request-path.yml
+++ b/.github/workflows/workflow-pull-request-path.yml
@@ -251,12 +251,30 @@ jobs:
       - terraform_apply_environment
       - workflow_variables
 
+  restart_point:
+    runs-on: ubuntu-latest
+    name: restart point
+    needs:
+      - workflow_variables
+      - terraform_apply_environment
+      - client_unit_tests
+      - api_phpstan
+      - client_phpstan
+      - miscellaneous_tests
+      - test_js
+      - api_unit_tests
+    steps:
+      - id: restart_point
+        run: |
+          echo "Restart workflow from here if you want to rerun the end to end tests"
+
   wait_for_ecs_services:
     name: wait for all ecs services to stabilise
     uses: ./.github/workflows/_wait-for-ecs-services.yml
     needs:
       - workflow_variables
       - terraform_apply_environment
+      - restart_point
     secrets:
       ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY_ALLOW_LIST_REPOSITORY }}
     with:
@@ -265,33 +283,13 @@ jobs:
       account_name: development
       timeout: "15"
 
-  restart_point:
-    runs-on: ubuntu-latest
-    name: restart point
-    needs:
-      - workflow_variables
-      - terraform_apply_environment
-      - wait_for_ecs_services
-      - client_unit_tests
-      - api_phpstan
-      - client_phpstan
-      - miscellaneous_tests
-      - test_js
-      - api_unit_tests
-      - api_integration_tests_1
-      - api_integration_tests_2
-      - api_integration_tests_3
-    steps:
-      - id: restart_point
-        run: |
-          echo "Restart workflow from here if you want to rerun the end to end tests"
-
   scale_services_up:
     name: scale up services
     uses: ./.github/workflows/_scale-services.yml
     needs:
       - workflow_variables
       - restart_point
+      - wait_for_ecs_services
     with:
       replicas: 10
       acu: 16
@@ -463,6 +461,9 @@ jobs:
       - end_to_end_tests_1
       - end_to_end_tests_2
       - end_to_end_tests_admin
+      - api_integration_tests_1
+      - api_integration_tests_2
+      - api_integration_tests_3
     env:
       START_TIME: ${{ needs.workflow_variables.outputs.start_time }}
     steps:

--- a/local-resources/localstack/Dockerfile
+++ b/local-resources/localstack/Dockerfile
@@ -11,4 +11,4 @@ RUN chmod 544 /etc/localstack/init/ready.d/init.sh
 COPY ./local-resources/localstack/wait/healthcheck.sh /scripts/wait/healthcheck.sh
 RUN chmod 544 /scripts/wait/healthcheck.sh
 
-RUN apt-get -y install jq
+RUN apt-get update && apt-get install -y jq

--- a/terraform/account/.envrc
+++ b/terraform/account/.envrc
@@ -1,6 +1,6 @@
 source ../../scripts/pipeline/terraform/switch-terraform-version.sh
 export TF_WORKSPACE=development
 export TF_VAR_DEFAULT_ROLE=operator
-export TF_VAR_MANAGEMENT_ROLE=viewer
+export TF_VAR_MANAGEMENT_ROLE=digideps-operator
 export TF_VAR_STATE_ROLE=operator
 export TF_CLI_ARGS_init="-backend-config=\"assume_role={role_arn=\\\"arn:aws:iam::311462405659:role/operator\\\"}\""

--- a/terraform/environment/.envrc
+++ b/terraform/environment/.envrc
@@ -1,6 +1,6 @@
 source ../../scripts/pipeline/terraform/switch-terraform-version.sh
 export TF_WORKSPACE=development
 export TF_VAR_DEFAULT_ROLE=operator
-export TF_VAR_MANAGEMENT_ROLE=viewer
+export TF_VAR_MANAGEMENT_ROLE=digideps-operator
 export TF_VAR_STATE_ROLE=operator
 export TF_CLI_ARGS_init="-backend-config=\"assume_role={role_arn=\\\"arn:aws:iam::311462405659:role/operator\\\"}\""


### PR DESCRIPTION
Create a single retry for the following parts of the integration tests job to remove some level of flakiness:
- build step
- test step

Below is screenshot of testing out that it properly fails the job after running a second attempt.

<img width="200" height="79" alt="image" src="https://github.com/user-attachments/assets/61214011-fa0c-46b3-9584-014ff6ada721" />

- I have also added the new digideps-operator role for local management access as this is limited to our resources.
- I have also made some speed improvements in pipeline by rejigging when the restore step runs.
