### PR TITLE
Stop superfluous logging from app container

### DIFF
--- a/client/docker/app/config/www.conf
+++ b/client/docker/app/config/www.conf
@@ -28,7 +28,7 @@ catch_workers_output = yes
 decorate_workers_output = no
 
 ; Send access log to stdout (optional)
-;access.log = /proc/self/fd/1
+access.log = /dev/null
 
 ; --- REQUEST MANAGEMENT ---
 request_terminate_timeout = 60s


### PR DESCRIPTION
Explicitly turn off access logging