### PR TITLE
Ddls 1525 added security on non prod tasks

### DIFF
--- a/terraform/environment/region/ecs_task_reset_database.tf
+++ b/terraform/environment/region/ecs_task_reset_database.tf
@@ -11,7 +11,7 @@ module "reset_database" {
   task_role_arn         = aws_iam_role.task_runner.arn
   architecture          = "ARM64"
   os                    = "LINUX"
-  security_group_id     = module.db_access_task_security_group.id
+  security_group_id     = module.db_access_task_non_prod_security_group.id
 }
 
 locals {

--- a/terraform/environment/region/ecs_task_restore.tf
+++ b/terraform/environment/region/ecs_task_restore.tf
@@ -14,7 +14,7 @@ module "restore" {
   task_role_arn         = data.aws_iam_role.sync.arn
   architecture          = "ARM64"
   os                    = "LINUX"
-  security_group_id     = module.db_access_task_security_group.id
+  security_group_id     = module.db_access_task_non_prod_security_group.id
 }
 
 locals {

--- a/terraform/environment/region/ecs_task_restore_from_production.tf
+++ b/terraform/environment/region/ecs_task_restore_from_production.tf
@@ -13,7 +13,7 @@ module "restore_from_production" {
   task_role_arn         = data.aws_iam_role.sync.arn
   architecture          = "ARM64"
   os                    = "LINUX"
-  security_group_id     = module.db_access_task_security_group.id
+  security_group_id     = module.db_access_task_non_prod_security_group.id
 }
 
 locals {

--- a/terraform/environment/region/ecs_task_shared_sg.tf
+++ b/terraform/environment/region/ecs_task_shared_sg.tf
@@ -26,3 +26,13 @@ module "db_access_task_security_group" {
   vpc_id      = data.aws_vpc.main.id
   environment = local.environment
 }
+
+module "db_access_task_non_prod_security_group" {
+  source      = "./modules/security_group"
+  description = "Task Requiring DB Access Non Prod"
+  rules       = local.db_access_task_sg_rules
+  name        = "db-access-task-non-prod"
+  tags        = var.default_tags
+  vpc_id      = data.aws_vpc.main.id
+  environment = local.environment
+}

--- a/terraform/environment/region/rds_sg.tf
+++ b/terraform/environment/region/rds_sg.tf
@@ -1,4 +1,18 @@
 locals {
+  sg_rules_disabled_by_env = {
+    preproduction = ["integration_test"]
+    production    = ["integration_test", "db_access_tasks_non_prod"]
+  }
+
+  api_rds_sg_rules_filtered = {
+    for k, v in local.api_rds_sg_rules :
+    k => v
+    if !contains(
+      lookup(local.sg_rules_disabled_by_env, local.environment, []),
+      k
+    )
+  }
+
   api_rds_sg_rules = {
     api_service = {
       port        = 5432
@@ -21,6 +35,13 @@ locals {
       target_type = "security_group_id"
       target      = module.db_access_task_security_group.id
     }
+    db_access_tasks_non_prod = {
+      port        = 5432
+      type        = "ingress"
+      protocol    = "tcp"
+      target_type = "security_group_id"
+      target      = module.db_access_task_non_prod_security_group.id
+    }
     integration_test = {
       port        = 5432
       type        = "ingress"
@@ -41,7 +62,7 @@ locals {
 module "api_rds_security_group" {
   source      = "./modules/security_group"
   description = "RDS Database"
-  rules       = local.api_rds_sg_rules
+  rules       = local.api_rds_sg_rules_filtered
   name        = "api-rds"
   tags        = var.default_tags
   vpc_id      = data.aws_vpc.main.id


### PR DESCRIPTION
So originally I was thinking about taking out the task definitions from prod for non prod tasks for a bit of added security so that accidental misconfig couldn't run tasks that would be very bad to run on prod. However, this would make quite a mess of the code.

Decided it's easier to simply remove the inbound security group rules to the DB for the following tasks:
- integration tests
- reset database
- restore from production
- restore

These are the ones that can directly access the DB that shouldn't in prod so if someone were to accidentally misconfigure these now then they couldn't do any damage. 
