### PR TITLE
DDLS-1519 - Stop creating reports during registration

### DIFF
--- a/api/app/src/Controller/Report/ReportController.php
+++ b/api/app/src/Controller/Report/ReportController.php
@@ -4,7 +4,6 @@ namespace OPG\Digideps\Backend\Controller\Report;
 
 use OPG\Digideps\Backend\Controller\RestController;
 use OPG\Digideps\Backend\Entity\Client;
-use OPG\Digideps\Backend\Entity\PreRegistration;
 use OPG\Digideps\Backend\Entity\Report\Checklist;
 use OPG\Digideps\Backend\Entity\Report\ChecklistInformation;
 use OPG\Digideps\Backend\Entity\Report\Debt;
@@ -15,7 +14,6 @@ use OPG\Digideps\Backend\Entity\Report\Report;
 use OPG\Digideps\Backend\Entity\Report\ReviewChecklist;
 use OPG\Digideps\Backend\Entity\User;
 use OPG\Digideps\Backend\Exception\UnauthorisedException;
-use OPG\Digideps\Backend\Repository\PreRegistrationRepository;
 use OPG\Digideps\Backend\Repository\ReportRepository;
 use OPG\Digideps\Backend\Service\Auth\AuthService;
 use OPG\Digideps\Backend\Service\Formatter\RestFormatter;
@@ -26,7 +24,6 @@ use Gedmo\SoftDeleteable\Filter\SoftDeleteableFilter;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -59,57 +56,8 @@ class ReportController extends RestController
         private readonly EntityManagerInterface $em,
         private readonly AuthService $authService,
         private readonly RestFormatter $formatter,
-        private readonly PreRegistrationRepository $preRegRepository,
     ) {
         parent::__construct($em);
-    }
-
-    /**
-     * Add a report
-     * Currently only used by Lay deputy during registration steps
-     * Pa report are instead created via OrgService::createReport().
-     */
-    #[Route(path: '', methods: ['POST'])]
-    #[IsGranted(attribute: 'ROLE_DEPUTY')]
-    public function add(Request $request): array
-    {
-        $reportData = $this->formatter->deserializeBodyContent($request);
-
-        if (empty($reportData['client']['id'])) {
-            throw new \InvalidArgumentException('Missing client.id');
-        }
-        /** @var Client $client */
-        $client = $this->findEntityBy(Client::class, $reportData['client']['id']);
-        $this->denyAccessIfClientDoesNotBelongToUser($client);
-
-        /** @var PreRegistration[] $preRegistrationRecord */
-        $preRegistrationRecord = $this->preRegRepository->findByCaseNumber($client->getCaseNumber());
-        $orderStartDate = $preRegistrationRecord[0]->getOrderDate();
-
-        if (is_null($orderStartDate)) {
-            throw new UnprocessableEntityHttpException(sprintf('OrderDate (made_date) is missing for Preregistration record: %s', $preRegistrationRecord[0]->getId()));
-        }
-
-        $today = new \DateTime();
-        // Day and month from order made date combined with current year
-        $amendedOrderStartDate = new \DateTime(date('d M ', $orderStartDate->getTimestamp()) . date('Y'));
-        if ($today < $amendedOrderStartDate) {
-            $amendedOrderStartDate->modify('-1 year');
-        }
-
-        $endDate = clone $amendedOrderStartDate;
-
-        // report type is taken from Sirius. In case that's not available (shouldn't happen unless pre registration table is dropped), use a 102
-        $reportType = $this->reportService->getReportTypeBasedOnSirius($client) ?: Report::LAY_PFA_HIGH_ASSETS_TYPE;
-        $report = new Report($client, $reportType, $amendedOrderStartDate, $endDate->add(new \DateInterval('P12M'))->sub(new \DateInterval('P1D')));
-        $report->setReportSeen(true);
-
-        $report->updateSectionsStatusCache($report->getAvailableSections());
-
-        $this->em->persist($report);
-        $this->em->flush();
-
-        return ['report' => $report->getId()];
     }
 
     #[Route(path: '/{id}', requirements: ['id' => '\d+'], methods: ['GET'])]

--- a/api/app/tests/Behat/bootstrap/v2/CourtOrder/CourtOrderTrait.php
+++ b/api/app/tests/Behat/bootstrap/v2/CourtOrder/CourtOrderTrait.php
@@ -439,4 +439,32 @@ trait CourtOrderTrait
         $this->em->persist($this->courtOrder);
         $this->em->flush();
     }
+
+    /**
+     * @Given the client with court order :courtOrderUid is associated with a :orderType report
+     */
+    public function clientAssociatedWithCourtOrderHasReport(string $courtOrderUid, string $orderType): void
+    {
+        $courtOrder = $this->em->getRepository(CourtOrder::class)->findOneBy(['courtOrderUid' => $courtOrderUid]);
+
+        if (!$courtOrder instanceof CourtOrder) {
+            throw new BehatException("Unable to find any CourtOrder with courtOrderUid {$courtOrderUid}");
+        }
+        $client = $courtOrder->getClient();
+
+        // create a new report
+        $type = Report::TYPE_HEALTH_WELFARE;
+        if ($orderType === CourtOrderType::PFA) {
+            $type = Report::TYPE_PROPERTY_AND_AFFAIRS_HIGH_ASSETS;
+        }
+
+        $now = new \DateTime();
+        $report = new Report($client, $type, $now, $now, false);
+        $report->setClient($client);
+
+        $courtOrder->addReport($report);
+
+        $this->em->persist($report);
+        $this->em->flush();
+    }
 }

--- a/api/app/tests/Behat/features-v2/registration/ingest.lay.multiclient.codeputies.sirius.feature
+++ b/api/app/tests/Behat/features-v2/registration/ingest.lay.multiclient.codeputies.sirius.feature
@@ -7,6 +7,7 @@ Feature: Lay CSV data ingestion - sirius source data for multiclient deputies
         And I run the lay CSV command for "lay-multiclient-codeputies-1.csv"
         And the lay deputy "Guuts Brineg" @ "ingest.lay.multiclient.codeputies.sirius.json" registers as a deputy
         And the client with case number 61513119 is associated with pfa court order 495823874
+        And the client with court order 495823874 is associated with a pfa report
         When "guuts.brineg@nowhere.1111.com" logs in
         Then I should see "Virta Plool"
 

--- a/api/app/tests/Integration/ControllerReport/ReportControllerTest.php
+++ b/api/app/tests/Integration/ControllerReport/ReportControllerTest.php
@@ -118,48 +118,6 @@ class ReportControllerTest extends AbstractTestController
         self::fixtures()->clear();
     }
 
-    public function testAddAuth(): void
-    {
-        $url = '/report';
-        $this->assertEndpointNeedsAuth('POST', $url);
-
-        $this->assertEndpointNotAllowedFor('POST', $url, self::$tokenAdmin);
-    }
-
-    public function testAddAcl(): void
-    {
-        $url = '/report';
-        $this->assertEndpointNotAllowedFor('POST', $url, self::$tokenDeputy, [
-            'client' => ['id' => self::$client2->getId()],
-        ]);
-    }
-
-    public function testAdd(): void
-    {
-        $url = '/report';
-
-        // add new report
-        $reportId = $this->assertJsonRequest('POST', $url, [
-            'mustSucceed' => true,
-            'AuthToken' => self::$tokenDeputy,
-            'data' => [
-                'client' => ['id' => self::$client3->getId()],
-            ],
-        ])['data']['report'];
-
-        self::fixtures()->clear();
-
-        // assert creation
-        $report = self::fixtures()->getReportById($reportId);
-
-        $this->assertEquals(self::$client3->getId(), $report->getClient()->getId());
-
-        $this->assertEquals(self::$order3->getOrderMadeDate()->format('Y-m-d'), $report->getStartDate()->format('Y-m-d'));
-        $this->assertEquals(self::$order3->getOrderMadeDate()->add(new \DateInterval('P1Y'))->sub(new \DateInterval('P1D'))->format('Y-m-d'), $report->getEndDate()->format('Y-m-d'));
-
-        self::fixtures()->flush();
-    }
-
     public function testGetByIdAuth(): void
     {
         $url = '/report/' . self::$report1->getId();

--- a/client/app/src/Controller/ClientController.php
+++ b/client/app/src/Controller/ClientController.php
@@ -155,12 +155,6 @@ class ClientController extends AbstractController
 
                 $client->setId($response['id']);
 
-                if (empty($client->getCurrentReport())) {
-                    $report = new Report();
-                    $report->setClient($client);
-                    $this->restClient->post('report', $report);
-                }
-
                 $currentUser = $this->userApi->getUserWithData();
 
                 $deputyResponse = $this->deputyApi->createDeputyFromUser($currentUser);

--- a/client/app/src/Controller/Report/ReportController.php
+++ b/client/app/src/Controller/Report/ReportController.php
@@ -11,7 +11,6 @@ use OPG\Digideps\Frontend\Entity\DeputyInterface;
 use OPG\Digideps\Frontend\Entity\Report\Document;
 use OPG\Digideps\Frontend\Entity\Report\Report;
 use OPG\Digideps\Frontend\Entity\User;
-use OPG\Digideps\Frontend\Event\RegistrationSucceededEvent;
 use OPG\Digideps\Frontend\EventDispatcher\ObservableEventDispatcher;
 use OPG\Digideps\Frontend\Exception\DisplayableException;
 use OPG\Digideps\Frontend\Exception\ReportNotSubmittableException;
@@ -140,57 +139,6 @@ class ReportController extends AbstractController
             'report' => $report,
             'form' => $editReportDatesForm->createView(),
             'returnLink' => $returnLink,
-        ];
-    }
-
-    /**
-     * Create report
-     * default action "create" will create only one report (used during registration steps to avoid duplicates when going back from the browser)
-     * action "add" will instead add another report.
-     */
-    #[Route(path: '/report/{action}/{clientId}', name: 'report_create', requirements: ['action' => '(create|add)'], defaults: ['action' => 'create'])]
-    #[Template('@App/Report/Report/create.html.twig')]
-    public function createAction(Request $request, string $clientId): RedirectResponse|array
-    {
-        /** @var Client $client */
-        $client = $this->restClient->get('client/' . $clientId, 'Client', ['client', 'client-id', 'client-reports', 'report-id']);
-
-        $existingReports = $this->reportApi->getReportsIndexedById($client);
-
-        if (count($existingReports)) {
-            throw $this->createAccessDeniedException('Client already has a report');
-        }
-
-        $report = new Report();
-        $report->setClient($client);
-
-        $form = $this->formFactory->createNamed(
-            'report',
-            ReportType::class,
-            $report,
-            [
-                'translation_domain' => 'registration',
-                'action' => $this->generateUrl('report_create', ['clientId' => $clientId]), // TODO useless ?
-            ]
-        );
-
-        $form->handleRequest($request);
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            /** @var array $data */
-            $data = $form->getData();
-
-            $this->restClient->post('report', $data);
-
-            $user = $this->userApi->getUserWithData();
-            $this->eventDispatcher->dispatch(new RegistrationSucceededEvent($user), RegistrationSucceededEvent::DEPUTY);
-
-            return $this->redirect($this->generateUrl('homepage'));
-        }
-
-        return [
-            'form' => $form->createView(),
-            'clientId' => $clientId,
         ];
     }
 


### PR DESCRIPTION
## Purpose
The current self-serve registration and admin invite pathways create a report.

However, under the new branch all reports will be created during the ingest, so we just want to remove the create report functionality at go live.

This ticket is to remove unnecessary report creation from the registration paths, because this will be handled by the ingest in future.

Fixes DDLS-1519

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
