### PR TITLE
Loosen WAF rate limits

### DIFF
--- a/terraform/account/region/waf.tf
+++ b/terraform/account/region/waf.tf
@@ -113,13 +113,14 @@ resource "aws_wafv2_web_acl" "main" {
       priority = 21
 
       action {
-        block {}
+        count {}
       }
 
       statement {
         rate_based_statement {
-          limit              = 200
-          aggregate_key_type = "IP"
+          limit                 = 200
+          aggregate_key_type    = "IP"
+          evaluation_window_sec = 60
         }
       }
 
@@ -215,6 +216,10 @@ resource "aws_wafv2_regex_pattern_set" "allow_uris" {
 
   regular_expression {
     regex_string = "^/public/favicon.ico$"
+  }
+
+  regular_expression {
+    regex_string = "^/favicon.ico$"
   }
 
   regular_expression {


### PR DESCRIPTION
Loosen the WAF rate limiting for now with further follow up PR to tighten it but excluding IPs on our VPN. I have set to count again for now as I want to do some proper analysis and try out different rules and monitor before re-enabling to block.