### PR TITLE
DDLS-1548 exclude allowed ips from rate limit block

### DIFF
--- a/terraform/account/region/variables.tf
+++ b/terraform/account/region/variables.tf
@@ -15,4 +15,9 @@ data "aws_caller_identity" "current" {}
 locals {
   current_main_region = data.aws_region.current.name
   s3_bucket           = var.account.name
+  default_allow_list  = concat(module.allow_list.palo_alto_prisma_access, module.allow_list.moj_sites)
+}
+
+module "allow_list" {
+  source = "git@github.com:ministryofjustice/opg-terraform-aws-moj-ip-allow-list.git?ref=v3.0.3"
 }

--- a/terraform/account/region/waf.tf
+++ b/terraform/account/region/waf.tf
@@ -113,14 +113,24 @@ resource "aws_wafv2_web_acl" "main" {
       priority = 21
 
       action {
-        count {}
+        block {}
       }
 
       statement {
         rate_based_statement {
-          limit                 = 200
+          limit                 = 60
           aggregate_key_type    = "IP"
           evaluation_window_sec = 60
+
+          scope_down_statement {
+            not_statement {
+              statement {
+                ip_set_reference_statement {
+                  arn = aws_wafv2_ip_set.rate_limit_exclusions.arn
+                }
+              }
+            }
+          }
         }
       }
 
@@ -353,4 +363,14 @@ resource "aws_wafv2_ip_set" "blocked_ips" {
       description
     ]
   }
+}
+
+
+resource "aws_wafv2_ip_set" "rate_limit_exclusions" {
+  name               = "rate-limit-exclusions"
+  description        = "IPs excluded from rate limiting"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+
+  addresses = local.default_allow_list
 }


### PR DESCRIPTION
- Exclude allow list IPs from the rate limiting (mainly to handle the autosave on checklist).
- Based on log queries I have done, 60 requests per 60s is fine for any authentic traffic.