### PR TITLE
php-cs-fixer has no support for multiple files without explicit config path

### DIFF
--- a/.github/workflows/_check-formatting.yml
+++ b/.github/workflows/_check-formatting.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   php-cs-fixer:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -27,4 +27,4 @@ jobs:
       - name: Run php-cs-fixer
         if: env.CHANGED_PHP_FILES != ''
         run: |
-          php php-cs-fixer.phar check -v --show-progress=none $CHANGED_PHP_FILES
+          php php-cs-fixer.phar check --config=.php-cs-fixer.dist.php -v --show-progress=none $CHANGED_PHP_FILES

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 
-$finder = (new Finder())
+$finder = new Finder()
     ->in(__DIR__)
     ->exclude(['api/app/vendor', 'client/app/vendor', 'api/app/cache', 'client/app/cache', 'api/app/var', 'client/app/var', 'common/vendor', 'vendor'])
     ->notName("bundles.php")
     ->notName("bootstrap.php")
 ;
 
-return (new Config())
+return new Config()
     ->setRules([
         '@PSR12' => true,
         'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => null],


### PR DESCRIPTION
## Purpose
_Briefly describe the purpose of the change, and/or link to the JIRA ticket for context_

Fixes DDLS-####

## Approach
_Explain how your code addresses the purpose of the change_

## Learning
_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about DigiDeps_

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/ADR/tech debt doc) where relevant
- [ ] I have added tests to prove my work
- [ ] The product team have approved these changes
- [ ] I have checked my work for potential security issues and refered to the [OWASP top 10](https://owasp.org/www-project-top-ten/)

### Frontend
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
- [ ] Any links or buttons added are screen reader friendly and contextually complete
