### PR TITLE
DDLS-1535d upgrade tls on loadbalancer

### DIFF
--- a/terraform/environment/region/load_balancer_admin.tf
+++ b/terraform/environment/region/load_balancer_admin.tf
@@ -21,7 +21,7 @@ resource "aws_lb_listener" "admin" {
   load_balancer_arn = aws_lb.admin.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   certificate_arn   = local.certificate_arn
 
   default_action {

--- a/terraform/environment/region/load_balancer_front.tf
+++ b/terraform/environment/region/load_balancer_front.tf
@@ -21,7 +21,7 @@ resource "aws_lb_listener" "front_https" {
   load_balancer_arn = aws_lb.front.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   certificate_arn   = local.certificate_arn
 
   default_action {


### PR DESCRIPTION
Based on log results, we should be fine with our user base upgrading this as everyone seems to be using tls version and encryption algo supported by ELBSecurityPolicy-TLS13-1-2-2021-06 (which is the latest we can upgrade safely to for now).
