### PR TITLE
Added cloudwatch alert if BatchGetImage results in ImageNotFound

### DIFF
--- a/terraform/account/region/cloudtrail_ecr_image_pull_alarm.tf
+++ b/terraform/account/region/cloudtrail_ecr_image_pull_alarm.tf
@@ -1,0 +1,49 @@
+data "aws_cloudwatch_log_group" "cloudtrail" {
+  name = "cloudtrail"
+}
+
+resource "aws_cloudwatch_log_metric_filter" "ecr_image_not_found" {
+  name           = "ECRImageNotFound.${var.account.name}"
+  log_group_name = data.aws_cloudwatch_log_group.cloudtrail.name
+  pattern        = "{ ($.eventSource = \"ecr.amazonaws.com\") && ($.eventName = \"BatchGetImage\") && ($.responseElements.failures[*].failureCode = \"ImageNotFound\") }"
+
+  metric_transformation {
+    name          = "ECRImageNotFound.${var.account.name}"
+    namespace     = "DigiDeps/Deployment"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "ecr_image_not_found" {
+  alarm_name          = "cloudtrail-${var.account.name}-ecr-image-not-found"
+  alarm_description   = "Triggers when an ECS deployment or redeployment attempts to pull an ECR image tag that does not exist."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  threshold           = 1
+  period              = 60
+  statistic           = "Sum"
+
+  namespace   = aws_cloudwatch_log_metric_filter.ecr_image_not_found.metric_transformation[0].namespace
+  metric_name = aws_cloudwatch_log_metric_filter.ecr_image_not_found.metric_transformation[0].name
+
+  alarm_actions      = [aws_sns_topic.alerts.arn]
+  treat_missing_data = "notBreaching"
+  actions_enabled    = true
+
+  tags = var.default_tags
+}
+
+resource "aws_cloudwatch_query_definition" "ecr_image_not_found" {
+  name            = "Deployment/ECR Image Not Found"
+  log_group_names = [data.aws_cloudwatch_log_group.cloudtrail.name]
+
+  query_string = <<EOF
+fields @timestamp, eventSource, eventName, errorCode, requestParameters.repositoryName, requestParameters.imageIds, responseElements.failures
+| filter eventSource = "ecr.amazonaws.com"
+| filter eventName = "BatchGetImage"
+| filter responseElements.failures like "ImageNotFound"
+| sort @timestamp desc
+EOF
+}


### PR DESCRIPTION
If a deployment tries to pull an image and the image is not available, trigger an alarm to the main channel about a failed deployment.

This is done by creating a CloudWatch metric filter on the CloudTrail log group that detects ECR BatchGetImage events with an ImageNotFound failure, publishes a custom metric, and uses a CloudWatch alarm to notify the alerts SNS topic.