### PR TITLE
DDLS-1578 add dodgy extension blocking to the waf

### DIFF
--- a/lambdas/functions/block_ips_lambda/app/block_ips.py
+++ b/lambdas/functions/block_ips_lambda/app/block_ips.py
@@ -96,6 +96,10 @@ def filter_logs(logs):
 
         request_uri = log["request_uri"]
 
+        # Ignore ACME, security.txt, etc.
+        if request_uri.startswith("/.well-known/"):
+            continue
+
         if status == 404:
             if suffix_pattern.match(request_uri):
                 filtered_logs[ip]["404_with_suffix"] += 1

--- a/terraform/account/region/waf.tf
+++ b/terraform/account/region/waf.tf
@@ -118,7 +118,7 @@ resource "aws_wafv2_web_acl" "main" {
 
       statement {
         rate_based_statement {
-          limit                 = 60
+          limit                 = 100
           aggregate_key_type    = "IP"
           evaluation_window_sec = 60
 
@@ -143,8 +143,138 @@ resource "aws_wafv2_web_acl" "main" {
   }
 
   rule {
-    name     = "AllowSpecificURIs"
+    name     = "RateLimitSuspiciousURIPatternsExec"
+    priority = 22
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit                 = 10
+        aggregate_key_type    = "IP"
+        evaluation_window_sec = 60
+
+        scope_down_statement {
+          regex_pattern_set_reference_statement {
+            arn = aws_wafv2_regex_pattern_set.suspicious_uri_patterns_exec.arn
+            field_to_match {
+              uri_path {}
+            }
+            text_transformation {
+              priority = 0
+              type     = "LOWERCASE"
+            }
+          }
+        }
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimitSuspiciousURIPatterns"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "RateLimitSuspiciousURIPatternsData"
+    priority = 23
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit                 = 10
+        aggregate_key_type    = "IP"
+        evaluation_window_sec = 60
+
+        scope_down_statement {
+          regex_pattern_set_reference_statement {
+            arn = aws_wafv2_regex_pattern_set.suspicious_uri_patterns_data.arn
+            field_to_match {
+              uri_path {}
+            }
+            text_transformation {
+              priority = 0
+              type     = "LOWERCASE"
+            }
+          }
+        }
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "RateLimitSuspiciousURIPatternsData"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "BlockSuspiciousExecURIPatterns"
+    priority = 24
+
+    action {
+      block {}
+    }
+
+    statement {
+      regex_pattern_set_reference_statement {
+        arn = aws_wafv2_regex_pattern_set.suspicious_uri_patterns_exec.arn
+
+        field_to_match {
+          uri_path {}
+        }
+
+        text_transformation {
+          priority = 0
+          type     = "LOWERCASE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockSuspiciousExecURIPatterns"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "BlockSuspiciousDataURIPatterns"
     priority = 25
+
+    action {
+      block {}
+    }
+
+    statement {
+      regex_pattern_set_reference_statement {
+        arn = aws_wafv2_regex_pattern_set.suspicious_uri_patterns_data.arn
+
+        field_to_match {
+          uri_path {}
+        }
+
+        text_transformation {
+          priority = 0
+          type     = "LOWERCASE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockSuspiciousDataURIPatterns"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AllowSpecificURIs"
+    priority = 26
 
     action {
       allow {}
@@ -214,6 +344,26 @@ resource "aws_wafv2_regex_pattern_set" "block_uris" {
   }
 
   scope = "REGIONAL"
+}
+
+resource "aws_wafv2_regex_pattern_set" "suspicious_uri_patterns_exec" {
+  name        = "suspicious-uri-patterns-exec"
+  description = "Executable, script and archive file extensions"
+  scope       = "REGIONAL"
+
+  regular_expression {
+    regex_string = "(?i)\\.(dll|msi|bat|py|bin|apk|php|asp|aspx|cgi|sh|exe|war|jar|tar|gz|tgz|zip|rar|7z|z|bz2|lz|xz|lzh)$"
+  }
+}
+
+resource "aws_wafv2_regex_pattern_set" "suspicious_uri_patterns_data" {
+  name        = "suspicious-uri-patterns-data"
+  description = "Configuration, database, document and secret file extensions"
+  scope       = "REGIONAL"
+
+  regular_expression {
+    regex_string = "(?i)\\.(env|xml|sql|bak|cfg|rtf|xls|tmp|doc|db|sqlite|sqlitedb|config|conf|ini|log|pem|key|p12|pfx|crt|ovpn|htaccess|htpasswd|DS_Store|swp)$"
+  }
 }
 
 resource "aws_wafv2_regex_pattern_set" "allow_uris" {


### PR DESCRIPTION
Had to split out the extensions into exec and data ones as they didn't fit in one list.

The idea behind this, is we rate limit the IP based on them putting in dodgy extensions and then hard block it too. 

This is already being done with most of this extensions in our nginx containers. This moves it to the WAF layer so we get less requests through.

I also noticed that some legitimate requests were being put in the sin bin for using /.wellknown/ paths which is legitimate action I believe by their browsers.

Very rarely it seems like some legit IPs were being rate limited. Now that we've added extra rate limiting to bad endpoints, it probably makes sense to relax the default rate limiting a bit.