### PR TITLE
DDLS-1609 make the lambda redeploy properly

### DIFF
--- a/terraform/account/region.tf
+++ b/terraform/account/region.tf
@@ -7,6 +7,7 @@ module "eu_west_1" {
 
   account      = local.account
   default_tags = local.default_tags
+  docker_tag   = var.OPG_DOCKER_TAG
 
   providers = {
     aws            = aws.digideps_eu_west_1
@@ -24,6 +25,7 @@ module "eu_west_2" {
 
   account      = local.account
   default_tags = local.default_tags
+  docker_tag   = var.OPG_DOCKER_TAG
 
   providers = {
     aws            = aws.digideps_eu_west_2

--- a/terraform/account/region/lambda_custom_sql.tf
+++ b/terraform/account/region/lambda_custom_sql.tf
@@ -32,7 +32,7 @@ locals {
 resource "aws_lambda_function" "custom_sql_tool" {
   function_name = "${local.lambda_custom_sql_name_tool}-${var.account.name}"
   description   = "Function to run custom sql queries"
-  image_uri     = "${data.aws_ecr_repository.custom_sql_query.repository_url}:latest"
+  image_uri     = "${data.aws_ecr_repository.custom_sql_query.repository_url}:${var.docker_tag}"
   package_type  = "Image"
   role          = aws_iam_role.custom_sql_query_task_role.arn
   timeout       = 600

--- a/terraform/account/region/variables.tf
+++ b/terraform/account/region/variables.tf
@@ -8,6 +8,11 @@ variable "default_tags" {
   type        = any
 }
 
+variable "docker_tag" {
+  type        = string
+  description = "The docker_tag"
+}
+
 data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}

--- a/terraform/account/variables.tf
+++ b/terraform/account/variables.tf
@@ -10,6 +10,12 @@ variable "MANAGEMENT_ROLE" {
   default     = "digideps-ci"
 }
 
+variable "OPG_DOCKER_TAG" {
+  description = "docker tag to deploy"
+  type        = string
+  default     = "latest"
+}
+
 variable "accounts" {
   type = map(
     object({


### PR DESCRIPTION
Lambda wasn't seeming to recognise new release based on the tags. Also it will be nicer to have an actual version we can see for the deployed version. A lot of the infra was already in place. Just pulling through the tag and using latest where it doesn't exist. In path to live this should now use the release tagged version correctly.