### PR TITLE
DDLS-1561 automate platform version updates

### DIFF
--- a/.github/workflows/scheduled-weekly-update-checks.yml
+++ b/.github/workflows/scheduled-weekly-update-checks.yml
@@ -1,0 +1,37 @@
+name: "[Scheduled] Weekly Update Checks"
+
+on:
+  schedule:
+    # 9am on Wednesdays
+    - cron: "0 9 * * 3"
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: none
+  security-events: none
+  actions: none
+  checks: none
+  deployments: none
+  issues: none
+  packages: none
+  repository-projects: none
+  statuses: none
+
+jobs:
+  run_weekly_update:
+    runs-on: ubuntu-latest
+    name: run platform version updates
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: update platform versions
+        run: python update_platform_versions.py
+        working-directory: scripts/pipeline/update_versions
+
+      - name: Create a signed commit
+        uses: ministryofjustice/modernisation-platform-github-actions/signed-commit@0d6fd59fa082417466d12e0e1a5e76da3f1712db # v6.1.8
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pr_title: "Update platform versions"
+          pr_body: "This PR was created automatically to update platform versions."

--- a/scripts/pipeline/update_versions/update_platform_versions.py
+++ b/scripts/pipeline/update_versions/update_platform_versions.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from urllib.request import urlopen
+
+"""
+This script is used for handling weekly checks for updates of various platform versions.
+To check a platform, add a new class for that platform and put all code in the class.
+"""
+
+CONFIG_FILE = Path("../../../terraform/environment/terraform.tfvars.json")
+
+AURORA_RELEASE_CALENDAR = (
+    "https://docs.aws.amazon.com/AmazonRDS/latest/"
+    "AuroraPostgreSQLReleaseNotes/"
+    "aurorapostgresql-release-calendar.md"
+)
+
+PRODUCTION = "production"
+
+NON_PROD = ["development", "staging", "training", "preproduction", "default"]
+
+
+class AuroraPostgresUpdater:
+    """
+    Handles Aurora PostgreSQL patch version updates.
+
+    Rules:
+
+    1. If production != preproduction
+       -> promote preproduction to production (as run weekly).
+
+    2. Otherwise:
+       -> find latest Aurora patch version available
+          within production major version.
+
+       -> update all non-prod environments.
+
+    3. If no changes required
+       -> exit with no modifications.
+    """
+
+    def __init__(self, config_path: Path):
+        self.config_path = config_path
+
+    def load(self) -> dict:
+        with self.config_path.open() as f:
+            return json.load(f)
+
+    def save(self, config: dict) -> None:
+        with self.config_path.open("w") as f:
+            json.dump(config, f, indent=2)
+            f.write("\n")
+
+    def get_engine_version(self, config: dict, environment: str) -> str:
+        return config["accounts"][environment]["db"]["psql_engine_version"]
+
+    def set_engine_version(
+        self,
+        config: dict,
+        environment: str,
+        version: str,
+    ) -> None:
+        config["accounts"][environment]["db"]["psql_engine_version"] = version
+
+    def fetch_release_calendar(self) -> str:
+        print("Fetching Aurora release calendar...")
+
+        with urlopen(AURORA_RELEASE_CALENDAR, timeout=30) as response:
+            if response.status != 200:
+                raise RuntimeError(f"Unexpected status code: {response.status}")
+
+            return response.read().decode("utf-8")
+
+    def latest_version_for_major(self, markdown: str, major: int) -> str:
+        """
+        Extract every version from the markdown and
+        find the highest version within the supplied major.
+        """
+
+        versions = set()
+
+        for match in re.findall(r"\b(\d+\.\d+)\b", markdown):
+            if match.startswith(f"{major}."):
+                versions.add(match)
+
+        if not versions:
+            raise RuntimeError(f"No Aurora PostgreSQL versions found for major {major}")
+
+        latest = max(versions, key=lambda v: tuple(int(x) for x in v.split(".")))
+
+        return latest
+
+    def run(self) -> bool:
+        config = self.load()
+
+        production_version = self.get_engine_version(
+            config,
+            PRODUCTION,
+        )
+
+        preprod_version = self.get_engine_version(
+            config,
+            "preproduction",
+        )
+
+        print(f"Production version:    {production_version}")
+        print(f"Preproduction version: {preprod_version}")
+
+        #
+        # Promotion phase
+        #
+        if production_version != preprod_version:
+            print()
+            print("Promotion phase detected")
+
+            print(f"Updating production " f"{production_version} -> {preprod_version}")
+
+            self.set_engine_version(
+                config,
+                PRODUCTION,
+                preprod_version,
+            )
+
+            self.save(config)
+
+            return True
+
+        #
+        # Upgrade phase
+        #
+        major = int(production_version.split(".")[0])
+
+        markdown = self.fetch_release_calendar()
+
+        latest_available = self.latest_version_for_major(
+            markdown,
+            major,
+        )
+
+        print(f"Latest available: {latest_available}")
+
+        if latest_available == preprod_version:
+            print()
+            print("No updates required")
+
+            return False
+
+        print()
+        print("Upgrade phase detected")
+
+        changed = False
+
+        for env in NON_PROD:
+            current = self.get_engine_version(
+                config,
+                env,
+            )
+
+            if current == latest_available:
+                continue
+
+            print(f"Updating {env}: " f"{current} -> {latest_available}")
+
+            self.set_engine_version(
+                config,
+                env,
+                latest_available,
+            )
+
+            changed = True
+
+        if changed:
+            self.save(config)
+
+        return changed
+
+
+def main() -> int:
+    print("Postgres Minor Version Update Checker")
+    updater = AuroraPostgresUpdater(CONFIG_FILE)
+
+    changed = updater.run()
+
+    if changed:
+        print()
+        print("Configuration updated")
+    else:
+        print()
+        print("Configuration unchanged")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
One of our security hub requirements is for auto incrementing RDS DB versions. Whilst low risk with minor updates.

We prefer to be in control of them for the following reasons:
- have them tested in lower environments before prod
- be able to see what version we are at in the code
- not have them upgrade unexpectedly
- have traceability for any unexpected performance side effects that we might notice (easier to diagnose if in git history)

As such I have created a renovate like script to handle various platform dependencies. This currently is just doing the minor RDS updates (as that is the ticket I picked up) but it could also apply to redis updates, fargate platform updates etc... I have made it so that each update can be handled as a class in the script. 

This will mean we keep up to date with updates and don't need to remember to check but that we are in control of the version we are using and when it is updated.

note: could have done this in a 'nicer' way with doing an aws describe on the db cluster to get latest available version but then I'd need to use aws permissions. This is a bit lower permissioned.

To then fix the underlying ticket I will just manually suppress the findings for auto updates.

What this actually does.
On a weekly basis checks we're at latest minor version for all no prod envs
If prod is less than preprod then update prod. 
this means first week it updates all the other envs where we would hopefully see any issues. Next week it raises the prod PR.