### PR TITLE
DDLS-1613 replace pecl with pie

### DIFF
--- a/api/docker/app/Dockerfile
+++ b/api/docker/app/Dockerfile
@@ -47,6 +47,8 @@ EXPOSE 443
 
 ENV TIMEOUT=20
 
+COPY --from=ghcr.io/php/pie:bin@sha256:65d91cecb73cb1fd03ae2a892d8ec76b25d34468532c0c2032afa9c412cf8b43 /pie /usr/bin/pie
+
 RUN apk --no-cache add \
     postgresql-dev \
     postgresql-client \
@@ -65,12 +67,13 @@ RUN docker-php-ext-install pdo pdo_pgsql opcache
 RUN docker-php-ext-enable opcache
 # Install pcov for faster coverage tooling
 RUN apk add --no-cache autoconf build-base
-RUN pecl install pcov && docker-php-ext-enable pcov
+RUN pie install pecl/pcov:^1.0.12 && docker-php-ext-enable pcov
+
 # Install Xdebug if directed to with build arg from docker-compose.yml
 ARG REQUIRE_XDEBUG=0
 RUN if [ "$REQUIRE_XDEBUG" = "1" ]; then \
     apk add --update linux-headers && \
-    pecl install xdebug && \
+    pie install xdebug/xdebug:^3.4 && \
     docker-php-ext-enable xdebug && \
     apk del linux-headers; \
   fi

--- a/client/docker/app/Dockerfile
+++ b/client/docker/app/Dockerfile
@@ -44,6 +44,8 @@ ARG LOCAL_RESOURCES=${LOCAL_RESOURCES:-"false"}
 WORKDIR /var/www
 ENV TIMEOUT=60
 
+COPY --from=ghcr.io/php/pie:bin@sha256:65d91cecb73cb1fd03ae2a892d8ec76b25d34468532c0c2032afa9c412cf8b43 /pie /usr/bin/pie
+
 # Dependencies
 RUN apk update && apk upgrade && apk add --no-cache \
     su-exec libzip-dev unzip \
@@ -52,13 +54,13 @@ RUN apk update && apk upgrade && apk add --no-cache \
     autoconf build-base wget \
  && docker-php-ext-install pcntl zip opcache gmp \
  && docker-php-ext-enable opcache \
- && pecl install pcov && docker-php-ext-enable pcov
+ && pie install pecl/pcov:^1.0.12 && docker-php-ext-enable pcov
 
 # Optional Xdebug
 ARG REQUIRE_XDEBUG=0
 RUN if [ "$REQUIRE_XDEBUG" = "1" ]; then \
       apk add --update linux-headers && \
-      pecl install xdebug && \
+      pie install xdebug/xdebug:^3.4 && \
       docker-php-ext-enable xdebug && \
       apk del linux-headers; \
     fi


### PR DESCRIPTION
PECL (PHP Extension Community Library) has been replaced with [PIE](https://github.com/php/pie) and should switch our extension installs to use that instead.