### PR TITLE
upgrade to newer docker images

### DIFF
--- a/client/docker/resources/Dockerfile
+++ b/client/docker/resources/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:25.6.0-alpine3.22@sha256:8c582bc73db57610b25f2ba4f71bd2d6f17f0b47367310c949acad09ea4dfcb3 AS node-base
+FROM node:26.8.1-alpine3.24@sha256:2d984a15c9b54fd0aeb608b8e0d0d83529eb34d2966db27a1fb4f1edc3d298a3 AS node-base
 WORKDIR /app
 COPY client/resources/package.json .
 COPY client/resources/package-lock.json .

--- a/disaster-recovery/backup/Dockerfile
+++ b/disaster-recovery/backup/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.6-alpine3.23@sha256:b165067c5afc37fa5608a3c05609cc3d51aafd808a30fbfd822ee594fef55ad4
+FROM python:3.14.7-alpine3.24@sha256:c6ead215bfd31f1e433d968853b7a769989117115b728874824e6c0a27cb96fc
 
 COPY requirements.txt /requirements.txt
 RUN apk update && apk upgrade

--- a/disaster-recovery/restore/Dockerfile
+++ b/disaster-recovery/restore/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.6-alpine3.23@sha256:b165067c5afc37fa5608a3c05609cc3d51aafd808a30fbfd822ee594fef55ad4
+FROM python:3.14.7-alpine3.24@sha256:c6ead215bfd31f1e433d968853b7a769989117115b728874824e6c0a27cb96fc
 
 COPY requirements.txt /requirements.txt
 RUN apk update && apk upgrade && pip install --no-cache-dir --upgrade pip

--- a/file-scanner/Dockerfile
+++ b/file-scanner/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM golang:1.26.4-alpine3.23@sha256:18b460dd17542c2ba43299a633cf6ebfc1115101509531471d7cfce1019af083 AS build
+FROM golang:1.26.8-alpine3.24@sha256:34efdd6036c92e155c8b0162a5da7626586b612ea636590035602c970eece564 AS build
 WORKDIR /go/src/clamav-rest
 
 COPY file-scanner/. .

--- a/lambdas/functions/block_ips_lambda/Dockerfile
+++ b/lambdas/functions/block_ips_lambda/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.6-alpine3.23@sha256:b165067c5afc37fa5608a3c05609cc3d51aafd808a30fbfd822ee594fef55ad4
+FROM python:3.14.7-alpine3.24@sha256:c6ead215bfd31f1e433d968853b7a769989117115b728874824e6c0a27cb96fc
 
 WORKDIR /
 COPY app /app

--- a/lambdas/functions/custom_sql_query/Dockerfile
+++ b/lambdas/functions/custom_sql_query/Dockerfile
@@ -1,6 +1,6 @@
 # Define function directory
 ARG FUNCTION_DIR="/function"
-FROM python:3.14.6-alpine3.23@sha256:b165067c5afc37fa5608a3c05609cc3d51aafd808a30fbfd822ee594fef55ad4 AS python-alpine
+FROM python:3.14.7-alpine3.24@sha256:c6ead215bfd31f1e433d968853b7a769989117115b728874824e6c0a27cb96fc AS python-alpine
 RUN apk update && apk add --no-cache \
     libstdc++ \
     zstd-libs \

--- a/orchestration/Dockerfile
+++ b/orchestration/Dockerfile
@@ -1,7 +1,7 @@
 # -------------------------
 # 1) Go builder
 # -------------------------
-FROM golang:1.26.4-alpine3.23@sha256:18b460dd17542c2ba43299a633cf6ebfc1115101509531471d7cfce1019af083 AS gobuilder
+FROM golang:1.26.8-alpine3.24@sha256:34efdd6036c92e155c8b0162a5da7626586b612ea636590035602c970eece564 AS gobuilder
 
 COPY sleep_mode /app/sleep_mode
 WORKDIR /app/sleep_mode

--- a/scripts/custom_sql_query/Dockerfile
+++ b/scripts/custom_sql_query/Dockerfile
@@ -1,7 +1,7 @@
 ARG FUNCTION_DIR="/function"
 
 # ===== BASE IMAGE =====
-FROM python:3.14.6-alpine3.23@sha256:b165067c5afc37fa5608a3c05609cc3d51aafd808a30fbfd822ee594fef55ad4 AS python-base
+FROM python:3.14.7-alpine3.24@sha256:c6ead215bfd31f1e433d968853b7a769989117115b728874824e6c0a27cb96fc AS python-base
 
 RUN apk update && apk upgrade
 

--- a/scripts/github_actions_audit/Dockerfile
+++ b/scripts/github_actions_audit/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.15-alpine3.24@sha256:540c7d91f98ff6880174c40e99067bf5941eb54d818a7a5e094d188b196a934d AS python
+FROM python:3.14.7-alpine3.24@sha256:c6ead215bfd31f1e433d968853b7a769989117115b728874824e6c0a27cb96fc AS python
 
 # Copy source files
 COPY requirements.txt /requirements.txt


### PR DESCRIPTION
Renovate doesn't update the alpine version annoyingly. So it updates the program version tag but not the alpine bit so here's manual update to latest.