### PR TITLE
DDLS-1670 add s3 vpc endpoint policy

### DIFF
--- a/terraform/account/region/modules/vpc_endpoint/main.tf
+++ b/terraform/account/region/modules/vpc_endpoint/main.tf
@@ -5,6 +5,7 @@ resource "aws_vpc_endpoint" "vpc_endpoint" {
   private_dns_enabled = true
   security_group_ids  = aws_security_group.vpc_endpoint[*].id
   subnet_ids          = var.subnet_ids
+  policy              = var.policy
   tags                = merge(var.tags, { Name = var.service_short_title })
 }
 

--- a/terraform/account/region/modules/vpc_endpoint/variables.tf
+++ b/terraform/account/region/modules/vpc_endpoint/variables.tf
@@ -1,5 +1,6 @@
 variable "vpc" {
   description = "VPC to use"
+  type        = any
 }
 
 variable "subnet_ids" {
@@ -26,4 +27,10 @@ variable "tags" {
   description = "A map of tags to use"
   type        = map(string)
   default     = {}
+}
+
+variable "policy" {
+  description = "VPC endpoint policy json"
+  type        = string
+  default     = ""
 }

--- a/terraform/account/region/modules/vpc_endpoint/versions.tf
+++ b/terraform/account/region/modules/vpc_endpoint/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0.0"
+    }
+  }
+  required_version = ">= 1.6.5"
+}

--- a/terraform/account/region/vpc_endpoint_s3.tf
+++ b/terraform/account/region/vpc_endpoint_s3.tf
@@ -1,0 +1,43 @@
+# For testing purposes we are going to limit to development initially
+resource "aws_vpc_endpoint" "s3_endpoint_vpc" {
+  service_name      = "com.amazonaws.eu-west-1.s3"
+  vpc_id            = module.network.vpc.id
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = module.network.application_subnet_route_tables[*].id
+  tags              = merge(var.default_tags, { Name = "s3" })
+  policy            = var.account.name == "development" ? data.aws_iam_policy_document.s3_endpoint.json : ""
+}
+
+data "aws_iam_policy_document" "s3_endpoint" {
+  statement {
+    sid    = "AllowApprovedBuckets"
+    effect = "Allow"
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+      "s3:Put*"
+    ]
+    resources = [
+      "arn:aws:s3:::pa-uploads-*",
+      "arn:aws:s3:::pa-uploads-*/*",
+      "arn:aws:s3:::s3-access-logs-opg-digideps-*",
+      "arn:aws:s3:::s3-access-logs-opg-digideps-*/*",
+      "arn:aws:s3:::opg-cloudtrail-*",
+      "arn:aws:s3:::opg-cloudtrail-*/*",
+      "arn:aws:s3:::cloudtrail*",
+      "arn:aws:s3:::cloudtrail*/*",
+      "arn:aws:s3:::digideps*",
+      "arn:aws:s3:::digideps*/*",
+      "arn:aws:s3:::config-eu-west-*",
+      "arn:aws:s3:::config-eu-west-*/*",
+      "arn:aws:s3:::alb-logs*",
+      "arn:aws:s3:::alb-logs*/*",
+      "arn:aws:s3:::alb-athena*",
+      "arn:aws:s3:::alb-athena*/*",
+    ]
+  }
+}

--- a/terraform/account/region/vpc_endpoints.tf
+++ b/terraform/account/region/vpc_endpoints.tf
@@ -88,11 +88,3 @@ module "rds_endpoint_vpc" {
   service_short_title = "rds"
   tags                = var.default_tags
 }
-
-resource "aws_vpc_endpoint" "s3_endpoint_vpc" {
-  service_name      = "com.amazonaws.eu-west-1.s3"
-  vpc_id            = module.network.vpc.id
-  vpc_endpoint_type = "Gateway"
-  route_table_ids   = module.network.application_subnet_route_tables[*].id
-  tags              = merge(var.default_tags, { Name = "s3" })
-}


### PR DESCRIPTION
Because the VPC endpoints are set up in the account module, we can't just manually apply without it getting overridden frequently. 

As such my plan is to do them one at a time in development only first, fully check everything works and then push out to the other environments.

Certain endpoints will be trickier than others. This one is the s3 endpoint.