### PR TITLE
Update curl to 8.22

### DIFF
--- a/htmltopdf/Dockerfile
+++ b/htmltopdf/Dockerfile
@@ -9,7 +9,7 @@ RUN addgroup -S htmltopdf \
 
 # Install curl for healthcheck, requirements for pdf generation and fonts
 RUN apk add --no-cache \
-    "curl==8.21.0-r0" \
+    "curl==8.22.0-r0" \
     "cairo==1.18.4-r1" \
     "pango==1.57.1-r0" \
     "gdk-pixbuf==2.44.7-r1" \


### PR DESCRIPTION
The docker builds are breaking because of this error:
```
> [ 3/14] RUN apk add --no-cache "curl==8.21.0-r0" "cairo==1.18.4-r1" "pango==1.57.1-r0" "gdk-pixbuf==2.44.7-r1" "jpeg==9f-r0" "libwebp==1.6.0-r0" "tiff==4.7.1-r0" "fontconfig==2.17.1-r1" "ttf-freefont==20120503-r4" "font-noto==2026.06.01-r0" "terminus-font==4.49.1-r4" && fc-cache -f:

0.676 ERROR: unable to select packages:

0.678 curl-8.22.0-r0:

0.678 breaks: world[curl=8.21.0-r0]
```

Therefore updating to 8.22 should resolve it.