### PR TITLE
Ddls 1670b RDS VPC endpoint permissions

### DIFF
--- a/terraform/account/region/vpc_endpoint_rds.tf
+++ b/terraform/account/region/vpc_endpoint_rds.tf
@@ -1,0 +1,26 @@
+module "rds_endpoint_vpc" {
+  source              = "./modules/vpc_endpoint"
+  subnet_ids          = module.network.application_subnets[*].id
+  vpc                 = module.network.vpc
+  region              = data.aws_region.current.name
+  service             = "rds"
+  service_short_title = "rds"
+  tags                = var.default_tags
+  policy            = var.account.name == "development" ? data.aws_iam_policy_document.rds_api_endpoint.json : ""
+}
+
+data "aws_iam_policy_document" "rds_api_endpoint" {
+  statement {
+    sid    = "AllowApprovedRDSOperations"
+    effect = "Allow"
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    actions = [
+      "rds:Describe*",
+      "rds:*Snapshot*"
+    ]
+    resources = ["*"]
+  }
+}

--- a/terraform/account/region/vpc_endpoints.tf
+++ b/terraform/account/region/vpc_endpoints.tf
@@ -78,6 +78,7 @@ module "sts_endpoint_vpc" {
   service_short_title = "sts"
   tags                = var.default_tags
 }
+<<<<<<< Updated upstream
 
 module "rds_endpoint_vpc" {
   source              = "./modules/vpc_endpoint"
@@ -96,3 +97,5 @@ resource "aws_vpc_endpoint" "s3_endpoint_vpc" {
   route_table_ids   = module.network.application_subnet_route_tables[*].id
   tags              = merge(var.default_tags, { Name = "s3" })
 }
+=======
+>>>>>>> Stashed changes


### PR DESCRIPTION
Lock down RDS VPC endpoint.

To find out the what events were used inside the VPC I used cloudtrail logs with this query:

```
fields @timestamp,
eventName,
userIdentity.arn,
sourceIPAddress,
vpcEndpointId
| filter eventSource = "rds.amazonaws.com"
| filter ispresent(vpcEndpointId)
| stats count() as calls by vpcEndpointId, eventName, userIdentity.arn
| sort calls desc
```

Checked over the last couple of weeks and the permissions I have given should allow normal operations to continue whilst cutting down on other destructive actions.

As before, I am trying to push this through development only for now.

Assumptions made: 
We won't increase the scope of actions we perform on the DB from within the VPC. 