### PR TITLE
DDLS-1670 ecr endpoints

### DIFF
--- a/terraform/account/region/variables.tf
+++ b/terraform/account/region/variables.tf
@@ -18,9 +18,10 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 locals {
-  current_main_region = data.aws_region.current.name
-  s3_bucket           = var.account.name
-  default_allow_list  = concat(module.allow_list.palo_alto_prisma_access, module.allow_list.moj_sites)
+  current_main_region   = data.aws_region.current.name
+  s3_bucket             = var.account.name
+  default_allow_list    = concat(module.allow_list.palo_alto_prisma_access, module.allow_list.moj_sites)
+  management_account_id = 311462405659
 }
 
 module "allow_list" {

--- a/terraform/account/region/vpc_endpoint_ecr.tf
+++ b/terraform/account/region/vpc_endpoint_ecr.tf
@@ -1,0 +1,54 @@
+module "ecr_endpoint_vpc" {
+  source              = "./modules/vpc_endpoint"
+  subnet_ids          = module.network.application_subnets[*].id
+  vpc                 = module.network.vpc
+  region              = data.aws_region.current.name
+  service             = "ecr.dkr"
+  service_short_title = "ecr"
+  tags                = var.default_tags
+  policy              = var.account.name == "development" ? data.aws_iam_policy_document.ecr_endpoint.json : ""
+}
+
+module "ecr_api_endpoint_vpc" {
+  source              = "./modules/vpc_endpoint"
+  subnet_ids          = module.network.application_subnets[*].id
+  vpc                 = module.network.vpc
+  region              = data.aws_region.current.name
+  service             = "ecr.api"
+  service_short_title = "ecr_api"
+  tags                = var.default_tags
+  policy              = var.account.name == "development" ? data.aws_iam_policy_document.ecr_endpoint.json : ""
+}
+
+data "aws_iam_policy_document" "ecr_endpoint" {
+  statement {
+    sid    = "AllowAccessToECR"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions = [
+      "ecr:Get*",
+      "ecr:Describe*",
+      "ecr:BatchGetImage"
+    ]
+    resources = [
+      "arn:aws:ecr:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*",
+      "arn:aws:ecr:${data.aws_region.current.region}:${local.management_account_id}:*"
+    ]
+  }
+
+  statement {
+    sid    = "AllowGetAuthToken"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions = [
+      "ecr:GetAuthorizationToken"
+    ]
+    resources = ["*"]
+  }
+}

--- a/terraform/account/region/vpc_endpoints.tf
+++ b/terraform/account/region/vpc_endpoints.tf
@@ -9,26 +9,6 @@ module "secrets_endpoint_vpc" {
   tags                = var.default_tags
 }
 
-module "ecr_endpoint_vpc" {
-  source              = "./modules/vpc_endpoint"
-  subnet_ids          = module.network.application_subnets[*].id
-  vpc                 = module.network.vpc
-  region              = data.aws_region.current.name
-  service             = "ecr.dkr"
-  service_short_title = "ecr"
-  tags                = var.default_tags
-}
-
-module "ecr_api_endpoint_vpc" {
-  source              = "./modules/vpc_endpoint"
-  subnet_ids          = module.network.application_subnets[*].id
-  vpc                 = module.network.vpc
-  region              = data.aws_region.current.name
-  service             = "ecr.api"
-  service_short_title = "ecr_api"
-  tags                = var.default_tags
-}
-
 module "logs_endpoint_vpc" {
   source              = "./modules/vpc_endpoint"
   subnet_ids          = module.network.application_subnets[*].id


### PR DESCRIPTION
The actions needed for ecr are based on:

```
SOURCE "cloudtrail" START=-2w END=0s |
fields @timestamp,
       eventName,
       sourceIPAddress,
       userIdentity.arn,
       vpcEndpointId
| filter eventSource = "ecr.amazonaws.com"
| stats count() as calls by eventName
| sort calls desc
```

The assumption is that we never do any pushing to ecr from within the VPC. This is a good thing to enforce as it would stop an attacker from modifying a docker image with an exploit and pushing it up to ECR. We also limit to our accounts so that we can't pull a dodgy image from another account.