### PR TITLE
DDLS-1670 add logs vpc endpoint policy

### DIFF
--- a/terraform/account/region/vpc_endpoint_logs.tf
+++ b/terraform/account/region/vpc_endpoint_logs.tf
@@ -1,0 +1,31 @@
+module "logs_endpoint_vpc" {
+  source              = "./modules/vpc_endpoint"
+  subnet_ids          = module.network.application_subnets[*].id
+  vpc                 = module.network.vpc
+  region              = data.aws_region.current.name
+  service             = "logs"
+  service_short_title = "logs"
+  tags                = var.default_tags
+  policy              = var.account.name == "development" ? data.aws_iam_policy_document.logs_endpoint.json : ""
+}
+
+data "aws_iam_policy_document" "logs_endpoint" {
+  statement {
+    sid    = "AllowApprovedBuckets"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions = [
+      "logs:*",
+      "rum:*",
+      "monitoring:*"
+    ]
+    resources = [
+      "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*",
+      "arn:aws:rum:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*",
+      "arn:aws:monitoring:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
+    ]
+  }
+}

--- a/terraform/account/region/vpc_endpoints.tf
+++ b/terraform/account/region/vpc_endpoints.tf
@@ -29,16 +29,6 @@ module "ecr_api_endpoint_vpc" {
   tags                = var.default_tags
 }
 
-module "logs_endpoint_vpc" {
-  source              = "./modules/vpc_endpoint"
-  subnet_ids          = module.network.application_subnets[*].id
-  vpc                 = module.network.vpc
-  region              = data.aws_region.current.name
-  service             = "logs"
-  service_short_title = "logs"
-  tags                = var.default_tags
-}
-
 module "ssm_endpoint_vpc" {
   source              = "./modules/vpc_endpoint"
   subnet_ids          = module.network.application_subnets[*].id


### PR DESCRIPTION
Logs VPC endpoint.

Limited to the operations that are currently used within the VPC

Trialling on development initially.