### PR TITLE
DDLS-1670 add vpc endpoint policy for secrets

### DIFF
--- a/terraform/account/region/vpc_endpoint_secrets.tf
+++ b/terraform/account/region/vpc_endpoint_secrets.tf
@@ -1,0 +1,28 @@
+module "secrets_endpoint_vpc" {
+  source              = "./modules/vpc_endpoint"
+  subnet_ids          = module.network.application_subnets[*].id
+  vpc                 = module.network.vpc
+  region              = data.aws_region.current.name
+  service             = "secretsmanager"
+  service_short_title = "secrets"
+  tags                = var.default_tags
+  policy              = var.account.name == "development" ? data.aws_iam_policy_document.secrets_endpoint.json : ""
+}
+
+data "aws_iam_policy_document" "secrets_endpoint" {
+  statement {
+    sid    = "AllowSecrets"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret"
+    ]
+    resources = [
+      "arn:aws:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
+    ]
+  }
+}


### PR DESCRIPTION
Nothing within the VPC needs to be able to change secrets. Checked in cloudtrail that these are only permissions needed.