### PR TITLE
DDLS-1627 typing

### DIFF
--- a/client/app/phpstan-baseline.neon
+++ b/client/app/phpstan-baseline.neon
@@ -319,12 +319,6 @@ parameters:
 			path: src/Components/OPG/Review/BankAccounts.php
 
 		-
-			message: '#^Parameter \#1 \$value of method OPG\\Digideps\\Frontend\\Components\\OPG\\Review\\BankAccounts\:\:formatBalance\(\) expects float\|int\|string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Components/OPG/Review/BankAccounts.php
-
-		-
 			message: '#^Parameter \#2 \$number of class OPG\\Digideps\\Frontend\\Components\\OPG\\Renderable\\BankAccount constructor expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -367,19 +361,7 @@ parameters:
 			path: src/Components/OPG/Review/Contacts.php
 
 		-
-			message: '#^Parameter \#2 \.\.\.\$cells of method OPG\\Digideps\\Frontend\\Components\\GOV\\Table\\TableBuilder\:\:addRow\(\) expects OPG\\Digideps\\Frontend\\Components\\GOV\\Table\\Cell\|OPG\\Digideps\\Frontend\\Components\\RenderableInterface\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Components/OPG/Review/Contacts.php
-
-		-
 			message: '#^Parameter \#3 \$address2 of class OPG\\Digideps\\Frontend\\Components\\OPG\\Renderable\\Contact constructor expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Components/OPG/Review/Contacts.php
-
-		-
-			message: '#^Parameter \#3 \.\.\.\$cells of method OPG\\Digideps\\Frontend\\Components\\GOV\\Table\\TableBuilder\:\:addRow\(\) expects OPG\\Digideps\\Frontend\\Components\\GOV\\Table\\Cell\|OPG\\Digideps\\Frontend\\Components\\RenderableInterface\|string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Components/OPG/Review/Contacts.php
@@ -401,36 +383,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Components/OPG/Review/Contacts.php
-
-		-
-			message: '#^Possibly invalid array key type mixed\.$#'
-			identifier: offsetAccess.invalidOffset
-			count: 1
-			path: src/Components/OPG/Review/Contacts.php
-
-		-
-			message: '#^Binary operation "\." between ''review\.'' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: src/Components/OPG/Review/Decisions.php
-
-		-
-			message: '#^Cannot call method format\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/Components/OPG/Review/Decisions.php
-
-		-
-			message: '#^Parameter \#2 \$value of method OPG\\Digideps\\Frontend\\Components\\GOV\\Summary\\SummaryListBuilder\:\:addItem\(\) expects OPG\\Digideps\\Frontend\\Components\\RenderableInterface\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 3
-			path: src/Components/OPG/Review/Decisions.php
-
-		-
-			message: '#^Parameter \#3 \.\.\.\$cells of method OPG\\Digideps\\Frontend\\Components\\GOV\\Table\\TableBuilder\:\:addRow\(\) expects OPG\\Digideps\\Frontend\\Components\\GOV\\Table\\Cell\|OPG\\Digideps\\Frontend\\Components\\RenderableInterface\|string, bool given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Components/OPG/Review/Decisions.php
 
 		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Controller\\AbstractController\:\:renderError\(\) has parameter \$message with no type specified\.$#'
@@ -1699,7 +1651,19 @@ parameters:
 			path: src/Controller/Report/BankAccountController.php
 
 		-
+			message: '#^Parameter \#1 \$closingBalance of method OPG\\Digideps\\Frontend\\Entity\\Report\\BankAccount\:\:setClosingBalance\(\) expects float\|int\|string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
 			message: '#^Parameter \#1 \$id of method Symfony\\Contracts\\Translation\\TranslatorInterface\:\:trans\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Controller/Report/BankAccountController.php
+
+		-
+			message: '#^Parameter \#1 \$openingBalance of method OPG\\Digideps\\Frontend\\Entity\\Report\\BankAccount\:\:setOpeningBalance\(\) expects float\|int\|string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Controller/Report/BankAccountController.php
@@ -1957,6 +1921,12 @@ parameters:
 			path: src/Controller/Report/LifestyleController.php
 
 		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 1
+			path: src/Controller/Report/LifestyleController.php
+
+		-
 			message: '#^Parameter \#2 \$mixed of method OPG\\Digideps\\Frontend\\Service\\Client\\RestClient\:\:post\(\) expects array\|object\|string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -1965,6 +1935,12 @@ parameters:
 		-
 			message: '#^Parameter \#2 \$mixed of method OPG\\Digideps\\Frontend\\Service\\Client\\RestClient\:\:put\(\) expects array\|object\|string, mixed given\.$#'
 			identifier: argument.type
+			count: 1
+			path: src/Controller/Report/LifestyleController.php
+
+		-
+			message: '#^Ternary operator condition is always true\.$#'
+			identifier: ternary.alwaysTrue
 			count: 1
 			path: src/Controller/Report/LifestyleController.php
 
@@ -2409,6 +2385,12 @@ parameters:
 		-
 			message: '#^Binary operation "\." between mixed and '' \(deputy\)'' results in an error\.$#'
 			identifier: binaryOp.invalid
+			count: 1
+			path: src/Controller/Report/ReportController.php
+
+		-
+			message: '#^Parameter \#1 \$reportId of method OPG\\Digideps\\Frontend\\Service\\Client\\Internal\\ReportApi\:\:getReportIfNotSubmitted\(\) expects int, int\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Controller/Report/ReportController.php
 
@@ -3163,12 +3145,6 @@ parameters:
 			path: src/Entity/Report/BankAccount.php
 
 		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\BankAccount\:\:getOpeningBalance\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Entity/Report/BankAccount.php
-
-		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\BankAccount\:\:getSortCode\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -3218,12 +3194,6 @@ parameters:
 
 		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\BankAccount\:\:setMeta\(\) has parameter \$meta with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Entity/Report/BankAccount.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\BankAccount\:\:setOpeningBalance\(\) has parameter \$openingBalance with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: src/Entity/Report/BankAccount.php
@@ -3325,12 +3295,6 @@ parameters:
 			path: src/Entity/Report/Contact.php
 
 		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Contact\:\:getExplanation\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Entity/Report/Contact.php
-
-		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Contact\:\:getId\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -3344,12 +3308,6 @@ parameters:
 
 		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Contact\:\:getPostcode\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Entity/Report/Contact.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Contact\:\:getRelationship\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: src/Entity/Report/Contact.php
@@ -3451,8 +3409,8 @@ parameters:
 			path: src/Entity/Report/Contact.php
 
 		-
-			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\Contact\:\:\$explanation has no type specified\.$#'
-			identifier: missingType.property
+			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\Contact\:\:\$explanation \(string\|null\) does not accept mixed\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/Entity/Report/Contact.php
 
@@ -3475,8 +3433,8 @@ parameters:
 			path: src/Entity/Report/Contact.php
 
 		-
-			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\Contact\:\:\$relationship has no type specified\.$#'
-			identifier: missingType.property
+			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\Contact\:\:\$relationship \(string\|null\) does not accept mixed\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/Entity/Report/Contact.php
 
@@ -3491,6 +3449,12 @@ parameters:
 			identifier: missingType.property
 			count: 1
 			path: src/Entity/Report/Debt.php
+
+		-
+			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\Decision\:\:\$id is never written, only read\.$#'
+			identifier: property.onlyRead
+			count: 1
+			path: src/Entity/Report/Decision.php
 
 		-
 			message: '#^Cannot call method getDocuments\(\) on OPG\\Digideps\\Frontend\\Entity\\Report\\Report\|null\.$#'
@@ -3607,6 +3571,30 @@ parameters:
 			path: src/Entity/Report/Gift.php
 
 		-
+			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Lifestyle\:\:getActivityDetailsNo\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Entity/Report/Lifestyle.php
+
+		-
+			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Lifestyle\:\:getActivityDetailsYes\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Entity/Report/Lifestyle.php
+
+		-
+			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Lifestyle\:\:getCareAppointments\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Entity/Report/Lifestyle.php
+
+		-
+			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Lifestyle\:\:getDoesClientUndertakeSocialActivities\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Entity/Report/Lifestyle.php
+
+		-
 			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\Lifestyle\:\:\$activityDetailsNo has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
@@ -3631,68 +3619,8 @@ parameters:
 			path: src/Entity/Report/Lifestyle.php
 
 		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:getHasCapacityChanged\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Entity/Report/MentalCapacity.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:getHasCapacityChangedDetails\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Entity/Report/MentalCapacity.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:getId\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Entity/Report/MentalCapacity.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:getMentalAssessmentDate\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Entity/Report/MentalCapacity.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:setHasCapacityChanged\(\) has parameter \$hasCapacityChanged with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Entity/Report/MentalCapacity.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:setHasCapacityChangedDetails\(\) has parameter \$hasCapacityChangedDetails with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Entity/Report/MentalCapacity.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:setMentalAssessmentDate\(\) has parameter \$mentalAssessmentDate with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: src/Entity/Report/MentalCapacity.php
-
-		-
-			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:\$hasCapacityChanged has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/Entity/Report/MentalCapacity.php
-
-		-
-			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:\$hasCapacityChangedDetails has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/Entity/Report/MentalCapacity.php
-
-		-
 			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:\$id is never written, only read\.$#'
 			identifier: property.onlyRead
-			count: 1
-			path: src/Entity/Report/MentalCapacity.php
-
-		-
-			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:\$mentalAssessmentDate has no type specified\.$#'
-			identifier: missingType.property
 			count: 1
 			path: src/Entity/Report/MentalCapacity.php
 
@@ -3701,12 +3629,6 @@ parameters:
 			identifier: property.onlyWritten
 			count: 1
 			path: src/Entity/Report/MoneyReceivedOnClientsBehalf.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\MoneyTransaction\:\:getCategoriesGrouped\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Entity/Report/MoneyTransaction.php
 
 		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\MoneyTransaction\:\:getCategoriesGrouped\(\) has parameter \$typeFilter with no type specified\.$#'
@@ -3841,8 +3763,20 @@ parameters:
 			path: src/Entity/Report/ProfDeputyOtherCost.php
 
 		-
+			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\ProfDeputyOtherCost\:\:getProfDeputyOtherCostTypeId\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Entity/Report/ProfDeputyOtherCost.php
+
+		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\ProfDeputyOtherCost\:\:setProfDeputyOtherCostTypeId\(\) has parameter \$profDeputyOtherCostTypeId with no type specified\.$#'
 			identifier: missingType.parameter
+			count: 1
+			path: src/Entity/Report/ProfDeputyOtherCost.php
+
+		-
+			message: '#^PHPDoc tag @return with type mixed is not subtype of native type string\.$#'
+			identifier: return.phpDocType
 			count: 1
 			path: src/Entity/Report/ProfDeputyOtherCost.php
 
@@ -4003,20 +3937,8 @@ parameters:
 			path: src/Entity/Report/Report.php
 
 		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:getSignificantDecisionsMade\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Entity/Report/Report.php
-
-		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:getTotalValue\(\) should return int but returns float\|int\.$#'
 			identifier: return.type
-			count: 1
-			path: src/Entity/Report/Report.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:hasContacts\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Entity/Report/Report.php
 
@@ -4087,12 +4009,6 @@ parameters:
 			path: src/Entity/Report/Report.php
 
 		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:setId\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Entity/Report/Report.php
-
-		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:setMentalCapacity\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -4113,12 +4029,6 @@ parameters:
 		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:setSignificantDecisionsMade\(\) has parameter \$significantDecisionsMade with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: src/Entity/Report/Report.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:setStartDate\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: src/Entity/Report/Report.php
 
@@ -4243,13 +4153,7 @@ parameters:
 			path: src/Entity/Report/Report.php
 
 		-
-			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:\$significantDecisionsMade has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: src/Entity/Report/Report.php
-
-		-
-			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:\$submittedBy \(OPG\\Digideps\\Frontend\\Entity\\User\) does not accept OPG\\Digideps\\Frontend\\Entity\\User\|null\.$#'
+			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:\$significantDecisionsMade \(string\|null\) does not accept mixed\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: src/Entity/Report/Report.php
@@ -6295,6 +6199,12 @@ parameters:
 			path: src/Model/FeedbackReport.php
 
 		-
+			message: '#^Parameter \#1 \$reportId of class OPG\\Digideps\\Common\\Report\\ReportMetadata constructor expects int, int\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Report/ReportSectionService.php
+
+		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Resolver\\SubSectionRoute\\ProfCostsEstimateSubSectionRouteResolver\:\:breakdownSubsectionIsIncomplete\(\) has parameter \$state with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -6818,6 +6728,12 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$message of class Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Service/Client/Internal/ReportApi.php
+
+		-
+			message: '#^Parameter \#1 \$reportId of method OPG\\Digideps\\Frontend\\Service\\Client\\Internal\\ReportApi\:\:getReport\(\) expects int, int\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Service/Client/Internal/ReportApi.php
@@ -9409,6 +9325,12 @@ parameters:
 			path: src/Sync/Service/ChecklistSyncService.php
 
 		-
+			message: '#^Method OPG\\Digideps\\Frontend\\Sync\\Service\\ChecklistSyncService\:\:syncChecklistsByReports\(\) should return array\{notSyncedCount\: int, reportIdsWithNullChecklists\: array\<int\>\} but returns array\{notSyncedCount\: int\<0, max\>, reportIdsWithNullChecklists\: list\<int\|null\>\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/Sync/Service/ChecklistSyncService.php
+
+		-
 			message: '#^Call to function method_exists\(\) with Throwable and ''getCode'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
@@ -9437,48 +9359,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Sync/Service/SiriusApiErrorTranslator.php
-
-		-
-			message: '#^Cannot call method setChecklist\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/TestHelpers/ChecklistTestHelper.php
-
-		-
-			message: '#^Cannot call method setClient\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/TestHelpers/ChecklistTestHelper.php
-
-		-
-			message: '#^Cannot call method setEndDate\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/TestHelpers/ChecklistTestHelper.php
-
-		-
-			message: '#^Cannot call method setReportSubmissions\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/TestHelpers/ChecklistTestHelper.php
-
-		-
-			message: '#^Cannot call method setType\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/TestHelpers/ChecklistTestHelper.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\TestHelpers\\ChecklistTestHelper\:\:buildPfaHighReport\(\) should return OPG\\Digideps\\Frontend\\Entity\\Report\\Report but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/TestHelpers/ChecklistTestHelper.php
-
-		-
-			message: '#^Parameter \#1 \$report of class OPG\\Digideps\\Frontend\\Entity\\Report\\Checklist constructor expects OPG\\Digideps\\Frontend\\Entity\\Report\\Report, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/TestHelpers/ChecklistTestHelper.php
 
 		-
 			message: '#^Method OPG\\Digideps\\Frontend\\TestHelpers\\ClientHelpers\:\:createValidCaseNumber\(\) has no return type specified\.$#'
@@ -9557,30 +9437,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/TestHelpers/OrganisationHelpers.php
-
-		-
-			message: '#^Cannot call method setDueDate\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/TestHelpers/ReportHelpers.php
-
-		-
-			message: '#^Cannot call method setEndDate\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/TestHelpers/ReportHelpers.php
-
-		-
-			message: '#^Cannot call method setStartDate\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: src/TestHelpers/ReportHelpers.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\TestHelpers\\ReportHelpers\:\:createReport\(\) should return OPG\\Digideps\\Frontend\\Entity\\Report\\Report but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: src/TestHelpers/ReportHelpers.php
 
 		-
 			message: '#^Parameter \#1 \$submittedBy of method OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:setSubmittedBy\(\) expects OPG\\Digideps\\Frontend\\Entity\\User\|null, array\|object given\.$#'
@@ -13693,12 +13549,6 @@ parameters:
 			path: tests/Unit/Service/Mailer/MailFactoryTest.php
 
 		-
-			message: '#^Cannot call method setEndDate\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: tests/Unit/Service/Mailer/MailFactoryTest.php
-
-		-
 			message: '#^Method Tests\\OPG\\Digideps\\Frontend\\Unit\\Service\\Mailer\\MailFactoryTest\:\:assertStaticEmailProperties\(\) has parameter \$email with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -13761,18 +13611,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$type of method OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:setType\(\) expects string, mixed given\.$#'
 			identifier: argument.type
-			count: 1
-			path: tests/Unit/Service/Mailer/MailFactoryTest.php
-
-		-
-			message: '#^Property Tests\\OPG\\Digideps\\Frontend\\Unit\\Service\\Mailer\\MailFactoryTest\:\:\$newReport \(OPG\\Digideps\\Frontend\\Entity\\Report\\Report\) does not accept mixed\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: tests/Unit/Service/Mailer/MailFactoryTest.php
-
-		-
-			message: '#^Property Tests\\OPG\\Digideps\\Frontend\\Unit\\Service\\Mailer\\MailFactoryTest\:\:\$submittedReport \(OPG\\Digideps\\Frontend\\Entity\\Report\\Report\) does not accept mixed\.$#'
-			identifier: assign.propertyType
 			count: 1
 			path: tests/Unit/Service/Mailer/MailFactoryTest.php
 

--- a/client/app/src/Entity/Report/BankAccount.php
+++ b/client/app/src/Entity/Report/BankAccount.php
@@ -96,14 +96,14 @@ class BankAccount implements BankAccountInterface
     #[JMS\Groups(['account'])]
     #[Assert\NotBlank(message: 'account.openingBalance.notBlank', groups: ['bank-account-opening-balance'])]
     #[Assert\Type(type: 'numeric', message: 'account.openingBalance.type', groups: ['bank-account-opening-balance'])]
-    #[Assert\Range(max: 100000000000, maxMessage: 'account.openingBalance.outOfRange', groups: ['bank-account-opening-balance'])]
-    private mixed $openingBalance = null;
+    #[Assert\Range(maxMessage: 'account.openingBalance.outOfRange', max: 100000000000, groups: ['bank-account-opening-balance'])]
+    private null|string|int|float $openingBalance = null;
 
     #[JMS\Type('string')]
     #[Assert\Type(type: 'numeric', message: 'account.closingBalance.type', groups: ['bank-account-closing-balance'])]
-    #[Assert\Range(max: 100000000000, maxMessage: 'account.closingBalance.outOfRange', groups: ['bank-account-closing-balance'])]
+    #[Assert\Range(maxMessage: 'account.closingBalance.outOfRange', max: 100000000000, groups: ['bank-account-closing-balance'])]
     #[JMS\Groups(['account'])]
-    private mixed $closingBalance = null;
+    private null|string|int|float $closingBalance = null;
 
     /**
      * @var bool
@@ -190,19 +190,19 @@ class BankAccount implements BankAccountInterface
         return $this->accountNumber;
     }
 
-    public function setOpeningBalance($openingBalance): static
+    public function setOpeningBalance(null|string|int|float $openingBalance): static
     {
         $this->openingBalance = $openingBalance;
 
         return $this;
     }
 
-    public function getOpeningBalance()
+    public function getOpeningBalance(): null|string|int|float
     {
         return $this->openingBalance;
     }
 
-    public function setClosingBalance(mixed $closingBalance): static
+    public function setClosingBalance(null|string|int|float $closingBalance): static
     {
         $this->closingBalance = $closingBalance;
 

--- a/client/app/src/Entity/Report/Contact.php
+++ b/client/app/src/Entity/Report/Contact.php
@@ -24,7 +24,7 @@ class Contact
     #[JMS\Type('string')]
     #[JMS\Groups(['contact'])]
     #[Assert\NotBlank(message: 'contact.name.notBlank')]
-    #[Assert\Length(min: 2, minMessage: 'contact.name.minMessage', max: 255, maxMessage: 'contact.name.maxMessage')]
+    #[Assert\Length(min: 2, max: 255, minMessage: 'contact.name.minMessage', maxMessage: 'contact.name.maxMessage')]
     private $contactName;
 
     #[JMS\Type('string')]
@@ -55,13 +55,13 @@ class Contact
     #[JMS\Groups(['contact'])]
     #[Assert\Length(min: 6, minMessage: 'contact.explanation.length')]
     #[Assert\NotBlank(message: 'contact.explanation.notBlank')]
-    private $explanation;
+    private ?string $explanation = null;
 
     #[JMS\Type('string')]
     #[JMS\Groups(['contact'])]
     #[Assert\NotBlank(message: 'contact.relationship.notBlank')]
-    #[Assert\Length(min: 2, minMessage: 'contact.relationship.minMessage', max: 100, maxMessage: 'contact.relationship.maxMessage')]
-    private $relationship;
+    #[Assert\Length(min: 2, max: 100, minMessage: 'contact.relationship.minMessage', maxMessage: 'contact.relationship.maxMessage')]
+    private ?string $relationship = null;
 
     #[JMS\Type('string')]
     #[JMS\Groups(['contact'])]
@@ -159,7 +159,7 @@ class Contact
         return $this;
     }
 
-    public function getExplanation()
+    public function getExplanation(): ?string
     {
         return $this->explanation;
     }
@@ -171,7 +171,7 @@ class Contact
         return $this;
     }
 
-    public function getRelationship()
+    public function getRelationship(): ?string
     {
         return $this->relationship;
     }

--- a/client/app/src/Entity/Report/Decision.php
+++ b/client/app/src/Entity/Report/Decision.php
@@ -10,38 +10,26 @@ class Decision
 {
     use HasReportTrait;
 
-    /**
-     * @var int
-     */
     #[JMS\Type('integer')]
     #[JMS\Groups(['decision'])]
-    private $id;
+    private int $id;
 
-    /**
-     * @var string
-     */
     #[JMS\Type('string')]
     #[JMS\Groups(['decision'])]
     #[Assert\NotBlank(message: 'decision.description.notBlank', groups: ['decision-description'])]
     #[Assert\Length(min: 2, minMessage: 'decision.description.length', groups: ['decision-description'])]
-    private $description;
+    private ?string $description = null;
 
-    /**
-     * @var bool
-     */
-    #[Assert\NotBlank(message: 'decision.clientInvolvedBoolean.notBlank', groups: ['decision-client-involved'])]
+    #[Assert\NotNull(message: 'decision.clientInvolvedBoolean.notBlank', groups: ['decision-client-involved'])]
     #[JMS\Type('boolean')]
     #[JMS\Groups(['decision'])]
-    private $clientInvolvedBoolean;
+    private ?bool $clientInvolvedBoolean = null;
 
-    /**
-     * @var bool
-     */
     #[Assert\NotBlank(message: 'decision.clientInvolvedDetails.notBlank', groups: ['decision-client-involved-details'])]
     #[Assert\Length(min: 2, minMessage: 'decision.clientInvolvedDetails.length', groups: ['decision-client-involved-details'])]
     #[JMS\Type('string')]
     #[JMS\Groups(['decision'])]
-    private $clientInvolvedDetails;
+    private ?string $clientInvolvedDetails = null;
 
     /**
      * @JMS\Type("DateTime")
@@ -50,72 +38,41 @@ class Decision
      */
     private ?\DateTime $createdAt = null;
 
-    /**
-     * @return int
-     */
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }
 
-    /**
-     * @param int $id
-     */
-    public function setId($id): static
-    {
-        $this->id = $id;
-
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function getDescription()
+    public function getDescription(): ?string
     {
         return $this->description;
     }
 
-    /**
-     * @param string $description
-     */
-    public function setDescription($description): static
+    public function setDescription(?string $description): static
     {
         $this->description = $description;
 
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function isClientInvolvedBoolean()
+    public function isClientInvolvedBoolean(): ?bool
     {
         return $this->clientInvolvedBoolean;
     }
 
-    /**
-     * @param bool $clientInvolvedBoolean
-     */
-    public function setClientInvolvedBoolean($clientInvolvedBoolean): static
+    public function setClientInvolvedBoolean(?bool $clientInvolvedBoolean): static
     {
         $this->clientInvolvedBoolean = $clientInvolvedBoolean;
 
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function isClientInvolvedDetails()
+    public function isClientInvolvedDetails(): ?string
     {
         return $this->clientInvolvedDetails;
     }
 
-    /**
-     * @param bool $clientInvolvedDetails
-     */
-    public function setClientInvolvedDetails($clientInvolvedDetails): static
+    public function setClientInvolvedDetails(?string $clientInvolvedDetails): static
     {
         $this->clientInvolvedDetails = $clientInvolvedDetails;
 

--- a/client/app/src/Entity/Report/Lifestyle.php
+++ b/client/app/src/Entity/Report/Lifestyle.php
@@ -55,10 +55,7 @@ class Lifestyle
         return $this;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getCareAppointments()
+    public function getCareAppointments(): ?string
     {
         return $this->careAppointments;
     }
@@ -73,10 +70,7 @@ class Lifestyle
         return $this;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getDoesClientUndertakeSocialActivities()
+    public function getDoesClientUndertakeSocialActivities(): ?string
     {
         return $this->doesClientUndertakeSocialActivities;
     }
@@ -99,10 +93,7 @@ class Lifestyle
         return true;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getActivityDetailsYes()
+    public function getActivityDetailsYes(): ?string
     {
         return $this->activityDetailsYes;
     }
@@ -117,10 +108,7 @@ class Lifestyle
         return $this;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getActivityDetailsNo()
+    public function getActivityDetailsNo(): ?string
     {
         return $this->activityDetailsNo;
     }

--- a/client/app/src/Entity/Report/MentalCapacity.php
+++ b/client/app/src/Entity/Report/MentalCapacity.php
@@ -13,63 +13,60 @@ class MentalCapacity
     public const string CAPACITY_CHANGED = 'changed';
     public const string CAPACITY_STAYED_SAME = 'stayedSame';
 
-    /**
-     * @var int
-     */
     #[JMS\Type('integer')]
     #[JMS\Groups(['mental-capacity'])]
-    private $id;
+    private int $id;
 
     #[JMS\Type('string')]
     #[JMS\Groups(['mental-capacity'])]
     #[Assert\NotBlank(message: 'mentalCapacity.hasCapacityChanged.notBlank', groups: ['capacity'])]
-    private $hasCapacityChanged;
+    private ?string $hasCapacityChanged = null;
 
     #[JMS\Type('string')]
     #[JMS\Groups(['mental-capacity'])]
     #[Assert\NotBlank(message: 'mentalCapacity.hasCapacityChangedDetails.notBlank', groups: ['has-capacity-changed-yes'])]
-    private $hasCapacityChangedDetails;
+    private ?string $hasCapacityChangedDetails = null;
 
     #[JMS\Type("DateTime<'Y-m-d'>")]
     #[JMS\Groups(['mental-assessment-date'])]
     #[Assert\NotBlank(message: 'mentalCapacity.mentalAssessmentDate.notBlank', groups: ['mental-assessment-date'])]
-    private $mentalAssessmentDate;
+    private ?\DateTime $mentalAssessmentDate = null;
 
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }
 
-    public function getHasCapacityChanged()
+    public function getHasCapacityChanged(): ?string
     {
         return $this->hasCapacityChanged;
     }
 
-    public function getHasCapacityChangedDetails()
+    public function getHasCapacityChangedDetails(): ?string
     {
         return $this->hasCapacityChangedDetails;
     }
 
-    public function setHasCapacityChanged($hasCapacityChanged): static
+    public function setHasCapacityChanged(?string $hasCapacityChanged): static
     {
         $this->hasCapacityChanged = $hasCapacityChanged;
 
         return $this;
     }
 
-    public function setHasCapacityChangedDetails($hasCapacityChangedDetails): static
+    public function setHasCapacityChangedDetails(?string $hasCapacityChangedDetails): static
     {
         $this->hasCapacityChangedDetails = $hasCapacityChangedDetails;
 
         return $this;
     }
 
-    public function getMentalAssessmentDate()
+    public function getMentalAssessmentDate(): ?\DateTime
     {
         return $this->mentalAssessmentDate;
     }
 
-    public function setMentalAssessmentDate($mentalAssessmentDate): static
+    public function setMentalAssessmentDate(?\DateTime $mentalAssessmentDate): static
     {
         $this->mentalAssessmentDate = $mentalAssessmentDate;
 

--- a/client/app/src/Entity/Report/MoneyTransaction.php
+++ b/client/app/src/Entity/Report/MoneyTransaction.php
@@ -11,7 +11,7 @@ class MoneyTransaction
 {
     use HasBankAccountTrait;
 
-    public static function getCategoriesGrouped($typeFilter)
+    public static function getCategoriesGrouped($typeFilter): array
     {
         $ret = [];
         foreach (MoneyTransaction::$categories as $k => $row) {

--- a/client/app/src/Entity/Report/ProfDeputyOtherCost.php
+++ b/client/app/src/Entity/Report/ProfDeputyOtherCost.php
@@ -55,7 +55,7 @@ class ProfDeputyOtherCost
     /**
      * @return mixed
      */
-    public function getProfDeputyOtherCostTypeId()
+    public function getProfDeputyOtherCostTypeId(): string
     {
         return $this->profDeputyOtherCostTypeId;
     }

--- a/client/app/src/Entity/Report/Report.php
+++ b/client/app/src/Entity/Report/Report.php
@@ -99,12 +99,9 @@ class Report implements StartEndDateComparableInterface
     public const string YES_MONEY_EXISTS = 'Yes';
     public const string NO_MONEY_EXISTS = 'No';
 
-    /**
-     * @var int
-     */
     #[JMS\Type('integer')]
-    #[JMS\Groups(['visits-care', 'report-id'])]
-    private $id;
+    #[JMS\Groups(['report', 'report-id'])]
+    private ?int $id = null;
 
     /**
      * see TYPE_* constant
@@ -163,11 +160,8 @@ class Report implements StartEndDateComparableInterface
     #[JMS\Groups(['unsubmit_date'])]
     private $unSubmitDate;
 
-    /**
-     * @var User
-     */
     #[JMS\Type('OPG\Digideps\Frontend\Entity\User')]
-    private $submittedBy;
+    private ?User $submittedBy = null;
 
     #[JMS\Type('OPG\Digideps\Frontend\Entity\Deputy')]
     #[JMS\Groups(['deputy'])]
@@ -245,7 +239,7 @@ class Report implements StartEndDateComparableInterface
 
     #[JMS\Type('string')]
     #[JMS\Groups(['report', 'significantDecisionsMade'])]
-    private $significantDecisionsMade;
+    private ?string $significantDecisionsMade = null;
 
     /**
      * @var string|null
@@ -389,18 +383,12 @@ class Report implements StartEndDateComparableInterface
     #[Assert\NotBlank(message: 'moneyOut.reasonForNoMoneyOut.notBlank', groups: ['reasonForNoMoneyOut'])]
     private $reasonForNoMoneyOut;
 
-    /**
-     * @return int $id
-     */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    /**
-     * @param int $id
-     */
-    public function setId($id)
+    public function setId(int $id): static
     {
         $this->id = $id;
 
@@ -451,7 +439,7 @@ class Report implements StartEndDateComparableInterface
         return $this->startDate;
     }
 
-    public function setStartDate(?\DateTime $startDate = null)
+    public function setStartDate(?\DateTime $startDate = null): static
     {
         if ($startDate instanceof \DateTime) {
             $startDate->setTime(0, 0, 0);
@@ -545,10 +533,7 @@ class Report implements StartEndDateComparableInterface
         return $this;
     }
 
-    /**
-     * @return User
-     */
-    public function getSubmittedBy()
+    public function getSubmittedBy(): ?User
     {
         return $this->submittedBy;
     }
@@ -732,7 +717,7 @@ class Report implements StartEndDateComparableInterface
         return $this->isDue;
     }
 
-    public function hasContacts()
+    public function hasContacts(): ?string
     {
         if (empty($this->getContacts()) && $this->getReasonForNoContacts() === null) {
             return null;
@@ -747,7 +732,7 @@ class Report implements StartEndDateComparableInterface
         return null;
     }
 
-    public function getSignificantDecisionsMade()
+    public function getSignificantDecisionsMade(): ?string
     {
         return $this->significantDecisionsMade;
     }
@@ -821,12 +806,9 @@ class Report implements StartEndDateComparableInterface
         $this->visitsCare = $visitsCare;
     }
 
-    /**
-     * @return Lifestyle
-     */
-    public function getLifestyle()
+    public function getLifestyle(): Lifestyle
     {
-        return $this->lifestyle ?: new Lifestyle();
+        return $this->lifestyle ?? new Lifestyle();
     }
 
     /**
@@ -852,10 +834,7 @@ class Report implements StartEndDateComparableInterface
         return $this;
     }
 
-    /**
-     * @return MentalCapacity
-     */
-    public function getMentalCapacity()
+    public function getMentalCapacity(): ?MentalCapacity
     {
         return $this->mentalCapacity;
     }

--- a/client/app/src/Entity/Report/Traits/ReportMoneyTransactionTrait.php
+++ b/client/app/src/Entity/Report/Traits/ReportMoneyTransactionTrait.php
@@ -76,9 +76,9 @@ trait ReportMoneyTransactionTrait
      *
      * @param MoneyTransaction[] $moneyTransactions
      *
-     * @return array array of [category=>[entries=>[[id=>,type=>]], amountTotal[]]]
+     * @return array<array> array of [category=>[entries=>[[id=>,type=>]], amountTotal[]]]
      */
-    public function groupMoneyTransactionsByGroup(array $moneyTransactions)
+    public function groupMoneyTransactionsByGroup(array $moneyTransactions): array
     {
         $ret = [];
 

--- a/client/app/src/Form/Report/TransactionSingleType.php
+++ b/client/app/src/Form/Report/TransactionSingleType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Validator\Constraints\Valid;
 
 class TransactionSingleType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
                  ->add('id', FormTypes\HiddenType::class)
@@ -40,7 +40,7 @@ class TransactionSingleType extends AbstractType
         });
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
              'data_class' => MoneyTransaction::class,
@@ -49,7 +49,7 @@ class TransactionSingleType extends AbstractType
         ]);
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'transaction_single';
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -139,12 +139,6 @@ parameters:
 			path: api/app/src/Command/ProcessLayCSVCommand.php
 
 		-
-			message: '#^Property OPG\\Digideps\\Backend\\Command\\ProcessLayCSVCommand\:\:\$defaultName has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: api/app/src/Command/ProcessLayCSVCommand.php
-
-		-
 			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
 			count: 2
@@ -227,12 +221,6 @@ parameters:
 			identifier: booleanAnd.rightAlwaysTrue
 			count: 1
 			path: api/app/src/Command/ReportStatusUpdaterCommand.php
-
-		-
-			message: '#^Property OPG\\Digideps\\Backend\\Command\\ResyncResubmittableErrorDocuments\:\:\$defaultName has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: api/app/src/Command/ResyncResubmittableErrorDocuments.php
 
 		-
 			message: '#^Method OPG\\Digideps\\Backend\\Command\\UserCleanupCommand\:\:deleteInactivateUsers\(\) should return int but returns mixed\.$#'
@@ -21559,13 +21547,13 @@ parameters:
 			path: api/app/tests/Integration/v2/Service/CourtOrderServiceIntegrationTest.php
 
 		-
-			message: '#^Parameter \#1 \$name of method Symfony\\Bundle\\FrameworkBundle\\Console\\Application\:\:find\(\) expects string, mixed given\.$#'
+			message: '#^Parameter \#1 \$name of method Symfony\\Bundle\\FrameworkBundle\\Console\\Application\:\:find\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: api/app/tests/Unit/Command/ProcessLayCSVCommandTest.php
 
 		-
-			message: '#^Parameter \#1 \$name of method Symfony\\Bundle\\FrameworkBundle\\Console\\Application\:\:find\(\) expects string, string\|null given\.$#'
+			message: '#^Parameter \#1 \$name of method Symfony\\Bundle\\FrameworkBundle\\Console\\Application\:\:find\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: api/app/tests/Unit/Command/ProcessOrgCSVCommandTest.php
@@ -22909,12 +22897,6 @@ parameters:
 			path: client/app/src/Components/OPG/Review/BankAccounts.php
 
 		-
-			message: '#^Parameter \#1 \$value of method OPG\\Digideps\\Frontend\\Components\\OPG\\Review\\BankAccounts\:\:formatBalance\(\) expects float\|int\|string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: client/app/src/Components/OPG/Review/BankAccounts.php
-
-		-
 			message: '#^Parameter \#2 \$number of class OPG\\Digideps\\Frontend\\Components\\OPG\\Renderable\\BankAccount constructor expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -22957,19 +22939,7 @@ parameters:
 			path: client/app/src/Components/OPG/Review/Contacts.php
 
 		-
-			message: '#^Parameter \#2 \.\.\.\$cells of method OPG\\Digideps\\Frontend\\Components\\GOV\\Table\\TableBuilder\:\:addRow\(\) expects OPG\\Digideps\\Frontend\\Components\\GOV\\Table\\Cell\|OPG\\Digideps\\Frontend\\Components\\RenderableInterface\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: client/app/src/Components/OPG/Review/Contacts.php
-
-		-
 			message: '#^Parameter \#3 \$address2 of class OPG\\Digideps\\Frontend\\Components\\OPG\\Renderable\\Contact constructor expects string\|null, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: client/app/src/Components/OPG/Review/Contacts.php
-
-		-
-			message: '#^Parameter \#3 \.\.\.\$cells of method OPG\\Digideps\\Frontend\\Components\\GOV\\Table\\TableBuilder\:\:addRow\(\) expects OPG\\Digideps\\Frontend\\Components\\GOV\\Table\\Cell\|OPG\\Digideps\\Frontend\\Components\\RenderableInterface\|string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: client/app/src/Components/OPG/Review/Contacts.php
@@ -22991,36 +22961,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: client/app/src/Components/OPG/Review/Contacts.php
-
-		-
-			message: '#^Possibly invalid array key type mixed\.$#'
-			identifier: offsetAccess.invalidOffset
-			count: 1
-			path: client/app/src/Components/OPG/Review/Contacts.php
-
-		-
-			message: '#^Binary operation "\." between ''review\.'' and mixed results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
-			path: client/app/src/Components/OPG/Review/Decisions.php
-
-		-
-			message: '#^Cannot call method format\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: client/app/src/Components/OPG/Review/Decisions.php
-
-		-
-			message: '#^Parameter \#2 \$value of method OPG\\Digideps\\Frontend\\Components\\GOV\\Summary\\SummaryListBuilder\:\:addItem\(\) expects OPG\\Digideps\\Frontend\\Components\\RenderableInterface\|string, mixed given\.$#'
-			identifier: argument.type
-			count: 3
-			path: client/app/src/Components/OPG/Review/Decisions.php
-
-		-
-			message: '#^Parameter \#3 \.\.\.\$cells of method OPG\\Digideps\\Frontend\\Components\\GOV\\Table\\TableBuilder\:\:addRow\(\) expects OPG\\Digideps\\Frontend\\Components\\GOV\\Table\\Cell\|OPG\\Digideps\\Frontend\\Components\\RenderableInterface\|string, bool given\.$#'
-			identifier: argument.type
-			count: 1
-			path: client/app/src/Components/OPG/Review/Decisions.php
 
 		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Controller\\AbstractController\:\:renderError\(\) has parameter \$message with no type specified\.$#'
@@ -24283,7 +24223,19 @@ parameters:
 			path: client/app/src/Controller/Report/BankAccountController.php
 
 		-
+			message: '#^Parameter \#1 \$closingBalance of method OPG\\Digideps\\Frontend\\Entity\\Report\\BankAccount\:\:setClosingBalance\(\) expects float\|int\|string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: client/app/src/Controller/Report/BankAccountController.php
+
+		-
 			message: '#^Parameter \#1 \$id of method Symfony\\Contracts\\Translation\\TranslatorInterface\:\:trans\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: client/app/src/Controller/Report/BankAccountController.php
+
+		-
+			message: '#^Parameter \#1 \$openingBalance of method OPG\\Digideps\\Frontend\\Entity\\Report\\BankAccount\:\:setOpeningBalance\(\) expects float\|int\|string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: client/app/src/Controller/Report/BankAccountController.php
@@ -24541,6 +24493,12 @@ parameters:
 			path: client/app/src/Controller/Report/LifestyleController.php
 
 		-
+			message: '#^Negated boolean expression is always false\.$#'
+			identifier: booleanNot.alwaysFalse
+			count: 1
+			path: client/app/src/Controller/Report/LifestyleController.php
+
+		-
 			message: '#^Parameter \#2 \$mixed of method OPG\\Digideps\\Frontend\\Service\\Client\\RestClient\:\:post\(\) expects array\|object\|string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
@@ -24549,6 +24507,12 @@ parameters:
 		-
 			message: '#^Parameter \#2 \$mixed of method OPG\\Digideps\\Frontend\\Service\\Client\\RestClient\:\:put\(\) expects array\|object\|string, mixed given\.$#'
 			identifier: argument.type
+			count: 1
+			path: client/app/src/Controller/Report/LifestyleController.php
+
+		-
+			message: '#^Ternary operator condition is always true\.$#'
+			identifier: ternary.alwaysTrue
 			count: 1
 			path: client/app/src/Controller/Report/LifestyleController.php
 
@@ -24993,6 +24957,12 @@ parameters:
 		-
 			message: '#^Binary operation "\." between mixed and '' \(deputy\)'' results in an error\.$#'
 			identifier: binaryOp.invalid
+			count: 1
+			path: client/app/src/Controller/Report/ReportController.php
+
+		-
+			message: '#^Parameter \#1 \$reportId of method OPG\\Digideps\\Frontend\\Service\\Client\\Internal\\ReportApi\:\:getReportIfNotSubmitted\(\) expects int, int\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: client/app/src/Controller/Report/ReportController.php
 
@@ -25747,12 +25717,6 @@ parameters:
 			path: client/app/src/Entity/Report/BankAccount.php
 
 		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\BankAccount\:\:getOpeningBalance\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: client/app/src/Entity/Report/BankAccount.php
-
-		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\BankAccount\:\:getSortCode\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -25802,12 +25766,6 @@ parameters:
 
 		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\BankAccount\:\:setMeta\(\) has parameter \$meta with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: client/app/src/Entity/Report/BankAccount.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\BankAccount\:\:setOpeningBalance\(\) has parameter \$openingBalance with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: client/app/src/Entity/Report/BankAccount.php
@@ -25909,12 +25867,6 @@ parameters:
 			path: client/app/src/Entity/Report/Contact.php
 
 		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Contact\:\:getExplanation\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: client/app/src/Entity/Report/Contact.php
-
-		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Contact\:\:getId\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -25928,12 +25880,6 @@ parameters:
 
 		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Contact\:\:getPostcode\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: client/app/src/Entity/Report/Contact.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Contact\:\:getRelationship\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: client/app/src/Entity/Report/Contact.php
@@ -26035,8 +25981,8 @@ parameters:
 			path: client/app/src/Entity/Report/Contact.php
 
 		-
-			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\Contact\:\:\$explanation has no type specified\.$#'
-			identifier: missingType.property
+			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\Contact\:\:\$explanation \(string\|null\) does not accept mixed\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: client/app/src/Entity/Report/Contact.php
 
@@ -26059,8 +26005,8 @@ parameters:
 			path: client/app/src/Entity/Report/Contact.php
 
 		-
-			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\Contact\:\:\$relationship has no type specified\.$#'
-			identifier: missingType.property
+			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\Contact\:\:\$relationship \(string\|null\) does not accept mixed\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: client/app/src/Entity/Report/Contact.php
 
@@ -26075,6 +26021,12 @@ parameters:
 			identifier: missingType.property
 			count: 1
 			path: client/app/src/Entity/Report/Debt.php
+
+		-
+			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\Decision\:\:\$id is never written, only read\.$#'
+			identifier: property.onlyRead
+			count: 1
+			path: client/app/src/Entity/Report/Decision.php
 
 		-
 			message: '#^Cannot call method getDocuments\(\) on OPG\\Digideps\\Frontend\\Entity\\Report\\Report\|null\.$#'
@@ -26191,6 +26143,30 @@ parameters:
 			path: client/app/src/Entity/Report/Gift.php
 
 		-
+			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Lifestyle\:\:getActivityDetailsNo\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: client/app/src/Entity/Report/Lifestyle.php
+
+		-
+			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Lifestyle\:\:getActivityDetailsYes\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: client/app/src/Entity/Report/Lifestyle.php
+
+		-
+			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Lifestyle\:\:getCareAppointments\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: client/app/src/Entity/Report/Lifestyle.php
+
+		-
+			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Lifestyle\:\:getDoesClientUndertakeSocialActivities\(\) should return string\|null but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: client/app/src/Entity/Report/Lifestyle.php
+
+		-
 			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\Lifestyle\:\:\$activityDetailsNo has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
@@ -26215,68 +26191,8 @@ parameters:
 			path: client/app/src/Entity/Report/Lifestyle.php
 
 		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:getHasCapacityChanged\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: client/app/src/Entity/Report/MentalCapacity.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:getHasCapacityChangedDetails\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: client/app/src/Entity/Report/MentalCapacity.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:getId\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: client/app/src/Entity/Report/MentalCapacity.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:getMentalAssessmentDate\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: client/app/src/Entity/Report/MentalCapacity.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:setHasCapacityChanged\(\) has parameter \$hasCapacityChanged with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: client/app/src/Entity/Report/MentalCapacity.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:setHasCapacityChangedDetails\(\) has parameter \$hasCapacityChangedDetails with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: client/app/src/Entity/Report/MentalCapacity.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:setMentalAssessmentDate\(\) has parameter \$mentalAssessmentDate with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: client/app/src/Entity/Report/MentalCapacity.php
-
-		-
-			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:\$hasCapacityChanged has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: client/app/src/Entity/Report/MentalCapacity.php
-
-		-
-			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:\$hasCapacityChangedDetails has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: client/app/src/Entity/Report/MentalCapacity.php
-
-		-
 			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:\$id is never written, only read\.$#'
 			identifier: property.onlyRead
-			count: 1
-			path: client/app/src/Entity/Report/MentalCapacity.php
-
-		-
-			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\MentalCapacity\:\:\$mentalAssessmentDate has no type specified\.$#'
-			identifier: missingType.property
 			count: 1
 			path: client/app/src/Entity/Report/MentalCapacity.php
 
@@ -26285,12 +26201,6 @@ parameters:
 			identifier: property.onlyWritten
 			count: 1
 			path: client/app/src/Entity/Report/MoneyReceivedOnClientsBehalf.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\MoneyTransaction\:\:getCategoriesGrouped\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: client/app/src/Entity/Report/MoneyTransaction.php
 
 		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\MoneyTransaction\:\:getCategoriesGrouped\(\) has parameter \$typeFilter with no type specified\.$#'
@@ -26425,8 +26335,20 @@ parameters:
 			path: client/app/src/Entity/Report/ProfDeputyOtherCost.php
 
 		-
+			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\ProfDeputyOtherCost\:\:getProfDeputyOtherCostTypeId\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: client/app/src/Entity/Report/ProfDeputyOtherCost.php
+
+		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\ProfDeputyOtherCost\:\:setProfDeputyOtherCostTypeId\(\) has parameter \$profDeputyOtherCostTypeId with no type specified\.$#'
 			identifier: missingType.parameter
+			count: 1
+			path: client/app/src/Entity/Report/ProfDeputyOtherCost.php
+
+		-
+			message: '#^PHPDoc tag @return with type mixed is not subtype of native type string\.$#'
+			identifier: return.phpDocType
 			count: 1
 			path: client/app/src/Entity/Report/ProfDeputyOtherCost.php
 
@@ -26587,20 +26509,8 @@ parameters:
 			path: client/app/src/Entity/Report/Report.php
 
 		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:getSignificantDecisionsMade\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: client/app/src/Entity/Report/Report.php
-
-		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:getTotalValue\(\) should return int but returns float\|int\.$#'
 			identifier: return.type
-			count: 1
-			path: client/app/src/Entity/Report/Report.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:hasContacts\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: client/app/src/Entity/Report/Report.php
 
@@ -26671,12 +26581,6 @@ parameters:
 			path: client/app/src/Entity/Report/Report.php
 
 		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:setId\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: client/app/src/Entity/Report/Report.php
-
-		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:setMentalCapacity\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -26697,12 +26601,6 @@ parameters:
 		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:setSignificantDecisionsMade\(\) has parameter \$significantDecisionsMade with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: client/app/src/Entity/Report/Report.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:setStartDate\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: client/app/src/Entity/Report/Report.php
 
@@ -26827,13 +26725,7 @@ parameters:
 			path: client/app/src/Entity/Report/Report.php
 
 		-
-			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:\$significantDecisionsMade has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: client/app/src/Entity/Report/Report.php
-
-		-
-			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:\$submittedBy \(OPG\\Digideps\\Frontend\\Entity\\User\) does not accept OPG\\Digideps\\Frontend\\Entity\\User\|null\.$#'
+			message: '#^Property OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:\$significantDecisionsMade \(string\|null\) does not accept mixed\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: client/app/src/Entity/Report/Report.php
@@ -28879,6 +28771,12 @@ parameters:
 			path: client/app/src/Model/FeedbackReport.php
 
 		-
+			message: '#^Parameter \#1 \$reportId of class OPG\\Digideps\\Common\\Report\\ReportMetadata constructor expects int, int\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: client/app/src/Report/ReportSectionService.php
+
+		-
 			message: '#^Method OPG\\Digideps\\Frontend\\Resolver\\SubSectionRoute\\ProfCostsEstimateSubSectionRouteResolver\:\:breakdownSubsectionIsIncomplete\(\) has parameter \$state with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -29403,6 +29301,18 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$message of class Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException constructor expects string, mixed given\.$#'
 			identifier: argument.type
+			count: 1
+			path: client/app/src/Service/Client/Internal/ReportApi.php
+
+		-
+			message: '#^Parameter \#1 \$reportId of method OPG\\Digideps\\Frontend\\Service\\Client\\Internal\\ReportApi\:\:getReport\(\) expects int, int\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: client/app/src/Service/Client/Internal/ReportApi.php
+
+		-
+			message: '#^Possibly invalid array key type int\|null\.$#'
+			identifier: offsetAccess.invalidOffset
 			count: 1
 			path: client/app/src/Service/Client/Internal/ReportApi.php
 
@@ -31999,6 +31909,12 @@ parameters:
 			path: client/app/src/Sync/Service/ChecklistSyncService.php
 
 		-
+			message: '#^Method OPG\\Digideps\\Frontend\\Sync\\Service\\ChecklistSyncService\:\:syncChecklistsByReports\(\) should return array\{notSyncedCount\: int, reportIdsWithNullChecklists\: array\<int\>\} but returns array\{notSyncedCount\: int\<0, max\>, reportIdsWithNullChecklists\: list\<int\|null\>\}\.$#'
+			identifier: return.type
+			count: 1
+			path: client/app/src/Sync/Service/ChecklistSyncService.php
+
+		-
 			message: '#^Call to function method_exists\(\) with Throwable and ''getCode'' will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
@@ -32027,48 +31943,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: client/app/src/Sync/Service/SiriusApiErrorTranslator.php
-
-		-
-			message: '#^Cannot call method setChecklist\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: client/app/src/TestHelpers/ChecklistTestHelper.php
-
-		-
-			message: '#^Cannot call method setClient\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: client/app/src/TestHelpers/ChecklistTestHelper.php
-
-		-
-			message: '#^Cannot call method setEndDate\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: client/app/src/TestHelpers/ChecklistTestHelper.php
-
-		-
-			message: '#^Cannot call method setReportSubmissions\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: client/app/src/TestHelpers/ChecklistTestHelper.php
-
-		-
-			message: '#^Cannot call method setType\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: client/app/src/TestHelpers/ChecklistTestHelper.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\TestHelpers\\ChecklistTestHelper\:\:buildPfaHighReport\(\) should return OPG\\Digideps\\Frontend\\Entity\\Report\\Report but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: client/app/src/TestHelpers/ChecklistTestHelper.php
-
-		-
-			message: '#^Parameter \#1 \$report of class OPG\\Digideps\\Frontend\\Entity\\Report\\Checklist constructor expects OPG\\Digideps\\Frontend\\Entity\\Report\\Report, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: client/app/src/TestHelpers/ChecklistTestHelper.php
 
 		-
 			message: '#^Method OPG\\Digideps\\Frontend\\TestHelpers\\ClientHelpers\:\:createValidCaseNumber\(\) has no return type specified\.$#'
@@ -32147,30 +32021,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: client/app/src/TestHelpers/OrganisationHelpers.php
-
-		-
-			message: '#^Cannot call method setDueDate\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: client/app/src/TestHelpers/ReportHelpers.php
-
-		-
-			message: '#^Cannot call method setEndDate\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: client/app/src/TestHelpers/ReportHelpers.php
-
-		-
-			message: '#^Cannot call method setStartDate\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 1
-			path: client/app/src/TestHelpers/ReportHelpers.php
-
-		-
-			message: '#^Method OPG\\Digideps\\Frontend\\TestHelpers\\ReportHelpers\:\:createReport\(\) should return OPG\\Digideps\\Frontend\\Entity\\Report\\Report but returns mixed\.$#'
-			identifier: return.type
-			count: 1
-			path: client/app/src/TestHelpers/ReportHelpers.php
 
 		-
 			message: '#^Parameter \#1 \$submittedBy of method OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:setSubmittedBy\(\) expects OPG\\Digideps\\Frontend\\Entity\\User\|null, array\|object given\.$#'
@@ -36517,12 +36367,6 @@ parameters:
 			path: client/app/tests/Unit/Service/Mailer/MailFactoryTest.php
 
 		-
-			message: '#^Cannot call method setEndDate\(\) on mixed\.$#'
-			identifier: method.nonObject
-			count: 2
-			path: client/app/tests/Unit/Service/Mailer/MailFactoryTest.php
-
-		-
 			message: '#^Cannot call method willReturn\(\) on mixed\.$#'
 			identifier: method.nonObject
 			count: 2
@@ -36591,18 +36435,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$type of method OPG\\Digideps\\Frontend\\Entity\\Report\\Report\:\:setType\(\) expects string, mixed given\.$#'
 			identifier: argument.type
-			count: 1
-			path: client/app/tests/Unit/Service/Mailer/MailFactoryTest.php
-
-		-
-			message: '#^Property Tests\\OPG\\Digideps\\Frontend\\Unit\\Service\\Mailer\\MailFactoryTest\:\:\$newReport \(OPG\\Digideps\\Frontend\\Entity\\Report\\Report\) does not accept mixed\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: client/app/tests/Unit/Service/Mailer/MailFactoryTest.php
-
-		-
-			message: '#^Property Tests\\OPG\\Digideps\\Frontend\\Unit\\Service\\Mailer\\MailFactoryTest\:\:\$submittedReport \(OPG\\Digideps\\Frontend\\Entity\\Report\\Report\) does not accept mixed\.$#'
-			identifier: assign.propertyType
 			count: 1
 			path: client/app/tests/Unit/Service/Mailer/MailFactoryTest.php
 
@@ -36985,6 +36817,12 @@ parameters:
 			path: client/app/tests/Unit/Service/StringUtilsTest.php
 
 		-
+			message: '#^Call to an undefined static method OPG\\Digideps\\Frontend\\Sync\\Command\\ChecklistSyncCommand\:\:getDefaultName\(\)\.$#'
+			identifier: staticMethod.notFound
+			count: 1
+			path: client/app/tests/Unit/Sync/Command/ChecklistSyncCommandTest.php
+
+		-
 			message: '#^Method Tests\\OPG\\Digideps\\Frontend\\Unit\\Sync\\Command\\ChecklistSyncCommandTest\:\:doesNotSyncIfFeatureIsNotEnabled\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -37003,7 +36841,7 @@ parameters:
 			path: client/app/tests/Unit/Sync/Command/ChecklistSyncCommandTest.php
 
 		-
-			message: '#^Parameter \#1 \$name of method Symfony\\Bundle\\FrameworkBundle\\Console\\Application\:\:find\(\) expects string, string\|null given\.$#'
+			message: '#^Parameter \#1 \$name of method Symfony\\Bundle\\FrameworkBundle\\Console\\Application\:\:find\(\) expects string, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: client/app/tests/Unit/Sync/Command/ChecklistSyncCommandTest.php


### PR DESCRIPTION
This caused issues before.

This differs from what it was before in that:
- `Report::getId` returns `?int`
- The JMS groups of id are now `['report', 'report-id']` instead of `['visits-care', 'report-id']`

It is unknown if the latter is the issue but it clearly was nonsensical. The first should 'fix' the issue but of course a lot of places do not expect null and could still crash (but would have done so anyway presumably)